### PR TITLE
feat!: Introduce new `Parser` struct which can configure and initiate parsing

### DIFF
--- a/parser/benches/element_attributes.rs
+++ b/parser/benches/element_attributes.rs
@@ -1,4 +1,4 @@
-use asciidoc_parser::Document;
+use asciidoc_parser::Parser;
 use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
 
 const BENCH_NAME: &str = "element attributes";
@@ -15,8 +15,9 @@ ghi
 "#;
 
 pub fn perf(c: &mut Criterion) {
+    let parser = Parser::default();
     c.bench_function(BENCH_NAME, |b| {
-        b.iter(|| Document::parse(black_box(PARSE_TEXT)))
+        b.iter(|| parser.parse(black_box(PARSE_TEXT)))
     });
 }
 

--- a/parser/benches/inline_macro.rs
+++ b/parser/benches/inline_macro.rs
@@ -1,12 +1,13 @@
-use asciidoc_parser::Document;
+use asciidoc_parser::Parser;
 use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
 
 const BENCH_NAME: &str = "inline macro";
 const PARSE_TEXT: &str = "= Example Title\n\nblah foo:bar[blah] bonus";
 
 pub fn inline_macro(c: &mut Criterion) {
+    let parser = Parser::default();
     c.bench_function(BENCH_NAME, |b| {
-        b.iter(|| Document::parse(black_box(PARSE_TEXT)))
+        b.iter(|| parser.parse(black_box(PARSE_TEXT)))
     });
 }
 

--- a/parser/benches/section_with_two_blocks.rs
+++ b/parser/benches/section_with_two_blocks.rs
@@ -1,12 +1,13 @@
-use asciidoc_parser::Document;
+use asciidoc_parser::Parser;
 use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
 
 const BENCH_NAME: &str = "section with 2 blocks";
 const PARSE_TEXT: &str = "== Section Title\n\nabc\n\ndef";
 
 pub fn section_with_two_blocks(c: &mut Criterion) {
+    let parser = Parser::default();
     c.bench_function(BENCH_NAME, |b| {
-        b.iter(|| Document::parse(black_box(PARSE_TEXT)))
+        b.iter(|| parser.parse(black_box(PARSE_TEXT)))
     });
 }
 

--- a/parser/benches/simple_parse.rs
+++ b/parser/benches/simple_parse.rs
@@ -1,12 +1,13 @@
-use asciidoc_parser::Document;
+use asciidoc_parser::Parser;
 use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
 
 const BENCH_NAME: &str = "2 blocks + title";
 const PARSE_TEXT: &str = "= Example Title\n\nabc\n\ndef";
 
 pub fn two_blocks_and_title(c: &mut Criterion) {
+    let parser = Parser::default();
     c.bench_function(BENCH_NAME, |b| {
-        b.iter(|| Document::parse(black_box(PARSE_TEXT)))
+        b.iter(|| parser.parse(black_box(PARSE_TEXT)))
     });
 }
 

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -8,7 +8,7 @@ use crate::{
     document::Header,
     strings::CowStr,
     warnings::Warning,
-    HasSpan, Span,
+    HasSpan, Parser, Span,
 };
 
 /// A document represents the top-level block element in AsciiDoc. It consists
@@ -52,7 +52,7 @@ impl<'src> Document<'src> {
     /// provided via the [`warnings()`] iterator.
     ///
     /// [`warnings()`]: Self::warnings
-    pub fn parse(source: &'src str) -> Self {
+    pub(crate) fn parse(source: &'src str, _parser: &mut Parser) -> Self {
         let source = Span::new(source);
         let i = source.discard_empty_lines();
         let i = if i.is_empty() { source } else { i };

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -13,6 +13,9 @@ pub mod blocks;
 pub mod document;
 pub use document::Document;
 
+pub mod parser;
+pub use parser::Parser;
+
 mod span;
 pub use span::{HasSpan, Span};
 

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -1,0 +1,5 @@
+//! The [`Parser`] struct and its related structs allow a caller to configure
+//! how AsciiDoc parsing occurs and then to initiate the parsing process.
+
+mod parser;
+pub use parser::Parser;

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -11,10 +11,10 @@ impl Parser {
     /// Note that the document references the underlying source string and
     /// necessarily has the same lifetime as the source.
     ///
-    /// The `Document` data structure returned by this call and nearly all data
-    /// structures contained within it are gated by the lifetime of the `source`
-    /// text passed in to this function. For that reason all of those data
-    /// structures are given the lifetime `'src`.
+    /// The [`Document`] data structure returned by this call and nearly all
+    /// data structures contained within it are gated by the lifetime of the
+    /// `source` text passed in to this function. For that reason all of
+    /// those data structures are given the lifetime `'src`.
     ///
     /// **IMPORTANT:** The AsciiDoc language documentation states that UTF-16
     /// encoding is allowed if a byte-order-mark (BOM) is present at the

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1,0 +1,38 @@
+use crate::Document;
+
+/// The [`Parser`] struct and its related structs allow a caller to configure
+/// how AsciiDoc parsing occurs and then to initiate the parsing process.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Parser {}
+
+impl Parser {
+    /// Parse a UTF-8 string as an AsciiDoc document.
+    ///
+    /// Note that the document references the underlying source string and
+    /// necessarily has the same lifetime as the source.
+    ///
+    /// The `Document` data structure returned by this call and nearly all data
+    /// structures contained within it are gated by the lifetime of the `source`
+    /// text passed in to this function. For that reason all of those data
+    /// structures are given the lifetime `'src`.
+    ///
+    /// **IMPORTANT:** The AsciiDoc language documentation states that UTF-16
+    /// encoding is allowed if a byte-order-mark (BOM) is present at the
+    /// start of a file. This format is not directly supported by the
+    /// `asciidoc-parser` crate. Any UTF-16 content must be re-encoded as
+    /// UTF-8 prior to parsing.
+    ///
+    /// # Warnings, not errors
+    ///
+    /// Any UTF-8 string is a valid AsciiDoc document, so this function does not
+    /// return an [`Option`] or [`Result`] data type. There may be any number of
+    /// character sequences that have ambiguous or potentially unintended
+    /// meanings. For that reason, a caller is advised to review the warnings
+    /// provided via the [`warnings()`] iterator.
+    ///
+    /// [`warnings()`]: Self::warnings
+    pub fn parse<'src>(&self, source: &'src str) -> Document<'src> {
+        let mut temp_copy = self.clone();
+        Document::parse(source, &mut temp_copy)
+    }
+}

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -30,7 +30,7 @@ impl Parser {
     /// meanings. For that reason, a caller is advised to review the warnings
     /// provided via the [`warnings()`] iterator.
     ///
-    /// [`warnings()`]: Self::warnings
+    /// [`warnings()`]: Document::warnings
     pub fn parse<'src>(&self, source: &'src str) -> Document<'src> {
         let mut temp_copy = self.clone();
         Document::parse(source, &mut temp_copy)

--- a/parser/src/tests/asciidoc_lang/blocks/build_basic_block.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/build_basic_block.rs
@@ -11,7 +11,7 @@ use crate::{
         },
         sdd::{non_normative, track_file, verifies},
     },
-    Document, Span,
+    Parser, Span,
 };
 
 track_file!("docs/modules/blocks/pages/build-basic-block.adoc");
@@ -79,7 +79,7 @@ This is more content in the sidebar block.
 "#
     );
 
-    let doc = Document::parse(
+    let doc = Parser::default().parse(
     "Text in your document.\n\n****\nThis is content in a sidebar block.\n\nimage::name.png[]\n\nThis is more content in the sidebar block.\n****",
 );
 

--- a/parser/src/tests/asciidoc_lang/root/document_structure.rs
+++ b/parser/src/tests/asciidoc_lang/root/document_structure.rs
@@ -20,7 +20,6 @@ mod documents {
     use pretty_assertions_sorted::assert_eq;
 
     use crate::{
-        document::Document,
         tests::{
             fixtures::{
                 blocks::{TBlock, TSimpleBlock},
@@ -29,6 +28,7 @@ mod documents {
             },
             sdd::{non_normative, verifies},
         },
+        Parser,
     };
 
     non_normative!(
@@ -55,7 +55,7 @@ This is a basic AsciiDoc document.
         );
 
         assert_eq!(
-            Document::parse("This is a basic AsciiDoc document.\n"),
+            Parser::default().parse("This is a basic AsciiDoc document.\n"),
             TDocument {
                 header: THeader {
                     title: None,
@@ -117,7 +117,7 @@ This document contains two paragraphs.
         );
 
         assert_eq!(
-            Document::parse(
+            Parser::default().parse(
                 "This is a basic AsciiDoc document.\n\nThis document contains two paragraphs.\n"
             ),
             TDocument {
@@ -199,7 +199,7 @@ It also has a header that specifies the document title.
         );
 
         assert_eq!(
-            Document::parse(
+            Parser::default().parse(
                 "= Document Title\n:reproducible:\n\nThis is a basic AsciiDoc document by {author}.\n\nThis document contains two paragraphs.\nIt also has a header that specifies the document title."
             ),
             TDocument {

--- a/parser/src/tests/asciidoc_lang/root/key_concepts.rs
+++ b/parser/src/tests/asciidoc_lang/root/key_concepts.rs
@@ -74,7 +74,20 @@ An element attribute is defined using an attribute list on an element, or an ava
 );
 
 mod macros {
-    use crate::tests::sdd::{non_normative, verifies};
+    use pretty_assertions_sorted::assert_eq;
+
+    use crate::{
+        tests::{
+            fixtures::{
+                attributes::{TAttrlist, TElementAttribute},
+                blocks::{TBlock, TMacroBlock, TSimpleBlock},
+                document::{TDocument, THeader},
+                TSpan,
+            },
+            sdd::{non_normative, verifies},
+        },
+        Parser,
+    };
 
     non_normative!(
         r#"
@@ -86,18 +99,6 @@ See https://en.wikipedia.org/wiki/Macro_(computer_science)[macro^] to learn more
 
 "#
     );
-
-    use pretty_assertions_sorted::assert_eq;
-
-    use crate::{
-        document::Document,
-        tests::fixtures::{
-            attributes::{TAttrlist, TElementAttribute},
-            blocks::{TBlock, TMacroBlock, TSimpleBlock},
-            document::{TDocument, THeader},
-            TSpan,
-        },
-    };
 
     #[test]
     fn block_macro() {
@@ -114,7 +115,7 @@ image::sunset.jpg[Sunset]
         );
 
         assert_eq!(
-            Document::parse("image::sunset.jpg[Sunset]\n"),
+            Parser::default().parse("image::sunset.jpg[Sunset]\n"),
             TDocument {
                 header: THeader {
                     title: None,
@@ -204,7 +205,7 @@ Click the button with the image:star.png[Star] to favorite the project.
         );
 
         assert_eq!(
-            Document::parse(
+            Parser::default().parse(
                 "Click the button with the image:star.png[Star] to favorite the project.\n"
             ),
             TDocument {

--- a/parser/src/tests/document/document.rs
+++ b/parser/src/tests/document/document.rs
@@ -4,7 +4,6 @@ use pretty_assertions_sorted::assert_eq;
 
 use crate::{
     blocks::{ContentModel, IsBlock},
-    document::Document,
     tests::fixtures::{
         attributes::{TAttrlist, TElementAttribute},
         blocks::{TBlock, TMacroBlock, TSectionBlock, TSimpleBlock},
@@ -13,19 +12,20 @@ use crate::{
         TSpan,
     },
     warnings::WarningType,
+    Parser,
 };
 
 #[test]
 fn impl_clone() {
     // Silly test to mark the #[derive(...)] line as covered.
-    let doc1 = Document::parse("");
+    let doc1 = Parser::default().parse("");
     let doc2 = doc1.clone();
     assert_eq!(doc1, doc2);
 }
 
 #[test]
 fn empty_source() {
-    let doc = Document::parse("");
+    let doc = Parser::default().parse("");
 
     assert_eq!(doc.content_model(), ContentModel::Compound);
     assert_eq!(doc.raw_context().deref(), "document");
@@ -65,7 +65,7 @@ fn empty_source() {
 #[test]
 fn only_spaces() {
     assert_eq!(
-        Document::parse("    "),
+        Parser::default().parse("    "),
         TDocument {
             header: THeader {
                 title: None,
@@ -91,7 +91,7 @@ fn only_spaces() {
 
 #[test]
 fn one_simple_block() {
-    let doc = Document::parse("abc");
+    let doc = Parser::default().parse("abc");
     assert_eq!(
         doc,
         TDocument {
@@ -138,7 +138,7 @@ fn one_simple_block() {
 #[test]
 fn two_simple_blocks() {
     assert_eq!(
-        Document::parse("abc\n\ndef"),
+        Parser::default().parse("abc\n\ndef"),
         TDocument {
             header: THeader {
                 title: None,
@@ -200,7 +200,7 @@ fn two_simple_blocks() {
 #[test]
 fn two_blocks_and_title() {
     assert_eq!(
-        Document::parse("= Example Title\n\nabc\n\ndef"),
+        Parser::default().parse("= Example Title\n\nabc\n\ndef"),
         TDocument {
             header: THeader {
                 title: Some(TSpan {
@@ -267,7 +267,7 @@ fn two_blocks_and_title() {
 #[test]
 fn extra_space_before_title() {
     assert_eq!(
-        Document::parse("=   Example Title\n\nabc"),
+        Parser::default().parse("=   Example Title\n\nabc"),
         TDocument {
             header: THeader {
                 title: Some(TSpan {
@@ -315,7 +315,7 @@ fn extra_space_before_title() {
 #[test]
 fn err_bad_header() {
     assert_eq!(
-        Document::parse("= Title\nnot an attribute\n"),
+        Parser::default().parse("= Title\nnot an attribute\n"),
         TDocument {
             header: THeader {
                 title: Some(TSpan {
@@ -371,7 +371,7 @@ fn err_bad_header() {
 #[test]
 fn err_bad_header_and_bad_macro() {
     assert_eq!(
-        Document::parse("= Title\nnot an attribute\n\n== Section Title\n\nfoo::bar[alt=Sunset,width=300,,height=400]"),
+        Parser::default().parse("= Title\nnot an attribute\n\n== Section Title\n\nfoo::bar[alt=Sunset,width=300,,height=400]"),
         TDocument {
             header: THeader {
                 title: Some(TSpan {


### PR DESCRIPTION
Remove `Document::parse` from public API surface in favor of new `Parser::parse`.