### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.1.1](https://github.com/scouten/asciidoc-parser/compare/v0.1.0...v0.1.1)
+_26 October 2024_
+
+### Fixed
+
+* Copy/paste error in crate description
+
 ## [0.1.0](https://github.com/scouten/asciidoc-parser/releases/tag/v0.1.0)
 _26 October 2024_
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asciidoc-parser"
-version = "0.1.0"
+version = "0.1.1"
 description = "Parser for AsciiDoc format"
 authors = ["Eric Scouten <git@scouten.me>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `asciidoc-parser`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/scouten/asciidoc-parser/compare/v0.1.0...v0.1.1)

_26 October 2024_

### Fixed

* Copy/paste error in crate description
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).