### PR TITLE
Remove serde dependency

### DIFF
--- a/src/strings.rs
+++ b/src/strings.rs
@@ -117,50 +117,6 @@ pub enum CowStr<'a> {
     Inlined(InlineStr),
 }
 
-#[cfg(feature = "serde")]
-mod serde_impl {
-    use std::fmt;
-
-    use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-
-    use super::CowStr;
-
-    impl<'a> Serialize for CowStr<'a> {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            serializer.serialize_str(self.as_ref())
-        }
-    }
-
-    struct CowStrVisitor;
-
-    impl<'de> de::Visitor<'de> for CowStrVisitor {
-        type Value = CowStr<'de>;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            formatter.write_str("a string")
-        }
-
-        fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-        where
-            E: de::Error,
-        {
-            Ok(CowStr::Borrowed(v))
-        }
-    }
-
-    impl<'a, 'de: 'a> Deserialize<'de> for CowStr<'a> {
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            deserializer.deserialize_str(CowStrVisitor)
-        }
-    }
-}
-
 impl<'a> AsRef<str> for CowStr<'a> {
     fn as_ref(&self) -> &str {
         self.deref()


### PR DESCRIPTION
Not sure for now that we'll need it. Rust 1.79 flags the missing feature declaration.