### PR TITLE
feat: Rename `IsBlock::context` to `raw_context`

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -223,13 +223,13 @@ impl<'src> IsBlock<'src> for Block<'src> {
         }
     }
 
-    fn context(&self) -> CowStr<'src> {
+    fn raw_context(&self) -> CowStr<'src> {
         match self {
-            Self::Simple(b) => b.context(),
-            Self::Macro(b) => b.context(),
-            Self::Section(b) => b.context(),
-            Self::RawDelimited(b) => b.context(),
-            Self::CompoundDelimited(b) => b.context(),
+            Self::Simple(b) => b.raw_context(),
+            Self::Macro(b) => b.raw_context(),
+            Self::Section(b) => b.raw_context(),
+            Self::RawDelimited(b) => b.raw_context(),
+            Self::CompoundDelimited(b) => b.raw_context(),
         }
     }
 

--- a/parser/src/blocks/compound_delimited.rs
+++ b/parser/src/blocks/compound_delimited.rs
@@ -126,7 +126,7 @@ impl<'src> IsBlock<'src> for CompoundDelimitedBlock<'src> {
         ContentModel::Compound
     }
 
-    fn context(&self) -> CowStr<'src> {
+    fn raw_context(&self) -> CowStr<'src> {
         self.context.clone()
     }
 

--- a/parser/src/blocks/is_block.rs
+++ b/parser/src/blocks/is_block.rs
@@ -18,7 +18,7 @@ pub trait IsBlock<'src>: HasSpan<'src> + Clone + Debug + Eq + PartialEq {
     /// Returns the [`ContentModel`] for this block.
     fn content_model(&self) -> ContentModel;
 
-    /// Returns the context for this block.
+    /// Returns the raw (uninterpreted) context for this block.
     ///
     /// A block’s context is also sometimes referred to as a name, such as an
     /// example block, a sidebar block, an admonition block, or a section.
@@ -31,7 +31,10 @@ pub trait IsBlock<'src>: HasSpan<'src> + Clone + Debug + Eq + PartialEq {
     /// For that reason, the context is not defined as an enumeration, but
     /// rather as a string type that is optimized for the case where predefined
     /// constants are viable.
-    fn context(&self) -> CowStr<'src>;
+    ///
+    /// A block's context can be replaced by a block style that matches a
+    /// built-in context. That transformation is not performed by this function.
+    fn raw_context(&self) -> CowStr<'src>;
 
     /// Returns an iterator over the nested blocks contained within
     /// this block.

--- a/parser/src/blocks/macro.rs
+++ b/parser/src/blocks/macro.rs
@@ -130,7 +130,7 @@ impl<'src> IsBlock<'src> for MacroBlock<'src> {
         ContentModel::Simple
     }
 
-    fn context(&self) -> CowStr<'src> {
+    fn raw_context(&self) -> CowStr<'src> {
         // TO DO: We'll probably want different macro types to provide different
         // contexts. For now, just default to "paragraph."
 

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -130,7 +130,7 @@ impl<'src> IsBlock<'src> for RawDelimitedBlock<'src> {
         self.content_model
     }
 
-    fn context(&self) -> CowStr<'src> {
+    fn raw_context(&self) -> CowStr<'src> {
         self.context.clone()
     }
 

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -79,7 +79,7 @@ impl<'src> IsBlock<'src> for SectionBlock<'src> {
         ContentModel::Compound
     }
 
-    fn context(&self) -> CowStr<'src> {
+    fn raw_context(&self) -> CowStr<'src> {
         "section".into()
     }
 

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -58,7 +58,7 @@ impl<'src> IsBlock<'src> for SimpleBlock<'src> {
         ContentModel::Simple
     }
 
-    fn context(&self) -> CowStr<'src> {
+    fn raw_context(&self) -> CowStr<'src> {
         "paragraph".into()
     }
 

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -89,7 +89,7 @@ impl<'src> IsBlock<'src> for Document<'src> {
         ContentModel::Compound
     }
 
-    fn context(&self) -> CowStr<'src> {
+    fn raw_context(&self) -> CowStr<'src> {
         "document".into()
     }
 

--- a/parser/src/tests/asciidoc_lang/blocks/delimited.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/delimited.rs
@@ -291,7 +291,7 @@ The table below lists the structural containers, documenting the name, default c
         .unwrap();
 
     assert_eq!(mi.item.content_model(), ContentModel::Raw);
-    assert_eq!(mi.item.context().as_ref(), "comment");
+    assert_eq!(mi.item.raw_context().as_ref(), "comment");
 
     verifies!(
         r#"
@@ -308,7 +308,7 @@ The table below lists the structural containers, documenting the name, default c
         .unwrap();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert_eq!(mi.item.context().as_ref(), "example");
+    assert_eq!(mi.item.raw_context().as_ref(), "example");
 
     verifies!(
         r#"
@@ -325,7 +325,7 @@ The table below lists the structural containers, documenting the name, default c
         .unwrap();
 
     assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
-    assert_eq!(mi.item.context().as_ref(), "listing");
+    assert_eq!(mi.item.raw_context().as_ref(), "listing");
 
     verifies!(
         r#"
@@ -342,7 +342,7 @@ The table below lists the structural containers, documenting the name, default c
         .unwrap();
 
     assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
-    assert_eq!(mi.item.context().as_ref(), "literal");
+    assert_eq!(mi.item.raw_context().as_ref(), "literal");
 
     verifies!(
         r#"
@@ -359,7 +359,7 @@ The table below lists the structural containers, documenting the name, default c
         .unwrap();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert_eq!(mi.item.context().as_ref(), "open");
+    assert_eq!(mi.item.raw_context().as_ref(), "open");
 
     verifies!(
         r#"
@@ -376,7 +376,7 @@ The table below lists the structural containers, documenting the name, default c
         .unwrap();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert_eq!(mi.item.context().as_ref(), "sidebar");
+    assert_eq!(mi.item.raw_context().as_ref(), "sidebar");
 
     to_do_verifies!(
         r#"
@@ -410,7 +410,7 @@ The table below lists the structural containers, documenting the name, default c
         .unwrap();
 
     assert_eq!(mi.item.content_model(), ContentModel::Raw);
-    assert_eq!(mi.item.context().as_ref(), "pass");
+    assert_eq!(mi.item.raw_context().as_ref(), "pass");
 
     verifies!(
         r#"
@@ -428,7 +428,7 @@ The table below lists the structural containers, documenting the name, default c
         .unwrap();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert_eq!(mi.item.context().as_ref(), "quote");
+    assert_eq!(mi.item.raw_context().as_ref(), "quote");
 
     non_normative!(
         r#"

--- a/parser/src/tests/asciidoc_lang/blocks/index.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/index.rs
@@ -102,7 +102,7 @@ You can think of the context as the block's type.
             .unwrap_if_no_warnings()
             .unwrap();
 
-        assert_eq!(mi.item.context().deref(), "section");
+        assert_eq!(mi.item.raw_context().deref(), "section");
     }
 
     #[test]
@@ -363,7 +363,7 @@ The context of the block is still the same, but it has additional metadata to in
         .unwrap_if_no_warnings()
         .unwrap();
 
-        assert_eq!(mi.item.context().as_ref(), "listing");
+        assert_eq!(mi.item.raw_context().as_ref(), "listing");
         // assert_eq!(mi.item.style(), "source");
         // assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
     }

--- a/parser/src/tests/blocks/block/compound_delimited.rs
+++ b/parser/src/tests/blocks/block/compound_delimited.rs
@@ -205,7 +205,7 @@ mod example {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "example");
+        assert_eq!(mi.item.raw_context().as_ref(), "example");
         assert!(mi.item.nested_blocks().next().is_none());
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
@@ -277,7 +277,7 @@ mod example {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "example");
+        assert_eq!(mi.item.raw_context().as_ref(), "example");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -396,7 +396,7 @@ mod example {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "example");
+        assert_eq!(mi.item.raw_context().as_ref(), "example");
 
         assert_eq!(
             mi.item.title().unwrap(),
@@ -531,7 +531,7 @@ mod example {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "example");
+        assert_eq!(mi.item.raw_context().as_ref(), "example");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -637,7 +637,7 @@ mod open {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "open");
+        assert_eq!(mi.item.raw_context().as_ref(), "open");
         assert!(mi.item.nested_blocks().next().is_none());
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
@@ -709,7 +709,7 @@ mod open {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "open");
+        assert_eq!(mi.item.raw_context().as_ref(), "open");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -845,7 +845,7 @@ mod open {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "open");
+        assert_eq!(mi.item.raw_context().as_ref(), "open");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -962,7 +962,7 @@ mod sidebar {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "sidebar");
+        assert_eq!(mi.item.raw_context().as_ref(), "sidebar");
         assert!(mi.item.nested_blocks().next().is_none());
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
@@ -1034,7 +1034,7 @@ mod sidebar {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "sidebar");
+        assert_eq!(mi.item.raw_context().as_ref(), "sidebar");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -1159,7 +1159,7 @@ mod sidebar {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "sidebar");
+        assert_eq!(mi.item.raw_context().as_ref(), "sidebar");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -1265,7 +1265,7 @@ mod quote {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "quote");
+        assert_eq!(mi.item.raw_context().as_ref(), "quote");
         assert!(mi.item.nested_blocks().next().is_none());
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
@@ -1337,7 +1337,7 @@ mod quote {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "quote");
+        assert_eq!(mi.item.raw_context().as_ref(), "quote");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -1462,7 +1462,7 @@ mod quote {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "quote");
+        assert_eq!(mi.item.raw_context().as_ref(), "quote");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 

--- a/parser/src/tests/blocks/block/macro.rs
+++ b/parser/src/tests/blocks/block/macro.rs
@@ -304,7 +304,7 @@ fn simplest_block_macro() {
     );
 
     assert_eq!(mi.item.content_model(), ContentModel::Simple);
-    assert_eq!(mi.item.context().deref(), "paragraph");
+    assert_eq!(mi.item.raw_context().deref(), "paragraph");
     assert_eq!(mi.item.nested_blocks().next(), None);
     assert!(mi.item.title().is_none());
     assert!(mi.item.attrlist().is_none());

--- a/parser/src/tests/blocks/block/mod.rs
+++ b/parser/src/tests/blocks/block/mod.rs
@@ -43,7 +43,7 @@ mod error_cases {
         .unwrap();
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().deref(), "section");
+        assert_eq!(mi.item.raw_context().deref(), "section");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -152,7 +152,7 @@ mod error_cases {
         .unwrap();
 
         assert_eq!(mi.item.content_model(), ContentModel::Simple);
-        assert_eq!(mi.item.context().deref(), "paragraph");
+        assert_eq!(mi.item.raw_context().deref(), "paragraph");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -214,7 +214,7 @@ mod error_cases {
         dbg!(&mi);
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().deref(), "section");
+        assert_eq!(mi.item.raw_context().deref(), "section");
         assert!(mi.item.title().is_none());
 
         assert_eq!(

--- a/parser/src/tests/blocks/block/raw_delimited.rs
+++ b/parser/src/tests/blocks/block/raw_delimited.rs
@@ -209,7 +209,7 @@ mod comment {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.context().as_ref(), "comment");
+        assert_eq!(mi.item.raw_context().as_ref(), "comment");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
     }
@@ -256,7 +256,7 @@ mod comment {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.context().as_ref(), "comment");
+        assert_eq!(mi.item.raw_context().as_ref(), "comment");
 
         assert_eq!(
             mi.item.title().unwrap(),
@@ -308,7 +308,7 @@ mod comment {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.context().as_ref(), "comment");
+        assert_eq!(mi.item.raw_context().as_ref(), "comment");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
     }
@@ -356,7 +356,7 @@ mod comment {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.context().as_ref(), "comment");
+        assert_eq!(mi.item.raw_context().as_ref(), "comment");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
     }
@@ -399,7 +399,7 @@ mod listing {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
-        assert_eq!(mi.item.context().as_ref(), "listing");
+        assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
     }
@@ -441,7 +441,7 @@ mod listing {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
-        assert_eq!(mi.item.context().as_ref(), "listing");
+        assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert_eq!(mi.item.nested_blocks().next(), None);
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
@@ -499,7 +499,7 @@ mod listing {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
-        assert_eq!(mi.item.context().as_ref(), "listing");
+        assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert_eq!(mi.item.nested_blocks().next(), None);
 
         assert_eq!(
@@ -568,7 +568,7 @@ mod listing {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
-        assert_eq!(mi.item.context().as_ref(), "listing");
+        assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert_eq!(mi.item.nested_blocks().next(), None);
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
@@ -622,7 +622,7 @@ mod pass {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.context().as_ref(), "pass");
+        assert_eq!(mi.item.raw_context().as_ref(), "pass");
         assert_eq!(mi.item.nested_blocks().next(), None);
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
@@ -675,7 +675,7 @@ mod pass {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.context().as_ref(), "pass");
+        assert_eq!(mi.item.raw_context().as_ref(), "pass");
         assert_eq!(mi.item.nested_blocks().next(), None);
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
@@ -733,7 +733,7 @@ mod pass {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.context().as_ref(), "pass");
+        assert_eq!(mi.item.raw_context().as_ref(), "pass");
         assert_eq!(mi.item.nested_blocks().next(), None);
 
         assert_eq!(
@@ -802,7 +802,7 @@ mod pass {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.context().as_ref(), "pass");
+        assert_eq!(mi.item.raw_context().as_ref(), "pass");
         assert_eq!(mi.item.nested_blocks().next(), None);
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());

--- a/parser/src/tests/blocks/block/section.rs
+++ b/parser/src/tests/blocks/block/section.rs
@@ -69,7 +69,7 @@ fn simplest_section_block() {
         .unwrap();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert_eq!(mi.item.context().deref(), "section");
+    assert_eq!(mi.item.raw_context().deref(), "section");
     assert!(mi.item.title().is_none());
     assert!(mi.item.attrlist().is_none());
 
@@ -115,7 +115,7 @@ fn has_child_block() {
         .unwrap();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert_eq!(mi.item.context().deref(), "section");
+    assert_eq!(mi.item.raw_context().deref(), "section");
     assert!(mi.item.title().is_none());
     assert!(mi.item.attrlist().is_none());
 
@@ -208,7 +208,7 @@ fn title() {
         .unwrap();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert_eq!(mi.item.context().deref(), "section");
+    assert_eq!(mi.item.raw_context().deref(), "section");
 
     assert_eq!(
         mi.item,

--- a/parser/src/tests/blocks/block/simple.rs
+++ b/parser/src/tests/blocks/block/simple.rs
@@ -75,7 +75,7 @@ fn single_line() {
     );
 
     assert_eq!(mi.item.content_model(), ContentModel::Simple);
-    assert_eq!(mi.item.context().deref(), "paragraph");
+    assert_eq!(mi.item.raw_context().deref(), "paragraph");
     assert_eq!(mi.item.nested_blocks().next(), None);
     assert!(mi.item.title().is_none());
     assert!(mi.item.attrlist().is_none());

--- a/parser/src/tests/blocks/compound_delimited.rs
+++ b/parser/src/tests/blocks/compound_delimited.rs
@@ -252,7 +252,7 @@ mod example {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "example");
+        assert_eq!(mi.item.raw_context().as_ref(), "example");
         assert!(mi.item.nested_blocks().next().is_none());
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
@@ -315,7 +315,7 @@ mod example {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "example");
+        assert_eq!(mi.item.raw_context().as_ref(), "example");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -433,7 +433,7 @@ mod example {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "example");
+        assert_eq!(mi.item.raw_context().as_ref(), "example");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -560,7 +560,7 @@ mod open {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "open");
+        assert_eq!(mi.item.raw_context().as_ref(), "open");
         assert!(mi.item.nested_blocks().next().is_none());
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
@@ -623,7 +623,7 @@ mod open {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "open");
+        assert_eq!(mi.item.raw_context().as_ref(), "open");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -752,7 +752,7 @@ mod open {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "open");
+        assert_eq!(mi.item.raw_context().as_ref(), "open");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -858,7 +858,7 @@ mod sidebar {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "sidebar");
+        assert_eq!(mi.item.raw_context().as_ref(), "sidebar");
         assert!(mi.item.nested_blocks().next().is_none());
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
@@ -921,7 +921,7 @@ mod sidebar {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "sidebar");
+        assert_eq!(mi.item.raw_context().as_ref(), "sidebar");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -1039,7 +1039,7 @@ mod sidebar {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "sidebar");
+        assert_eq!(mi.item.raw_context().as_ref(), "sidebar");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -1178,7 +1178,7 @@ mod quote {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "quote");
+        assert_eq!(mi.item.raw_context().as_ref(), "quote");
         assert!(mi.item.nested_blocks().next().is_none());
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
@@ -1241,7 +1241,7 @@ mod quote {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "quote");
+        assert_eq!(mi.item.raw_context().as_ref(), "quote");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -1359,7 +1359,7 @@ mod quote {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert_eq!(mi.item.context().as_ref(), "quote");
+        assert_eq!(mi.item.raw_context().as_ref(), "quote");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 

--- a/parser/src/tests/blocks/macro.rs
+++ b/parser/src/tests/blocks/macro.rs
@@ -127,7 +127,7 @@ fn simplest_block_macro() {
         .unwrap();
 
     assert_eq!(mi.item.content_model(), ContentModel::Simple);
-    assert_eq!(mi.item.context().deref(), "paragraph");
+    assert_eq!(mi.item.raw_context().deref(), "paragraph");
     assert!(mi.item.title().is_none());
     assert!(mi.item.attrlist().is_none());
 

--- a/parser/src/tests/blocks/raw_delimited.rs
+++ b/parser/src/tests/blocks/raw_delimited.rs
@@ -167,7 +167,7 @@ mod comment {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.context().as_ref(), "comment");
+        assert_eq!(mi.item.raw_context().as_ref(), "comment");
         assert!(mi.item.lines().next().is_none());
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
@@ -210,7 +210,7 @@ mod comment {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.context().as_ref(), "comment");
+        assert_eq!(mi.item.raw_context().as_ref(), "comment");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -282,7 +282,7 @@ mod comment {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.context().as_ref(), "comment");
+        assert_eq!(mi.item.raw_context().as_ref(), "comment");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -367,7 +367,7 @@ mod listing {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
-        assert_eq!(mi.item.context().as_ref(), "listing");
+        assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert!(mi.item.lines().next().is_none());
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
@@ -410,7 +410,7 @@ mod listing {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
-        assert_eq!(mi.item.context().as_ref(), "listing");
+        assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -482,7 +482,7 @@ mod listing {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
-        assert_eq!(mi.item.context().as_ref(), "listing");
+        assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -587,7 +587,7 @@ mod pass {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.context().as_ref(), "pass");
+        assert_eq!(mi.item.raw_context().as_ref(), "pass");
         assert!(mi.item.lines().next().is_none());
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
@@ -630,7 +630,7 @@ mod pass {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.context().as_ref(), "pass");
+        assert_eq!(mi.item.raw_context().as_ref(), "pass");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 
@@ -702,7 +702,7 @@ mod pass {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.context().as_ref(), "pass");
+        assert_eq!(mi.item.raw_context().as_ref(), "pass");
         assert!(mi.item.title().is_none());
         assert!(mi.item.attrlist().is_none());
 

--- a/parser/src/tests/blocks/section.rs
+++ b/parser/src/tests/blocks/section.rs
@@ -49,7 +49,7 @@ fn simplest_section_block() {
         .unwrap_if_no_warnings();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert_eq!(mi.item.context().deref(), "section");
+    assert_eq!(mi.item.raw_context().deref(), "section");
     assert!(mi.item.title().is_none());
     assert!(mi.item.attrlist().is_none());
 
@@ -93,7 +93,7 @@ fn has_child_block() {
         .unwrap_if_no_warnings();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert_eq!(mi.item.context().deref(), "section");
+    assert_eq!(mi.item.raw_context().deref(), "section");
     assert!(mi.item.title().is_none());
     assert!(mi.item.attrlist().is_none());
 
@@ -154,7 +154,7 @@ fn has_macro_block_with_extra_blank_line() {
     .unwrap_if_no_warnings();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert_eq!(mi.item.context().deref(), "section");
+    assert_eq!(mi.item.raw_context().deref(), "section");
     assert!(mi.item.title().is_none());
     assert!(mi.item.attrlist().is_none());
 
@@ -295,7 +295,7 @@ fn has_child_block_with_errors() {
     let mi = maw.item.clone();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert_eq!(mi.item.context().deref(), "section");
+    assert_eq!(mi.item.raw_context().deref(), "section");
     assert!(mi.item.title().is_none());
     assert!(mi.item.attrlist().is_none());
 
@@ -448,7 +448,7 @@ fn dont_stop_at_child_section() {
     .unwrap_if_no_warnings();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert_eq!(mi.item.context().deref(), "section");
+    assert_eq!(mi.item.raw_context().deref(), "section");
     assert!(mi.item.title().is_none());
     assert!(mi.item.attrlist().is_none());
 
@@ -544,7 +544,7 @@ fn stop_at_peer_section() {
     .unwrap_if_no_warnings();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert_eq!(mi.item.context().deref(), "section");
+    assert_eq!(mi.item.raw_context().deref(), "section");
     assert!(mi.item.title().is_none());
     assert!(mi.item.attrlist().is_none());
 
@@ -606,7 +606,7 @@ fn stop_at_ancestor_section() {
     .unwrap_if_no_warnings();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert_eq!(mi.item.context().deref(), "section");
+    assert_eq!(mi.item.raw_context().deref(), "section");
     assert!(mi.item.title().is_none());
     assert!(mi.item.attrlist().is_none());
 

--- a/parser/src/tests/blocks/simple.rs
+++ b/parser/src/tests/blocks/simple.rs
@@ -50,7 +50,7 @@ fn single_line() {
     );
 
     assert_eq!(mi.item.content_model(), ContentModel::Simple);
-    assert_eq!(mi.item.context().deref(), "paragraph");
+    assert_eq!(mi.item.raw_context().deref(), "paragraph");
     assert!(mi.item.title().is_none());
     assert!(mi.item.attrlist().is_none());
 

--- a/parser/src/tests/document/document.rs
+++ b/parser/src/tests/document/document.rs
@@ -29,7 +29,7 @@ fn empty_source() {
     let doc = Document::parse("");
 
     assert_eq!(doc.content_model(), ContentModel::Compound);
-    assert_eq!(doc.context().deref(), "document");
+    assert_eq!(doc.raw_context().deref(), "document");
     assert!(doc.title().is_none());
     assert!(doc.attrlist().is_none());
 

--- a/parser/src/tests/fixtures/blocks/compound_delimited.rs
+++ b/parser/src/tests/fixtures/blocks/compound_delimited.rs
@@ -53,7 +53,7 @@ fn fixture_eq_observed(
         }
     }
 
-    if fixture.context != observed.context().as_ref() {
+    if fixture.context != observed.raw_context().as_ref() {
         return false;
     }
 

--- a/parser/src/tests/fixtures/blocks/raw_delimited.rs
+++ b/parser/src/tests/fixtures/blocks/raw_delimited.rs
@@ -56,7 +56,7 @@ fn fixture_eq_observed(fixture: &TRawDelimitedBlock, observed: &RawDelimitedBloc
         return false;
     }
 
-    if fixture.context != observed.context().as_ref() {
+    if fixture.context != observed.raw_context().as_ref() {
         return false;
     }
 


### PR DESCRIPTION
This function does not account for the possibility that a block's context can be modified by certain block styles.