### PR TITLE
fix: User-defined attribute names may start with a digit

### DIFF
--- a/parser/src/span/primitives.rs
+++ b/parser/src/span/primitives.rs
@@ -75,7 +75,7 @@ impl<'src> Span<'src> {
         let mut chars = self.data.char_indices();
 
         let (_, c) = chars.next()?;
-        if !c.is_ascii_alphabetic() && c != '_' {
+        if !c.is_ascii_alphanumeric() && c != '_' {
             return None;
         }
 

--- a/parser/src/tests/asciidoc_lang/attributes/mod.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/mod.rs
@@ -2,6 +2,7 @@ mod attribute_entries;
 mod document_attributes;
 mod element_attributes;
 mod id;
+mod names_and_values;
 mod options;
 mod positional_and_named_attributes;
 mod role;

--- a/parser/src/tests/asciidoc_lang/attributes/names_and_values.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/names_and_values.rs
@@ -1,0 +1,293 @@
+use crate::tests::sdd::{non_normative, track_file};
+
+track_file!("docs/modules/attributes/pages/names-and-values.adoc");
+// Tracking commit 636ceedc, current as of 2025-04-12.
+
+non_normative!(
+    r#"
+= Attribute Entry Names and Values
+
+== Valid built-in names
+
+Built-in attribute names are reserved and can't be re-purposed for user-defined attribute names.
+The built-in attribute names are listed in the xref:document-attributes-ref.adoc[] and xref:character-replacement-ref.adoc[].
+
+"#
+);
+
+mod valid_user_defined_names {
+    use crate::{
+        document::{Attribute, AttributeValue},
+        tests::{
+            fixtures::{
+                document::{TAttribute, TRawAttributeValue},
+                TSpan,
+            },
+            sdd::verifies,
+        },
+        Span,
+    };
+
+    verifies!(
+        r#"
+[#user-defined]
+== Valid user-defined names
+
+User-defined attribute names must:
+
+* be at least one character long,
+* begin with a word character (a-z, 0-9, or _), and
+* only contain word characters and hyphens (-).
+
+A user-defined attribute name cannot contain dots (.) or spaces.
+Although uppercase characters are permitted in an attribute name, the name is converted to lowercase before being stored.
+For example, `URL-REPO` and `URL-Repo` are treated as `url-repo` when a document is loaded or converted.
+A best practice is to only use lowercase letters in the name and avoid starting the name with a number.
+
+"#
+    );
+
+    #[test]
+    fn at_least_one_character_long() {
+        assert!(Attribute::parse(Span::new("::")).is_none());
+
+        let mi = Attribute::parse(Span::new(":a:")).unwrap();
+
+        assert_eq!(
+            mi.item,
+            TAttribute {
+                name: TSpan {
+                    data: "a",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+                value: TRawAttributeValue::Set,
+                source: TSpan {
+                    data: ":a:",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            }
+        );
+
+        assert_eq!(mi.item.value(), AttributeValue::Set);
+    }
+
+    #[test]
+    fn begin_with_word_character() {
+        assert!(Attribute::parse(Span::new(":-abc:")).is_none());
+
+        let mi = Attribute::parse(Span::new(":9abc:")).unwrap();
+
+        assert_eq!(
+            mi.item,
+            TAttribute {
+                name: TSpan {
+                    data: "9abc",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+                value: TRawAttributeValue::Set,
+                source: TSpan {
+                    data: ":9abc:",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            }
+        );
+
+        assert_eq!(mi.item.value(), AttributeValue::Set);
+
+        let mi = Attribute::parse(Span::new(":_abc:")).unwrap();
+
+        assert_eq!(
+            mi.item,
+            TAttribute {
+                name: TSpan {
+                    data: "_abc",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+                value: TRawAttributeValue::Set,
+                source: TSpan {
+                    data: ":_abc:",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            }
+        );
+
+        assert_eq!(mi.item.value(), AttributeValue::Set);
+    }
+
+    #[test]
+    fn only_contain_word_characters_and_hyphens() {
+        assert!(Attribute::parse(Span::new(":abc def:")).is_none());
+        assert!(Attribute::parse(Span::new(":abc.def:")).is_none());
+
+        let mi = Attribute::parse(Span::new(":9ab-cdef:")).unwrap();
+
+        assert_eq!(
+            mi.item,
+            TAttribute {
+                name: TSpan {
+                    data: "9ab-cdef",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+                value: TRawAttributeValue::Set,
+                source: TSpan {
+                    data: ":9ab-cdef:",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            }
+        );
+
+        assert_eq!(mi.item.value(), AttributeValue::Set);
+    }
+
+    #[test]
+    fn may_contain_uppercase() {
+        // IMPORTANT: We've defined the lower-case normalization as out of scope for
+        // the parser crate for now.
+        let mi = Attribute::parse(Span::new(":URL-REPO:")).unwrap();
+
+        assert_eq!(
+            mi.item,
+            TAttribute {
+                name: TSpan {
+                    data: "URL-REPO",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+                value: TRawAttributeValue::Set,
+                source: TSpan {
+                    data: ":URL-REPO:",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            }
+        );
+
+        assert_eq!(mi.item.value(), AttributeValue::Set);
+
+        let mi = Attribute::parse(Span::new(":URL-REPO:")).unwrap();
+
+        assert_eq!(
+            mi.item,
+            TAttribute {
+                name: TSpan {
+                    data: "URL-REPO",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+                value: TRawAttributeValue::Set,
+                source: TSpan {
+                    data: ":URL-REPO:",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            }
+        );
+
+        assert_eq!(mi.item.value(), AttributeValue::Set);
+    }
+}
+
+// TO DO (https://github.com/scouten/asciidoc-parser/issues/219): Determine how or whether to handle default/built-in document attributes values in parser.
+//
+// For now, assuming that default and built-in values are not in scope for
+// parser, but more likely part of an upstream renderer crate. For that reason,
+// treating these sections as non-normative.
+non_normative!(
+    r#"
+== Attribute value types and assignment methods
+
+Depending on the attribute, its value may be an empty string, an integer such as 5 or 2, or a string of characters like your name or a URL.
+Attributes that accept string values may include references to other attributes and inline macros.
+Values can't contain complex, multi-line block elements such as tables or sidebars.
+
+An attribute's value may be assigned by default when the value is left empty in an attribute entry or the value may be assigned explicitly by the user.
+The type of value an attribute accepts and whether it uses a default value, has multiple built-in values, accepts a user-defined value, or requires a value to be explicitly assigned depends on the attribute.
+
+=== Built-in values
+
+Many built-in attributes have one or more built-in values.
+One of these values may be designated as the attribute's default value.
+The AsciiDoc processor will fall back to this default value if you set the attribute but leave the value empty.
+Additionally, the processor automatically sets numerous built-in attributes at processing time and assigns them their default values unless you explicitly unset the attribute or assign it another value.
+For instance, the processor automatically sets all of the xref:character-replacement-ref.adoc[character replacement attributes].
+
+If you want to use the non-default value of a built-in attribute, you need to set it and assign it an alternative value.
+
+=== Empty string values
+
+The value for built-in boolean attributes is always left empty in an attribute entry since these attributes only turn on or turn off a feature.
+During processing, the AsciiDoc processor assigns any activated boolean attributes an _empty string_ value.
+
+=== Explicit values
+
+You must explicitly assign a value to an attribute when:
+
+* it doesn't have a default value,
+* you want to override the default value, or
+* it's a user-defined attribute.
+
+The type of explicit value a built-in attribute accepts depends on the attribute.
+User-defined attributes accept string values.
+Long explicit values can be xref:wrap-values.adoc[wrapped].
+
+////
+For example,
+
+[source]
+----
+:keywords: content engineering, branch collisions, 42, {meta-topics}, FTW <1> <2>
+----
+<1> The xref:header:metadata.adoc#keywords[built-in keywords attribute] doesn't have a default value, so you must explicitly assign it a value when you set it.
+<2> Attributes that accept string values may include <<attribute-reference,references to other attributes>>, e.g, `+{meta-topics}+`.
+See the xref:document-attributes-ref.adoc[Document Attributes Reference] for information about each built-in attribute's accepted value types.
+
+You must explicitly assign a value to a built-in attribute when you want to override its default value.
+For instance, when a section in a document is assigned the appendix style, that section title will be automatically prefixed with a label and a letter that signifies that section's order, e.g., Appendix A, by default.
+Let's override the default letter ordering and use a number instead.
+
+[source]
+----
+:appendix-number: 1
+----
+
+Now the first section assigned the appendix style will be prefixed Appendix 1, the second, Appendix 2, and so forth.
+
+=== User-defined values
+
+The value field of a built-in attribute is left empty if it's a boolean attribute.
+The value can also be left empty if the attribute has an inferred default value and that's the value you want to use.
+
+When you're setting a built-in attribute, the value may be _empty string_ if it's a boolean attribute, a built-in value, or a user-defined value.
+However, if the document attribute is built-in, the value may be _empty
+Depending on the type of document attribute--built-in or user-defined--the value may be _empty string_,
+Some attributes may not have a value explicitly assigned to them.
+When a value is not specified, the value _empty string_ is assumed.
+An empty value is often used to set a boolean attribute (thus making an empty value implicitly true).
+
+* it's a built-in attribute doesn't accept any explicitly set values because it only turns on a behavior,
+* it's a built-in attribute that uses a default value when its value is left empty, or
+* the attribute was set, but not assigned a value by accident.
+In this case, it will use its default value if applicable or output an error message when the document is processed.
+////
+"#
+);

--- a/parser/src/tests/span/primitives.rs
+++ b/parser/src/tests/span/primitives.rs
@@ -364,7 +364,27 @@ mod take_user_attr_name {
     #[test]
     fn numeric() {
         let span = Span::new("94!");
-        assert!(span.take_user_attr_name().is_none());
+        let mi = span.take_user_attr_name().unwrap();
+
+        assert_eq!(
+            mi.item,
+            TSpan {
+                data: "94",
+                line: 1,
+                col: 1,
+                offset: 0
+            }
+        );
+
+        assert_eq!(
+            mi.after,
+            TSpan {
+                data: "!",
+                line: 1,
+                col: 3,
+                offset: 2
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
Also: Add spec coverage for names-and-values.adoc.