### PR TITLE
ElementAttribute: Add support for parsing shorthand items

### DIFF
--- a/src/attributes/attrlist.rs
+++ b/src/attributes/attrlist.rs
@@ -23,11 +23,23 @@ impl<'a> Attrlist<'a> {
     pub(crate) fn parse(source: Span<'a>) -> Option<ParseResult<Self>> {
         let mut rem = source;
         let mut attributes: Vec<ElementAttribute> = vec![];
+        let mut parse_shorthand_items = true;
 
         loop {
-            let Some(attr) = ElementAttribute::parse(rem) else {
+            let maybe_attr = if parse_shorthand_items {
+                ElementAttribute::parse_with_shorthand(rem)
+            } else {
+                ElementAttribute::parse(rem)
+            };
+
+            let Some(attr) = maybe_attr else {
                 break;
             };
+
+            if attr.t.name().is_none() {
+                parse_shorthand_items = false;
+            }
+
             attributes.push(attr.t);
 
             rem = attr.rem.take_whitespace().rem;

--- a/src/attributes/element_attribute.rs
+++ b/src/attributes/element_attribute.rs
@@ -91,7 +91,7 @@ impl<'a> ElementAttribute<'a> {
         self.shorthand_items
             .first()
             .filter(|span| matches!(span.position(is_shorthand_delimiter), None | Some(0)))
-            .map(|span| span.clone())
+            .copied()
     }
 
     /// Return the attribute's raw value.

--- a/src/attributes/element_attribute.rs
+++ b/src/attributes/element_attribute.rs
@@ -147,15 +147,14 @@ fn parse_shorthand_items<'a>(span: Span<'a>) -> Vec<Span<'a>> {
         match after_delimiter.position(is_shorthand_delimiter) {
             None => {
                 if after_delimiter.is_empty() {
-                    span = after_delimiter;
+                    todo!("Flag warning for empty shorthand item (issue #120)");
                 } else {
                     shorthand_items.push(span);
                     span = span.discard_all();
                 }
             }
             Some(0) => {
-                // TO DO: File issue and test case for this.
-                todo!("This is should be flagged as a warning.");
+                todo!("Flag warning for duplicate shorthand delimiter (issue #121)");
             }
             Some(index) => {
                 let pr: ParseResult<Span> = span.into_parse_result(index + 1);

--- a/src/attributes/element_attribute.rs
+++ b/src/attributes/element_attribute.rs
@@ -10,12 +10,21 @@ use crate::{primitives::trim_input_for_rem, span::ParseResult, HasSpan, Span};
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ElementAttribute<'a> {
     name: Option<Span<'a>>,
+    shorthand_items: Vec<Span<'a>>,
     value: Span<'a>,
     source: Span<'a>,
 }
 
 impl<'a> ElementAttribute<'a> {
     pub(crate) fn parse(source: Span<'a>) -> Option<ParseResult<Self>> {
+        Self::parse_internal(source, false)
+    }
+
+    pub(crate) fn parse_with_shorthand(source: Span<'a>) -> Option<ParseResult<Self>> {
+        Self::parse_internal(source, true)
+    }
+
+    fn parse_internal(source: Span<'a>, parse_shorthand: bool) -> Option<ParseResult<Self>> {
         let (name, rem): (Option<Span>, Span) = match source.take_attr_name() {
             Some(name) => {
                 let space = name.rem.take_whitespace();
@@ -50,9 +59,16 @@ impl<'a> ElementAttribute<'a> {
 
         let source = trim_input_for_rem(source, value.rem);
 
+        let shorthand_items = if name.is_none() && parse_shorthand {
+            parse_shorthand_items(source)
+        } else {
+            vec![]
+        };
+
         Some(ParseResult {
             t: Self {
                 name,
+                shorthand_items,
                 value: value.t,
                 source,
             },
@@ -63,6 +79,11 @@ impl<'a> ElementAttribute<'a> {
     /// Return a [`Span`] describing the attribute name.
     pub fn name(&'a self) -> &'a Option<Span<'a>> {
         &self.name
+    }
+
+    /// Return the shorthand items, if this is the first positional attribute.
+    pub fn shorthand_items(&'a self) -> &'a Vec<Span<'a>> {
+        &self.shorthand_items
     }
 
     /// Return the attribute's raw value.
@@ -80,4 +101,36 @@ impl<'a> HasSpan<'a> for ElementAttribute<'a> {
     fn span(&'a self) -> &'a Span<'a> {
         &self.source
     }
+}
+
+fn parse_shorthand_items<'a>(span: Span<'a>) -> Vec<Span<'a>> {
+    let mut span = span.clone();
+    let mut shorthand_items: Vec<Span<'a>> = vec![];
+
+    // Look for block style selector.
+    if let Some(block_style_pr) = span.split_at_match_non_empty(is_shorthand_delimiter) {
+        shorthand_items.push(block_style_pr.t);
+        span = block_style_pr.rem.clone();
+    }
+
+    while !span.is_empty() {
+        // Assumption: First character is a delimiter.
+        let after_delimiter = span.into_parse_result(1).rem;
+        match after_delimiter.position(is_shorthand_delimiter) {
+            None | Some(0) => {
+                span = after_delimiter;
+            }
+            Some(index) => {
+                let pr = span.into_parse_result(index + 1);
+                shorthand_items.push(pr.t);
+                span = pr.rem;
+            }
+        }
+    }
+
+    shorthand_items
+}
+
+fn is_shorthand_delimiter(c: char) -> bool {
+    c == '#' || c == '%' || c == '.'
 }

--- a/src/attributes/element_attribute.rs
+++ b/src/attributes/element_attribute.rs
@@ -102,7 +102,7 @@ impl<'a> ElementAttribute<'a> {
         self.shorthand_items
             .iter()
             .find(|span| span.starts_with('#'))
-            .map(|span| span.into_parse_result(1).rem)
+            .map(|span| span.discard(1))
     }
 
     /// Return any role attributes that were found in shorthand syntax.
@@ -110,7 +110,7 @@ impl<'a> ElementAttribute<'a> {
         self.shorthand_items
             .iter()
             .filter(|span| span.starts_with('.'))
-            .map(|span| span.into_parse_result(1).rem)
+            .map(|span| span.discard(1))
             .collect()
     }
 
@@ -143,14 +143,14 @@ fn parse_shorthand_items<'a>(span: Span<'a>) -> Vec<Span<'a>> {
 
     while !span.is_empty() {
         // Assumption: First character is a delimiter.
-        let after_delimiter = span.into_parse_result(1).rem;
+        let after_delimiter = span.discard(1);
         match after_delimiter.position(is_shorthand_delimiter) {
             None => {
                 if after_delimiter.is_empty() {
                     span = after_delimiter;
                 } else {
                     shorthand_items.push(span);
-                    span = span.into_parse_result(span.len()).rem;
+                    span = span.discard_all();
                 }
             }
             Some(0) => {

--- a/src/attributes/element_attribute.rs
+++ b/src/attributes/element_attribute.rs
@@ -114,6 +114,15 @@ impl<'a> ElementAttribute<'a> {
             .collect()
     }
 
+    /// Return any option attributes that were found in shorthand syntax.
+    pub fn options(&'a self) -> Vec<Span<'a>> {
+        self.shorthand_items
+            .iter()
+            .filter(|span| span.starts_with('%'))
+            .map(|span| span.discard(1))
+            .collect()
+    }
+
     /// Return the attribute's raw value.
     pub fn raw_value(&'a self) -> &'a Span<'a> {
         &self.value

--- a/src/attributes/element_attribute.rs
+++ b/src/attributes/element_attribute.rs
@@ -95,7 +95,7 @@ impl<'a> ElementAttribute<'a> {
     }
 
     /// Return the id attribute from shorthand syntax.
-    /// 
+    ///
     /// If multiple id attributes were specified, only the first
     /// match is returned. (Multiple ids are not supported.)
     pub fn id(&'a self) -> Option<Span<'a>> {
@@ -103,6 +103,15 @@ impl<'a> ElementAttribute<'a> {
             .iter()
             .find(|span| span.starts_with('#'))
             .map(|span| span.into_parse_result(1).rem)
+    }
+
+    /// Return any role attributes that were found in shorthand syntax.
+    pub fn roles(&'a self) -> Vec<Span<'a>> {
+        self.shorthand_items
+            .iter()
+            .filter(|span| span.starts_with('.'))
+            .map(|span| span.into_parse_result(1).rem)
+            .collect()
     }
 
     /// Return the attribute's raw value.

--- a/src/attributes/element_attribute.rs
+++ b/src/attributes/element_attribute.rs
@@ -81,7 +81,7 @@ impl<'a> ElementAttribute<'a> {
         &self.name
     }
 
-    /// Return the shorthand items, if this is the first positional attribute.
+    /// Return the shorthand items, if parsed via `parse_with_shorthand`.
     pub fn shorthand_items(&'a self) -> &'a Vec<Span<'a>> {
         &self.shorthand_items
     }

--- a/src/attributes/element_attribute.rs
+++ b/src/attributes/element_attribute.rs
@@ -86,6 +86,14 @@ impl<'a> ElementAttribute<'a> {
         &self.shorthand_items
     }
 
+    /// Return the block style name.
+    pub fn block_style(&'a self) -> Option<Span<'a>> {
+        self.shorthand_items
+            .first()
+            .filter(|span| matches!(span.position(is_shorthand_delimiter), None | Some(0)))
+            .map(|span| span.clone())
+    }
+
     /// Return the attribute's raw value.
     pub fn raw_value(&'a self) -> &'a Span<'a> {
         &self.value

--- a/src/attributes/element_attribute.rs
+++ b/src/attributes/element_attribute.rs
@@ -104,13 +104,13 @@ impl<'a> HasSpan<'a> for ElementAttribute<'a> {
 }
 
 fn parse_shorthand_items<'a>(span: Span<'a>) -> Vec<Span<'a>> {
-    let mut span = span.clone();
+    let mut span = span;
     let mut shorthand_items: Vec<Span<'a>> = vec![];
 
     // Look for block style selector.
     if let Some(block_style_pr) = span.split_at_match_non_empty(is_shorthand_delimiter) {
         shorthand_items.push(block_style_pr.t);
-        span = block_style_pr.rem.clone();
+        span = block_style_pr.rem;
     }
 
     while !span.is_empty() {

--- a/src/tests/asciidoc_lang/attributes/element_attributes.rs
+++ b/src/tests/asciidoc_lang/attributes/element_attributes.rs
@@ -90,6 +90,12 @@ mod attrlist {
                 attributes: vec!(
                     TElementAttribute {
                         name: None,
+                        shorthand_items: vec![TSpan {
+                            data: "first-positional",
+                            line: 1,
+                            col: 1,
+                            offset: 0,
+                        }],
                         value: TSpan {
                             data: "first-positional",
                             line: 1,
@@ -105,6 +111,7 @@ mod attrlist {
                     },
                     TElementAttribute {
                         name: None,
+                        shorthand_items: vec![],
                         value: TSpan {
                             data: "second-positional",
                             line: 1,
@@ -125,6 +132,7 @@ mod attrlist {
                             col: 36,
                             offset: 35,
                         },),
+                        shorthand_items: vec![],
                         value: TSpan {
                             data: "value of named",
                             line: 1,
@@ -156,6 +164,12 @@ mod attrlist {
             pr.t.nth_attribute(1).unwrap(),
             TElementAttribute {
                 name: None,
+                shorthand_items: vec![TSpan {
+                    data: "first-positional",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                }],
                 value: TSpan {
                     data: "first-positional",
                     line: 1,
@@ -175,6 +189,7 @@ mod attrlist {
             pr.t.nth_attribute(2).unwrap(),
             TElementAttribute {
                 name: None,
+                shorthand_items: vec![],
                 value: TSpan {
                     data: "second-positional",
                     line: 1,
@@ -201,6 +216,7 @@ mod attrlist {
                     col: 36,
                     offset: 35,
                 },),
+                shorthand_items: vec![],
                 value: TSpan {
                     data: "value of named",
                     line: 1,

--- a/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
+++ b/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
@@ -66,6 +66,12 @@ mod positional_attribute {
             a1.named_or_positional_attribute("alt", 1).unwrap(),
             TElementAttribute {
                 name: None,
+                shorthand_items: vec![TSpan {
+                    data: "Sunset",
+                    line: 1,
+                    col: 19,
+                    offset: 18,
+                }],
                 value: TSpan {
                     data: "Sunset",
                     line: 1,
@@ -90,6 +96,7 @@ mod positional_attribute {
                     col: 19,
                     offset: 18,
                 },),
+                shorthand_items: vec![],
                 value: TSpan {
                     data: "Sunset",
                     line: 1,

--- a/src/tests/asciidoc_lang/root/key_concepts.rs
+++ b/src/tests/asciidoc_lang/root/key_concepts.rs
@@ -159,6 +159,12 @@ mod macros {
                     attrlist: TAttrlist {
                         attributes: vec!(TElementAttribute {
                             name: None,
+                            shorthand_items: vec![TSpan {
+                                data: "Sunset",
+                                line: 1,
+                                col: 19,
+                                offset: 18,
+                            }],
                             value: TSpan {
                                 data: "Sunset",
                                 line: 1,

--- a/src/tests/attributes/attrlist.rs
+++ b/src/tests/attributes/attrlist.rs
@@ -75,6 +75,12 @@ fn only_positional_attributes() {
             attributes: vec!(
                 TElementAttribute {
                     name: None,
+                    shorthand_items: vec![TSpan {
+                        data: "Sunset",
+                        line: 1,
+                        col: 1,
+                        offset: 0,
+                    }],
                     value: TSpan {
                         data: "Sunset",
                         line: 1,
@@ -90,6 +96,7 @@ fn only_positional_attributes() {
                 },
                 TElementAttribute {
                     name: None,
+                    shorthand_items: vec![],
                     value: TSpan {
                         data: "300",
                         line: 1,
@@ -105,6 +112,7 @@ fn only_positional_attributes() {
                 },
                 TElementAttribute {
                     name: None,
+                    shorthand_items: vec![],
                     value: TSpan {
                         data: "400",
                         line: 1,
@@ -136,6 +144,12 @@ fn only_positional_attributes() {
         pr.t.nth_attribute(1).unwrap(),
         TElementAttribute {
             name: None,
+            shorthand_items: vec![TSpan {
+                data: "Sunset",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }],
             value: TSpan {
                 data: "Sunset",
                 line: 1,
@@ -155,6 +169,12 @@ fn only_positional_attributes() {
         pr.t.named_or_positional_attribute("alt", 1).unwrap(),
         TElementAttribute {
             name: None,
+            shorthand_items: vec![TSpan {
+                data: "Sunset",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }],
             value: TSpan {
                 data: "Sunset",
                 line: 1,
@@ -174,6 +194,7 @@ fn only_positional_attributes() {
         pr.t.nth_attribute(2).unwrap(),
         TElementAttribute {
             name: None,
+            shorthand_items: vec![],
             value: TSpan {
                 data: "300",
                 line: 1,
@@ -193,6 +214,7 @@ fn only_positional_attributes() {
         pr.t.named_or_positional_attribute("width", 2).unwrap(),
         TElementAttribute {
             name: None,
+            shorthand_items: vec![],
             value: TSpan {
                 data: "300",
                 line: 1,
@@ -212,6 +234,7 @@ fn only_positional_attributes() {
         pr.t.nth_attribute(3).unwrap(),
         TElementAttribute {
             name: None,
+            shorthand_items: vec![],
             value: TSpan {
                 data: "400",
                 line: 1,
@@ -231,6 +254,7 @@ fn only_positional_attributes() {
         pr.t.named_or_positional_attribute("height", 3).unwrap(),
         TElementAttribute {
             name: None,
+            shorthand_items: vec![],
             value: TSpan {
                 data: "400",
                 line: 1,
@@ -288,6 +312,7 @@ fn only_named_attributes() {
                         col: 1,
                         offset: 0,
                     },),
+                    shorthand_items: vec![],
                     value: TSpan {
                         data: "Sunset",
                         line: 1,
@@ -308,6 +333,7 @@ fn only_named_attributes() {
                         col: 12,
                         offset: 11,
                     },),
+                    shorthand_items: vec![],
                     value: TSpan {
                         data: "300",
                         line: 1,
@@ -328,6 +354,7 @@ fn only_named_attributes() {
                         col: 22,
                         offset: 21,
                     },),
+                    shorthand_items: vec![],
                     value: TSpan {
                         data: "400",
                         line: 1,
@@ -363,6 +390,7 @@ fn only_named_attributes() {
                 col: 1,
                 offset: 0,
             },),
+            shorthand_items: vec![],
             value: TSpan {
                 data: "Sunset",
                 line: 1,
@@ -387,6 +415,7 @@ fn only_named_attributes() {
                 col: 1,
                 offset: 0,
             },),
+            shorthand_items: vec![],
             value: TSpan {
                 data: "Sunset",
                 line: 1,
@@ -411,6 +440,7 @@ fn only_named_attributes() {
                 col: 12,
                 offset: 11,
             },),
+            shorthand_items: vec![],
             value: TSpan {
                 data: "300",
                 line: 1,
@@ -435,6 +465,7 @@ fn only_named_attributes() {
                 col: 12,
                 offset: 11,
             },),
+            shorthand_items: vec![],
             value: TSpan {
                 data: "300",
                 line: 1,
@@ -459,6 +490,7 @@ fn only_named_attributes() {
                 col: 22,
                 offset: 21,
             },),
+            shorthand_items: vec![],
             value: TSpan {
                 data: "400",
                 line: 1,
@@ -483,6 +515,7 @@ fn only_named_attributes() {
                 col: 22,
                 offset: 21,
             },),
+            shorthand_items: vec![],
             value: TSpan {
                 data: "400",
                 line: 1,

--- a/src/tests/attributes/element_attribute.rs
+++ b/src/tests/attributes/element_attribute.rs
@@ -932,6 +932,22 @@ mod parse_with_shorthand {
     }
 
     #[test]
+    #[should_panic]
+    fn error_empty_id() {
+        let _pr = ElementAttribute::parse_with_shorthand(Span::new("abc#")).unwrap();
+
+        // TO DO (#120): Flag warning for empty shorthand item
+    }
+
+    #[test]
+    #[should_panic]
+    fn error_duplicate_delimiter() {
+        let _pr = ElementAttribute::parse_with_shorthand(Span::new("abc##id")).unwrap();
+
+        // TO DO (#121): Flag warning for duplicate shorthand delimiters
+    }
+
+    #[test]
     fn id_only() {
         let pr = ElementAttribute::parse_with_shorthand(Span::new("#xyz")).unwrap();
 

--- a/src/tests/attributes/element_attribute.rs
+++ b/src/tests/attributes/element_attribute.rs
@@ -932,6 +932,72 @@ mod parse_with_shorthand {
     }
 
     #[test]
+    fn ignore_if_named_attribute() {
+        let pr = ElementAttribute::parse_with_shorthand(Span::new("name=block_style#id")).unwrap();
+
+        assert_eq!(
+            pr.t,
+            TElementAttribute {
+                name: Some(TSpan {
+                    data: "name",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                }),
+                shorthand_items: vec![],
+                value: TSpan {
+                    data: "block_style#id",
+                    line: 1,
+                    col: 6,
+                    offset: 5,
+                },
+                source: TSpan {
+                    data: "name=block_style#id",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            }
+        );
+
+        assert_eq!(
+            pr.t.name().unwrap(),
+            TSpan {
+                data: "name",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }
+        );
+
+        assert!(pr.t.shorthand_items().is_empty());
+        assert!(pr.t.block_style().is_none());
+        assert!(pr.t.id().is_none());
+        assert!(pr.t.roles().is_empty());
+        assert!(pr.t.options().is_empty());
+
+        assert_eq!(
+            pr.t.span(),
+            TSpan {
+                data: "name=block_style#id",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }
+        );
+
+        assert_eq!(
+            pr.rem,
+            TSpan {
+                data: "",
+                line: 1,
+                col: 20,
+                offset: 19
+            }
+        );
+    }
+
+    #[test]
     #[should_panic]
     fn error_empty_id() {
         let _pr = ElementAttribute::parse_with_shorthand(Span::new("abc#")).unwrap();

--- a/src/tests/attributes/element_attribute.rs
+++ b/src/tests/attributes/element_attribute.rs
@@ -44,6 +44,7 @@ fn only_spaces() {
     );
 
     assert!(pr.t.block_style().is_none());
+    assert!(pr.t.id().is_none());
 
     assert_eq!(
         pr.rem,
@@ -94,6 +95,7 @@ fn unquoted_and_unnamed_value() {
 
     assert!(pr.t.name().is_none());
     assert!(pr.t.block_style().is_none());
+    assert!(pr.t.id().is_none());
 
     assert_eq!(
         pr.t.span(),
@@ -252,6 +254,7 @@ mod quoted_string {
 
         assert!(pr.t.name().is_none());
         assert!(pr.t.block_style().is_none());
+        assert!(pr.t.id().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -300,6 +303,7 @@ mod quoted_string {
 
         assert!(pr.t.name().is_none());
         assert!(pr.t.block_style().is_none());
+        assert!(pr.t.id().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -353,6 +357,7 @@ mod quoted_string {
 
         assert!(pr.t.name().is_none());
         assert!(pr.t.block_style().is_none());
+        assert!(pr.t.id().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -401,6 +406,7 @@ mod quoted_string {
 
         assert!(pr.t.name().is_none());
         assert!(pr.t.block_style().is_none());
+        assert!(pr.t.id().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -449,6 +455,7 @@ mod quoted_string {
 
         assert!(pr.t.name().is_none());
         assert!(pr.t.block_style().is_none());
+        assert!(pr.t.id().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -521,6 +528,7 @@ mod named {
         );
 
         assert!(pr.t.block_style().is_none());
+        assert!(pr.t.id().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -643,6 +651,7 @@ mod named {
         );
 
         assert!(pr.t.block_style().is_none());
+        assert!(pr.t.id().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -705,6 +714,7 @@ mod named {
         );
 
         assert!(pr.t.block_style().is_none());
+        assert!(pr.t.id().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -753,6 +763,7 @@ mod named {
 
         assert!(pr.t.name().is_none());
         assert!(pr.t.block_style().is_none());
+        assert!(pr.t.id().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -801,6 +812,7 @@ mod named {
 
         assert!(pr.t.name().is_none());
         assert!(pr.t.block_style().is_none());
+        assert!(pr.t.id().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -884,6 +896,8 @@ mod parse_with_shorthand {
             }
         );
 
+        assert!(pr.t.id().is_none());
+
         assert_eq!(
             pr.t.span(),
             TSpan {
@@ -901,6 +915,80 @@ mod parse_with_shorthand {
                 line: 1,
                 col: 4,
                 offset: 3
+            }
+        );
+    }
+
+    #[test]
+    fn id_only() {
+        let pr = ElementAttribute::parse_with_shorthand(Span::new("#xyz")).unwrap();
+
+        assert_eq!(
+            pr.t,
+            TElementAttribute {
+                name: None,
+                shorthand_items: vec![TSpan {
+                    data: "#xyz",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                }],
+                value: TSpan {
+                    data: "#xyz",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                source: TSpan {
+                    data: "#xyz",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            }
+        );
+
+        assert!(pr.t.name().is_none());
+
+        assert_eq!(
+            pr.t.shorthand_items(),
+            &vec![TSpan {
+                data: "#xyz",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }]
+        );
+
+        assert!(pr.t.block_style().is_none());
+
+        assert_eq!(
+            pr.t.id().unwrap(),
+            TSpan {
+                data: "xyz",
+                line: 1,
+                col: 2,
+                offset: 1,
+            }
+        );
+
+        assert_eq!(
+            pr.t.span(),
+            TSpan {
+                data: "#xyz",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }
+        );
+
+        assert_eq!(
+            pr.rem,
+            TSpan {
+                data: "",
+                line: 1,
+                col: 5,
+                offset: 4
             }
         );
     }

--- a/src/tests/attributes/element_attribute.rs
+++ b/src/tests/attributes/element_attribute.rs
@@ -1494,7 +1494,226 @@ mod parse_with_shorthand {
     }
 
     #[test]
-    fn complex_scenarios() {
-        todo!("Write test cases for combinations of id, role, option");
+    fn block_style_and_id() {
+        let pr = ElementAttribute::parse_with_shorthand(Span::new("appendix#custom-id")).unwrap();
+
+        assert_eq!(
+            pr.t,
+            TElementAttribute {
+                name: None,
+                shorthand_items: vec![
+                    TSpan {
+                        data: "appendix",
+                        line: 1,
+                        col: 1,
+                        offset: 0,
+                    },
+                    TSpan {
+                        data: "#custom-id",
+                        line: 1,
+                        col: 9,
+                        offset: 8,
+                    },
+                ],
+                value: TSpan {
+                    data: "appendix#custom-id",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                source: TSpan {
+                    data: "appendix#custom-id",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            }
+        );
+
+        assert!(pr.t.name().is_none());
+
+        assert_eq!(
+            pr.t.shorthand_items(),
+            &vec![
+                TSpan {
+                    data: "appendix",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                TSpan {
+                    data: "#custom-id",
+                    line: 1,
+                    col: 9,
+                    offset: 8,
+                },
+            ]
+        );
+
+        assert_eq!(
+            pr.t.block_style().unwrap(),
+            TSpan {
+                data: "appendix",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }
+        );
+
+        assert_eq!(
+            pr.t.id().unwrap(),
+            TSpan {
+                data: "custom-id",
+                line: 1,
+                col: 10,
+                offset: 9,
+            }
+        );
+
+        assert!(pr.t.roles().is_empty());
+        assert!(pr.t.options().is_empty());
+
+        assert_eq!(
+            pr.t.span(),
+            TSpan {
+                data: "appendix#custom-id",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }
+        );
+
+        assert_eq!(
+            pr.rem,
+            TSpan {
+                data: "",
+                line: 1,
+                col: 19,
+                offset: 18
+            }
+        );
+    }
+
+    #[test]
+    fn id_role_and_option() {
+        let pr = ElementAttribute::parse_with_shorthand(Span::new("#rules.prominent%incremental"))
+            .unwrap();
+
+        assert_eq!(
+            pr.t,
+            TElementAttribute {
+                name: None,
+                shorthand_items: vec![
+                    TSpan {
+                        data: "#rules",
+                        line: 1,
+                        col: 1,
+                        offset: 0,
+                    },
+                    TSpan {
+                        data: ".prominent",
+                        line: 1,
+                        col: 7,
+                        offset: 6,
+                    },
+                    TSpan {
+                        data: "%incremental",
+                        line: 1,
+                        col: 17,
+                        offset: 16,
+                    },
+                ],
+                value: TSpan {
+                    data: "#rules.prominent%incremental",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                source: TSpan {
+                    data: "#rules.prominent%incremental",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            }
+        );
+
+        assert!(pr.t.name().is_none());
+
+        assert_eq!(
+            pr.t.shorthand_items(),
+            &vec![
+                TSpan {
+                    data: "#rules",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                TSpan {
+                    data: ".prominent",
+                    line: 1,
+                    col: 7,
+                    offset: 6,
+                },
+                TSpan {
+                    data: "%incremental",
+                    line: 1,
+                    col: 17,
+                    offset: 16,
+                },
+            ]
+        );
+
+        assert!(pr.t.block_style().is_none());
+
+        assert_eq!(
+            pr.t.id().unwrap(),
+            TSpan {
+                data: "rules",
+                line: 1,
+                col: 2,
+                offset: 1,
+            }
+        );
+
+        assert_eq!(
+            pr.t.roles(),
+            vec!(TSpan {
+                data: "prominent",
+                line: 1,
+                col: 8,
+                offset: 7,
+            })
+        );
+
+        assert_eq!(
+            pr.t.options(),
+            vec!(TSpan {
+                data: "incremental",
+                line: 1,
+                col: 18,
+                offset: 17,
+            })
+        );
+
+        assert_eq!(
+            pr.t.span(),
+            TSpan {
+                data: "#rules.prominent%incremental",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }
+        );
+
+        assert_eq!(
+            pr.rem,
+            TSpan {
+                data: "",
+                line: 1,
+                col: 29,
+                offset: 28
+            }
+        );
     }
 }

--- a/src/tests/attributes/element_attribute.rs
+++ b/src/tests/attributes/element_attribute.rs
@@ -46,6 +46,7 @@ fn only_spaces() {
     assert!(pr.t.block_style().is_none());
     assert!(pr.t.id().is_none());
     assert!(pr.t.roles().is_empty());
+    assert!(pr.t.options().is_empty());
 
     assert_eq!(
         pr.rem,
@@ -257,6 +258,7 @@ mod quoted_string {
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
         assert!(pr.t.roles().is_empty());
+        assert!(pr.t.options().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -307,6 +309,7 @@ mod quoted_string {
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
         assert!(pr.t.roles().is_empty());
+        assert!(pr.t.options().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -362,6 +365,7 @@ mod quoted_string {
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
         assert!(pr.t.roles().is_empty());
+        assert!(pr.t.options().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -412,6 +416,7 @@ mod quoted_string {
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
         assert!(pr.t.roles().is_empty());
+        assert!(pr.t.options().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -462,6 +467,7 @@ mod quoted_string {
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
         assert!(pr.t.roles().is_empty());
+        assert!(pr.t.options().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -536,6 +542,7 @@ mod named {
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
         assert!(pr.t.roles().is_empty());
+        assert!(pr.t.options().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -660,6 +667,7 @@ mod named {
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
         assert!(pr.t.roles().is_empty());
+        assert!(pr.t.options().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -724,6 +732,7 @@ mod named {
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
         assert!(pr.t.roles().is_empty());
+        assert!(pr.t.options().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -774,6 +783,7 @@ mod named {
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
         assert!(pr.t.roles().is_empty());
+        assert!(pr.t.options().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -824,6 +834,7 @@ mod named {
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
         assert!(pr.t.roles().is_empty());
+        assert!(pr.t.options().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -909,6 +920,7 @@ mod parse_with_shorthand {
 
         assert!(pr.t.id().is_none());
         assert!(pr.t.roles().is_empty());
+        assert!(pr.t.options().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -1067,6 +1079,7 @@ mod parse_with_shorthand {
         );
 
         assert!(pr.t.roles().is_empty());
+        assert!(pr.t.options().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -1142,6 +1155,8 @@ mod parse_with_shorthand {
                 offset: 1,
             })
         );
+
+        assert!(pr.t.options().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -1260,6 +1275,8 @@ mod parse_with_shorthand {
             )
         );
 
+        assert!(pr.t.options().is_empty());
+
         assert_eq!(
             pr.t.span(),
             TSpan {
@@ -1277,6 +1294,82 @@ mod parse_with_shorthand {
                 line: 1,
                 col: 19,
                 offset: 18
+            }
+        );
+    }
+
+    #[test]
+    fn one_option_only() {
+        let pr = ElementAttribute::parse_with_shorthand(Span::new("%option1")).unwrap();
+
+        assert_eq!(
+            pr.t,
+            TElementAttribute {
+                name: None,
+                shorthand_items: vec![TSpan {
+                    data: "%option1",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                }],
+                value: TSpan {
+                    data: "%option1",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                source: TSpan {
+                    data: "%option1",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            }
+        );
+
+        assert!(pr.t.name().is_none());
+
+        assert_eq!(
+            pr.t.shorthand_items(),
+            &vec![TSpan {
+                data: "%option1",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }]
+        );
+
+        assert!(pr.t.block_style().is_none());
+        assert!(pr.t.id().is_none());
+        assert!(pr.t.roles().is_empty());
+
+        assert_eq!(
+            pr.t.options(),
+            vec!(TSpan {
+                data: "option1",
+                line: 1,
+                col: 2,
+                offset: 1,
+            })
+        );
+
+        assert_eq!(
+            pr.t.span(),
+            TSpan {
+                data: "%option1",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }
+        );
+
+        assert_eq!(
+            pr.rem,
+            TSpan {
+                data: "",
+                line: 1,
+                col: 9,
+                offset: 8
             }
         );
     }

--- a/src/tests/attributes/element_attribute.rs
+++ b/src/tests/attributes/element_attribute.rs
@@ -1492,4 +1492,9 @@ mod parse_with_shorthand {
             }
         );
     }
+
+    #[test]
+    fn complex_scenarios() {
+        todo!("Write test cases for combinations of id, role, option");
+    }
 }

--- a/src/tests/attributes/element_attribute.rs
+++ b/src/tests/attributes/element_attribute.rs
@@ -43,6 +43,8 @@ fn only_spaces() {
         }
     );
 
+    assert!(pr.t.block_style().is_none());
+
     assert_eq!(
         pr.rem,
         TSpan {
@@ -91,6 +93,7 @@ fn unquoted_and_unnamed_value() {
     );
 
     assert!(pr.t.name().is_none());
+    assert!(pr.t.block_style().is_none());
 
     assert_eq!(
         pr.t.span(),
@@ -138,6 +141,7 @@ fn unquoted_stops_at_comma() {
     );
 
     assert!(pr.t.name().is_none());
+    assert!(pr.t.block_style().is_none());
 
     assert_eq!(
         pr.t.span(),
@@ -199,6 +203,7 @@ mod quoted_string {
         );
 
         assert!(pr.t.name().is_none());
+        assert!(pr.t.block_style().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -246,6 +251,7 @@ mod quoted_string {
         );
 
         assert!(pr.t.name().is_none());
+        assert!(pr.t.block_style().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -293,6 +299,7 @@ mod quoted_string {
         );
 
         assert!(pr.t.name().is_none());
+        assert!(pr.t.block_style().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -345,6 +352,7 @@ mod quoted_string {
         );
 
         assert!(pr.t.name().is_none());
+        assert!(pr.t.block_style().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -392,6 +400,7 @@ mod quoted_string {
         );
 
         assert!(pr.t.name().is_none());
+        assert!(pr.t.block_style().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -439,6 +448,7 @@ mod quoted_string {
         );
 
         assert!(pr.t.name().is_none());
+        assert!(pr.t.block_style().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -509,6 +519,8 @@ mod named {
                 offset: 0,
             }
         );
+
+        assert!(pr.t.block_style().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -630,6 +642,8 @@ mod named {
             }
         );
 
+        assert!(pr.t.block_style().is_none());
+
         assert_eq!(
             pr.t.span(),
             TSpan {
@@ -690,6 +704,8 @@ mod named {
             }
         );
 
+        assert!(pr.t.block_style().is_none());
+
         assert_eq!(
             pr.t.span(),
             TSpan {
@@ -736,6 +752,7 @@ mod named {
         );
 
         assert!(pr.t.name().is_none());
+        assert!(pr.t.block_style().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -783,6 +800,7 @@ mod named {
         );
 
         assert!(pr.t.name().is_none());
+        assert!(pr.t.block_style().is_none());
 
         assert_eq!(
             pr.t.span(),
@@ -801,6 +819,88 @@ mod named {
                 line: 1,
                 col: 5,
                 offset: 4
+            }
+        );
+    }
+}
+
+mod parse_with_shorthand {
+    use pretty_assertions_sorted::assert_eq;
+
+    use crate::{
+        attributes::ElementAttribute,
+        tests::fixtures::{attributes::TElementAttribute, TSpan},
+        HasSpan, Span,
+    };
+
+    #[test]
+    fn block_style_only() {
+        let pr = ElementAttribute::parse_with_shorthand(Span::new("abc")).unwrap();
+
+        assert_eq!(
+            pr.t,
+            TElementAttribute {
+                name: None,
+                shorthand_items: vec![TSpan {
+                    data: "abc",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                }],
+                value: TSpan {
+                    data: "abc",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                source: TSpan {
+                    data: "abc",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            }
+        );
+
+        assert!(pr.t.name().is_none());
+
+        assert_eq!(
+            pr.t.shorthand_items(),
+            &vec![TSpan {
+                data: "abc",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }]
+        );
+
+        assert_eq!(
+            pr.t.block_style().unwrap(),
+            TSpan {
+                data: "abc",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }
+        );
+
+        assert_eq!(
+            pr.t.span(),
+            TSpan {
+                data: "abc",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }
+        );
+
+        assert_eq!(
+            pr.rem,
+            TSpan {
+                data: "",
+                line: 1,
+                col: 4,
+                offset: 3
             }
         );
     }

--- a/src/tests/attributes/element_attribute.rs
+++ b/src/tests/attributes/element_attribute.rs
@@ -1097,4 +1097,121 @@ mod parse_with_shorthand {
             }
         );
     }
+
+    #[test]
+    fn multiple_roles() {
+        let pr = ElementAttribute::parse_with_shorthand(Span::new(".role1.role2.role3")).unwrap();
+
+        assert_eq!(
+            pr.t,
+            TElementAttribute {
+                name: None,
+                shorthand_items: vec![
+                    TSpan {
+                        data: ".role1",
+                        line: 1,
+                        col: 1,
+                        offset: 0,
+                    },
+                    TSpan {
+                        data: ".role2",
+                        line: 1,
+                        col: 7,
+                        offset: 6,
+                    },
+                    TSpan {
+                        data: ".role3",
+                        line: 1,
+                        col: 13,
+                        offset: 12,
+                    }
+                ],
+                value: TSpan {
+                    data: ".role1.role2.role3",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                source: TSpan {
+                    data: ".role1.role2.role3",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            }
+        );
+
+        assert!(pr.t.name().is_none());
+
+        assert_eq!(
+            pr.t.shorthand_items(),
+            &vec![
+                TSpan {
+                    data: ".role1",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                TSpan {
+                    data: ".role2",
+                    line: 1,
+                    col: 7,
+                    offset: 6,
+                },
+                TSpan {
+                    data: ".role3",
+                    line: 1,
+                    col: 13,
+                    offset: 12,
+                }
+            ]
+        );
+
+        assert!(pr.t.block_style().is_none());
+        assert!(pr.t.id().is_none());
+
+        assert_eq!(
+            pr.t.roles(),
+            vec!(
+                TSpan {
+                    data: "role1",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+                TSpan {
+                    data: "role2",
+                    line: 1,
+                    col: 8,
+                    offset: 7,
+                },
+                TSpan {
+                    data: "role3",
+                    line: 1,
+                    col: 14,
+                    offset: 13,
+                }
+            )
+        );
+
+        assert_eq!(
+            pr.t.span(),
+            TSpan {
+                data: ".role1.role2.role3",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }
+        );
+
+        assert_eq!(
+            pr.rem,
+            TSpan {
+                data: "",
+                line: 1,
+                col: 19,
+                offset: 18
+            }
+        );
+    }
 }

--- a/src/tests/attributes/element_attribute.rs
+++ b/src/tests/attributes/element_attribute.rs
@@ -45,6 +45,7 @@ fn only_spaces() {
 
     assert!(pr.t.block_style().is_none());
     assert!(pr.t.id().is_none());
+    assert!(pr.t.roles().is_empty());
 
     assert_eq!(
         pr.rem,
@@ -255,6 +256,7 @@ mod quoted_string {
         assert!(pr.t.name().is_none());
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
+        assert!(pr.t.roles().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -304,6 +306,7 @@ mod quoted_string {
         assert!(pr.t.name().is_none());
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
+        assert!(pr.t.roles().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -358,6 +361,7 @@ mod quoted_string {
         assert!(pr.t.name().is_none());
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
+        assert!(pr.t.roles().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -407,6 +411,7 @@ mod quoted_string {
         assert!(pr.t.name().is_none());
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
+        assert!(pr.t.roles().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -456,6 +461,7 @@ mod quoted_string {
         assert!(pr.t.name().is_none());
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
+        assert!(pr.t.roles().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -529,6 +535,7 @@ mod named {
 
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
+        assert!(pr.t.roles().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -652,6 +659,7 @@ mod named {
 
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
+        assert!(pr.t.roles().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -715,6 +723,7 @@ mod named {
 
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
+        assert!(pr.t.roles().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -764,6 +773,7 @@ mod named {
         assert!(pr.t.name().is_none());
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
+        assert!(pr.t.roles().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -813,6 +823,7 @@ mod named {
         assert!(pr.t.name().is_none());
         assert!(pr.t.block_style().is_none());
         assert!(pr.t.id().is_none());
+        assert!(pr.t.roles().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -897,6 +908,7 @@ mod parse_with_shorthand {
         );
 
         assert!(pr.t.id().is_none());
+        assert!(pr.t.roles().is_empty());
 
         assert_eq!(
             pr.t.span(),
@@ -972,6 +984,8 @@ mod parse_with_shorthand {
             }
         );
 
+        assert!(pr.t.roles().is_empty());
+
         assert_eq!(
             pr.t.span(),
             TSpan {
@@ -989,6 +1003,81 @@ mod parse_with_shorthand {
                 line: 1,
                 col: 5,
                 offset: 4
+            }
+        );
+    }
+
+    #[test]
+    fn one_role_only() {
+        let pr = ElementAttribute::parse_with_shorthand(Span::new(".role1")).unwrap();
+
+        assert_eq!(
+            pr.t,
+            TElementAttribute {
+                name: None,
+                shorthand_items: vec![TSpan {
+                    data: ".role1",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                }],
+                value: TSpan {
+                    data: ".role1",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                source: TSpan {
+                    data: ".role1",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            }
+        );
+
+        assert!(pr.t.name().is_none());
+
+        assert_eq!(
+            pr.t.shorthand_items(),
+            &vec![TSpan {
+                data: ".role1",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }]
+        );
+
+        assert!(pr.t.block_style().is_none());
+        assert!(pr.t.id().is_none());
+
+        assert_eq!(
+            pr.t.roles(),
+            vec!(TSpan {
+                data: "role1",
+                line: 1,
+                col: 2,
+                offset: 1,
+            })
+        );
+
+        assert_eq!(
+            pr.t.span(),
+            TSpan {
+                data: ".role1",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }
+        );
+
+        assert_eq!(
+            pr.rem,
+            TSpan {
+                data: "",
+                line: 1,
+                col: 7,
+                offset: 6
             }
         );
     }

--- a/src/tests/attributes/element_attribute.rs
+++ b/src/tests/attributes/element_attribute.rs
@@ -1373,4 +1373,123 @@ mod parse_with_shorthand {
             }
         );
     }
+
+    #[test]
+    fn multiple_options() {
+        let pr =
+            ElementAttribute::parse_with_shorthand(Span::new("%option1%option2%option3")).unwrap();
+
+        assert_eq!(
+            pr.t,
+            TElementAttribute {
+                name: None,
+                shorthand_items: vec![
+                    TSpan {
+                        data: "%option1",
+                        line: 1,
+                        col: 1,
+                        offset: 0,
+                    },
+                    TSpan {
+                        data: "%option2",
+                        line: 1,
+                        col: 9,
+                        offset: 8,
+                    },
+                    TSpan {
+                        data: "%option3",
+                        line: 1,
+                        col: 17,
+                        offset: 16,
+                    }
+                ],
+                value: TSpan {
+                    data: "%option1%option2%option3",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                source: TSpan {
+                    data: "%option1%option2%option3",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            }
+        );
+
+        assert!(pr.t.name().is_none());
+
+        assert_eq!(
+            pr.t.shorthand_items(),
+            &vec![
+                TSpan {
+                    data: "%option1",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                TSpan {
+                    data: "%option2",
+                    line: 1,
+                    col: 9,
+                    offset: 8,
+                },
+                TSpan {
+                    data: "%option3",
+                    line: 1,
+                    col: 17,
+                    offset: 16,
+                }
+            ]
+        );
+
+        assert!(pr.t.block_style().is_none());
+        assert!(pr.t.id().is_none());
+        assert!(pr.t.roles().is_empty());
+
+        assert_eq!(
+            pr.t.options(),
+            vec!(
+                TSpan {
+                    data: "option1",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+                TSpan {
+                    data: "option2",
+                    line: 1,
+                    col: 10,
+                    offset: 9,
+                },
+                TSpan {
+                    data: "option3",
+                    line: 1,
+                    col: 18,
+                    offset: 17,
+                }
+            )
+        );
+
+        assert_eq!(
+            pr.t.span(),
+            TSpan {
+                data: "%option1%option2%option3",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }
+        );
+
+        assert_eq!(
+            pr.rem,
+            TSpan {
+                data: "",
+                line: 1,
+                col: 25,
+                offset: 24
+            }
+        );
+    }
 }

--- a/src/tests/attributes/element_attribute.rs
+++ b/src/tests/attributes/element_attribute.rs
@@ -98,6 +98,8 @@ fn unquoted_and_unnamed_value() {
     assert!(pr.t.name().is_none());
     assert!(pr.t.block_style().is_none());
     assert!(pr.t.id().is_none());
+    assert!(pr.t.roles().is_empty());
+    assert!(pr.t.options().is_empty());
 
     assert_eq!(
         pr.t.span(),
@@ -146,6 +148,9 @@ fn unquoted_stops_at_comma() {
 
     assert!(pr.t.name().is_none());
     assert!(pr.t.block_style().is_none());
+    assert!(pr.t.id().is_none());
+    assert!(pr.t.roles().is_empty());
+    assert!(pr.t.options().is_empty());
 
     assert_eq!(
         pr.t.span(),
@@ -208,6 +213,9 @@ mod quoted_string {
 
         assert!(pr.t.name().is_none());
         assert!(pr.t.block_style().is_none());
+        assert!(pr.t.id().is_none());
+        assert!(pr.t.roles().is_empty());
+        assert!(pr.t.options().is_empty());
 
         assert_eq!(
             pr.t.span(),

--- a/src/tests/attributes/element_attribute.rs
+++ b/src/tests/attributes/element_attribute.rs
@@ -27,6 +27,7 @@ fn only_spaces() {
         pr.t,
         TElementAttribute {
             name: None,
+            shorthand_items: vec![],
             value: TSpan {
                 data: "   ",
                 line: 1,
@@ -73,6 +74,7 @@ fn unquoted_and_unnamed_value() {
         pr.t,
         TElementAttribute {
             name: None,
+            shorthand_items: vec![],
             value: TSpan {
                 data: "abc",
                 line: 1,
@@ -119,6 +121,7 @@ fn unquoted_stops_at_comma() {
         pr.t,
         TElementAttribute {
             name: None,
+            shorthand_items: vec![],
             value: TSpan {
                 data: "abc",
                 line: 1,
@@ -179,6 +182,7 @@ mod quoted_string {
             pr.t,
             TElementAttribute {
                 name: None,
+                shorthand_items: vec![],
                 value: TSpan {
                     data: "abc",
                     line: 1,
@@ -225,6 +229,7 @@ mod quoted_string {
             pr.t,
             TElementAttribute {
                 name: None,
+                shorthand_items: vec![],
                 value: TSpan {
                     data: "a\\\"bc",
                     line: 1,
@@ -271,6 +276,7 @@ mod quoted_string {
             pr.t,
             TElementAttribute {
                 name: None,
+                shorthand_items: vec![],
                 value: TSpan {
                     data: "a'bc",
                     line: 1,
@@ -322,6 +328,7 @@ mod quoted_string {
             pr.t,
             TElementAttribute {
                 name: None,
+                shorthand_items: vec![],
                 value: TSpan {
                     data: "abc",
                     line: 1,
@@ -368,6 +375,7 @@ mod quoted_string {
             pr.t,
             TElementAttribute {
                 name: None,
+                shorthand_items: vec![],
                 value: TSpan {
                     data: "a\\'bc",
                     line: 1,
@@ -414,6 +422,7 @@ mod quoted_string {
             pr.t,
             TElementAttribute {
                 name: None,
+                shorthand_items: vec![],
                 value: TSpan {
                     data: "a\"bc",
                     line: 1,
@@ -475,6 +484,7 @@ mod named {
                     col: 1,
                     offset: 0,
                 }),
+                shorthand_items: vec![],
                 value: TSpan {
                     data: "def",
                     line: 1,
@@ -534,6 +544,7 @@ mod named {
                     col: 1,
                     offset: 0,
                 }),
+                shorthand_items: vec![],
                 value: TSpan {
                     data: "def",
                     line: 1,
@@ -593,6 +604,7 @@ mod named {
                     col: 1,
                     offset: 0,
                 }),
+                shorthand_items: vec![],
                 value: TSpan {
                     data: "def",
                     line: 1,
@@ -652,6 +664,7 @@ mod named {
                     col: 1,
                     offset: 0,
                 }),
+                shorthand_items: vec![],
                 value: TSpan {
                     data: "def",
                     line: 1,
@@ -706,6 +719,7 @@ mod named {
             pr.t,
             TElementAttribute {
                 name: None,
+                shorthand_items: vec![],
                 value: TSpan {
                     data: "abc=",
                     line: 1,
@@ -752,6 +766,7 @@ mod named {
             pr.t,
             TElementAttribute {
                 name: None,
+                shorthand_items: vec![],
                 value: TSpan {
                     data: "abc=",
                     line: 1,

--- a/src/tests/blocks/block.rs
+++ b/src/tests/blocks/block.rs
@@ -504,6 +504,12 @@ mod r#macro {
                 attrlist: TAttrlist {
                     attributes: vec!(TElementAttribute {
                         name: None,
+                        shorthand_items: vec![TSpan {
+                            data: "blah",
+                            line: 1,
+                            col: 10,
+                            offset: 9,
+                        }],
                         value: TSpan {
                             data: "blah",
                             line: 1,

--- a/src/tests/blocks/macro.rs
+++ b/src/tests/blocks/macro.rs
@@ -170,6 +170,12 @@ fn has_target_and_attrlist() {
             attrlist: TAttrlist {
                 attributes: vec!(TElementAttribute {
                     name: None,
+                    shorthand_items: vec![TSpan {
+                        data: "blah",
+                        line: 1,
+                        col: 10,
+                        offset: 9,
+                    }],
                     value: TSpan {
                         data: "blah",
                         line: 1,

--- a/src/tests/fixtures/attributes/element_attribute.rs
+++ b/src/tests/fixtures/attributes/element_attribute.rs
@@ -5,6 +5,7 @@ use crate::{attributes::ElementAttribute, tests::fixtures::TSpan, HasSpan};
 #[derive(Eq, PartialEq)]
 pub(crate) struct TElementAttribute {
     pub name: Option<TSpan>,
+    pub shorthand_items: Vec<TSpan>,
     pub value: TSpan,
     pub source: TSpan,
 }
@@ -13,6 +14,7 @@ impl fmt::Debug for TElementAttribute {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ElementAttribute")
             .field("name", &self.name)
+            .field("shorthand_items", &self.shorthand_items)
             .field("value", &self.value)
             .field("source", &self.source)
             .finish()
@@ -43,6 +45,10 @@ fn tattribute_eq(tattribute: &TElementAttribute, attribute: &ElementAttribute) -
     }
 
     if &tattribute.value != attribute.raw_value() {
+        return false;
+    }
+
+    if &tattribute.shorthand_items != attribute.shorthand_items() {
         return false;
     }
 


### PR DESCRIPTION
Shorthand items are in the first positional item and delimited by a leading #, %, or . character.