### PR TITLE
fix: Do not treat triple-hyphen as a delimiter for open block

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,7 @@ allow = [
   "Apache-2.0",
   "MIT",
   "Unicode-DFS-2016",
+  "Unicode-3.0",
 ]
 confidence-threshold = 0.9
 

--- a/src/blocks/compound_delimited.rs
+++ b/src/blocks/compound_delimited.rs
@@ -29,10 +29,7 @@ impl<'src> CompoundDelimitedBlock<'src> {
     pub(crate) fn is_valid_delimiter(line: &Span<'src>) -> bool {
         let data = line.data();
 
-        if data == "--" || data == "---" {
-            // TO DO (https://github.com/scouten/asciidoc-parser/issues/146):
-            // Seek spec clarity on whether three hyphens can be used to
-            // delimit an open block. Assuming yes for now.
+        if data == "--" {
             return true;
         }
 
@@ -69,7 +66,7 @@ impl<'src> CompoundDelimitedBlock<'src> {
             .0
         {
             "====" => "example",
-            "--" | "---" => "open",
+            "--" => "open",
             "****" => "sidebar",
             "____" => "quote",
             _ => return None,

--- a/src/tests/blocks/block/compound_delimited.rs
+++ b/src/tests/blocks/block/compound_delimited.rs
@@ -464,23 +464,34 @@ mod open {
                         col: 1,
                         offset: 3,
                     },),),),
-                    TBlock::CompoundDelimited(TCompoundDelimitedBlock {
-                        blocks: vec!(TBlock::Simple(TSimpleBlock(TInline::Uninterpreted(
-                            TSpan {
+                    TBlock::Simple(TSimpleBlock(TInline::Sequence(
+                        vec![
+                            TInline::Uninterpreted(TSpan {
+                                data: "---",
+                                line: 4,
+                                col: 1,
+                                offset: 11,
+                            },),
+                            TInline::Uninterpreted(TSpan {
                                 data: "block2",
                                 line: 5,
                                 col: 1,
                                 offset: 15,
-                            },
-                        ),),),),
-                        context: "open",
-                        source: TSpan {
+                            },),
+                            TInline::Uninterpreted(TSpan {
+                                data: "---",
+                                line: 6,
+                                col: 1,
+                                offset: 22,
+                            },),
+                        ],
+                        TSpan {
                             data: "---\nblock2\n---\n",
                             line: 4,
                             col: 1,
                             offset: 11,
                         },
-                    })
+                    ),),)
                 ),
                 context: "open",
                 source: TSpan {
@@ -508,23 +519,34 @@ mod open {
 
         assert_eq!(
             blocks.next().unwrap(),
-            &TBlock::CompoundDelimited(TCompoundDelimitedBlock {
-                blocks: vec!(TBlock::Simple(TSimpleBlock(TInline::Uninterpreted(
-                    TSpan {
+            &TBlock::Simple(TSimpleBlock(TInline::Sequence(
+                vec![
+                    TInline::Uninterpreted(TSpan {
+                        data: "---",
+                        line: 4,
+                        col: 1,
+                        offset: 11,
+                    },),
+                    TInline::Uninterpreted(TSpan {
                         data: "block2",
                         line: 5,
                         col: 1,
                         offset: 15,
-                    },
-                ),),),),
-                context: "open",
-                source: TSpan {
+                    },),
+                    TInline::Uninterpreted(TSpan {
+                        data: "---",
+                        line: 6,
+                        col: 1,
+                        offset: 22,
+                    },),
+                ],
+                TSpan {
                     data: "---\nblock2\n---\n",
                     line: 4,
                     col: 1,
                     offset: 11,
                 },
-            })
+            )))
         );
 
         assert!(blocks.next().is_none());

--- a/src/tests/blocks/compound_delimited.rs
+++ b/src/tests/blocks/compound_delimited.rs
@@ -527,6 +527,7 @@ mod open {
 
     #[test]
     fn nested_blocks() {
+        // Spec says three hyphens does NOT mark an open block.
         let maw =
             CompoundDelimitedBlock::parse(Span::new("--\nblock1\n\n---\nblock2\n---\n--")).unwrap();
 
@@ -542,23 +543,34 @@ mod open {
                         col: 1,
                         offset: 3,
                     },),),),
-                    TBlock::CompoundDelimited(TCompoundDelimitedBlock {
-                        blocks: vec!(TBlock::Simple(TSimpleBlock(TInline::Uninterpreted(
-                            TSpan {
+                    TBlock::Simple(TSimpleBlock(TInline::Sequence(
+                        vec![
+                            TInline::Uninterpreted(TSpan {
+                                data: "---",
+                                line: 4,
+                                col: 1,
+                                offset: 11,
+                            }),
+                            TInline::Uninterpreted(TSpan {
                                 data: "block2",
                                 line: 5,
                                 col: 1,
                                 offset: 15,
-                            },
-                        ),),),),
-                        context: "open",
-                        source: TSpan {
+                            }),
+                            TInline::Uninterpreted(TSpan {
+                                data: "---",
+                                line: 6,
+                                col: 1,
+                                offset: 22,
+                            }),
+                        ],
+                        TSpan {
                             data: "---\nblock2\n---\n",
                             line: 4,
                             col: 1,
                             offset: 11,
-                        },
-                    })
+                        }
+                    ),))
                 ),
                 context: "open",
                 source: TSpan {
@@ -586,23 +598,34 @@ mod open {
 
         assert_eq!(
             blocks.next().unwrap(),
-            &TBlock::CompoundDelimited(TCompoundDelimitedBlock {
-                blocks: vec!(TBlock::Simple(TSimpleBlock(TInline::Uninterpreted(
-                    TSpan {
+            &TBlock::Simple(TSimpleBlock(TInline::Sequence(
+                vec![
+                    TInline::Uninterpreted(TSpan {
+                        data: "---",
+                        line: 4,
+                        col: 1,
+                        offset: 11,
+                    }),
+                    TInline::Uninterpreted(TSpan {
                         data: "block2",
                         line: 5,
                         col: 1,
                         offset: 15,
-                    },
-                ),),),),
-                context: "open",
-                source: TSpan {
+                    }),
+                    TInline::Uninterpreted(TSpan {
+                        data: "---",
+                        line: 6,
+                        col: 1,
+                        offset: 22,
+                    }),
+                ],
+                TSpan {
                     data: "---\nblock2\n---\n",
                     line: 4,
                     col: 1,
                     offset: 11,
-                },
-            })
+                }
+            ),))
         );
 
         assert!(blocks.next().is_none());


### PR DESCRIPTION
Fixes #146.