### PR TITLE
feat: Implement `PathResolver` struct

### DIFF
--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -13,3 +13,6 @@ pub use inline_substitution_renderer::{
 
 mod parser;
 pub use parser::Parser;
+
+mod path_resolver;
+pub use path_resolver::PathResolver;

--- a/parser/src/parser/path_resolver.rs
+++ b/parser/src/parser/path_resolver.rs
@@ -1,3 +1,7 @@
+use std::sync::LazyLock;
+
+use regex::Regex;
+
 /// A `PathResolver` handles all operations for resolving, cleaning, and joining
 /// paths. This struct includes operations for handling both web paths (request
 /// URIs) and system paths.
@@ -53,25 +57,40 @@ impl PathResolver {
     ///
     /// Returns a path that joins the target path with the start path with any
     /// parent references resolved and self references removed.
-    pub fn web_path(&self, _target: &str, _start: Option<&str>) -> String {
+    #[allow(unused)] // TEMPORARY while building
+    pub fn web_path(&self, target: &str, start: Option<&str>) -> String {
+        let mut target = self.posixify(target);
+        let start = start.map(|start| self.posixify(start));
+
+        dbg!(&target);
+        dbg!(&start);
+
+        let mut uri_prefix: Option<String> = None;
+
+        if start.is_some() || self.is_web_root(&target) {
+            (target, uri_prefix) = extract_uri_prefix(&format!(
+                "{start}{maybe_add_slash}{target}",
+                start = start.as_ref().map(|s| s.as_str()).unwrap_or_default(),
+                maybe_add_slash = start
+                    .as_ref()
+                    .map(|s| if s.ends_with("/") { "" } else { "/" })
+                    .unwrap_or_default()
+            ));
+        }
+
+        dbg!(&target);
+        dbg!(&uri_prefix);
+
+        let (target_segments, target_root) = self.partition_path(&target, WebPath(true));
+
+        dbg!(&target_segments);
+        dbg!(&target_root);
+
+        let resolved_segments: Vec<String> = vec![];
+
         todo!(
             "Port this: {}",
             r#"
-			target = posixify target
-			start = posixify start
-		
-			unless start.nil_or_empty? || (web_root? target)
-			  target, uri_prefix = extract_uri_prefix %(#{start}#{(start.end_with? SLASH) ? '' : SLASH}#{target})
-			end
-		
-			# use this logic instead if we want to normalize target if it contains a URI
-			#unless web_root? target
-			#  target, uri_prefix = extract_uri_prefix target if preserve_uri_target
-			#  target, uri_prefix = extract_uri_prefix %(#{start}#{SLASH}#{target}) unless uri_prefix || start.nil_or_empty?
-			#end
-		
-			target_segments, target_root = partition_path target, true
-			resolved_segments = []
 			target_segments.each do |segment|
 			  if segment == DOT_DOT
 				if resolved_segments.empty?
@@ -96,4 +115,124 @@ impl PathResolver {
         "#
         );
     }
+
+    /// Partition the path into path segments and remove self references (`.`)
+    /// and the trailing slash, if present. Prior to being partitioned, the path
+    /// is converted to a Posix path.
+    ///
+    /// Parent references are not resolved by this method since the caller often
+    /// needs to handle this resolution in a certain context (checking for the
+    /// breach of a jail, for instance).
+    ///
+    /// Returns a 2-item tuple containing a `Vec<String>` of path segments and
+    /// an optional path root (e.g., `/`, `./`, `c:/`, or `//`), which is only
+    /// present if the path is absolute.
+    fn partition_path(&self, path: &str, web: WebPath) -> (Vec<String>, Option<String>) {
+        // TO DO: Add cache implementation?
+
+        let posix_path = self.posixify(path);
+
+        let root: Option<String> = if web.0 {
+            if self.is_web_root(&posix_path) {
+                Some("/".to_owned())
+            } else if posix_path.starts_with("./") {
+                Some("./".to_owned())
+            } else {
+                None
+            }
+        } else {
+            todo!(
+                "Port this: {}",
+                r#"
+				elsif root? posix_path
+				  # ex. //sample/path
+				  if unc? posix_path
+					root = DOUBLE_SLASH
+				  # ex. /sample/path
+				  elsif posix_path.start_with? SLASH
+					root = SLASH
+				  # ex. uri:classloader:sample/path (or uri:classloader:/sample/path)
+				  elsif posix_path.start_with? URI_CLASSLOADER
+					root = posix_path.slice 0, URI_CLASSLOADER.length
+				  # ex. C:/sample/path (or file:///sample/path in browser environment)
+				  else
+					root = posix_path.slice 0, (posix_path.index SLASH) + 1
+				  end
+				# ex. ./sample/path
+				elsif posix_path.start_with? DOT_SLASH
+				  root = DOT_SLASH
+				end
+				# otherwise ex. sample/path
+                "#
+            );
+        };
+
+        let path_after_root = if let Some(root) = &root {
+            &posix_path[root.len()..]
+        } else {
+            &posix_path
+        };
+
+        let path_segments: Vec<String> = path_after_root
+            .split('/')
+            .filter(|s| *s != ".")
+            .map(|s| s.to_owned())
+            .collect();
+
+        // TO DO: Add cache write?
+
+        (path_segments, root)
+    }
+
+    /// Return `true` if the path is an absolute (root) web path (i.e. starts
+    /// with a `'/'`.
+    pub fn is_web_root(&self, path: &str) -> bool {
+        path.starts_with('/')
+    }
 }
+
+/// Efficiently extracts the URI prefix from the specified string if the string
+/// is a URI.
+///
+/// Attempts to match the URI prefix in the specified string (e.g., `http://`). If present, the prefix is removed.
+///
+/// Returns a tuple containing the specified string without the URI prefix, if
+/// present, and the extracted URI prefix if found.
+fn extract_uri_prefix(s: &str) -> (String, Option<String>) {
+    if s.contains(':') {
+        if let Some(prefix) = URI_SNIFF.find(s) {
+            return (
+                s[prefix.len()..].to_string(),
+                Some(prefix.as_str().to_owned()),
+            );
+        }
+    }
+
+    (s.to_string(), None)
+}
+
+static URI_SNIFF: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(
+        r#"(?x)
+        ^                   # Anchor: start of string
+
+        \p{Alphabetic}      # First character: a Unicode letter
+
+        [\p{Alphabetic}     # Followed by one or more of:
+         \p{Number}         #   - Unicode letters or numbers
+         .                  #   - Period
+         \+                 #   - Plus sign
+         \-                 #   - Hyphen
+        ]+                  # One or more of the above
+
+        :                   # Followed by a literal colon
+
+        /{0,2}              # Followed by zero, one, or two literal slashes
+    "#,
+    )
+    .unwrap()
+});
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct WebPath(pub(crate) bool);

--- a/parser/src/parser/path_resolver.rs
+++ b/parser/src/parser/path_resolver.rs
@@ -1,0 +1,99 @@
+/// A `PathResolver` handles all operations for resolving, cleaning, and joining
+/// paths. This struct includes operations for handling both web paths (request
+/// URIs) and system paths.
+///
+/// The main emphasis of the struct is on creating clean and secure paths. Clean
+/// paths are void of duplicate parent and current directory references in the
+/// path name. Secure paths are paths which are restricted from accessing
+/// directories outside of a jail path, if specified.
+///
+/// Since joining two paths can result in an insecure path, this struct also
+/// handles the task of joining a parent (start) and child (target) path.
+///
+/// Like its counterpart in the Ruby Asciidoctor implementation, this struct
+/// makes no use of path utilities from the underlying Rust libraries. Instead,
+/// it handles all aspects of path manipulation. The main benefit of
+/// internalizing these operations is that the struct is able to handle both
+/// Posix and Windows paths independent of the operating system on which it
+/// runs. This makes the class both deterministic and easier to test.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PathResolver {
+    /// File separator to use for path operations. (Defaults to
+    /// platform-appropriate separator.)
+    pub file_separator: char,
+    // TO DO: Port this from Ruby?
+    // attr_accessor :working_dir
+}
+
+impl Default for PathResolver {
+    fn default() -> Self {
+        Self {
+            file_separator: std::path::MAIN_SEPARATOR,
+        }
+    }
+}
+
+impl PathResolver {
+    /// Normalize path by converting any backslashes to forward slashes.
+    pub fn posixify(&self, path: &str) -> String {
+        if self.file_separator == '\\' && path.contains('\\') {
+            path.replace('\\', "/")
+        } else {
+            path.to_string()
+        }
+    }
+
+    /// Resolve a web path from the target and start paths.
+    ///
+    /// The main function of this operation is to resolve any parent references
+    /// and remove any self references.
+    ///
+    /// The target is assumed to be a path, not a qualified URI. That check
+    /// should happen before this method is invoked.
+    ///
+    /// Returns a path that joins the target path with the start path with any
+    /// parent references resolved and self references removed.
+    pub fn web_path(&self, _target: &str, _start: Option<&str>) -> String {
+        todo!(
+            "Port this: {}",
+            r#"
+			target = posixify target
+			start = posixify start
+		
+			unless start.nil_or_empty? || (web_root? target)
+			  target, uri_prefix = extract_uri_prefix %(#{start}#{(start.end_with? SLASH) ? '' : SLASH}#{target})
+			end
+		
+			# use this logic instead if we want to normalize target if it contains a URI
+			#unless web_root? target
+			#  target, uri_prefix = extract_uri_prefix target if preserve_uri_target
+			#  target, uri_prefix = extract_uri_prefix %(#{start}#{SLASH}#{target}) unless uri_prefix || start.nil_or_empty?
+			#end
+		
+			target_segments, target_root = partition_path target, true
+			resolved_segments = []
+			target_segments.each do |segment|
+			  if segment == DOT_DOT
+				if resolved_segments.empty?
+				  resolved_segments << segment unless target_root && target_root != DOT_SLASH
+				elsif resolved_segments[-1] == DOT_DOT
+				  resolved_segments << segment
+				else
+				  resolved_segments.pop
+				end
+			  else
+				resolved_segments << segment
+				# checking for empty would eliminate repeating forward slashes
+				#resolved_segments << segment unless segment.empty?
+			  end
+			end
+		
+			if (resolved_path = join_path resolved_segments, target_root).include? ' '
+			  resolved_path = resolved_path.gsub ' ', '%20'
+			end
+		
+			uri_prefix ? %(#{uri_prefix}#{resolved_path}) : resolved_path
+        "#
+        );
+    }
+}

--- a/parser/src/parser/path_resolver.rs
+++ b/parser/src/parser/path_resolver.rs
@@ -90,18 +90,21 @@ impl PathResolver {
 
         for segment in target_segments {
             if segment == ".." {
-                todo!(
-                    "Port this: {}",
-                    r#"
-                      if resolved_segments.empty?
-                        resolved_segments << segment unless target_root && target_root != DOT_SLASH
-                      elsif resolved_segments[-1] == DOT_DOT
-                        resolved_segments << segment
-                      else
-                        resolved_segments.pop
-                      end
-                    "#
-                );
+                if resolved_segments.is_empty() {
+                    if let Some(target_root) = target_root.as_ref()
+                        && target_root != ".'"
+                    {
+                        // Do nothing.
+                    } else {
+                        resolved_segments.push(segment);
+                    }
+                } else if let Some(last_segment) = resolved_segments.last()
+                    && last_segment == ".."
+                {
+                    resolved_segments.push(segment);
+                } else {
+                    resolved_segments.pop();
+                }
             } else {
                 resolved_segments.push(segment);
             }

--- a/parser/src/parser/path_resolver.rs
+++ b/parser/src/parser/path_resolver.rs
@@ -70,7 +70,7 @@ impl PathResolver {
         if start.is_some() || self.is_web_root(&target) {
             (target, uri_prefix) = extract_uri_prefix(&format!(
                 "{start}{maybe_add_slash}{target}",
-                start = start.as_ref().map(|s| s.as_str()).unwrap_or_default(),
+                start = start.as_deref().unwrap_or_default(),
                 maybe_add_slash = start
                     .as_ref()
                     .map(|s| if s.ends_with("/") { "" } else { "/" })
@@ -111,7 +111,7 @@ impl PathResolver {
         }
 
         let resolved_path = self
-            .join_path(&resolved_segments, target_root.as_ref().map(|s| s.as_str()))
+            .join_path(&resolved_segments, target_root.as_deref())
             .replace(" ", "%20");
 
         format!(

--- a/parser/src/parser/path_resolver.rs
+++ b/parser/src/parser/path_resolver.rs
@@ -92,7 +92,7 @@ impl PathResolver {
             if segment == ".." {
                 if resolved_segments.is_empty() {
                     if let Some(target_root) = target_root.as_ref()
-                        && target_root != ".'"
+                        && target_root != "./"
                     {
                         // Do nothing.
                     } else {

--- a/parser/src/tests/parser/mod.rs
+++ b/parser/src/tests/parser/mod.rs
@@ -1,1 +1,2 @@
 mod parser;
+mod path_resolver;

--- a/parser/src/tests/parser/path_resolver.rs
+++ b/parser/src/tests/parser/path_resolver.rs
@@ -47,17 +47,14 @@ mod web_path {
             "./assets/images"
         );
 
-        // #     resolver.web_path('./images/../assets/images')
-        // #     => './assets/images'
-        // #
-        // #     resolver.web_path('/../images')
-        // #     => '/images'
-        // #
-        // #     resolver.web_path('images', 'assets')
-        // #     => 'assets/images'
-        // #
-        // #     resolver.web_path('tiger.png', '../assets/images')
-        // #     => '../assets/images/tiger.png'
+        assert_eq!(pr.web_path("/../images", None), "/images");
+
+        assert_eq!(pr.web_path("/../images", Some("assets")), "assets/images");
+
+        assert_eq!(
+            pr.web_path("tiger.png", Some("../assets/images")),
+            "../assets/images/tiger.png"
+        );
     }
 }
 

--- a/parser/src/tests/parser/path_resolver.rs
+++ b/parser/src/tests/parser/path_resolver.rs
@@ -1,3 +1,5 @@
+use crate::parser::PathResolver;
+
 mod posixify {
     use crate::parser::PathResolver;
 
@@ -27,4 +29,41 @@ mod posixify {
 
         assert_eq!(pr.posixify("abc/def"), "abc/def");
     }
+}
+
+mod web_path {
+    use crate::parser::PathResolver;
+
+    #[test]
+    fn test_cases_from_asciidoctor_rb() {
+        let pr = PathResolver::default();
+
+        assert_eq!(pr.web_path("images", None), "images");
+
+        // #     resolver.web_path('./images')
+        // #     => './images'
+        // #
+        // #     resolver.web_path('/images')
+        // #     => '/images'
+        // #
+        // #     resolver.web_path('./images/../assets/images')
+        // #     => './assets/images'
+        // #
+        // #     resolver.web_path('/../images')
+        // #     => '/images'
+        // #
+        // #     resolver.web_path('images', 'assets')
+        // #     => 'assets/images'
+        // #
+        // #     resolver.web_path('tiger.png', '../assets/images')
+        // #     => '../assets/images/tiger.png'
+    }
+}
+
+#[test]
+fn is_web_root() {
+    let pr = PathResolver::default();
+    assert!(pr.is_web_root("/blah"));
+    assert!(!pr.is_web_root(""));
+    assert!(!pr.is_web_root("./blah"));
 }

--- a/parser/src/tests/parser/path_resolver.rs
+++ b/parser/src/tests/parser/path_resolver.rs
@@ -3,22 +3,28 @@ mod posixify {
 
     #[test]
     fn replaces_backslashes_if_windowsish() {
-        let mut pr = PathResolver::default();
-        pr.file_separator = '\\';
+        let pr = PathResolver {
+            file_separator: '\\',
+        };
+
         assert_eq!(pr.posixify("abc/def\\ghi"), "abc/def/ghi");
     }
 
     #[test]
     fn doesnt_replace_backslashes_if_posixish() {
-        let mut pr = PathResolver::default();
-        pr.file_separator = '/';
+        let pr = PathResolver {
+            file_separator: '/',
+        };
+
         assert_eq!(pr.posixify("abc/def\\ghi"), "abc/def\\ghi");
     }
 
     #[test]
     fn doesnt_replace_backslashes_if_none_exist() {
-        let mut pr = PathResolver::default();
-        pr.file_separator = '\\';
+        let pr = PathResolver {
+            file_separator: '\\',
+        };
+
         assert_eq!(pr.posixify("abc/def"), "abc/def");
     }
 }

--- a/parser/src/tests/parser/path_resolver.rs
+++ b/parser/src/tests/parser/path_resolver.rs
@@ -39,13 +39,14 @@ mod web_path {
         let pr = PathResolver::default();
 
         assert_eq!(pr.web_path("images", None), "images");
+        assert_eq!(pr.web_path("./images", None), "./images");
+        assert_eq!(pr.web_path("/images", None), "/images");
 
-        // #     resolver.web_path('./images')
-        // #     => './images'
-        // #
-        // #     resolver.web_path('/images')
-        // #     => '/images'
-        // #
+        assert_eq!(
+            pr.web_path("./images/../assets/images", None),
+            "./assets/images"
+        );
+
         // #     resolver.web_path('./images/../assets/images')
         // #     => './assets/images'
         // #

--- a/parser/src/tests/parser/path_resolver.rs
+++ b/parser/src/tests/parser/path_resolver.rs
@@ -1,0 +1,24 @@
+mod posixify {
+    use crate::parser::PathResolver;
+
+    #[test]
+    fn replaces_backslashes_if_windowsish() {
+        let mut pr = PathResolver::default();
+        pr.file_separator = '\\';
+        assert_eq!(pr.posixify("abc/def\\ghi"), "abc/def/ghi");
+    }
+
+    #[test]
+    fn doesnt_replace_backslashes_if_posixish() {
+        let mut pr = PathResolver::default();
+        pr.file_separator = '/';
+        assert_eq!(pr.posixify("abc/def\\ghi"), "abc/def\\ghi");
+    }
+
+    #[test]
+    fn doesnt_replace_backslashes_if_none_exist() {
+        let mut pr = PathResolver::default();
+        pr.file_separator = '\\';
+        assert_eq!(pr.posixify("abc/def"), "abc/def");
+    }
+}

--- a/parser/src/tests/parser/path_resolver.rs
+++ b/parser/src/tests/parser/path_resolver.rs
@@ -50,6 +50,8 @@ mod web_path {
         assert_eq!(pr.web_path("/../images", None), "/images");
 
         assert_eq!(pr.web_path("/../images", Some("assets")), "assets/images");
+        assert_eq!(pr.web_path("../images", Some("./")), "./../images");
+        assert_eq!(pr.web_path("../../images", Some("./")), "./../../images");
 
         assert_eq!(
             pr.web_path("tiger.png", Some("../assets/images")),


### PR DESCRIPTION
The `PathResolver` handles all operations for resolving, cleaning, and joining paths. This struct includes operations for handling both web paths (request URIs) and system paths.

Initial porting effort from Ruby Asciidoctor implementation.