### PR TITLE
feat!: Revert rename `AttributeValue` to `InterpretedValue` (#229)

### DIFF
--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -273,8 +273,8 @@ impl<'src> ElementAttribute<'src> {
     }
 
     //-/ Return the attribute's interpolated value.
-    // pub fn value(&'src self) -> InterpretedValue<'src> {
-    //     self.value.as_interpreted_value()
+    // pub fn value(&'src self) -> AttributeValue<'src> {
+    //     self.value.as_attribute_value()
     // }
 }
 

--- a/parser/src/document/attribute.rs
+++ b/parser/src/document/attribute.rs
@@ -67,8 +67,8 @@ impl<'src> Attribute<'src> {
     }
 
     /// Return the attribute's interpolated value.
-    pub fn value(&'src self) -> InterpretedValue<'src> {
-        self.value.as_interpreted_value()
+    pub fn value(&'src self) -> AttributeValue<'src> {
+        self.value.as_attribute_value()
     }
 }
 
@@ -96,9 +96,9 @@ pub enum RawAttributeValue<'src> {
 }
 
 impl<'src> RawAttributeValue<'src> {
-    /// Convert this to an [`InterpretedValue`], resolving any interpolation
+    /// Convert this to an [`AttributeValue`], resolving any interpolation
     /// necessary if the value contains a textual value.
-    pub fn as_interpreted_value(&self) -> InterpretedValue<'src> {
+    pub fn as_attribute_value(&self) -> AttributeValue<'src> {
         match self {
             Self::Value(span) => {
                 let data = span.data();
@@ -133,14 +133,14 @@ impl<'src> RawAttributeValue<'src> {
                         .collect();
 
                     let value = value.join("");
-                    InterpretedValue::Value(CowStr::from(value))
+                    AttributeValue::Value(CowStr::from(value))
                 } else {
-                    InterpretedValue::Value(CowStr::Borrowed(data))
+                    AttributeValue::Value(CowStr::Borrowed(data))
                 }
             }
 
-            Self::Set => InterpretedValue::Set,
-            Self::Unset => InterpretedValue::Unset,
+            Self::Set => AttributeValue::Set,
+            Self::Unset => AttributeValue::Unset,
         }
     }
 }
@@ -151,7 +151,7 @@ impl<'src> RawAttributeValue<'src> {
 /// have any continuation markers resolved, but will no longer
 /// contain a reference to the [`Span`] that contains the value.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum InterpretedValue<'src> {
+pub enum AttributeValue<'src> {
     /// A custom value with all necessary interpolations applied.
     Value(CowStr<'src>),
 

--- a/parser/src/document/mod.rs
+++ b/parser/src/document/mod.rs
@@ -1,7 +1,7 @@
 //! Describes the top-level document structure.
 
 mod attribute;
-pub use attribute::{Attribute, InterpretedValue, RawAttributeValue};
+pub use attribute::{Attribute, AttributeValue, RawAttributeValue};
 
 mod document;
 pub use document::Document;

--- a/parser/src/tests/asciidoc_lang/attributes/attribute_entries.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/attribute_entries.rs
@@ -1,5 +1,5 @@
 use crate::{
-    document::{Attribute, InterpretedValue},
+    document::{Attribute, AttributeValue},
     tests::{
         fixtures::{
             document::{TAttribute, TRawAttributeValue},
@@ -68,7 +68,7 @@ This [.term]*sets* -- that is, turns on -- the document attribute so you can use
         }
     );
 
-    assert_eq!(mi.item.value(), InterpretedValue::Set);
+    assert_eq!(mi.item.value(), AttributeValue::Set);
 }
 
 #[test]
@@ -114,7 +114,7 @@ At the end of the value, press kbd:[Enter].
         }
     );
 
-    if let InterpretedValue::Value(value) = mi.item.value() {
+    if let AttributeValue::Value(value) = mi.item.value() {
         assert_eq!(value.as_ref(), "value of the attribute");
     } else {
         panic!("unexpected value type {v:?}", v = mi.item.value());

--- a/parser/src/tests/asciidoc_lang/attributes/custom_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/custom_attributes.rs
@@ -2,7 +2,7 @@ use crate::{
     document::Attribute,
     tests::{
         fixtures::{
-            document::{TAttribute, TInterpretedValue, TRawAttributeValue},
+            document::{TAttribute, TAttributeValue, TRawAttributeValue},
             TSpan,
         },
         sdd::{non_normative, track_file, verifies},
@@ -26,7 +26,7 @@ When you find yourself typing the same text repeatedly, or text that often needs
 
 mod user_defined_names {
     use crate::{
-        document::{Attribute, InterpretedValue},
+        document::{Attribute, AttributeValue},
         tests::{
             fixtures::{
                 document::{TAttribute, TRawAttributeValue},
@@ -84,7 +84,7 @@ A best practice is to only use lowercase letters in the name and avoid starting 
             }
         );
 
-        assert_eq!(mi.item.value(), InterpretedValue::Set);
+        assert_eq!(mi.item.value(), AttributeValue::Set);
     }
 
     #[test]
@@ -112,7 +112,7 @@ A best practice is to only use lowercase letters in the name and avoid starting 
             }
         );
 
-        assert_eq!(mi.item.value(), InterpretedValue::Set);
+        assert_eq!(mi.item.value(), AttributeValue::Set);
 
         let mi = Attribute::parse(Span::new(":_abc:")).unwrap();
 
@@ -135,7 +135,7 @@ A best practice is to only use lowercase letters in the name and avoid starting 
             }
         );
 
-        assert_eq!(mi.item.value(), InterpretedValue::Set);
+        assert_eq!(mi.item.value(), AttributeValue::Set);
     }
 
     #[test]
@@ -164,7 +164,7 @@ A best practice is to only use lowercase letters in the name and avoid starting 
             }
         );
 
-        assert_eq!(mi.item.value(), InterpretedValue::Set);
+        assert_eq!(mi.item.value(), AttributeValue::Set);
     }
 
     #[test]
@@ -192,7 +192,7 @@ A best practice is to only use lowercase letters in the name and avoid starting 
             }
         );
 
-        assert_eq!(mi.item.value(), InterpretedValue::Set);
+        assert_eq!(mi.item.value(), AttributeValue::Set);
 
         let mi = Attribute::parse(Span::new(":Url:")).unwrap();
 
@@ -215,7 +215,7 @@ A best practice is to only use lowercase letters in the name and avoid starting 
             }
         );
 
-        assert_eq!(mi.item.value(), InterpretedValue::Set);
+        assert_eq!(mi.item.value(), AttributeValue::Set);
     }
 }
 
@@ -276,7 +276,7 @@ Now, you can xref:reference-attributes.adoc#reference-custom[reference these att
         },
     });
 
-    assert_eq!(mi.item.value(), TInterpretedValue::Value("Don't pet the wild Wolpertingers. If you let them into your system, we're not responsible for any loss of hair, chocolate, or purple socks."));
+    assert_eq!(mi.item.value(), TAttributeValue::Value("Don't pet the wild Wolpertingers. If you let them into your system, we're not responsible for any loss of hair, chocolate, or purple socks."));
 
     let mi = Attribute::parse(Span::new(
         ":url-repo: https://github.com/asciidoctor/asciidoctor",
@@ -309,6 +309,6 @@ Now, you can xref:reference-attributes.adoc#reference-custom[reference these att
 
     assert_eq!(
         mi.item.value(),
-        TInterpretedValue::Value("https://github.com/asciidoctor/asciidoctor")
+        TAttributeValue::Value("https://github.com/asciidoctor/asciidoctor")
     );
 }

--- a/parser/src/tests/asciidoc_lang/attributes/names_and_values.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/names_and_values.rs
@@ -17,7 +17,7 @@ The built-in attribute names are listed in the xref:document-attributes-ref.adoc
 
 mod valid_user_defined_names {
     use crate::{
-        document::{Attribute, InterpretedValue},
+        document::{Attribute, AttributeValue},
         tests::{
             fixtures::{
                 document::{TAttribute, TRawAttributeValue},
@@ -72,7 +72,7 @@ A best practice is to only use lowercase letters in the name and avoid starting 
             }
         );
 
-        assert_eq!(mi.item.value(), InterpretedValue::Set);
+        assert_eq!(mi.item.value(), AttributeValue::Set);
     }
 
     #[test]
@@ -100,7 +100,7 @@ A best practice is to only use lowercase letters in the name and avoid starting 
             }
         );
 
-        assert_eq!(mi.item.value(), InterpretedValue::Set);
+        assert_eq!(mi.item.value(), AttributeValue::Set);
 
         let mi = Attribute::parse(Span::new(":_abc:")).unwrap();
 
@@ -123,7 +123,7 @@ A best practice is to only use lowercase letters in the name and avoid starting 
             }
         );
 
-        assert_eq!(mi.item.value(), InterpretedValue::Set);
+        assert_eq!(mi.item.value(), AttributeValue::Set);
     }
 
     #[test]
@@ -152,7 +152,7 @@ A best practice is to only use lowercase letters in the name and avoid starting 
             }
         );
 
-        assert_eq!(mi.item.value(), InterpretedValue::Set);
+        assert_eq!(mi.item.value(), AttributeValue::Set);
     }
 
     #[test]
@@ -180,7 +180,7 @@ A best practice is to only use lowercase letters in the name and avoid starting 
             }
         );
 
-        assert_eq!(mi.item.value(), InterpretedValue::Set);
+        assert_eq!(mi.item.value(), AttributeValue::Set);
 
         let mi = Attribute::parse(Span::new(":URL-REPO:")).unwrap();
 
@@ -203,7 +203,7 @@ A best practice is to only use lowercase letters in the name and avoid starting 
             }
         );
 
-        assert_eq!(mi.item.value(), InterpretedValue::Set);
+        assert_eq!(mi.item.value(), AttributeValue::Set);
     }
 }
 

--- a/parser/src/tests/asciidoc_lang/attributes/wrap_values.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/wrap_values.rs
@@ -1,5 +1,5 @@
 use crate::{
-    document::{Attribute, InterpretedValue},
+    document::{Attribute, AttributeValue},
     strings::CowStr,
     tests::{
         fixtures::{
@@ -78,7 +78,7 @@ If the line continuation is missing, the processor will assume it has found the 
         },
     });
 
-    assert_eq!(mi.item.value(), InterpretedValue::Value(
+    assert_eq!(mi.item.value(), AttributeValue::Value(
         CowStr::Boxed("If you have a very long line of text that you need to substitute regularly in a document, you may find it easier to split the value neatly in the header so it remains readable to folks looking at the AsciiDoc source.".to_string().into_boxed_str())
         ),
     );
@@ -140,7 +140,7 @@ This syntax ensures that the newlines are preserved in the output as hard line b
 
     assert_eq!(
         mi.item.value(),
-        InterpretedValue::Value(CowStr::Boxed(
+        AttributeValue::Value(CowStr::Boxed(
             "Write your docs in text,\nAsciiDoc makes it easy,\nNow get back to work!"
                 .to_string()
                 .into_boxed_str()

--- a/parser/src/tests/asciidoc_lang/root/document_structure.rs
+++ b/parser/src/tests/asciidoc_lang/root/document_structure.rs
@@ -299,7 +299,7 @@ mod lines {
         document::Attribute,
         tests::{
             fixtures::{
-                document::{TAttribute, TInterpretedValue, TRawAttributeValue},
+                document::{TAttribute, TAttributeValue, TRawAttributeValue},
                 TSpan,
             },
             sdd::verifies,
@@ -444,10 +444,7 @@ more value
             }
         );
 
-        assert_eq!(
-            mi.item.value(),
-            TInterpretedValue::Value("value more value")
-        );
+        assert_eq!(mi.item.value(), TAttributeValue::Value("value more value"));
 
         assert_eq!(
             mi.after,

--- a/parser/src/tests/document/attribute.rs
+++ b/parser/src/tests/document/attribute.rs
@@ -3,7 +3,7 @@ use pretty_assertions_sorted::assert_eq;
 use crate::{
     document::Attribute,
     tests::fixtures::{
-        document::{TAttribute, TInterpretedValue, TRawAttributeValue},
+        document::{TAttribute, TAttributeValue, TRawAttributeValue},
         TSpan,
     },
     Span,
@@ -45,7 +45,7 @@ fn simple_value() {
         }
     );
 
-    assert_eq!(mi.item.value(), TInterpretedValue::Value("bar"));
+    assert_eq!(mi.item.value(), TAttributeValue::Value("bar"));
 
     assert_eq!(
         mi.after,
@@ -81,7 +81,7 @@ fn no_value() {
         }
     );
 
-    assert_eq!(mi.item.value(), TInterpretedValue::Set);
+    assert_eq!(mi.item.value(), TAttributeValue::Set);
 
     assert_eq!(
         mi.after,
@@ -117,7 +117,7 @@ fn name_with_hyphens() {
         }
     );
 
-    assert_eq!(mi.item.value(), TInterpretedValue::Set);
+    assert_eq!(mi.item.value(), TAttributeValue::Set);
 
     assert_eq!(
         mi.after,
@@ -153,7 +153,7 @@ fn unset_prefix() {
         }
     );
 
-    assert_eq!(mi.item.value(), TInterpretedValue::Unset);
+    assert_eq!(mi.item.value(), TAttributeValue::Unset);
 
     assert_eq!(
         mi.after,
@@ -189,7 +189,7 @@ fn unset_postfix() {
         }
     );
 
-    assert_eq!(mi.item.value(), TInterpretedValue::Unset);
+    assert_eq!(mi.item.value(), TAttributeValue::Unset);
 
     assert_eq!(
         mi.after,
@@ -250,7 +250,7 @@ fn value_with_soft_wrap() {
         }
     );
 
-    assert_eq!(mi.item.value(), TInterpretedValue::Value("bar blah"));
+    assert_eq!(mi.item.value(), TAttributeValue::Value("bar blah"));
 
     assert_eq!(
         mi.after,
@@ -291,7 +291,7 @@ fn value_with_hard_wrap() {
         }
     );
 
-    assert_eq!(mi.item.value(), TInterpretedValue::Value("bar\nblah"));
+    assert_eq!(mi.item.value(), TAttributeValue::Value("bar\nblah"));
 
     assert_eq!(
         mi.after,

--- a/parser/src/tests/fixtures/document/attribute_value.rs
+++ b/parser/src/tests/fixtures/document/attribute_value.rs
@@ -1,43 +1,43 @@
 use std::cmp::PartialEq;
 
-use crate::document::InterpretedValue;
+use crate::document::AttributeValue;
 
 #[derive(Debug, Eq, PartialEq)]
-pub(crate) enum TInterpretedValue {
+pub(crate) enum TAttributeValue {
     Value(&'static str),
     Set,
     Unset,
 }
 
-impl<'src> PartialEq<InterpretedValue<'src>> for TInterpretedValue {
-    fn eq(&self, other: &InterpretedValue<'src>) -> bool {
+impl<'src> PartialEq<AttributeValue<'src>> for TAttributeValue {
+    fn eq(&self, other: &AttributeValue<'src>) -> bool {
         fixture_eq_observed(self, other)
     }
 }
 
-impl PartialEq<TInterpretedValue> for InterpretedValue<'_> {
-    fn eq(&self, other: &TInterpretedValue) -> bool {
+impl PartialEq<TAttributeValue> for AttributeValue<'_> {
+    fn eq(&self, other: &TAttributeValue) -> bool {
         fixture_eq_observed(other, self)
     }
 }
 
-impl PartialEq<TInterpretedValue> for &InterpretedValue<'_> {
-    fn eq(&self, other: &TInterpretedValue) -> bool {
+impl PartialEq<TAttributeValue> for &AttributeValue<'_> {
+    fn eq(&self, other: &TAttributeValue) -> bool {
         fixture_eq_observed(other, self)
     }
 }
 
-fn fixture_eq_observed(fixture: &TInterpretedValue, observed: &InterpretedValue) -> bool {
+fn fixture_eq_observed(fixture: &TAttributeValue, observed: &AttributeValue) -> bool {
     match fixture {
-        TInterpretedValue::Value(ref fixture_value) => {
-            if let InterpretedValue::Value(ref observed_value) = observed {
+        TAttributeValue::Value(ref fixture_value) => {
+            if let AttributeValue::Value(ref observed_value) = observed {
                 fixture_value == &observed_value.as_ref()
             } else {
                 false
             }
         }
 
-        TInterpretedValue::Set => observed == &InterpretedValue::Set,
-        TInterpretedValue::Unset => observed == &InterpretedValue::Unset,
+        TAttributeValue::Set => observed == &AttributeValue::Set,
+        TAttributeValue::Unset => observed == &AttributeValue::Unset,
     }
 }

--- a/parser/src/tests/fixtures/document/mod.rs
+++ b/parser/src/tests/fixtures/document/mod.rs
@@ -13,7 +13,7 @@ mod attribute;
 pub(crate) use attribute::TAttribute;
 
 mod attribute_value;
-pub(crate) use attribute_value::TInterpretedValue;
+pub(crate) use attribute_value::TAttributeValue;
 
 mod document;
 pub(crate) use document::TDocument;


### PR DESCRIPTION
This reverts commit 95264114c0be571f8d72ad3a704c6cead857731a.