### PR TITLE
feat!: Change `Parser::parse` so that parser state is available after the fact

### DIFF
--- a/parser/benches/element_attributes.rs
+++ b/parser/benches/element_attributes.rs
@@ -15,9 +15,8 @@ ghi
 "#;
 
 pub fn perf(c: &mut Criterion) {
-    let parser = Parser::default();
     c.bench_function(BENCH_NAME, |b| {
-        b.iter(|| parser.parse(black_box(PARSE_TEXT)))
+        b.iter(|| Parser::default().parse(black_box(PARSE_TEXT)))
     });
 }
 

--- a/parser/benches/inline_macro.rs
+++ b/parser/benches/inline_macro.rs
@@ -5,9 +5,8 @@ const BENCH_NAME: &str = "inline macro";
 const PARSE_TEXT: &str = "= Example Title\n\nblah foo:bar[blah] bonus";
 
 pub fn inline_macro(c: &mut Criterion) {
-    let parser = Parser::default();
     c.bench_function(BENCH_NAME, |b| {
-        b.iter(|| parser.parse(black_box(PARSE_TEXT)))
+        b.iter(|| Parser::default().parse(black_box(PARSE_TEXT)))
     });
 }
 

--- a/parser/benches/section_with_two_blocks.rs
+++ b/parser/benches/section_with_two_blocks.rs
@@ -5,9 +5,8 @@ const BENCH_NAME: &str = "section with 2 blocks";
 const PARSE_TEXT: &str = "== Section Title\n\nabc\n\ndef";
 
 pub fn section_with_two_blocks(c: &mut Criterion) {
-    let parser = Parser::default();
     c.bench_function(BENCH_NAME, |b| {
-        b.iter(|| parser.parse(black_box(PARSE_TEXT)))
+        b.iter(|| Parser::default().parse(black_box(PARSE_TEXT)))
     });
 }
 

--- a/parser/benches/simple_parse.rs
+++ b/parser/benches/simple_parse.rs
@@ -5,9 +5,8 @@ const BENCH_NAME: &str = "2 blocks + title";
 const PARSE_TEXT: &str = "= Example Title\n\nabc\n\ndef";
 
 pub fn two_blocks_and_title(c: &mut Criterion) {
-    let parser = Parser::default();
     c.bench_function(BENCH_NAME, |b| {
-        b.iter(|| parser.parse(black_box(PARSE_TEXT)))
+        b.iter(|| Parser::default().parse(black_box(PARSE_TEXT)))
     });
 }
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -61,7 +61,7 @@ impl<'p> Parser<'p> {
     pub fn parse<'src>(&mut self, source: &'src str) -> Document<'src> {
         Document::parse(source, self)
     }
-
+    
     /// Retrieves the current interpreted value of a [document attribute].
     ///
     /// Each document holds a set of name-value pairs called document

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -61,7 +61,7 @@ impl<'p> Parser<'p> {
     pub fn parse<'src>(&mut self, source: &'src str) -> Document<'src> {
         Document::parse(source, self)
     }
-    
+
     /// Retrieves the current interpreted value of a [document attribute].
     ///
     /// Each document holds a set of name-value pairs called document

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -46,6 +46,9 @@ impl<'p> Parser<'p> {
     /// `asciidoc-parser` crate. Any UTF-16 content must be re-encoded as
     /// UTF-8 prior to parsing.
     ///
+    /// **IMPORTANT:** The `Parser` struct will be updated with attributes and
+    /// similar values discovered during parsing.
+    ///
     /// # Warnings, not errors
     ///
     /// Any UTF-8 string is a valid AsciiDoc document, so this function does not
@@ -55,9 +58,8 @@ impl<'p> Parser<'p> {
     /// provided via the [`warnings()`] iterator.
     ///
     /// [`warnings()`]: Document::warnings
-    pub fn parse<'src>(&self, source: &'src str) -> Document<'src> {
-        let mut temp_copy = self.clone();
-        Document::parse(source, &mut temp_copy)
+    pub fn parse<'src>(&mut self, source: &'src str) -> Document<'src> {
+        Document::parse(source, self)
     }
 
     /// Retrieves the current interpreted value of a [document attribute].


### PR DESCRIPTION
(In other words, it no longer creates a temporary copy of self and uses that to parse.)