### PR TITLE
feat!: Revise HasSpan::span() to return `Span` by value not reference

### DIFF
--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -368,7 +368,7 @@ impl<'src> Attrlist<'src> {
 }
 
 impl<'src> HasSpan<'src> for Attrlist<'src> {
-    fn span(&'src self) -> &'src Span<'src> {
-        &self.source
+    fn span(&self) -> Span<'src> {
+        self.source
     }
 }

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -290,7 +290,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
 }
 
 impl<'src> HasSpan<'src> for Block<'src> {
-    fn span(&'src self) -> &'src Span<'src> {
+    fn span(&self) -> Span<'src> {
         match self {
             Self::Simple(b) => b.span(),
             Self::Media(b) => b.span(),

--- a/parser/src/blocks/compound_delimited.rs
+++ b/parser/src/blocks/compound_delimited.rs
@@ -151,7 +151,7 @@ impl<'src> IsBlock<'src> for CompoundDelimitedBlock<'src> {
 }
 
 impl<'src> HasSpan<'src> for CompoundDelimitedBlock<'src> {
-    fn span(&'src self) -> &'src Span<'src> {
-        &self.source
+    fn span(&self) -> Span<'src> {
+        self.source
     }
 }

--- a/parser/src/blocks/media.rs
+++ b/parser/src/blocks/media.rs
@@ -177,7 +177,7 @@ impl<'src> IsBlock<'src> for MediaBlock<'src> {
 }
 
 impl<'src> HasSpan<'src> for MediaBlock<'src> {
-    fn span(&'src self) -> &'src Span<'src> {
-        &self.source
+    fn span(&self) -> Span<'src> {
+        self.source
     }
 }

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -163,7 +163,7 @@ impl<'src> IsBlock<'src> for RawDelimitedBlock<'src> {
 }
 
 impl<'src> HasSpan<'src> for RawDelimitedBlock<'src> {
-    fn span(&'src self) -> &'src Span<'src> {
-        &self.source
+    fn span(&self) -> Span<'src> {
+        self.source
     }
 }

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -107,8 +107,8 @@ impl<'src> IsBlock<'src> for SectionBlock<'src> {
 }
 
 impl<'src> HasSpan<'src> for SectionBlock<'src> {
-    fn span(&'src self) -> &'src Span<'src> {
-        &self.source
+    fn span(&self) -> Span<'src> {
+        self.source
     }
 }
 

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -93,7 +93,7 @@ impl<'src> IsBlock<'src> for SimpleBlock<'src> {
 }
 
 impl<'src> HasSpan<'src> for SimpleBlock<'src> {
-    fn span(&'src self) -> &'src Span<'src> {
-        &self.source
+    fn span(&self) -> Span<'src> {
+        self.source
     }
 }

--- a/parser/src/document/attribute.rs
+++ b/parser/src/document/attribute.rs
@@ -73,8 +73,8 @@ impl<'src> Attribute<'src> {
 }
 
 impl<'src> HasSpan<'src> for Attribute<'src> {
-    fn span(&'src self) -> &'src Span<'src> {
-        &self.source
+    fn span(&self) -> Span<'src> {
+        self.source
     }
 }
 

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -117,7 +117,7 @@ impl<'src> IsBlock<'src> for Document<'src> {
 }
 
 impl<'src> HasSpan<'src> for Document<'src> {
-    fn span(&'src self) -> &'src Span<'src> {
-        &self.source
+    fn span(&self) -> Span<'src> {
+        self.source
     }
 }

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -94,8 +94,8 @@ impl<'src> Header<'src> {
 }
 
 impl<'src> HasSpan<'src> for Header<'src> {
-    fn span(&'src self) -> &'src Span<'src> {
-        &self.source
+    fn span(&self) -> Span<'src> {
+        self.source
     }
 }
 

--- a/parser/src/span/mod.rs
+++ b/parser/src/span/mod.rs
@@ -127,5 +127,5 @@ pub(crate) use matched_item::MatchedItem;
 pub trait HasSpan<'src> {
     /// Return a [`Span`] describing the syntactic element's
     /// location within the source string/file.
-    fn span(&'src self) -> &'src Span<'src>;
+    fn span(&self) -> Span<'src>;
 }

--- a/parser/src/tests/fixtures/attributes/attrlist.rs
+++ b/parser/src/tests/fixtures/attributes/attrlist.rs
@@ -40,7 +40,7 @@ impl PartialEq<TAttrlist> for &Attrlist<'_> {
 }
 
 fn fixture_eq_observed(fixture: &TAttrlist, observed: &Attrlist) -> bool {
-    if &fixture.source != observed.span() {
+    if fixture.source != observed.span() {
         return false;
     }
 

--- a/parser/src/tests/fixtures/blocks/compound_delimited.rs
+++ b/parser/src/tests/fixtures/blocks/compound_delimited.rs
@@ -91,5 +91,5 @@ fn fixture_eq_observed(
         return false;
     }
 
-    &fixture.source == observed.span()
+    fixture.source == observed.span()
 }

--- a/parser/src/tests/fixtures/blocks/media.rs
+++ b/parser/src/tests/fixtures/blocks/media.rs
@@ -93,5 +93,5 @@ fn fixture_eq_observed(fixture: &TMediaBlock, observed: &MediaBlock) -> bool {
         return false;
     }
 
-    &fixture.source == observed.span()
+    fixture.source == observed.span()
 }

--- a/parser/src/tests/fixtures/blocks/raw_delimited.rs
+++ b/parser/src/tests/fixtures/blocks/raw_delimited.rs
@@ -92,6 +92,5 @@ fn fixture_eq_observed(fixture: &TRawDelimitedBlock, observed: &RawDelimitedBloc
         return false;
     }
 
-    &fixture.source == observed.span()
-        && fixture.substitution_group == observed.substitution_group()
+    fixture.source == observed.span() && fixture.substitution_group == observed.substitution_group()
 }

--- a/parser/src/tests/fixtures/blocks/section.rs
+++ b/parser/src/tests/fixtures/blocks/section.rs
@@ -95,5 +95,5 @@ fn fixture_eq_observed(fixture: &TSectionBlock, observed: &SectionBlock) -> bool
         return false;
     }
 
-    &fixture.source == observed.span()
+    fixture.source == observed.span()
 }

--- a/parser/src/tests/fixtures/blocks/simple.rs
+++ b/parser/src/tests/fixtures/blocks/simple.rs
@@ -73,5 +73,5 @@ fn fixture_eq_observed(fixture: &TSimpleBlock, observed: &SimpleBlock) -> bool {
         return false;
     }
 
-    &fixture.source == observed.span() && &fixture.content == observed.content()
+    fixture.source == observed.span() && &fixture.content == observed.content()
 }

--- a/parser/src/tests/fixtures/document/attribute.rs
+++ b/parser/src/tests/fixtures/document/attribute.rs
@@ -42,7 +42,7 @@ impl PartialEq<TAttribute> for &Attribute<'_> {
 }
 
 fn fixture_eq_observed(fixture: &TAttribute, observed: &Attribute) -> bool {
-    if &fixture.source != observed.span() {
+    if fixture.source != observed.span() {
         return false;
     }
 

--- a/parser/src/tests/fixtures/document/document.rs
+++ b/parser/src/tests/fixtures/document/document.rs
@@ -45,7 +45,7 @@ impl PartialEq<TDocument> for &Document<'_> {
 }
 
 fn fixture_eq_observed(fixture: &TDocument, observed: &Document) -> bool {
-    if &fixture.source != observed.span() {
+    if fixture.source != observed.span() {
         return false;
     }
 

--- a/parser/src/tests/fixtures/document/header.rs
+++ b/parser/src/tests/fixtures/document/header.rs
@@ -42,7 +42,7 @@ impl PartialEq<THeader> for &Header<'_> {
 }
 
 fn fixture_eq_observed(fixture: &THeader, observed: &Header) -> bool {
-    if &fixture.source != observed.span() {
+    if fixture.source != observed.span() {
         return false;
     }
 


### PR DESCRIPTION
This avoids lifetime issues that can occur when the implementing object's lifespan is shorter than 'src.