### PR TITLE
Code clarity: Use `source` for input text consistently

### DIFF
--- a/src/attributes/element_attribute.rs
+++ b/src/attributes/element_attribute.rs
@@ -1,4 +1,4 @@
-use crate::{primitives::trim_input_for_rem, span::ParseResult, HasSpan, Span};
+use crate::{primitives::trim_source_for_rem, span::ParseResult, HasSpan, Span};
 
 /// This struct represents a single element attribute.
 ///
@@ -60,7 +60,7 @@ impl<'src> ElementAttribute<'src> {
             return None;
         }
 
-        let source = trim_input_for_rem(source, value.rem);
+        let source = trim_source_for_rem(source, value.rem);
 
         let shorthand_items = if name.is_none() && parse_shorthand {
             parse_shorthand_items(source)

--- a/src/blocks/block.rs
+++ b/src/blocks/block.rs
@@ -40,13 +40,13 @@ impl<'src> Block<'src> {
     /// Parse a block of any type and return a `Block` that describes it.
     ///
     /// Consumes any blank lines before and after the block.
-    pub(crate) fn parse(i: Span<'src>) -> Option<ParseResult<'src, Self>> {
-        let i = i.discard_empty_lines();
+    pub(crate) fn parse(source: Span<'src>) -> Option<ParseResult<'src, Self>> {
+        let source = source.discard_empty_lines();
 
         // Try to discern the block type by scanning the first line.
-        let line = i.take_normalized_line();
+        let line = source.take_normalized_line();
         if line.t.contains("::") {
-            if let Some(macro_block) = MacroBlock::parse(i) {
+            if let Some(macro_block) = MacroBlock::parse(source) {
                 return Some(ParseResult {
                     t: Self::Macro(macro_block.t),
                     rem: macro_block.rem,
@@ -56,7 +56,7 @@ impl<'src> Block<'src> {
             // A line containing `::` might be some other kind of block, so we
             // don't automatically error out on a parse failure.
         } else if line.t.starts_with('=') {
-            if let Some(section_block) = SectionBlock::parse(i) {
+            if let Some(section_block) = SectionBlock::parse(source) {
                 return Some(ParseResult {
                     t: Self::Section(section_block.t),
                     rem: section_block.rem,
@@ -68,7 +68,7 @@ impl<'src> Block<'src> {
         }
 
         // If no other block kind matches, we can always use SimpleBlock.
-        SimpleBlock::parse(i).map(|pr| ParseResult {
+        SimpleBlock::parse(source).map(|pr| ParseResult {
             t: Self::Simple(pr.t),
             rem: pr.rem,
         })

--- a/src/blocks/parse_utils.rs
+++ b/src/blocks/parse_utils.rs
@@ -3,24 +3,27 @@ use crate::{blocks::Block, span::ParseResult, Span};
 /// Parse blocks until end of input or a pre-determined stop condition is
 /// reached.
 pub(crate) fn parse_blocks_until<'src, F>(
-    mut i: Span<'src>,
+    mut source: Span<'src>,
     f: F,
 ) -> Option<ParseResult<'src, Vec<Block<'src>>>>
 where
     F: Fn(&Span<'src>) -> bool,
 {
     let mut blocks: Vec<Block<'src>> = vec![];
-    i = i.discard_empty_lines();
+    source = source.discard_empty_lines();
 
-    while !i.data().is_empty() {
-        if f(&i) {
+    while !source.data().is_empty() {
+        if f(&source) {
             break;
         }
 
-        let pr = Block::parse(i)?;
-        i = pr.rem;
+        let pr = Block::parse(source)?;
+        source = pr.rem;
         blocks.push(pr.t);
     }
 
-    Some(ParseResult { t: blocks, rem: i })
+    Some(ParseResult {
+        t: blocks,
+        rem: source,
+    })
 }

--- a/src/blocks/section.rs
+++ b/src/blocks/section.rs
@@ -2,7 +2,7 @@ use std::slice::Iter;
 
 use crate::{
     blocks::{parse_utils::parse_blocks_until, Block, ContentModel, IsBlock},
-    primitives::trim_input_for_rem,
+    primitives::trim_source_for_rem,
     span::ParseResult,
     strings::CowStr,
     HasSpan, Span,
@@ -28,7 +28,7 @@ impl<'src> SectionBlock<'src> {
         let source = source.discard_empty_lines();
         let level = parse_title_line(source)?;
         let blocks = parse_blocks_until(level.rem, |i| peer_or_ancestor_section(*i, level.t.0))?;
-        let source = trim_input_for_rem(source, blocks.rem);
+        let source = trim_source_for_rem(source, blocks.rem);
 
         Some(ParseResult {
             t: Self {
@@ -103,8 +103,8 @@ fn parse_title_line(source: Span<'_>) -> Option<ParseResult<(usize, Span)>> {
     })
 }
 
-fn peer_or_ancestor_section(i: Span<'_>, level: usize) -> bool {
-    if let Some(pr) = parse_title_line(i) {
+fn peer_or_ancestor_section(source: Span<'_>, level: usize) -> bool {
+    if let Some(pr) = parse_title_line(source) {
         pr.t.0 <= level
     } else {
         false

--- a/src/document/attribute.rs
+++ b/src/document/attribute.rs
@@ -1,4 +1,4 @@
-use crate::{primitives::trim_input_for_rem, span::ParseResult, strings::CowStr, HasSpan, Span};
+use crate::{primitives::trim_source_for_rem, span::ParseResult, strings::CowStr, HasSpan, Span};
 
 /// Document attributes are effectively document-scoped variables for the
 /// AsciiDoc language. The AsciiDoc language defines a set of built-in
@@ -12,8 +12,8 @@ pub struct Attribute<'src> {
 }
 
 impl<'src> Attribute<'src> {
-    pub(crate) fn parse(i: Span<'src>) -> Option<ParseResult<'src, Self>> {
-        let attr_line = i.take_line_with_continuation()?;
+    pub(crate) fn parse(source: Span<'src>) -> Option<ParseResult<'src, Self>> {
+        let attr_line = source.take_line_with_continuation()?;
         let colon = attr_line.t.take_prefix(":")?;
 
         let mut unset = false;
@@ -45,7 +45,7 @@ impl<'src> Attribute<'src> {
             RawAttributeValue::Value(value.rem)
         };
 
-        let source = trim_input_for_rem(i, attr_line.rem);
+        let source = trim_source_for_rem(source, attr_line.rem);
         Some(ParseResult {
             t: Self {
                 name: name.t,

--- a/src/document/header.rs
+++ b/src/document/header.rs
@@ -1,7 +1,7 @@
 use std::slice::Iter;
 
 use crate::{
-    document::Attribute, primitives::trim_input_for_rem, span::ParseResult, HasSpan, Span,
+    document::Attribute, primitives::trim_source_for_rem, span::ParseResult, HasSpan, Span,
 };
 
 /// An AsciiDoc document may begin with a document header. The document header
@@ -15,8 +15,8 @@ pub struct Header<'src> {
 }
 
 impl<'src> Header<'src> {
-    pub(crate) fn parse(i: Span<'src>) -> Option<ParseResult<'src, Self>> {
-        let source = i.discard_empty_lines();
+    pub(crate) fn parse(source: Span<'src>) -> Option<ParseResult<'src, Self>> {
+        let source = source.discard_empty_lines();
 
         // TEMPORARY: Titles are optional, but we're not prepared for that yet.
         let title = parse_title(source)?;
@@ -29,7 +29,7 @@ impl<'src> Header<'src> {
             rem = attr.rem;
         }
 
-        let source = trim_input_for_rem(source, rem);
+        let source = trim_source_for_rem(source, rem);
 
         // Header must be followed by an empty line or EOF.
         let pr = rem.take_empty_line()?;
@@ -61,8 +61,8 @@ impl<'src> HasSpan<'src> for Header<'src> {
     }
 }
 
-fn parse_title(i: Span<'_>) -> Option<ParseResult<Span>> {
-    let line = i.take_non_empty_line()?;
+fn parse_title(source: Span<'_>) -> Option<ParseResult<Span>> {
+    let line = source.take_non_empty_line()?;
     let equal = line.t.take_prefix("=")?;
     let ws = equal.rem.take_required_whitespace()?;
 

--- a/src/inlines/macro.rs
+++ b/src/inlines/macro.rs
@@ -1,4 +1,4 @@
-use crate::{primitives::trim_input_for_rem, span::ParseResult, HasSpan, Span};
+use crate::{primitives::trim_source_for_rem, span::ParseResult, HasSpan, Span};
 
 /// An inline macro can be used in an inline context to create new inline
 /// content.
@@ -24,7 +24,7 @@ impl<'src> InlineMacro<'src> {
         let open_brace = target.rem.take_prefix("[")?;
         let attrlist = open_brace.rem.take_while(|c| c != ']');
         let close_brace = attrlist.rem.take_prefix("]")?;
-        let source = trim_input_for_rem(source, close_brace.rem);
+        let source = trim_source_for_rem(source, close_brace.rem);
 
         Some(ParseResult {
             t: Self {

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -4,15 +4,15 @@ use crate::Span;
 /// of the first, return the first input trimmed to exclude the second.
 ///
 /// Note that the trailing remainder condition is not enforced.
-pub(crate) fn trim_input_for_rem<'src>(inp: Span<'src>, rem: Span<'src>) -> Span<'src> {
-    // Sanity check: If rem is longer than inp, we can't trim.
+pub(crate) fn trim_source_for_rem<'src>(source: Span<'src>, rem: Span<'src>) -> Span<'src> {
+    // Sanity check: If rem is longer than source, we can't trim.
     let rlen = rem.len();
-    let ilen = inp.len();
+    let slen = source.len();
 
-    if rlen >= ilen {
-        inp.slice(0..0)
+    if rlen >= slen {
+        source.slice(0..0)
     } else {
-        let trim_len = ilen - rlen;
-        inp.slice(0..trim_len)
+        let trim_len = slen - rlen;
+        source.slice(0..trim_len)
     }
 }

--- a/src/tests/primitives/mod.rs
+++ b/src/tests/primitives/mod.rs
@@ -1,7 +1,7 @@
-mod trim_input_for_rem {
+mod trim_source_for_rem {
     use pretty_assertions_sorted::assert_eq;
 
-    use crate::{primitives::trim_input_for_rem, tests::fixtures::TSpan, Span};
+    use crate::{primitives::trim_source_for_rem, tests::fixtures::TSpan, Span};
 
     fn advanced_span(source: &'static str, skip: usize) -> Span<'static> {
         let span = Span::new(source);
@@ -10,11 +10,11 @@ mod trim_input_for_rem {
 
     #[test]
     fn empty_spans() {
-        let inp = advanced_span("abcdef", 6);
+        let source = advanced_span("abcdef", 6);
         let rem = Span::new("");
 
         assert_eq!(
-            trim_input_for_rem(inp, rem),
+            trim_source_for_rem(source, rem),
             TSpan {
                 data: "",
                 line: 1,
@@ -25,12 +25,12 @@ mod trim_input_for_rem {
     }
 
     #[test]
-    fn rem_equals_inp() {
-        let inp = advanced_span("abcdef", 6);
+    fn rem_equals_source() {
+        let source = advanced_span("abcdef", 6);
         let rem = Span::new("abcdef");
 
         assert_eq!(
-            trim_input_for_rem(inp, rem),
+            trim_source_for_rem(source, rem),
             TSpan {
                 data: "",
                 line: 1,
@@ -44,11 +44,11 @@ mod trim_input_for_rem {
     fn rem_too_long() {
         // This is nonsense input, but we should at least not panic in this case.
 
-        let inp = advanced_span("abcdef", 6);
+        let source = advanced_span("abcdef", 6);
         let rem = Span::new("abcdef_bogus_bogus");
 
         assert_eq!(
-            trim_input_for_rem(inp, rem),
+            trim_source_for_rem(source, rem),
             TSpan {
                 data: "",
                 line: 1,
@@ -59,12 +59,12 @@ mod trim_input_for_rem {
     }
 
     #[test]
-    fn rem_is_subset_of_inp() {
-        let inp = advanced_span("abcdef", 2);
+    fn rem_is_subset_of_source() {
+        let source = advanced_span("abcdef", 2);
         let rem = advanced_span("abcdef", 4);
 
         assert_eq!(
-            trim_input_for_rem(inp, rem),
+            trim_source_for_rem(source, rem),
             TSpan {
                 data: "cd",
                 line: 1,

--- a/src/tests/span/discard.rs
+++ b/src/tests/span/discard.rs
@@ -2,7 +2,7 @@ mod discard {
     use crate::{tests::fixtures::TSpan, Span};
 
     #[test]
-    fn empty_input() {
+    fn empty_source() {
         let span = Span::new("");
         assert_eq!(
             span.discard(4),
@@ -76,7 +76,7 @@ mod discard_all {
     use crate::{tests::fixtures::TSpan, Span};
 
     #[test]
-    fn empty_input() {
+    fn empty_source() {
         let span = Span::new("");
         assert_eq!(
             span.discard_all(),

--- a/src/tests/span/mod.rs
+++ b/src/tests/span/mod.rs
@@ -35,7 +35,7 @@ mod split_at_match_non_empty {
     use crate::Span;
 
     #[test]
-    fn empty_input() {
+    fn empty_source() {
         let s = Span::new("");
         assert!(s.split_at_match_non_empty(|c| c == ':').is_none());
     }

--- a/src/tests/span/split.rs
+++ b/src/tests/span/split.rs
@@ -58,7 +58,7 @@ mod split_at_match_non_empty {
     use crate::Span;
 
     #[test]
-    fn empty_input() {
+    fn empty_source() {
         let s = Span::new("");
         assert!(s.split_at_match_non_empty(|c| c == ':').is_none());
     }

--- a/src/tests/span/take.rs
+++ b/src/tests/span/take.rs
@@ -2,7 +2,7 @@ mod take_prefix {
     use crate::{tests::fixtures::TSpan, Span};
 
     #[test]
-    fn empty_input() {
+    fn empty_source() {
         let span = Span::new("");
         assert!(span.take_prefix("foo").is_none());
     }
@@ -76,7 +76,7 @@ mod take_whitespace {
     use crate::{tests::fixtures::TSpan, Span};
 
     #[test]
-    fn empty_input() {
+    fn empty_source() {
         let span = Span::new("");
         let pr = span.take_whitespace();
 
@@ -184,7 +184,7 @@ mod take_required_whitespace {
     use crate::{tests::fixtures::TSpan, Span};
 
     #[test]
-    fn empty_input() {
+    fn empty_source() {
         let span = Span::new("");
         assert!(span.take_required_whitespace().is_none());
     }
@@ -252,7 +252,7 @@ mod take_while {
     use crate::{tests::fixtures::TSpan, Span};
 
     #[test]
-    fn empty_input() {
+    fn empty_source() {
         let span = Span::new("");
         let pr = span.take_while(|c| c != ':');
 


### PR DESCRIPTION
Remove uses of `i`, `inp`, or `input`