### PR TITLE
Introduce new (internal) ParseResult type

### DIFF
--- a/src/blocks/block.rs
+++ b/src/blocks/block.rs
@@ -46,15 +46,15 @@ impl<'a> Block<'a> {
         let i = consume_empty_lines(i);
 
         // Try to discern the block type by scanning the first line.
-        let (_, line) = normalized_line(i);
-        if line.contains("::") {
+        let line = normalized_line(i);
+        if line.t.contains("::") {
             if let Ok((rem, macro_block)) = MacroBlock::parse(i) {
                 return Ok((rem, Self::Macro(macro_block)));
             }
 
             // A line containing `::` might be some other kind of block, so we
             // don't automatically error out on a parse failure.
-        } else if line.starts_with('=') {
+        } else if line.t.starts_with('=') {
             if let Ok((rem, section_block)) = SectionBlock::parse(i) {
                 return Ok((rem, Self::Section(section_block)));
             }

--- a/src/blocks/macro.rs
+++ b/src/blocks/macro.rs
@@ -30,14 +30,14 @@ pub struct MacroBlock<'a> {
 
 impl<'a> MacroBlock<'a> {
     pub(crate) fn parse(source: Span<'a>) -> IResult<Span, Self> {
-        let (rem, line) = normalized_line(source);
+        let line = normalized_line(source);
 
         // Line must end with `]`; otherwise, it's not a block macro.
-        if !line.ends_with(']') {
-            return Err(Err::Error(Error::new(line, ErrorKind::Tag)));
+        if !line.t.ends_with(']') {
+            return Err(Err::Error(Error::new(line.t, ErrorKind::Tag)));
         }
 
-        let line_wo_brace = line.slice(0..line.len() - 1);
+        let line_wo_brace = line.t.slice(0..line.t.len() - 1);
 
         let (attrlist, (name, _colons, target, _braces)) =
             tuple((ident, tag("::"), take_until("["), tag("[")))(line_wo_brace)?;
@@ -45,7 +45,7 @@ impl<'a> MacroBlock<'a> {
         let (_, attrlist) = Attrlist::parse(attrlist)?;
 
         Ok((
-            consume_empty_lines(rem),
+            consume_empty_lines(line.rem),
             Self {
                 name,
                 target: if target.is_empty() {
@@ -54,7 +54,7 @@ impl<'a> MacroBlock<'a> {
                     Some(target)
                 },
                 attrlist,
-                source: line,
+                source: line.t,
             },
         ))
     }

--- a/src/blocks/section.rs
+++ b/src/blocks/section.rs
@@ -86,7 +86,7 @@ impl<'a> HasSpan<'a> for SectionBlock<'a> {
 }
 
 fn parse_title_line(source: Span<'_>) -> IResult<Span<'_>, (usize, Span<'_>)> {
-    let (rem, line) = non_empty_line(source).ok_or(nom::Err::Error(nom::error::Error::new(
+    let line = non_empty_line(source).ok_or(nom::Err::Error(nom::error::Error::new(
         source,
         nom::error::ErrorKind::TakeTill1,
     )))?;
@@ -94,10 +94,10 @@ fn parse_title_line(source: Span<'_>) -> IResult<Span<'_>, (usize, Span<'_>)> {
     // TO DO: Also support Markdown-style `#` markers.
     // TO DO: Enforce maximum of 6 `=` or `#` markers.
     // TO DO: Disallow empty title.
-    let (space_title, count) = many1_count(tag("="))(line)?;
+    let (space_title, count) = many1_count(tag("="))(line.t)?;
     let (title, _) = space1(space_title)?;
 
-    Ok((rem, (count - 1, title)))
+    Ok((line.rem, (count - 1, title)))
 }
 
 fn peer_or_ancestor_section(i: Span<'_>, level: usize) -> bool {

--- a/src/blocks/simple.rs
+++ b/src/blocks/simple.rs
@@ -10,10 +10,11 @@ pub struct SimpleBlock<'a>(Inline<'a>);
 
 impl<'a> SimpleBlock<'a> {
     pub(crate) fn parse(source: Span<'a>) -> IResult<Span, Self> {
-        let (rem, inline) = Inline::parse_lines(source).ok_or(nom::Err::Error(
-            nom::error::Error::new(source, nom::error::ErrorKind::TakeTill1),
-        ))?;
-        Ok((consume_empty_lines(rem), Self(inline)))
+        let inline = Inline::parse_lines(source).ok_or(nom::Err::Error(nom::error::Error::new(
+            source,
+            nom::error::ErrorKind::TakeTill1,
+        )))?;
+        Ok((consume_empty_lines(inline.rem), Self(inline.t)))
     }
 
     /// Return the inline content of this block.

--- a/src/document/header.rs
+++ b/src/document/header.rs
@@ -58,13 +58,13 @@ impl<'a> HasSpan<'a> for Header<'a> {
 }
 
 fn parse_title(i: Span<'_>) -> IResult<Span, Span<'_>> {
-    let (rem, line) = non_empty_line(i).ok_or(nom::Err::Error(nom::error::Error::new(
+    let line = non_empty_line(i).ok_or(nom::Err::Error(nom::error::Error::new(
         i,
         nom::error::ErrorKind::TakeTill1,
     )))?;
 
-    let (title, _) = tag("=")(line)?;
+    let (title, _) = tag("=")(line.t)?;
     let (title, _) = space1(title)?;
 
-    Ok((rem, title))
+    Ok((line.rem, title))
 }

--- a/src/document/header.rs
+++ b/src/document/header.rs
@@ -1,6 +1,12 @@
 use std::slice::Iter;
 
-use nom::{bytes::complete::tag, character::complete::space1, multi::many0, IResult};
+use nom::{
+    bytes::complete::tag,
+    character::complete::space1,
+    error::{Error, ErrorKind},
+    multi::many0,
+    Err, IResult,
+};
 
 use crate::{
     document::Attribute,
@@ -27,7 +33,9 @@ impl<'a> Header<'a> {
         let (rem, attributes) = many0(Attribute::parse)(rem)?;
 
         // Header must be followed by an empty line.
-        let (_, _) = empty_line(rem)?;
+        if empty_line(rem).is_none() {
+            return Err(Err::Error(Error::new(rem, ErrorKind::NonEmpty)));
+        }
 
         let source = trim_input_for_rem(source, rem);
         Ok((

--- a/src/inlines/inline.rs
+++ b/src/inlines/inline.rs
@@ -55,15 +55,14 @@ impl<'a> Inline<'a> {
                 break;
             }
 
-            let (span3, interp) = parse_interpreted(span)?;
+            let interp = parse_interpreted(span)?;
 
-            if span3.is_empty() && inlines.is_empty() {
-                return Some(ParseResult { t: interp, rem });
+            if interp.rem.is_empty() && inlines.is_empty() {
+                return Some(interp);
             }
 
-            inlines.push(interp);
-
-            span = span3;
+            inlines.push(interp.t);
+            span = interp.rem;
 
             uninterp = parse_uninterpreted(span);
         }
@@ -148,8 +147,11 @@ fn parse_uninterpreted(i: Span<'_>) -> ParseResult<Span> {
 }
 
 // Parse the block as a special "interpreted" inline sequence or error out.
-fn parse_interpreted(i: Span<'_>) -> Option<(Span, Inline<'_>)> {
+fn parse_interpreted(i: Span<'_>) -> Option<ParseResult<Inline<'_>>> {
     InlineMacro::parse(i)
-        .map(|(rem, x)| (rem, Inline::Macro(x)))
+        .map(|(rem, x)| ParseResult {
+            t: Inline::Macro(x),
+            rem,
+        })
         .ok()
 }

--- a/src/inlines/inline.rs
+++ b/src/inlines/inline.rs
@@ -28,7 +28,8 @@ impl<'a> Inline<'a> {
     ///
     /// Returns `None` if input doesn't start with a non-empty line.
     pub(crate) fn parse(i: Span<'a>) -> Option<ParseResult<Self>> {
-        let (rem, mut span) = non_empty_line(i)?;
+        let line = non_empty_line(i)?;
+        let mut span = line.t;
 
         // Special-case optimization: If the entire span is one
         // uninterpreted block, just return that without the allocation
@@ -39,7 +40,7 @@ impl<'a> Inline<'a> {
         if uninterp.rem.is_empty() {
             return Some(ParseResult {
                 t: Self::Uninterpreted(uninterp.t),
-                rem,
+                rem: line.rem,
             });
         }
 
@@ -68,8 +69,8 @@ impl<'a> Inline<'a> {
         }
 
         Some(ParseResult {
-            t: Self::Sequence(inlines, trim_input_for_rem(i, rem)),
-            rem,
+            t: Self::Sequence(inlines, trim_input_for_rem(i, line.rem)),
+            rem: line.rem,
         })
     }
 

--- a/src/inlines/inline.rs
+++ b/src/inlines/inline.rs
@@ -79,7 +79,7 @@ impl<'a> Inline<'a> {
     ///
     /// Returns `None` if there is not at least one non-empty line at
     /// beginning of input.
-    pub(crate) fn parse_lines(i: Span<'a>) -> Option<(Span, Self)> {
+    pub(crate) fn parse_lines(i: Span<'a>) -> Option<ParseResult<Self>> {
         let mut inlines: Vec<Inline<'a>> = vec![];
         let mut next = i;
 
@@ -89,10 +89,16 @@ impl<'a> Inline<'a> {
         }
 
         if inlines.len() < 2 {
-            inlines.pop().map(|inline| (next, inline))
+            inlines.pop().map(|inline| ParseResult {
+                t: inline,
+                rem: next,
+            })
         } else {
             let source = trim_input_for_rem(i, next);
-            Some((next, Self::Sequence(inlines, source)))
+            Some(ParseResult {
+                t: Self::Sequence(inlines, source),
+                rem: next,
+            })
         }
     }
 }

--- a/src/primitives/line.rs
+++ b/src/primitives/line.rs
@@ -57,7 +57,7 @@ pub(crate) fn normalized_line(input: Span<'_>) -> ParseResult<Span> {
 ///
 /// Returns `None` if the line becomes empty after trailing spaces have been
 /// removed.
-pub(crate) fn non_empty_line(input: Span<'_>) -> Option<(Span, Span)> {
+pub(crate) fn non_empty_line(input: Span<'_>) -> Option<ParseResult<Span>> {
     // Result<(Spanned<&str>, Spanned<&str>),
     // nom::Err<nom::error::Error<Spanned<&str>>>>
     take_till1::<_, Span, nom::error::Error<Span>>(|c| c == '\n')(input)
@@ -70,7 +70,7 @@ pub(crate) fn non_empty_line(input: Span<'_>) -> Option<(Span, Span)> {
                 None
                 // Err(Err::Error(Error::new(input, ErrorKind::TakeTill1)))
             } else {
-                Some((rem, inp))
+                Some(ParseResult { rem, t: inp })
             }
         })
 }

--- a/src/primitives/line.rs
+++ b/src/primitives/line.rs
@@ -40,9 +40,10 @@ pub(crate) fn line(input: Span<'_>) -> ParseResult<Span> {
 /// but not included in the returned line.
 ///
 /// All trailing spaces are removed from the line.
-pub(crate) fn normalized_line(input: Span<'_>) -> (Span, Span) {
+pub(crate) fn normalized_line(input: Span<'_>) -> ParseResult<Span> {
     let line = line(input); // TEMPORARY: Re-inline this.
-    trim_trailing_spaces((line.rem, line.t))
+    let x = trim_trailing_spaces((line.rem, line.t));
+    ParseResult { rem: x.0, t: x.1 }
 }
 
 /// Returns a single _normalized, non-empty_ line from the source
@@ -110,9 +111,9 @@ pub(crate) fn line_with_continuation(input: Span<'_>) -> IResult<Span, Span> {
 }
 
 fn one_line_with_continuation(input: Span<'_>) -> IResult<Span, Span> {
-    let (rem, line) = normalized_line(input);
-    if line.ends_with('\\') {
-        Ok((rem, line))
+    let line = normalized_line(input);
+    if line.t.ends_with('\\') {
+        Ok((line.rem, line.t))
     } else {
         Err(Err::Error(Error::new(input, ErrorKind::NonEmpty)))
     }

--- a/src/primitives/line.rs
+++ b/src/primitives/line.rs
@@ -129,29 +129,29 @@ fn one_line_with_continuation(input: Span<'_>) -> IResult<Span, Span> {
 ///
 /// An empty line may contain any number of white space characters.
 ///
-/// Returns an error if the line contains any non-white-space characters.
-pub(crate) fn empty_line(input: Span<'_>) -> IResult<Span, Span> {
-    let l = line(input);
+/// Returns `None` if the line contains any non-white-space characters.
+pub(crate) fn empty_line(i: Span<'_>) -> Option<ParseResult<Span>> {
+    let l = line(i);
 
     if l.t.data().bytes().all(nom::character::is_space) {
-        Ok((l.rem, l.t))
+        Some(l)
     } else {
-        Err(Err::Error(Error::new(input, ErrorKind::NonEmpty)))
+        None
     }
 }
 
 /// Consumes zero or more empty lines.
 ///
 /// Returns the original input if any error occurs or no empty lines are found.
-pub(crate) fn consume_empty_lines(mut input: Span<'_>) -> Span {
-    while !input.data().is_empty() {
-        match empty_line(input) {
-            Ok((rem, _)) => input = rem,
-            Err(_) => break,
+pub(crate) fn consume_empty_lines(mut i: Span<'_>) -> Span {
+    while !i.data().is_empty() {
+        match empty_line(i) {
+            Some(line) => i = line.rem,
+            None => break,
         }
     }
 
-    input
+    i
 }
 
 fn trim_rem_start_matches<'a>(i: ParseResult<'a, Span<'a>>, c: char) -> ParseResult<Span<'a>> {

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -24,6 +24,13 @@ pub(crate) use line::{
 /// syntactic element in question.
 pub type Span<'a> = nom_span::Spanned<&'a str>;
 
+/// Represents a successful parse result and subsequent remainder of the input
+/// stream.
+pub(crate) struct ParseResult<'a, T> {
+    pub(crate) t: T,
+    pub(crate) rem: Span<'a>,
+}
+
 /// Given two [`Span`]s, the second of which must be a trailing remainder
 /// of the first, return the first input trimmed to exclude the second.
 ///

--- a/src/tests/asciidoc_lang/root/document_structure.rs
+++ b/src/tests/asciidoc_lang/root/document_structure.rs
@@ -253,10 +253,10 @@ mod lines {
         // == Section Title
         // ----
 
-        let (rem, line) = line(Span::new("== Section Title\n", true));
+        let l = line(Span::new("== Section Title\n", true));
 
         assert_eq!(
-            rem,
+            l.rem,
             TSpan {
                 data: "",
                 line: 2,
@@ -266,7 +266,7 @@ mod lines {
         );
 
         assert_eq!(
-            line,
+            l.t,
             TSpan {
                 data: "== Section Title",
                 line: 1,

--- a/src/tests/asciidoc_lang/root/normalization.rs
+++ b/src/tests/asciidoc_lang/root/normalization.rs
@@ -30,10 +30,10 @@ fn force_utf8() {
 
 #[test]
 fn strips_trailing_spaces() {
-    let (rem, line) = normalized_line(Span::new("abc   ", true));
+    let line = normalized_line(Span::new("abc   ", true));
 
     assert_eq!(
-        rem,
+        line.rem,
         TSpan {
             data: "",
             line: 1,
@@ -43,7 +43,7 @@ fn strips_trailing_spaces() {
     );
 
     assert_eq!(
-        line,
+        line.t,
         TSpan {
             data: "abc",
             line: 1,
@@ -57,10 +57,10 @@ fn strips_trailing_spaces() {
 fn strips_trailing_lf() {
     // Should consume but not return \n.
 
-    let (rem, line) = normalized_line(Span::new("abc  \ndef", true));
+    let line = normalized_line(Span::new("abc  \ndef", true));
 
     assert_eq!(
-        rem,
+        line.rem,
         TSpan {
             data: "def",
             line: 2,
@@ -70,7 +70,7 @@ fn strips_trailing_lf() {
     );
 
     assert_eq!(
-        line,
+        line.t,
         TSpan {
             data: "abc",
             line: 1,
@@ -84,10 +84,10 @@ fn strips_trailing_lf() {
 fn strips_trailing_crlf() {
     // Should consume but not return \r\n.
 
-    let (rem, line) = normalized_line(Span::new("abc  \r\ndef", true));
+    let line = normalized_line(Span::new("abc  \r\ndef", true));
 
     assert_eq!(
-        rem,
+        line.rem,
         TSpan {
             data: "def",
             line: 2,
@@ -97,7 +97,7 @@ fn strips_trailing_crlf() {
     );
 
     assert_eq!(
-        line,
+        line.t,
         TSpan {
             data: "abc",
             line: 1,

--- a/src/tests/inlines/inline.rs
+++ b/src/tests/inlines/inline.rs
@@ -10,7 +10,8 @@ mod uninterpreted {
     #[test]
     fn impl_clone() {
         // Silly test to mark the #[derive(...)] line as covered.
-        let (_, b1) = Inline::parse(Span::new("abc", true)).unwrap();
+        let b1 = Inline::parse(Span::new("abc", true)).unwrap();
+        let b1 = b1.t;
         let b2 = b1.clone();
         assert_eq!(b1, b2);
     }
@@ -27,10 +28,10 @@ mod uninterpreted {
 
     #[test]
     fn simple_line() {
-        let (rem, inline) = Inline::parse(Span::new("abc", true)).unwrap();
+        let inline = Inline::parse(Span::new("abc", true)).unwrap();
 
         assert_eq!(
-            rem,
+            inline.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -40,7 +41,7 @@ mod uninterpreted {
         );
 
         assert_eq!(
-            inline,
+            inline.t,
             TInline::Uninterpreted(TSpan {
                 data: "abc",
                 line: 1,
@@ -50,7 +51,7 @@ mod uninterpreted {
         );
 
         assert_eq!(
-            inline.span(),
+            inline.t.span(),
             TSpan {
                 data: "abc",
                 line: 1,

--- a/src/tests/inlines/inline.rs
+++ b/src/tests/inlines/inline.rs
@@ -83,10 +83,10 @@ mod parse_lines {
 
     #[test]
     fn simple_line() {
-        let (rem, inline) = Inline::parse_lines(Span::new("abc", true)).unwrap();
+        let inline = Inline::parse_lines(Span::new("abc", true)).unwrap();
 
         assert_eq!(
-            rem,
+            inline.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -96,7 +96,7 @@ mod parse_lines {
         );
 
         assert_eq!(
-            inline,
+            inline.t,
             TInline::Uninterpreted(TSpan {
                 data: "abc",
                 line: 1,
@@ -106,7 +106,7 @@ mod parse_lines {
         );
 
         assert_eq!(
-            inline.span(),
+            inline.t.span(),
             TSpan {
                 data: "abc",
                 line: 1,
@@ -118,10 +118,10 @@ mod parse_lines {
 
     #[test]
     fn two_lines() {
-        let (rem, inline) = Inline::parse_lines(Span::new("abc\ndef", true)).unwrap();
+        let inline = Inline::parse_lines(Span::new("abc\ndef", true)).unwrap();
 
         assert_eq!(
-            rem,
+            inline.rem,
             TSpan {
                 data: "",
                 line: 2,
@@ -131,7 +131,7 @@ mod parse_lines {
         );
 
         assert_eq!(
-            inline,
+            inline.t,
             TInline::Sequence(
                 vec!(
                     TInline::Uninterpreted(TSpan {
@@ -157,7 +157,7 @@ mod parse_lines {
         );
 
         assert_eq!(
-            inline.span(),
+            inline.t.span(),
             TSpan {
                 data: "abc\ndef",
                 line: 1,

--- a/src/tests/primitives/line.rs
+++ b/src/tests/primitives/line.rs
@@ -5,10 +5,10 @@ mod fn_line {
 
     #[test]
     fn empty_source() {
-        let (rem, line) = line(Span::new("", true));
+        let l = line(Span::new("", true));
 
         assert_eq!(
-            rem,
+            l.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -18,7 +18,7 @@ mod fn_line {
         );
 
         assert_eq!(
-            line,
+            l.t,
             TSpan {
                 data: "",
                 line: 1,
@@ -30,10 +30,10 @@ mod fn_line {
 
     #[test]
     fn simple_line() {
-        let (rem, line) = line(Span::new("abc", true));
+        let l = line(Span::new("abc", true));
 
         assert_eq!(
-            rem,
+            l.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -43,7 +43,7 @@ mod fn_line {
         );
 
         assert_eq!(
-            line,
+            l.t,
             TSpan {
                 data: "abc",
                 line: 1,
@@ -55,10 +55,10 @@ mod fn_line {
 
     #[test]
     fn trailing_space() {
-        let (rem, line) = line(Span::new("abc ", true));
+        let l = line(Span::new("abc ", true));
 
         assert_eq!(
-            rem,
+            l.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -68,7 +68,7 @@ mod fn_line {
         );
 
         assert_eq!(
-            line,
+            l.t,
             TSpan {
                 data: "abc ",
                 line: 1,
@@ -82,10 +82,10 @@ mod fn_line {
     fn consumes_lf() {
         // Should consume but not return \n.
 
-        let (rem, line) = line(Span::new("abc\ndef", true));
+        let l = line(Span::new("abc\ndef", true));
 
         assert_eq!(
-            rem,
+            l.rem,
             TSpan {
                 data: "def",
                 line: 2,
@@ -95,7 +95,7 @@ mod fn_line {
         );
 
         assert_eq!(
-            line,
+            l.t,
             TSpan {
                 data: "abc",
                 line: 1,
@@ -109,10 +109,10 @@ mod fn_line {
     fn consumes_crlf() {
         // Should consume but not return \r\n.
 
-        let (rem, line) = line(Span::new("abc\r\ndef", true));
+        let l = line(Span::new("abc\r\ndef", true));
 
         assert_eq!(
-            rem,
+            l.rem,
             TSpan {
                 data: "def",
                 line: 2,
@@ -122,7 +122,7 @@ mod fn_line {
         );
 
         assert_eq!(
-            line,
+            l.t,
             TSpan {
                 data: "abc",
                 line: 1,
@@ -136,10 +136,10 @@ mod fn_line {
     fn doesnt_consume_lfcr() {
         // Should consume \n but not a subsequent \r.
 
-        let (rem, line) = line(Span::new("abc\n\rdef", true));
+        let l = line(Span::new("abc\n\rdef", true));
 
         assert_eq!(
-            rem,
+            l.rem,
             TSpan {
                 data: "\rdef",
                 line: 2,
@@ -149,7 +149,7 @@ mod fn_line {
         );
 
         assert_eq!(
-            line,
+            l.t,
             TSpan {
                 data: "abc",
                 line: 1,
@@ -163,10 +163,10 @@ mod fn_line {
     fn standalone_cr_doesnt_end_line() {
         // Shouldn't terminate line at \r without \n.
 
-        let (rem, line) = line(Span::new("abc\rdef", true));
+        let l = line(Span::new("abc\rdef", true));
 
         assert_eq!(
-            rem,
+            l.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -176,7 +176,7 @@ mod fn_line {
         );
 
         assert_eq!(
-            line,
+            l.t,
             TSpan {
                 data: "abc\rdef",
                 line: 1,

--- a/src/tests/primitives/line.rs
+++ b/src/tests/primitives/line.rs
@@ -889,20 +889,16 @@ mod line_with_continuation {
 }
 
 mod empty_line {
-    use nom::{
-        error::{Error, ErrorKind},
-        Err,
-    };
     use pretty_assertions_sorted::assert_eq;
 
     use crate::{primitives::empty_line, tests::fixtures::TSpan, Span};
 
     #[test]
     fn empty_source() {
-        let (rem, line) = empty_line(Span::new("", true)).unwrap();
+        let line = empty_line(Span::new("", true)).unwrap();
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -912,7 +908,7 @@ mod empty_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "",
                 line: 1,
@@ -924,32 +920,22 @@ mod empty_line {
 
     #[test]
     fn simple_line() {
-        let expected_err: Err<Error<nom_span::Spanned<&str>>> =
-            Err::Error(Error::new(Span::new("abc", true), ErrorKind::NonEmpty));
-
-        let actual_err = empty_line(Span::new("abc", true)).unwrap_err();
-
-        assert_eq!(expected_err, actual_err);
+        assert!(empty_line(Span::new("abc", true)).is_none());
     }
 
     #[test]
     fn leading_space() {
-        let expected_err: Err<Error<nom_span::Spanned<&str>>> =
-            Err::Error(Error::new(Span::new("  abc", true), ErrorKind::NonEmpty));
-
-        let actual_err = empty_line(Span::new("  abc", true)).unwrap_err();
-
-        assert_eq!(expected_err, actual_err);
+        assert!(empty_line(Span::new("  abc", true)).is_none());
     }
 
     #[test]
     fn consumes_spaces() {
         // Should consume a source containing only spaces.
 
-        let (rem, line) = empty_line(Span::new("     ", true)).unwrap();
+        let line = empty_line(Span::new("     ", true)).unwrap();
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -959,7 +945,7 @@ mod empty_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "     ",
                 line: 1,
@@ -973,10 +959,10 @@ mod empty_line {
     fn consumes_spaces_and_tabs() {
         // Should consume a source containing only spaces.
 
-        let (rem, line) = empty_line(Span::new("  \t  ", true)).unwrap();
+        let line = empty_line(Span::new("  \t  ", true)).unwrap();
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -986,7 +972,7 @@ mod empty_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "  \t  ",
                 line: 1,
@@ -1000,10 +986,10 @@ mod empty_line {
     fn consumes_lf() {
         // Should consume but not return \n.
 
-        let (rem, line) = empty_line(Span::new("   \ndef", true)).unwrap();
+        let line = empty_line(Span::new("   \ndef", true)).unwrap();
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "def",
                 line: 2,
@@ -1013,7 +999,7 @@ mod empty_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "   ",
                 line: 1,
@@ -1027,10 +1013,10 @@ mod empty_line {
     fn consumes_crlf() {
         // Should consume but not return \r\n.
 
-        let (rem, line) = empty_line(Span::new("   \r\ndef", true)).unwrap();
+        let line = empty_line(Span::new("   \r\ndef", true)).unwrap();
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "def",
                 line: 2,
@@ -1040,7 +1026,7 @@ mod empty_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "   ",
                 line: 1,
@@ -1054,10 +1040,10 @@ mod empty_line {
     fn doesnt_consume_lfcr() {
         // Should consume \n but not a subsequent \r.
 
-        let (rem, line) = empty_line(Span::new("   \n\rdef", true)).unwrap();
+        let line = empty_line(Span::new("   \n\rdef", true)).unwrap();
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "\rdef",
                 line: 2,
@@ -1067,7 +1053,7 @@ mod empty_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "   ",
                 line: 1,
@@ -1081,12 +1067,7 @@ mod empty_line {
     fn standalone_cr_doesnt_end_line() {
         // A "line" with \r and no immediate \n is not considered empty.
 
-        let expected_err: Err<Error<nom_span::Spanned<&str>>> =
-            Err::Error(Error::new(Span::new("   \rdef", true), ErrorKind::NonEmpty));
-
-        let actual_err = empty_line(Span::new("   \rdef", true)).unwrap_err();
-
-        assert_eq!(expected_err, actual_err);
+        assert!(empty_line(Span::new("   \rdef", true)).is_none());
     }
 }
 

--- a/src/tests/primitives/line.rs
+++ b/src/tests/primitives/line.rs
@@ -194,10 +194,10 @@ mod normalized_line {
 
     #[test]
     fn empty_source() {
-        let (rem, line) = normalized_line(Span::new("", true));
+        let line = normalized_line(Span::new("", true));
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -207,7 +207,7 @@ mod normalized_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "",
                 line: 1,
@@ -219,10 +219,10 @@ mod normalized_line {
 
     #[test]
     fn simple_line() {
-        let (rem, line) = normalized_line(Span::new("abc", true));
+        let line = normalized_line(Span::new("abc", true));
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -232,7 +232,7 @@ mod normalized_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "abc",
                 line: 1,
@@ -244,10 +244,10 @@ mod normalized_line {
 
     #[test]
     fn discards_trailing_space() {
-        let (rem, line) = normalized_line(Span::new("abc ", true));
+        let line = normalized_line(Span::new("abc ", true));
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -257,7 +257,7 @@ mod normalized_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "abc",
                 line: 1,
@@ -269,10 +269,10 @@ mod normalized_line {
 
     #[test]
     fn discards_multiple_trailing_spaces() {
-        let (rem, line) = normalized_line(Span::new("abc   ", true));
+        let line = normalized_line(Span::new("abc   ", true));
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -282,7 +282,7 @@ mod normalized_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "abc",
                 line: 1,
@@ -296,10 +296,10 @@ mod normalized_line {
     fn consumes_lf() {
         // Should consume but not return \n.
 
-        let (rem, line) = normalized_line(Span::new("abc  \ndef", true));
+        let line = normalized_line(Span::new("abc  \ndef", true));
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "def",
                 line: 2,
@@ -309,7 +309,7 @@ mod normalized_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "abc",
                 line: 1,
@@ -323,10 +323,10 @@ mod normalized_line {
     fn consumes_crlf() {
         // Should consume but not return \r\n.
 
-        let (rem, line) = normalized_line(Span::new("abc  \r\ndef", true));
+        let line = normalized_line(Span::new("abc  \r\ndef", true));
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "def",
                 line: 2,
@@ -336,7 +336,7 @@ mod normalized_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "abc",
                 line: 1,
@@ -350,10 +350,10 @@ mod normalized_line {
     fn doesnt_consume_lfcr() {
         // Should consume \n but not a subsequent \r.
 
-        let (rem, line) = normalized_line(Span::new("abc  \n\rdef", true));
+        let line = normalized_line(Span::new("abc  \n\rdef", true));
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "\rdef",
                 line: 2,
@@ -363,7 +363,7 @@ mod normalized_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "abc",
                 line: 1,
@@ -377,10 +377,10 @@ mod normalized_line {
     fn standalone_cr_doesnt_end_line() {
         // Shouldn't terminate normalized line at \r without \n.
 
-        let (rem, line) = normalized_line(Span::new("abc   \rdef", true));
+        let line = normalized_line(Span::new("abc   \rdef", true));
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -390,7 +390,7 @@ mod normalized_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "abc   \rdef",
                 line: 1,

--- a/src/tests/primitives/line.rs
+++ b/src/tests/primitives/line.rs
@@ -418,10 +418,10 @@ mod non_empty_line {
 
     #[test]
     fn simple_line() {
-        let (rem, line) = non_empty_line(Span::new("abc", true)).unwrap();
+        let line = non_empty_line(Span::new("abc", true)).unwrap();
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -431,7 +431,7 @@ mod non_empty_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "abc",
                 line: 1,
@@ -443,10 +443,10 @@ mod non_empty_line {
 
     #[test]
     fn discards_trailing_space() {
-        let (rem, line) = non_empty_line(Span::new("abc ", true)).unwrap();
+        let line = non_empty_line(Span::new("abc ", true)).unwrap();
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -456,7 +456,7 @@ mod non_empty_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "abc",
                 line: 1,
@@ -470,10 +470,10 @@ mod non_empty_line {
     fn consumes_lf() {
         // Should consume but not return \n.
 
-        let (rem, line) = non_empty_line(Span::new("abc  \ndef", true)).unwrap();
+        let line = non_empty_line(Span::new("abc  \ndef", true)).unwrap();
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "def",
                 line: 2,
@@ -483,7 +483,7 @@ mod non_empty_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "abc",
                 line: 1,
@@ -497,10 +497,10 @@ mod non_empty_line {
     fn consumes_crlf() {
         // Should consume but not return \r\n.
 
-        let (rem, line) = non_empty_line(Span::new("abc  \r\ndef", true)).unwrap();
+        let line = non_empty_line(Span::new("abc  \r\ndef", true)).unwrap();
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "def",
                 line: 2,
@@ -510,7 +510,7 @@ mod non_empty_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "abc",
                 line: 1,
@@ -524,10 +524,10 @@ mod non_empty_line {
     fn doesnt_consume_lfcr() {
         // Should consume \n but not a subsequent \r.
 
-        let (rem, line) = non_empty_line(Span::new("abc  \n\rdef", true)).unwrap();
+        let line = non_empty_line(Span::new("abc  \n\rdef", true)).unwrap();
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "\rdef",
                 line: 2,
@@ -537,7 +537,7 @@ mod non_empty_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "abc",
                 line: 1,
@@ -551,10 +551,10 @@ mod non_empty_line {
     fn standalone_cr_doesnt_end_line() {
         // Shouldn't terminate line at \r without \n.
 
-        let (rem, line) = non_empty_line(Span::new("abc   \rdef", true)).unwrap();
+        let line = non_empty_line(Span::new("abc   \rdef", true)).unwrap();
 
         assert_eq!(
-            rem,
+            line.rem,
             TSpan {
                 data: "",
                 line: 1,
@@ -564,7 +564,7 @@ mod non_empty_line {
         );
 
         assert_eq!(
-            line,
+            line.t,
             TSpan {
                 data: "abc   \rdef",
                 line: 1,


### PR DESCRIPTION
Avoids the nom-influenced API pattern of `(rem, t)` tuples which don't make it obvious which is which.