### PR TITLE
chore: Rename `MacroBlock::attrlist()` to `MacroBlock::macro_attrlist()`

### DIFF
--- a/src/blocks/macro.rs
+++ b/src/blocks/macro.rs
@@ -18,7 +18,7 @@ use crate::{
 pub struct MacroBlock<'src> {
     name: Span<'src>,
     target: Option<Span<'src>>,
-    attrlist: Attrlist<'src>,
+    macro_attrlist: Attrlist<'src>,
     source: Span<'src>,
     title: Option<Span<'src>>,
 }
@@ -72,7 +72,7 @@ impl<'src> MacroBlock<'src> {
         let attrlist = open_brace.after.slice(0..open_brace.after.len() - 1);
         // Note that we already checked that this line ends with a close brace.
 
-        let attrlist = Attrlist::parse(attrlist);
+        let macro_attrlist = Attrlist::parse(attrlist);
 
         let source: Span = preamble.source.trim_remainder(line.after);
         let source = source.slice(0..source.trim().len());
@@ -86,14 +86,14 @@ impl<'src> MacroBlock<'src> {
                     } else {
                         Some(target.item)
                     },
-                    attrlist: attrlist.item.item,
+                    macro_attrlist: macro_attrlist.item.item,
                     source,
                     title: preamble.title,
                 },
 
                 after: line.after.discard_empty_lines(),
             }),
-            warnings: attrlist.warnings,
+            warnings: macro_attrlist.warnings,
         }
     }
 
@@ -108,8 +108,11 @@ impl<'src> MacroBlock<'src> {
     }
 
     /// Return the macro's attribute list.
-    pub fn attrlist(&'src self) -> &'src Attrlist<'src> {
-        &self.attrlist
+    ///
+    /// IMPORTANT: This is the list of attributes _within_ the macro block
+    /// definition itself.
+    pub fn macro_attrlist(&'src self) -> &'src Attrlist<'src> {
+        &self.macro_attrlist
     }
 }
 

--- a/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
+++ b/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
@@ -61,8 +61,8 @@ mod positional_attribute {
         .unwrap_if_no_warnings()
         .unwrap();
 
-        let a1 = m1.item.attrlist();
-        let a2 = m2.item.attrlist();
+        let a1 = m1.item.macro_attrlist();
+        let a2 = m2.item.macro_attrlist();
 
         assert_eq!(
             a1.named_or_positional_attribute("alt", 1).unwrap(),

--- a/src/tests/asciidoc_lang/root/key_concepts.rs
+++ b/src/tests/asciidoc_lang/root/key_concepts.rs
@@ -165,7 +165,7 @@ mod macros {
                         col: 8,
                         offset: 7,
                     }),
-                    attrlist: TAttrlist {
+                    macro_attrlist: TAttrlist {
                         attributes: vec!(TElementAttribute {
                             name: None,
                             shorthand_items: vec![TSpan {

--- a/src/tests/blocks/block/macro.rs
+++ b/src/tests/blocks/block/macro.rs
@@ -269,7 +269,7 @@ fn simplest_block_macro() {
                 offset: 0,
             },
             target: None,
-            attrlist: TAttrlist {
+            macro_attrlist: TAttrlist {
                 attributes: vec!(),
                 source: TSpan {
                     data: "",
@@ -335,7 +335,7 @@ fn has_target() {
                 col: 6,
                 offset: 5,
             }),
-            attrlist: TAttrlist {
+            macro_attrlist: TAttrlist {
                 attributes: vec!(),
                 source: TSpan {
                     data: "",
@@ -376,7 +376,7 @@ fn has_target() {
 }
 
 #[test]
-fn has_target_and_attrlist() {
+fn has_target_and_macro_attrlist() {
     let mi = Block::parse(Span::new("foo::bar[blah]"))
         .unwrap_if_no_warnings()
         .unwrap();
@@ -396,7 +396,7 @@ fn has_target_and_attrlist() {
                 col: 6,
                 offset: 5,
             }),
-            attrlist: TAttrlist {
+            macro_attrlist: TAttrlist {
                 attributes: vec!(TElementAttribute {
                     name: None,
                     shorthand_items: vec![TSpan {
@@ -457,7 +457,7 @@ fn has_target_and_attrlist() {
 }
 
 #[test]
-fn warn_attrlist_has_extra_comma() {
+fn warn_macro_attrlist_has_extra_comma() {
     let maw = Block::parse(Span::new("foo::bar[alt=Sunset,width=300,,height=400]"));
 
     let mi = maw.item.as_ref().unwrap().clone();
@@ -477,7 +477,7 @@ fn warn_attrlist_has_extra_comma() {
                 col: 6,
                 offset: 5,
             }),
-            attrlist: TAttrlist {
+            macro_attrlist: TAttrlist {
                 attributes: vec!(
                     TElementAttribute {
                         name: Some(TSpan {
@@ -614,7 +614,7 @@ fn has_title() {
                 col: 6,
                 offset: 18,
             }),
-            attrlist: TAttrlist {
+            macro_attrlist: TAttrlist {
                 attributes: vec!(),
                 source: TSpan {
                     data: "",

--- a/src/tests/blocks/block/section.rs
+++ b/src/tests/blocks/block/section.rs
@@ -328,7 +328,7 @@ fn warn_child_attrlist_has_extra_comma() {
                     col: 6,
                     offset: 23,
                 }),
-                attrlist: TAttrlist {
+                macro_attrlist: TAttrlist {
                     attributes: vec!(
                         TElementAttribute {
                             name: Some(TSpan {

--- a/src/tests/blocks/macro.rs
+++ b/src/tests/blocks/macro.rs
@@ -80,7 +80,7 @@ fn err_missing_double_colon() {
 }
 
 #[test]
-fn err_missing_attrlist() {
+fn err_missing_macro_attrlist() {
     let maw = MacroBlock::parse(&Preamble::new("foo::barblah,blap]"));
 
     assert!(maw.item.is_none());
@@ -140,7 +140,7 @@ fn simplest_block_macro() {
                 offset: 0,
             },
             target: None,
-            attrlist: TAttrlist {
+            macro_attrlist: TAttrlist {
                 attributes: vec!(),
                 source: TSpan {
                     data: "",
@@ -191,7 +191,7 @@ fn has_target() {
                 col: 6,
                 offset: 5,
             }),
-            attrlist: TAttrlist {
+            macro_attrlist: TAttrlist {
                 attributes: vec!(),
                 source: TSpan {
                     data: "",
@@ -242,7 +242,7 @@ fn has_target_and_attrlist() {
                 col: 6,
                 offset: 5,
             }),
-            attrlist: TAttrlist {
+            macro_attrlist: TAttrlist {
                 attributes: vec!(TElementAttribute {
                     name: None,
                     shorthand_items: vec![TSpan {
@@ -313,7 +313,7 @@ fn err_duplicate_comma() {
                 col: 6,
                 offset: 5,
             }),
-            attrlist: TAttrlist {
+            macro_attrlist: TAttrlist {
                 attributes: vec!(
                     TElementAttribute {
                         name: None,

--- a/src/tests/blocks/section.rs
+++ b/src/tests/blocks/section.rs
@@ -175,7 +175,7 @@ fn has_macro_block_with_extra_blank_line() {
                     col: 6,
                     offset: 23,
                 }),
-                attrlist: TAttrlist {
+                macro_attrlist: TAttrlist {
                     attributes: vec!(
                         TElementAttribute {
                             name: Some(TSpan {
@@ -313,7 +313,7 @@ fn has_child_block_with_errors() {
                     col: 6,
                     offset: 23,
                 }),
-                attrlist: TAttrlist {
+                macro_attrlist: TAttrlist {
                     attributes: vec!(
                         TElementAttribute {
                             name: Some(TSpan {

--- a/src/tests/document/document.rs
+++ b/src/tests/document/document.rs
@@ -407,7 +407,7 @@ fn err_bad_header_and_bad_macro() {
                                         offset: 49,
                                     },
                                 ),
-                                attrlist: TAttrlist {
+                                macro_attrlist: TAttrlist {
                                     attributes: vec![
                                         TElementAttribute {
                                             name: Some(

--- a/src/tests/fixtures/blocks/macro.rs
+++ b/src/tests/fixtures/blocks/macro.rs
@@ -10,7 +10,7 @@ use crate::{
 pub(crate) struct TMacroBlock {
     pub name: TSpan,
     pub target: Option<TSpan>,
-    pub attrlist: TAttrlist,
+    pub macro_attrlist: TAttrlist,
     pub source: TSpan,
     pub title: Option<TSpan>,
 }
@@ -20,7 +20,7 @@ impl fmt::Debug for TMacroBlock {
         f.debug_struct("MacroBlock")
             .field("name", &self.name)
             .field("target", &self.target)
-            .field("attrlist", &self.attrlist)
+            .field("macro_attrlist", &self.macro_attrlist)
             .field("source", &self.source)
             .finish()
     }
@@ -55,7 +55,7 @@ fn tmacro_block_eq(tmacro_block: &TMacroBlock, macro_block: &MacroBlock) -> bool
         }
     }
 
-    if tmacro_block.attrlist != *macro_block.attrlist() {
+    if tmacro_block.macro_attrlist != *macro_block.macro_attrlist() {
         return false;
     }
 


### PR DESCRIPTION
Anticipates upcoming support for attrlist for all blocks, which has a different conceptual positions.