### PR TITLE
chore: Add `SubstitutionGroup::from_custom_string`

### DIFF
--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -158,7 +158,7 @@ impl<'src> IsBlock<'src> for RawDelimitedBlock<'src> {
     }
 
     fn substitution_group(&'src self) -> SubstitutionGroup {
-        self.substitution_group
+        self.substitution_group.clone()
     }
 }
 

--- a/parser/src/span/content/substitution_step.rs
+++ b/parser/src/span/content/substitution_step.rs
@@ -19,7 +19,7 @@ use crate::{
 /// depending on the block or inline element’s assigned substitution group. The
 /// processor runs the substitutions in the following order:
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum SubstitutionStep {
+pub enum SubstitutionStep {
     /// Searches for three characters (`<`, `>`, `&`) and replaces them with
     /// their named character references.
     SpecialCharacters,

--- a/parser/src/tests/span/content/substitution_group.rs
+++ b/parser/src/tests/span/content/substitution_group.rs
@@ -1,3 +1,170 @@
+mod from_custom_string {
+    use pretty_assertions_sorted::assert_eq;
+
+    use crate::span::content::{SubstitutionGroup, SubstitutionStep};
+
+    #[test]
+    fn empty() {
+        assert_eq!(SubstitutionGroup::from_custom_string(""), None);
+    }
+
+    #[test]
+    fn normal() {
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("n"),
+            Some(SubstitutionGroup::Normal)
+        );
+
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("normal"),
+            Some(SubstitutionGroup::Normal)
+        );
+
+        assert_eq!(SubstitutionGroup::from_custom_string("nermal"), None);
+    }
+
+    #[test]
+    fn verbatim() {
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("v"),
+            Some(SubstitutionGroup::Verbatim)
+        );
+
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("verbatim"),
+            Some(SubstitutionGroup::Verbatim)
+        );
+
+        assert_eq!(SubstitutionGroup::from_custom_string("verboten"), None);
+    }
+
+    #[test]
+    fn special_chars() {
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("c"),
+            Some(SubstitutionGroup::Custom(vec![
+                SubstitutionStep::SpecialCharacters
+            ]))
+        );
+
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("specialchars"),
+            Some(SubstitutionGroup::Custom(vec![
+                SubstitutionStep::SpecialCharacters
+            ]))
+        );
+    }
+
+    #[test]
+    fn quotes() {
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("q"),
+            Some(SubstitutionGroup::Custom(vec![SubstitutionStep::Quotes]))
+        );
+
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("quotes"),
+            Some(SubstitutionGroup::Custom(vec![SubstitutionStep::Quotes]))
+        );
+    }
+
+    #[test]
+    fn attributes() {
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("a"),
+            Some(SubstitutionGroup::Custom(vec![
+                SubstitutionStep::AttributeReferences
+            ]))
+        );
+
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("attributes"),
+            Some(SubstitutionGroup::Custom(vec![
+                SubstitutionStep::AttributeReferences
+            ]))
+        );
+    }
+
+    #[test]
+    fn replacements() {
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("r"),
+            Some(SubstitutionGroup::Custom(vec![
+                SubstitutionStep::CharacterReplacements
+            ]))
+        );
+
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("replacements"),
+            Some(SubstitutionGroup::Custom(vec![
+                SubstitutionStep::CharacterReplacements
+            ]))
+        );
+    }
+
+    #[test]
+    fn macros() {
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("m"),
+            Some(SubstitutionGroup::Custom(vec![SubstitutionStep::Macros]))
+        );
+
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("macros"),
+            Some(SubstitutionGroup::Custom(vec![SubstitutionStep::Macros]))
+        );
+    }
+
+    #[test]
+    fn post_replacements() {
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("p"),
+            Some(SubstitutionGroup::Custom(vec![
+                SubstitutionStep::PostReplacement
+            ]))
+        );
+
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("post replacements"),
+            Some(SubstitutionGroup::Custom(vec![
+                SubstitutionStep::PostReplacement
+            ]))
+        );
+    }
+
+    #[test]
+    fn multiple() {
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("q,a"),
+            Some(SubstitutionGroup::Custom(vec![
+                SubstitutionStep::Quotes,
+                SubstitutionStep::AttributeReferences
+            ]))
+        );
+
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("q, a"),
+            Some(SubstitutionGroup::Custom(vec![
+                SubstitutionStep::Quotes,
+                SubstitutionStep::AttributeReferences
+            ]))
+        );
+
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("quotes,attributes"),
+            Some(SubstitutionGroup::Custom(vec![
+                SubstitutionStep::Quotes,
+                SubstitutionStep::AttributeReferences
+            ]))
+        );
+
+        assert_eq!(
+            SubstitutionGroup::from_custom_string("x,bogus,no such step"),
+            None
+        );
+    }
+}
+
 mod normal {
     use crate::{span::content::SubstitutionGroup, strings::CowStr, Content, Parser, Span};
 


### PR DESCRIPTION
This parses the syntax defined in https://docs.asciidoctor.org/asciidoc/latest/pass/pass-macro/#custom-substitutions.