### PR TITLE
chore: Rename `Preamble` to `BlockMetadata`

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -181,10 +181,10 @@ impl<'src> Block<'src> {
             // don't automatically error out on a parse failure.
         }
 
-        // First, let's look for a fun edge case. Perhaps the text contains a metadata
-        // but no block immediately following. If we're not careful, we could spin in a
-        // loop (for example, `parse_blocks_until`) thinking there will be another
-        // block, but there isn't.
+        // First, let's look for a fun edge case. Perhaps the text contains block
+        // metadata but no block immediately following. If we're not careful, we could
+        // spin in a loop (for example, `parse_blocks_until`) thinking there will be
+        // another block, but there isn't.
 
         // The following check disables that spin loop.
         let simple_block_mi = SimpleBlock::parse(&metadata, parser);

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -5,7 +5,7 @@ use crate::{
     attributes::Attrlist,
     blocks::{
         CompoundDelimitedBlock, ContentModel, IsBlock, MediaBlock, RawDelimitedBlock, SectionBlock,
-        SimpleBlock, preamble::Preamble,
+        SimpleBlock, metadata::BlockMetadata,
     },
     span::{MatchedItem, content::SubstitutionGroup},
     strings::CowStr,
@@ -87,14 +87,14 @@ impl<'src> Block<'src> {
             }
         }
 
-        // Optimization not possible; start by looking for a preamble (title and/or
-        // attrlist).
+        // Optimization not possible; start by looking for block metadata (title,
+        // attrlist, etc.).
         let MatchAndWarnings {
-            item: mut preamble,
+            item: mut metadata,
             mut warnings,
-        } = Preamble::parse(source, parser);
+        } = BlockMetadata::parse(source, parser);
 
-        if let Some(mut rdb_maw) = RawDelimitedBlock::parse(&preamble, parser) {
+        if let Some(mut rdb_maw) = RawDelimitedBlock::parse(&metadata, parser) {
             // If we found an initial delimiter without its matching
             // closing delimiter, we will issue an unmatched delimiter warning
             // and attempt to parse this as some other kind of block.
@@ -113,7 +113,7 @@ impl<'src> Block<'src> {
             }
         }
 
-        if let Some(mut cdb_maw) = CompoundDelimitedBlock::parse(&preamble, parser) {
+        if let Some(mut cdb_maw) = CompoundDelimitedBlock::parse(&metadata, parser) {
             // If we found an initial delimiter without its matching
             // closing delimiter, we will issue an unmatched delimiter warning
             // and attempt to parse this as some other kind of block.
@@ -133,13 +133,13 @@ impl<'src> Block<'src> {
         }
 
         // Try to discern the block type by scanning the first line.
-        let line = preamble.block_start.take_normalized_line();
+        let line = metadata.block_start.take_normalized_line();
 
         if line.item.starts_with("image::")
             || line.item.starts_with("video::")
             || line.item.starts_with("video::")
         {
-            let mut media_block_maw = MediaBlock::parse(&preamble, parser);
+            let mut media_block_maw = MediaBlock::parse(&metadata, parser);
 
             if let Some(media_block) = media_block_maw.item {
                 // Only propagate warnings from media block parsing if we think this
@@ -163,7 +163,7 @@ impl<'src> Block<'src> {
         }
 
         if line.item.starts_with('=') {
-            if let Some(mut maw_section_block) = SectionBlock::parse(&preamble, parser) {
+            if let Some(mut maw_section_block) = SectionBlock::parse(&metadata, parser) {
                 if !maw_section_block.warnings.is_empty() {
                     warnings.append(&mut maw_section_block.warnings);
                 }
@@ -181,34 +181,34 @@ impl<'src> Block<'src> {
             // don't automatically error out on a parse failure.
         }
 
-        // First, let's look for a fun edge case. Perhaps the text contains a preamble
+        // First, let's look for a fun edge case. Perhaps the text contains a metadata
         // but no block immediately following. If we're not careful, we could spin in a
         // loop (for example, `parse_blocks_until`) thinking there will be another
         // block, but there isn't.
 
         // The following check disables that spin loop.
-        let simple_block_mi = SimpleBlock::parse(&preamble, parser);
+        let simple_block_mi = SimpleBlock::parse(&metadata, parser);
 
-        if simple_block_mi.is_none() && !preamble.is_empty() {
-            // We have a preamble with no block. Treat it as a simple block but issue a
+        if simple_block_mi.is_none() && !metadata.is_empty() {
+            // We have a metadata with no block. Treat it as a simple block but issue a
             // warning.
 
             warnings.push(Warning {
-                source: preamble.source,
+                source: metadata.source,
                 warning: WarningType::MissingBlockAfterTitleOrAttributeList,
             });
 
-            // Remove the preamble content so that SimpleBlock will read the title/attrlist
+            // Remove the metadata content so that SimpleBlock will read the title/attrlist
             // line(s) as regular content.
-            preamble.title = None;
-            preamble.anchor = None;
-            preamble.attrlist = None;
-            preamble.block_start = preamble.source;
+            metadata.title = None;
+            metadata.anchor = None;
+            metadata.attrlist = None;
+            metadata.block_start = metadata.source;
         }
 
         // If no other block kind matches, we can always use SimpleBlock.
         MatchAndWarnings {
-            item: SimpleBlock::parse(&preamble, parser).map(|mi| MatchedItem {
+            item: SimpleBlock::parse(&metadata, parser).map(|mi| MatchedItem {
                 item: Self::Simple(mi.item),
                 after: mi.after,
             }),

--- a/parser/src/blocks/media.rs
+++ b/parser/src/blocks/media.rs
@@ -1,7 +1,7 @@
 use crate::{
     HasSpan, Parser, Span,
     attributes::Attrlist,
-    blocks::{ContentModel, IsBlock, preamble::Preamble},
+    blocks::{ContentModel, IsBlock, metadata::BlockMetadata},
     span::MatchedItem,
     strings::CowStr,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -34,10 +34,10 @@ pub enum MediaType {
 
 impl<'src> MediaBlock<'src> {
     pub(crate) fn parse(
-        preamble: &Preamble<'src>,
+        metadata: &BlockMetadata<'src>,
         parser: &mut Parser,
     ) -> MatchAndWarnings<'src, Option<MatchedItem<'src, Self>>> {
-        let line = preamble.block_start.take_normalized_line();
+        let line = metadata.block_start.take_normalized_line();
 
         // Line must end with `]`; otherwise, it's not a block macro.
         if !line.item.ends_with(']') {
@@ -104,7 +104,7 @@ impl<'src> MediaBlock<'src> {
 
         let macro_attrlist = Attrlist::parse(attrlist, parser);
 
-        let source: Span = preamble.source.trim_remainder(line.after);
+        let source: Span = metadata.source.trim_remainder(line.after);
         let source = source.slice(0..source.trim().len());
 
         MatchAndWarnings {
@@ -114,9 +114,9 @@ impl<'src> MediaBlock<'src> {
                     target: target.item,
                     macro_attrlist: macro_attrlist.item.item,
                     source,
-                    title: preamble.title,
-                    anchor: preamble.anchor,
-                    attrlist: preamble.attrlist.clone(),
+                    title: metadata.title,
+                    anchor: metadata.anchor,
+                    attrlist: metadata.attrlist.clone(),
                 },
 
                 after: line.after.discard_empty_lines(),

--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -5,10 +5,10 @@ use crate::{
     warnings::{MatchAndWarnings, Warning, WarningType},
 };
 
-/// A preamble represents the common elements that can precede any block type
-/// (title and attribute list). It is used internally to track those values
-/// before the specific block type is fully formed.
-pub(crate) struct Preamble<'src> {
+/// `BlockMetadata` represents the common elements that can precede any block
+/// type (such as title and attribute list). It is used internally to track
+/// those values before the specific block type is fully formed.
+pub(crate) struct BlockMetadata<'src> {
     /// The block's title, if any.
     pub(crate) title: Option<Span<'src>>,
 
@@ -19,7 +19,7 @@ pub(crate) struct Preamble<'src> {
     /// The block's attribute list, if any.
     pub(crate) attrlist: Option<Attrlist<'src>>,
 
-    /// The source span as understood when the preamble content was first
+    /// The source span as understood when the block metadata was first
     /// encountered. Does not necessarily end at the end of the block.
     pub(crate) source: Span<'src>,
 
@@ -28,8 +28,8 @@ pub(crate) struct Preamble<'src> {
     pub(crate) block_start: Span<'src>,
 }
 
-impl<'src> Preamble<'src> {
-    /// (For testing only) Parse the preamble from a raw text constant.
+impl<'src> BlockMetadata<'src> {
+    /// (For testing only) Parse the block metadata from a raw text constant.
     #[cfg(test)]
     pub(crate) fn new(data: &'src str) -> Self {
         let mut temp_parser = Parser::default();

--- a/parser/src/blocks/mod.rs
+++ b/parser/src/blocks/mod.rs
@@ -37,8 +37,8 @@ pub use is_block::{ContentModel, IsBlock};
 mod media;
 pub use media::{MediaBlock, MediaType};
 
+pub(crate) mod metadata;
 pub(crate) mod parse_utils;
-pub(crate) mod preamble;
 
 mod raw_delimited;
 pub use raw_delimited::RawDelimitedBlock;

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -1,7 +1,7 @@
 use crate::{
     Content, HasSpan, Parser, Span,
     attributes::Attrlist,
-    blocks::{ContentModel, IsBlock, preamble::Preamble},
+    blocks::{ContentModel, IsBlock, metadata::BlockMetadata},
     span::{MatchedItem, content::SubstitutionGroup},
     strings::CowStr,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -56,10 +56,10 @@ impl<'src> RawDelimitedBlock<'src> {
     }
 
     pub(crate) fn parse(
-        preamble: &Preamble<'src>,
+        metadata: &BlockMetadata<'src>,
         parser: &mut Parser,
     ) -> Option<MatchAndWarnings<'src, Option<MatchedItem<'src, Self>>>> {
-        let delimiter = preamble.block_start.take_normalized_line();
+        let delimiter = metadata.block_start.take_normalized_line();
 
         if delimiter.item.len() < 4 {
             return None;
@@ -95,7 +95,7 @@ impl<'src> RawDelimitedBlock<'src> {
                 let content = content_start.trim_remainder(next).trim_trailing_line_end();
 
                 let mut content: Content<'src> = content.into();
-                substitution_group.apply(&mut content, parser, preamble.attrlist.as_ref());
+                substitution_group.apply(&mut content, parser, metadata.attrlist.as_ref());
 
                 return Some(MatchAndWarnings {
                     item: Some(MatchedItem {
@@ -103,13 +103,13 @@ impl<'src> RawDelimitedBlock<'src> {
                             content,
                             content_model,
                             context: context.into(),
-                            source: preamble
+                            source: metadata
                                 .source
                                 .trim_remainder(line.after)
                                 .trim_trailing_line_end(),
-                            title: preamble.title,
-                            anchor: preamble.anchor,
-                            attrlist: preamble.attrlist.clone(),
+                            title: metadata.title,
+                            anchor: metadata.anchor,
+                            attrlist: metadata.attrlist.clone(),
                             substitution_group,
                         },
                         after: line.after,

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -3,7 +3,9 @@ use std::slice::Iter;
 use crate::{
     HasSpan, Parser, Span,
     attributes::Attrlist,
-    blocks::{Block, ContentModel, IsBlock, parse_utils::parse_blocks_until, preamble::Preamble},
+    blocks::{
+        Block, ContentModel, IsBlock, metadata::BlockMetadata, parse_utils::parse_blocks_until,
+    },
     span::MatchedItem,
     strings::CowStr,
     warnings::MatchAndWarnings,
@@ -29,10 +31,10 @@ pub struct SectionBlock<'src> {
 
 impl<'src> SectionBlock<'src> {
     pub(crate) fn parse(
-        preamble: &Preamble<'src>,
+        metadata: &BlockMetadata<'src>,
         parser: &mut Parser,
     ) -> Option<MatchAndWarnings<'src, MatchedItem<'src, Self>>> {
-        let source = preamble.block_start.discard_empty_lines();
+        let source = metadata.block_start.discard_empty_lines();
         let level = parse_title_line(source)?;
 
         let maw_blocks = parse_blocks_until(
@@ -42,7 +44,7 @@ impl<'src> SectionBlock<'src> {
         );
 
         let blocks = maw_blocks.item;
-        let source = preamble.source.trim_remainder(blocks.after);
+        let source = metadata.source.trim_remainder(blocks.after);
 
         Some(MatchAndWarnings {
             item: MatchedItem {
@@ -51,9 +53,9 @@ impl<'src> SectionBlock<'src> {
                     section_title: level.item.1,
                     blocks: blocks.item,
                     source: source.trim_trailing_whitespace(),
-                    title: preamble.title,
-                    anchor: preamble.anchor,
-                    attrlist: preamble.attrlist.clone(),
+                    title: metadata.title,
+                    anchor: metadata.anchor,
+                    attrlist: metadata.attrlist.clone(),
                 },
                 after: blocks.after,
             },

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -1,7 +1,7 @@
 use crate::{
     Content, HasSpan, Parser, Span,
     attributes::Attrlist,
-    blocks::{ContentModel, IsBlock, preamble::Preamble},
+    blocks::{ContentModel, IsBlock, metadata::BlockMetadata},
     span::{MatchedItem, content::SubstitutionGroup},
     strings::CowStr,
 };
@@ -19,25 +19,25 @@ pub struct SimpleBlock<'src> {
 
 impl<'src> SimpleBlock<'src> {
     pub(crate) fn parse(
-        preamble: &Preamble<'src>,
+        metadata: &BlockMetadata<'src>,
         parser: &mut Parser,
     ) -> Option<MatchedItem<'src, Self>> {
-        let source = preamble.block_start.take_non_empty_lines()?;
+        let source = metadata.block_start.take_non_empty_lines()?;
 
         // TO DO: Allow overrides for SubstitutionGroup.
         let mut content: Content<'src> = source.item.into();
-        SubstitutionGroup::Normal.apply(&mut content, parser, preamble.attrlist.as_ref());
+        SubstitutionGroup::Normal.apply(&mut content, parser, metadata.attrlist.as_ref());
 
         Some(MatchedItem {
             item: Self {
                 content,
-                source: preamble
+                source: metadata
                     .source
                     .trim_remainder(source.after)
                     .trim_trailing_whitespace(),
-                title: preamble.title,
-                anchor: preamble.anchor,
-                attrlist: preamble.attrlist.clone(),
+                title: metadata.title,
+                anchor: metadata.anchor,
+                attrlist: metadata.attrlist.clone(),
             },
             after: source.after.discard_empty_lines(),
         })

--- a/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
@@ -17,7 +17,7 @@ mod positional_attribute {
 
     use crate::{
         Parser, Span,
-        blocks::{Block, IsBlock, MediaBlock, preamble::Preamble},
+        blocks::{Block, IsBlock, MediaBlock, metadata::BlockMetadata},
         span::content::SubstitutionGroup,
         tests::{
             fixtures::{
@@ -74,7 +74,7 @@ The second macro is the same as the first, but written out in longhand form.
         let mut parser = Parser::default();
 
         let m1 = MediaBlock::parse(
-            &Preamble::new("image::sunset.jpg[Sunset,300,400]"),
+            &BlockMetadata::new("image::sunset.jpg[Sunset,300,400]"),
             &mut parser,
         )
         .unwrap_if_no_warnings()
@@ -83,7 +83,7 @@ The second macro is the same as the first, but written out in longhand form.
         let mut parser = Parser::default();
 
         let m2 = MediaBlock::parse(
-            &Preamble::new("image::sunset.jpg[alt=Sunset,width=300,height=400]"),
+            &BlockMetadata::new("image::sunset.jpg[alt=Sunset,width=300,height=400]"),
             &mut parser,
         )
         .unwrap_if_no_warnings()

--- a/parser/src/tests/blocks/block/mod.rs
+++ b/parser/src/tests/blocks/block/mod.rs
@@ -23,7 +23,7 @@ mod error_cases {
 
     use crate::{
         Parser, Span,
-        blocks::{Block, ContentModel, IsBlock, SectionBlock, preamble::Preamble},
+        blocks::{Block, ContentModel, IsBlock, SectionBlock, metadata::BlockMetadata},
         span::{HasSpan, content::SubstitutionGroup},
         tests::fixtures::{
             TSpan,
@@ -40,7 +40,7 @@ mod error_cases {
         let mut parser = Parser::default();
 
         let MatchAndWarnings { item: mi, warnings } = SectionBlock::parse(
-            &Preamble::new("=== Section Title\n\nabc\n\n.ancestor section== Section 2\n\ndef"),
+            &BlockMetadata::new("=== Section Title\n\nabc\n\n.ancestor section== Section 2\n\ndef"),
             &mut parser,
         )
         .unwrap();

--- a/parser/src/tests/blocks/compound_delimited.rs
+++ b/parser/src/tests/blocks/compound_delimited.rs
@@ -166,7 +166,7 @@ mod parse {
 
     use crate::{
         Parser,
-        blocks::{CompoundDelimitedBlock, preamble::Preamble},
+        blocks::{CompoundDelimitedBlock, metadata::BlockMetadata},
         tests::fixtures::{TSpan, warnings::TWarning},
         warnings::WarningType,
     };
@@ -174,22 +174,24 @@ mod parse {
     #[test]
     fn err_invalid_delimiter() {
         let mut parser = Parser::default();
-        assert!(CompoundDelimitedBlock::parse(&Preamble::new(""), &mut parser).is_none());
+        assert!(CompoundDelimitedBlock::parse(&BlockMetadata::new(""), &mut parser).is_none());
 
         let mut parser = Parser::default();
-        assert!(CompoundDelimitedBlock::parse(&Preamble::new("///"), &mut parser).is_none());
+        assert!(CompoundDelimitedBlock::parse(&BlockMetadata::new("///"), &mut parser).is_none());
 
         let mut parser = Parser::default();
-        assert!(CompoundDelimitedBlock::parse(&Preamble::new("////x"), &mut parser).is_none());
+        assert!(CompoundDelimitedBlock::parse(&BlockMetadata::new("////x"), &mut parser).is_none());
 
         let mut parser = Parser::default();
-        assert!(CompoundDelimitedBlock::parse(&Preamble::new("--x"), &mut parser).is_none());
+        assert!(CompoundDelimitedBlock::parse(&BlockMetadata::new("--x"), &mut parser).is_none());
 
         let mut parser = Parser::default();
-        assert!(CompoundDelimitedBlock::parse(&Preamble::new("****x"), &mut parser).is_none());
+        assert!(CompoundDelimitedBlock::parse(&BlockMetadata::new("****x"), &mut parser).is_none());
 
         let mut parser = Parser::default();
-        assert!(CompoundDelimitedBlock::parse(&Preamble::new("__\n__"), &mut parser).is_none());
+        assert!(
+            CompoundDelimitedBlock::parse(&BlockMetadata::new("__\n__"), &mut parser).is_none()
+        );
     }
 
     #[test]
@@ -197,7 +199,7 @@ mod parse {
         let mut parser = Parser::default();
 
         let maw =
-            CompoundDelimitedBlock::parse(&Preamble::new("====\nblah blah blah"), &mut parser)
+            CompoundDelimitedBlock::parse(&BlockMetadata::new("====\nblah blah blah"), &mut parser)
                 .unwrap();
 
         assert!(maw.item.is_none());
@@ -220,13 +222,15 @@ mod parse {
 mod comment {
     use crate::{
         Parser,
-        blocks::{CompoundDelimitedBlock, preamble::Preamble},
+        blocks::{CompoundDelimitedBlock, metadata::BlockMetadata},
     };
 
     #[test]
     fn empty() {
         let mut parser = Parser::default();
-        assert!(CompoundDelimitedBlock::parse(&Preamble::new("////\n////"), &mut parser).is_none());
+        assert!(
+            CompoundDelimitedBlock::parse(&BlockMetadata::new("////\n////"), &mut parser).is_none()
+        );
     }
 
     #[test]
@@ -235,7 +239,7 @@ mod comment {
 
         assert!(
             CompoundDelimitedBlock::parse(
-                &Preamble::new("////\nline1  \nline2\n////"),
+                &BlockMetadata::new("////\nline1  \nline2\n////"),
                 &mut parser
             )
             .is_none()
@@ -248,7 +252,7 @@ mod example {
 
     use crate::{
         Parser,
-        blocks::{CompoundDelimitedBlock, ContentModel, IsBlock, preamble::Preamble},
+        blocks::{CompoundDelimitedBlock, ContentModel, IsBlock, metadata::BlockMetadata},
         span::content::SubstitutionGroup,
         tests::fixtures::{
             TSpan,
@@ -261,7 +265,8 @@ mod example {
     fn empty() {
         let mut parser = Parser::default();
 
-        let maw = CompoundDelimitedBlock::parse(&Preamble::new("====\n===="), &mut parser).unwrap();
+        let maw =
+            CompoundDelimitedBlock::parse(&BlockMetadata::new("====\n===="), &mut parser).unwrap();
         let mi = maw.item.unwrap().clone();
 
         assert_eq!(
@@ -300,7 +305,7 @@ mod example {
         let mut parser = Parser::default();
 
         let maw = CompoundDelimitedBlock::parse(
-            &Preamble::new("====\nblock1\n\nblock2\n===="),
+            &BlockMetadata::new("====\nblock1\n\nblock2\n===="),
             &mut parser,
         )
         .unwrap();
@@ -434,7 +439,7 @@ mod example {
         let mut parser = Parser::default();
 
         let maw = CompoundDelimitedBlock::parse(
-            &Preamble::new("====\nblock1\n\n=====\nblock2\n=====\n===="),
+            &BlockMetadata::new("====\nblock1\n\n=====\nblock2\n=====\n===="),
             &mut parser,
         )
         .unwrap();
@@ -591,13 +596,15 @@ mod example {
 mod listing {
     use crate::{
         Parser,
-        blocks::{CompoundDelimitedBlock, preamble::Preamble},
+        blocks::{CompoundDelimitedBlock, metadata::BlockMetadata},
     };
 
     #[test]
     fn empty() {
         let mut parser = Parser::default();
-        assert!(CompoundDelimitedBlock::parse(&Preamble::new("----\n----"), &mut parser).is_none());
+        assert!(
+            CompoundDelimitedBlock::parse(&BlockMetadata::new("----\n----"), &mut parser).is_none()
+        );
     }
 
     #[test]
@@ -606,7 +613,7 @@ mod listing {
 
         assert!(
             CompoundDelimitedBlock::parse(
-                &Preamble::new("----\nline1  \nline2\n----"),
+                &BlockMetadata::new("----\nline1  \nline2\n----"),
                 &mut parser
             )
             .is_none()
@@ -617,13 +624,15 @@ mod listing {
 mod literal {
     use crate::{
         Parser,
-        blocks::{CompoundDelimitedBlock, preamble::Preamble},
+        blocks::{CompoundDelimitedBlock, metadata::BlockMetadata},
     };
 
     #[test]
     fn empty() {
         let mut parser = Parser::default();
-        assert!(CompoundDelimitedBlock::parse(&Preamble::new("....\n...."), &mut parser).is_none());
+        assert!(
+            CompoundDelimitedBlock::parse(&BlockMetadata::new("....\n...."), &mut parser).is_none()
+        );
     }
 
     #[test]
@@ -632,7 +641,7 @@ mod literal {
 
         assert!(
             CompoundDelimitedBlock::parse(
-                &Preamble::new("....\nline1  \nline2\n...."),
+                &BlockMetadata::new("....\nline1  \nline2\n...."),
                 &mut parser
             )
             .is_none()
@@ -645,7 +654,7 @@ mod open {
 
     use crate::{
         Parser,
-        blocks::{CompoundDelimitedBlock, ContentModel, IsBlock, preamble::Preamble},
+        blocks::{CompoundDelimitedBlock, ContentModel, IsBlock, metadata::BlockMetadata},
         span::content::SubstitutionGroup,
         tests::fixtures::{
             TSpan,
@@ -658,7 +667,8 @@ mod open {
     fn empty() {
         let mut parser = Parser::default();
 
-        let maw = CompoundDelimitedBlock::parse(&Preamble::new("--\n--"), &mut parser).unwrap();
+        let maw =
+            CompoundDelimitedBlock::parse(&BlockMetadata::new("--\n--"), &mut parser).unwrap();
         let mi = maw.item.unwrap().clone();
 
         assert_eq!(
@@ -696,9 +706,11 @@ mod open {
     fn multiple_blocks() {
         let mut parser = Parser::default();
 
-        let maw =
-            CompoundDelimitedBlock::parse(&Preamble::new("--\nblock1\n\nblock2\n--"), &mut parser)
-                .unwrap();
+        let maw = CompoundDelimitedBlock::parse(
+            &BlockMetadata::new("--\nblock1\n\nblock2\n--"),
+            &mut parser,
+        )
+        .unwrap();
 
         let mi = maw.item.unwrap().clone();
 
@@ -830,7 +842,7 @@ mod open {
         let mut parser = Parser::default();
 
         let maw = CompoundDelimitedBlock::parse(
-            &Preamble::new("--\nblock1\n\n---\nblock2\n---\n--"),
+            &BlockMetadata::new("--\nblock1\n\n---\nblock2\n---\n--"),
             &mut parser,
         )
         .unwrap();
@@ -965,7 +977,7 @@ mod sidebar {
 
     use crate::{
         Parser,
-        blocks::{CompoundDelimitedBlock, ContentModel, IsBlock, preamble::Preamble},
+        blocks::{CompoundDelimitedBlock, ContentModel, IsBlock, metadata::BlockMetadata},
         span::content::SubstitutionGroup,
         tests::fixtures::{
             TSpan,
@@ -978,7 +990,8 @@ mod sidebar {
     fn empty() {
         let mut parser = Parser::default();
 
-        let maw = CompoundDelimitedBlock::parse(&Preamble::new("****\n****"), &mut parser).unwrap();
+        let maw =
+            CompoundDelimitedBlock::parse(&BlockMetadata::new("****\n****"), &mut parser).unwrap();
         let mi = maw.item.unwrap().clone();
 
         assert_eq!(
@@ -1017,7 +1030,7 @@ mod sidebar {
         let mut parser = Parser::default();
 
         let maw = CompoundDelimitedBlock::parse(
-            &Preamble::new("****\nblock1\n\nblock2\n****"),
+            &BlockMetadata::new("****\nblock1\n\nblock2\n****"),
             &mut parser,
         )
         .unwrap();
@@ -1151,7 +1164,7 @@ mod sidebar {
         let mut parser = Parser::default();
 
         let maw = CompoundDelimitedBlock::parse(
-            &Preamble::new("****\nblock1\n\n*****\nblock2\n*****\n****"),
+            &BlockMetadata::new("****\nblock1\n\n*****\nblock2\n*****\n****"),
             &mut parser,
         )
         .unwrap();
@@ -1308,22 +1321,30 @@ mod sidebar {
 mod table {
     use crate::{
         Parser,
-        blocks::{CompoundDelimitedBlock, preamble::Preamble},
+        blocks::{CompoundDelimitedBlock, metadata::BlockMetadata},
     };
 
     #[test]
     fn empty() {
         let mut parser = Parser::default();
-        assert!(CompoundDelimitedBlock::parse(&Preamble::new("|===\n|==="), &mut parser).is_none());
+        assert!(
+            CompoundDelimitedBlock::parse(&BlockMetadata::new("|===\n|==="), &mut parser).is_none()
+        );
 
         let mut parser = Parser::default();
-        assert!(CompoundDelimitedBlock::parse(&Preamble::new(",===\n,==="), &mut parser).is_none());
+        assert!(
+            CompoundDelimitedBlock::parse(&BlockMetadata::new(",===\n,==="), &mut parser).is_none()
+        );
 
         let mut parser = Parser::default();
-        assert!(CompoundDelimitedBlock::parse(&Preamble::new(":===\n:==="), &mut parser).is_none());
+        assert!(
+            CompoundDelimitedBlock::parse(&BlockMetadata::new(":===\n:==="), &mut parser).is_none()
+        );
 
         let mut parser = Parser::default();
-        assert!(CompoundDelimitedBlock::parse(&Preamble::new("!===\n!==="), &mut parser).is_none());
+        assert!(
+            CompoundDelimitedBlock::parse(&BlockMetadata::new("!===\n!==="), &mut parser).is_none()
+        );
     }
 
     #[test]
@@ -1331,7 +1352,7 @@ mod table {
         let mut parser = Parser::default();
         assert!(
             CompoundDelimitedBlock::parse(
-                &Preamble::new("|===\nline1  \nline2\n|==="),
+                &BlockMetadata::new("|===\nline1  \nline2\n|==="),
                 &mut parser
             )
             .is_none()
@@ -1340,7 +1361,7 @@ mod table {
         let mut parser = Parser::default();
         assert!(
             CompoundDelimitedBlock::parse(
-                &Preamble::new(",===\nline1  \nline2\n,==="),
+                &BlockMetadata::new(",===\nline1  \nline2\n,==="),
                 &mut parser
             )
             .is_none()
@@ -1349,7 +1370,7 @@ mod table {
         let mut parser = Parser::default();
         assert!(
             CompoundDelimitedBlock::parse(
-                &Preamble::new(":===\nline1  \nline2\n:==="),
+                &BlockMetadata::new(":===\nline1  \nline2\n:==="),
                 &mut parser
             )
             .is_none()
@@ -1358,7 +1379,7 @@ mod table {
         let mut parser = Parser::default();
         assert!(
             CompoundDelimitedBlock::parse(
-                &Preamble::new("!===\nline1  \nline2\n!==="),
+                &BlockMetadata::new("!===\nline1  \nline2\n!==="),
                 &mut parser
             )
             .is_none()
@@ -1369,13 +1390,15 @@ mod table {
 mod pass {
     use crate::{
         Parser,
-        blocks::{CompoundDelimitedBlock, preamble::Preamble},
+        blocks::{CompoundDelimitedBlock, metadata::BlockMetadata},
     };
 
     #[test]
     fn empty() {
         let mut parser = Parser::default();
-        assert!(CompoundDelimitedBlock::parse(&Preamble::new("++++\n++++"), &mut parser).is_none());
+        assert!(
+            CompoundDelimitedBlock::parse(&BlockMetadata::new("++++\n++++"), &mut parser).is_none()
+        );
     }
 
     #[test]
@@ -1384,7 +1407,7 @@ mod pass {
 
         assert!(
             CompoundDelimitedBlock::parse(
-                &Preamble::new("++++\nline1  \nline2\n++++"),
+                &BlockMetadata::new("++++\nline1  \nline2\n++++"),
                 &mut parser
             )
             .is_none()
@@ -1397,7 +1420,7 @@ mod quote {
 
     use crate::{
         Parser,
-        blocks::{CompoundDelimitedBlock, ContentModel, IsBlock, preamble::Preamble},
+        blocks::{CompoundDelimitedBlock, ContentModel, IsBlock, metadata::BlockMetadata},
         span::content::SubstitutionGroup,
         tests::fixtures::{
             TSpan,
@@ -1410,7 +1433,8 @@ mod quote {
     fn empty() {
         let mut parser = Parser::default();
 
-        let maw = CompoundDelimitedBlock::parse(&Preamble::new("____\n____"), &mut parser).unwrap();
+        let maw =
+            CompoundDelimitedBlock::parse(&BlockMetadata::new("____\n____"), &mut parser).unwrap();
         let mi = maw.item.unwrap().clone();
 
         assert_eq!(
@@ -1449,7 +1473,7 @@ mod quote {
         let mut parser = Parser::default();
 
         let maw = CompoundDelimitedBlock::parse(
-            &Preamble::new("____\nblock1\n\nblock2\n____"),
+            &BlockMetadata::new("____\nblock1\n\nblock2\n____"),
             &mut parser,
         )
         .unwrap();
@@ -1583,7 +1607,7 @@ mod quote {
         let mut parser = Parser::default();
 
         let maw = CompoundDelimitedBlock::parse(
-            &Preamble::new("____\nblock1\n\n_____\nblock2\n_____\n____"),
+            &BlockMetadata::new("____\nblock1\n\n_____\nblock2\n_____\n____"),
             &mut parser,
         )
         .unwrap();

--- a/parser/src/tests/blocks/media.rs
+++ b/parser/src/tests/blocks/media.rs
@@ -4,7 +4,7 @@ use pretty_assertions_sorted::assert_eq;
 
 use crate::{
     Parser,
-    blocks::{ContentModel, IsBlock, MediaBlock, MediaType, preamble::Preamble},
+    blocks::{ContentModel, IsBlock, MediaBlock, MediaType, metadata::BlockMetadata},
     span::content::SubstitutionGroup,
     tests::fixtures::{
         TSpan,
@@ -20,7 +20,7 @@ fn impl_clone() {
     // Silly test to mark the #[derive(...)] line as covered.
     let mut parser = Parser::default();
 
-    let b1 = MediaBlock::parse(&Preamble::new("image::foo.jpg[]"), &mut parser)
+    let b1 = MediaBlock::parse(&BlockMetadata::new("image::foo.jpg[]"), &mut parser)
         .unwrap_if_no_warnings()
         .unwrap()
         .item;
@@ -34,7 +34,7 @@ fn err_empty_source() {
     let mut parser = Parser::default();
 
     assert!(
-        MediaBlock::parse(&Preamble::new(""), &mut parser)
+        MediaBlock::parse(&BlockMetadata::new(""), &mut parser)
             .unwrap_if_no_warnings()
             .is_none()
     );
@@ -45,7 +45,7 @@ fn err_only_spaces() {
     let mut parser = Parser::default();
 
     assert!(
-        MediaBlock::parse(&Preamble::new("    "), &mut parser)
+        MediaBlock::parse(&BlockMetadata::new("    "), &mut parser)
             .unwrap_if_no_warnings()
             .is_none()
     );
@@ -54,7 +54,7 @@ fn err_only_spaces() {
 #[test]
 fn err_macro_name_not_ident() {
     let mut parser = Parser::default();
-    let maw = MediaBlock::parse(&Preamble::new("98xyz::bar[blah,blap]"), &mut parser);
+    let maw = MediaBlock::parse(&BlockMetadata::new("98xyz::bar[blah,blap]"), &mut parser);
 
     assert!(maw.item.is_none());
     assert!(maw.warnings.is_empty());
@@ -63,7 +63,7 @@ fn err_macro_name_not_ident() {
 #[test]
 fn err_missing_double_colon() {
     let mut parser = Parser::default();
-    let maw = MediaBlock::parse(&Preamble::new("image:bar[blah,blap]"), &mut parser);
+    let maw = MediaBlock::parse(&BlockMetadata::new("image:bar[blah,blap]"), &mut parser);
 
     assert!(maw.item.is_none());
 
@@ -84,7 +84,7 @@ fn err_missing_double_colon() {
 #[test]
 fn err_missing_macro_attrlist() {
     let mut parser = Parser::default();
-    let maw = MediaBlock::parse(&Preamble::new("image::barblah,blap]"), &mut parser);
+    let maw = MediaBlock::parse(&BlockMetadata::new("image::barblah,blap]"), &mut parser);
 
     assert!(maw.item.is_none());
 
@@ -107,7 +107,7 @@ fn err_unknown_type() {
     let mut parser = Parser::default();
 
     assert!(
-        MediaBlock::parse(&Preamble::new("imagex::bar[]"), &mut parser)
+        MediaBlock::parse(&BlockMetadata::new("imagex::bar[]"), &mut parser)
             .unwrap_if_no_warnings()
             .is_none()
     );
@@ -118,7 +118,7 @@ fn err_no_attr_list() {
     let mut parser = Parser::default();
 
     assert!(
-        MediaBlock::parse(&Preamble::new("image::bar"), &mut parser)
+        MediaBlock::parse(&BlockMetadata::new("image::bar"), &mut parser)
             .unwrap_if_no_warnings()
             .is_none()
     );
@@ -129,7 +129,7 @@ fn err_attr_list_not_closed() {
     let mut parser = Parser::default();
 
     assert!(
-        MediaBlock::parse(&Preamble::new("image::bar[blah"), &mut parser)
+        MediaBlock::parse(&BlockMetadata::new("image::bar[blah"), &mut parser)
             .unwrap_if_no_warnings()
             .is_none()
     );
@@ -140,7 +140,7 @@ fn err_unexpected_after_attr_list() {
     let mut parser = Parser::default();
 
     assert!(
-        MediaBlock::parse(&Preamble::new("image::bar[blah]bonus"), &mut parser)
+        MediaBlock::parse(&BlockMetadata::new("image::bar[blah]bonus"), &mut parser)
             .unwrap_if_no_warnings()
             .is_none()
     );
@@ -150,7 +150,7 @@ fn err_unexpected_after_attr_list() {
 fn simplest_block_macro() {
     let mut parser = Parser::default();
 
-    let mi = MediaBlock::parse(&Preamble::new("image::[]"), &mut parser);
+    let mi = MediaBlock::parse(&BlockMetadata::new("image::[]"), &mut parser);
 
     assert!(mi.item.is_none());
 
@@ -172,7 +172,7 @@ fn simplest_block_macro() {
 fn has_target() {
     let mut parser = Parser::default();
 
-    let mi = MediaBlock::parse(&Preamble::new("image::bar[]"), &mut parser)
+    let mi = MediaBlock::parse(&BlockMetadata::new("image::bar[]"), &mut parser)
         .unwrap_if_no_warnings()
         .unwrap();
 
@@ -230,7 +230,7 @@ fn has_target() {
 fn has_target_and_attrlist() {
     let mut parser = Parser::default();
 
-    let mi = MediaBlock::parse(&Preamble::new("image::bar[blah]"), &mut parser)
+    let mi = MediaBlock::parse(&BlockMetadata::new("image::bar[blah]"), &mut parser)
         .unwrap_if_no_warnings()
         .unwrap();
 
@@ -284,7 +284,7 @@ fn has_target_and_attrlist() {
 fn audio() {
     let mut parser = Parser::default();
 
-    let mi = MediaBlock::parse(&Preamble::new("audio::bar[]"), &mut parser)
+    let mi = MediaBlock::parse(&BlockMetadata::new("audio::bar[]"), &mut parser)
         .unwrap_if_no_warnings()
         .unwrap();
 
@@ -342,7 +342,7 @@ fn audio() {
 fn video() {
     let mut parser = Parser::default();
 
-    let mi = MediaBlock::parse(&Preamble::new("video::bar[]"), &mut parser)
+    let mi = MediaBlock::parse(&BlockMetadata::new("video::bar[]"), &mut parser)
         .unwrap_if_no_warnings()
         .unwrap();
 
@@ -399,7 +399,7 @@ fn video() {
 #[test]
 fn err_duplicate_comma() {
     let mut parser = Parser::default();
-    let maw = MediaBlock::parse(&Preamble::new("image::bar[blah,,blap]"), &mut parser);
+    let maw = MediaBlock::parse(&BlockMetadata::new("image::bar[blah,,blap]"), &mut parser);
 
     let mi = maw.item.unwrap().clone();
 

--- a/parser/src/tests/blocks/raw_delimited.rs
+++ b/parser/src/tests/blocks/raw_delimited.rs
@@ -100,7 +100,7 @@ mod parse {
 
     use crate::{
         Parser,
-        blocks::{RawDelimitedBlock, preamble::Preamble},
+        blocks::{RawDelimitedBlock, metadata::BlockMetadata},
         tests::fixtures::{TSpan, warnings::TWarning},
         warnings::WarningType,
     };
@@ -108,22 +108,22 @@ mod parse {
     #[test]
     fn err_invalid_delimiter() {
         let mut parser = Parser::default();
-        assert!(RawDelimitedBlock::parse(&Preamble::new(""), &mut parser).is_none());
+        assert!(RawDelimitedBlock::parse(&BlockMetadata::new(""), &mut parser).is_none());
 
         let mut parser = Parser::default();
-        assert!(RawDelimitedBlock::parse(&Preamble::new("..."), &mut parser).is_none());
+        assert!(RawDelimitedBlock::parse(&BlockMetadata::new("..."), &mut parser).is_none());
 
         let mut parser = Parser::default();
-        assert!(RawDelimitedBlock::parse(&Preamble::new("++++x"), &mut parser).is_none());
+        assert!(RawDelimitedBlock::parse(&BlockMetadata::new("++++x"), &mut parser).is_none());
 
         let mut parser = Parser::default();
-        assert!(RawDelimitedBlock::parse(&Preamble::new("____x"), &mut parser).is_none());
+        assert!(RawDelimitedBlock::parse(&BlockMetadata::new("____x"), &mut parser).is_none());
 
         let mut parser = Parser::default();
-        assert!(RawDelimitedBlock::parse(&Preamble::new("====x"), &mut parser).is_none());
+        assert!(RawDelimitedBlock::parse(&BlockMetadata::new("====x"), &mut parser).is_none());
 
         let mut parser = Parser::default();
-        assert!(RawDelimitedBlock::parse(&Preamble::new("==\n=="), &mut parser).is_none());
+        assert!(RawDelimitedBlock::parse(&BlockMetadata::new("==\n=="), &mut parser).is_none());
     }
 
     #[test]
@@ -131,7 +131,8 @@ mod parse {
         let mut parser = Parser::default();
 
         let maw =
-            RawDelimitedBlock::parse(&Preamble::new("....\nblah blah blah"), &mut parser).unwrap();
+            RawDelimitedBlock::parse(&BlockMetadata::new("....\nblah blah blah"), &mut parser)
+                .unwrap();
 
         assert!(maw.item.is_none());
 
@@ -155,7 +156,7 @@ mod comment {
 
     use crate::{
         Parser,
-        blocks::{ContentModel, IsBlock, RawDelimitedBlock, preamble::Preamble},
+        blocks::{ContentModel, IsBlock, RawDelimitedBlock, metadata::BlockMetadata},
         span::content::SubstitutionGroup,
         tests::fixtures::{TSpan, blocks::TRawDelimitedBlock, content::TContent},
     };
@@ -163,7 +164,7 @@ mod comment {
     #[test]
     fn empty() {
         let mut parser = Parser::default();
-        let maw = RawDelimitedBlock::parse(&Preamble::new("////\n////"), &mut parser).unwrap();
+        let maw = RawDelimitedBlock::parse(&BlockMetadata::new("////\n////"), &mut parser).unwrap();
 
         let mi = maw.item.unwrap().clone();
 
@@ -212,9 +213,11 @@ mod comment {
     fn multiple_lines() {
         let mut parser = Parser::default();
 
-        let maw =
-            RawDelimitedBlock::parse(&Preamble::new("////\nline1  \nline2\n////"), &mut parser)
-                .unwrap();
+        let maw = RawDelimitedBlock::parse(
+            &BlockMetadata::new("////\nline1  \nline2\n////"),
+            &mut parser,
+        )
+        .unwrap();
 
         let mi = maw.item.unwrap().clone();
 
@@ -276,7 +279,7 @@ mod comment {
         let mut parser = Parser::default();
 
         let maw = RawDelimitedBlock::parse(
-            &Preamble::new("////\nline1  \n/////\nline2\n////"),
+            &BlockMetadata::new("////\nline1  \n/////\nline2\n////"),
             &mut parser,
         )
         .unwrap();
@@ -340,13 +343,13 @@ mod comment {
 mod example {
     use crate::{
         Parser,
-        blocks::{RawDelimitedBlock, preamble::Preamble},
+        blocks::{RawDelimitedBlock, metadata::BlockMetadata},
     };
 
     #[test]
     fn empty() {
         let mut parser = Parser::default();
-        assert!(RawDelimitedBlock::parse(&Preamble::new("====\n===="), &mut parser).is_none());
+        assert!(RawDelimitedBlock::parse(&BlockMetadata::new("====\n===="), &mut parser).is_none());
     }
 
     #[test]
@@ -354,8 +357,11 @@ mod example {
         let mut parser = Parser::default();
 
         assert!(
-            RawDelimitedBlock::parse(&Preamble::new("====\nline1  \nline2\n===="), &mut parser)
-                .is_none()
+            RawDelimitedBlock::parse(
+                &BlockMetadata::new("====\nline1  \nline2\n===="),
+                &mut parser
+            )
+            .is_none()
         );
     }
 }
@@ -365,7 +371,7 @@ mod listing {
 
     use crate::{
         Parser,
-        blocks::{ContentModel, IsBlock, RawDelimitedBlock, preamble::Preamble},
+        blocks::{ContentModel, IsBlock, RawDelimitedBlock, metadata::BlockMetadata},
         span::content::SubstitutionGroup,
         tests::fixtures::{TSpan, blocks::TRawDelimitedBlock, content::TContent},
     };
@@ -373,7 +379,7 @@ mod listing {
     #[test]
     fn empty() {
         let mut parser = Parser::default();
-        let maw = RawDelimitedBlock::parse(&Preamble::new("----\n----"), &mut parser).unwrap();
+        let maw = RawDelimitedBlock::parse(&BlockMetadata::new("----\n----"), &mut parser).unwrap();
 
         let mi = maw.item.unwrap().clone();
 
@@ -422,9 +428,11 @@ mod listing {
     fn multiple_lines() {
         let mut parser = Parser::default();
 
-        let maw =
-            RawDelimitedBlock::parse(&Preamble::new("----\nline1  \nline2\n----"), &mut parser)
-                .unwrap();
+        let maw = RawDelimitedBlock::parse(
+            &BlockMetadata::new("----\nline1  \nline2\n----"),
+            &mut parser,
+        )
+        .unwrap();
 
         let mi = maw.item.unwrap().clone();
 
@@ -486,7 +494,7 @@ mod listing {
         let mut parser = Parser::default();
 
         let maw = RawDelimitedBlock::parse(
-            &Preamble::new("----\nline1  \n-----\nline2\n----"),
+            &BlockMetadata::new("----\nline1  \n-----\nline2\n----"),
             &mut parser,
         )
         .unwrap();
@@ -563,21 +571,24 @@ mod listing {
 mod sidebar {
     use crate::{
         Parser,
-        blocks::{RawDelimitedBlock, preamble::Preamble},
+        blocks::{RawDelimitedBlock, metadata::BlockMetadata},
     };
 
     #[test]
     fn empty() {
         let mut parser = Parser::default();
-        assert!(RawDelimitedBlock::parse(&Preamble::new("****\n****"), &mut parser).is_none());
+        assert!(RawDelimitedBlock::parse(&BlockMetadata::new("****\n****"), &mut parser).is_none());
     }
 
     #[test]
     fn multiple_lines() {
         let mut parser = Parser::default();
         assert!(
-            RawDelimitedBlock::parse(&Preamble::new("****\nline1  \nline2\n****"), &mut parser)
-                .is_none()
+            RawDelimitedBlock::parse(
+                &BlockMetadata::new("****\nline1  \nline2\n****"),
+                &mut parser
+            )
+            .is_none()
         );
     }
 }
@@ -585,48 +596,60 @@ mod sidebar {
 mod table {
     use crate::{
         Parser,
-        blocks::{RawDelimitedBlock, preamble::Preamble},
+        blocks::{RawDelimitedBlock, metadata::BlockMetadata},
     };
 
     #[test]
     fn empty() {
         let mut parser = Parser::default();
-        assert!(RawDelimitedBlock::parse(&Preamble::new("|===\n|==="), &mut parser).is_none());
+        assert!(RawDelimitedBlock::parse(&BlockMetadata::new("|===\n|==="), &mut parser).is_none());
 
         let mut parser = Parser::default();
-        assert!(RawDelimitedBlock::parse(&Preamble::new(",===\n,==="), &mut parser).is_none());
+        assert!(RawDelimitedBlock::parse(&BlockMetadata::new(",===\n,==="), &mut parser).is_none());
 
         let mut parser = Parser::default();
-        assert!(RawDelimitedBlock::parse(&Preamble::new(":===\n:==="), &mut parser).is_none());
+        assert!(RawDelimitedBlock::parse(&BlockMetadata::new(":===\n:==="), &mut parser).is_none());
 
         let mut parser = Parser::default();
-        assert!(RawDelimitedBlock::parse(&Preamble::new("!===\n!==="), &mut parser).is_none());
+        assert!(RawDelimitedBlock::parse(&BlockMetadata::new("!===\n!==="), &mut parser).is_none());
     }
 
     #[test]
     fn multiple_lines() {
         let mut parser = Parser::default();
         assert!(
-            RawDelimitedBlock::parse(&Preamble::new("|===\nline1  \nline2\n|==="), &mut parser)
-                .is_none()
+            RawDelimitedBlock::parse(
+                &BlockMetadata::new("|===\nline1  \nline2\n|==="),
+                &mut parser
+            )
+            .is_none()
         );
 
         let mut parser = Parser::default();
         assert!(
-            RawDelimitedBlock::parse(&Preamble::new(",===\nline1  \nline2\n,==="), &mut parser)
-                .is_none()
+            RawDelimitedBlock::parse(
+                &BlockMetadata::new(",===\nline1  \nline2\n,==="),
+                &mut parser
+            )
+            .is_none()
         );
 
         let mut parser = Parser::default();
         assert!(
-            RawDelimitedBlock::parse(&Preamble::new(":===\nline1  \nline2\n:==="), &mut parser)
-                .is_none()
+            RawDelimitedBlock::parse(
+                &BlockMetadata::new(":===\nline1  \nline2\n:==="),
+                &mut parser
+            )
+            .is_none()
         );
 
         let mut parser = Parser::default();
         assert!(
-            RawDelimitedBlock::parse(&Preamble::new("!===\nline1  \nline2\n!==="), &mut parser)
-                .is_none()
+            RawDelimitedBlock::parse(
+                &BlockMetadata::new("!===\nline1  \nline2\n!==="),
+                &mut parser
+            )
+            .is_none()
         );
     }
 }
@@ -636,7 +659,7 @@ mod pass {
 
     use crate::{
         Parser,
-        blocks::{ContentModel, IsBlock, RawDelimitedBlock, preamble::Preamble},
+        blocks::{ContentModel, IsBlock, RawDelimitedBlock, metadata::BlockMetadata},
         span::content::SubstitutionGroup,
         tests::fixtures::{TSpan, blocks::TRawDelimitedBlock, content::TContent},
     };
@@ -644,7 +667,7 @@ mod pass {
     #[test]
     fn empty() {
         let mut parser = Parser::default();
-        let maw = RawDelimitedBlock::parse(&Preamble::new("++++\n++++"), &mut parser).unwrap();
+        let maw = RawDelimitedBlock::parse(&BlockMetadata::new("++++\n++++"), &mut parser).unwrap();
 
         let mi = maw.item.unwrap().clone();
 
@@ -693,9 +716,11 @@ mod pass {
     fn multiple_lines() {
         let mut parser = Parser::default();
 
-        let maw =
-            RawDelimitedBlock::parse(&Preamble::new("++++\nline1  \nline2\n++++"), &mut parser)
-                .unwrap();
+        let maw = RawDelimitedBlock::parse(
+            &BlockMetadata::new("++++\nline1  \nline2\n++++"),
+            &mut parser,
+        )
+        .unwrap();
 
         let mi = maw.item.unwrap().clone();
 
@@ -757,7 +782,7 @@ mod pass {
         let mut parser = Parser::default();
 
         let maw = RawDelimitedBlock::parse(
-            &Preamble::new("++++\nline1  \n+++++\nline2\n++++"),
+            &BlockMetadata::new("++++\nline1  \n+++++\nline2\n++++"),
             &mut parser,
         )
         .unwrap();
@@ -821,21 +846,24 @@ mod pass {
 mod quote {
     use crate::{
         Parser,
-        blocks::{RawDelimitedBlock, preamble::Preamble},
+        blocks::{RawDelimitedBlock, metadata::BlockMetadata},
     };
 
     #[test]
     fn empty() {
         let mut parser = Parser::default();
-        assert!(RawDelimitedBlock::parse(&Preamble::new("____\n____"), &mut parser).is_none());
+        assert!(RawDelimitedBlock::parse(&BlockMetadata::new("____\n____"), &mut parser).is_none());
     }
 
     #[test]
     fn multiple_lines() {
         let mut parser = Parser::default();
         assert!(
-            RawDelimitedBlock::parse(&Preamble::new("____\nline1  \nline2\n____"), &mut parser)
-                .is_none()
+            RawDelimitedBlock::parse(
+                &BlockMetadata::new("____\nline1  \nline2\n____"),
+                &mut parser
+            )
+            .is_none()
         );
     }
 }

--- a/parser/src/tests/blocks/section.rs
+++ b/parser/src/tests/blocks/section.rs
@@ -4,7 +4,7 @@ use pretty_assertions_sorted::assert_eq;
 
 use crate::{
     Parser,
-    blocks::{ContentModel, IsBlock, MediaType, SectionBlock, preamble::Preamble},
+    blocks::{ContentModel, IsBlock, MediaType, SectionBlock, metadata::BlockMetadata},
     span::content::SubstitutionGroup,
     tests::fixtures::{
         TSpan,
@@ -21,7 +21,7 @@ fn impl_clone() {
     // Silly test to mark the #[derive(...)] line as covered.
     let mut parser = Parser::default();
 
-    let b1 = SectionBlock::parse(&Preamble::new("== Section Title"), &mut parser).unwrap();
+    let b1 = SectionBlock::parse(&BlockMetadata::new("== Section Title"), &mut parser).unwrap();
 
     let b2 = b1.item.clone();
     assert_eq!(b1.item, b2);
@@ -30,32 +30,32 @@ fn impl_clone() {
 #[test]
 fn err_empty_source() {
     let mut parser = Parser::default();
-    assert!(SectionBlock::parse(&Preamble::new(""), &mut parser).is_none());
+    assert!(SectionBlock::parse(&BlockMetadata::new(""), &mut parser).is_none());
 }
 
 #[test]
 fn err_only_spaces() {
     let mut parser = Parser::default();
-    assert!(SectionBlock::parse(&Preamble::new("    "), &mut parser).is_none());
+    assert!(SectionBlock::parse(&BlockMetadata::new("    "), &mut parser).is_none());
 }
 
 #[test]
 fn err_not_section() {
     let mut parser = Parser::default();
-    assert!(SectionBlock::parse(&Preamble::new("blah blah"), &mut parser).is_none());
+    assert!(SectionBlock::parse(&BlockMetadata::new("blah blah"), &mut parser).is_none());
 }
 
 #[test]
 fn err_missing_space_before_title() {
     let mut parser = Parser::default();
-    assert!(SectionBlock::parse(&Preamble::new("=blah blah"), &mut parser).is_none());
+    assert!(SectionBlock::parse(&BlockMetadata::new("=blah blah"), &mut parser).is_none());
 }
 
 #[test]
 fn simplest_section_block() {
     let mut parser = Parser::default();
 
-    let mi = SectionBlock::parse(&Preamble::new("== Section Title"), &mut parser)
+    let mi = SectionBlock::parse(&BlockMetadata::new("== Section Title"), &mut parser)
         .unwrap()
         .unwrap_if_no_warnings();
 
@@ -109,7 +109,7 @@ fn simplest_section_block() {
 fn has_child_block() {
     let mut parser = Parser::default();
 
-    let mi = SectionBlock::parse(&Preamble::new("== Section Title\n\nabc"), &mut parser)
+    let mi = SectionBlock::parse(&BlockMetadata::new("== Section Title\n\nabc"), &mut parser)
         .unwrap()
         .unwrap_if_no_warnings();
 
@@ -183,7 +183,7 @@ fn has_macro_block_with_extra_blank_line() {
     let mut parser = Parser::default();
 
     let mi = SectionBlock::parse(
-        &Preamble::new("== Section Title\n\nimage::bar[alt=Sunset,width=300,height=400]\n\n"),
+        &BlockMetadata::new("== Section Title\n\nimage::bar[alt=Sunset,width=300,height=400]\n\n"),
         &mut parser,
     )
     .unwrap()
@@ -282,7 +282,7 @@ fn has_child_block_with_errors() {
     let mut parser = Parser::default();
 
     let maw = SectionBlock::parse(
-        &Preamble::new("== Section Title\n\nimage::bar[alt=Sunset,width=300,,height=400]"),
+        &BlockMetadata::new("== Section Title\n\nimage::bar[alt=Sunset,width=300,,height=400]"),
         &mut parser,
     )
     .unwrap();
@@ -395,7 +395,7 @@ fn dont_stop_at_child_section() {
     let mut parser = Parser::default();
 
     let mi = SectionBlock::parse(
-        &Preamble::new("== Section Title\n\nabc\n\n=== Section 2\n\ndef"),
+        &BlockMetadata::new("== Section Title\n\nabc\n\n=== Section 2\n\ndef"),
         &mut parser,
     )
     .unwrap()
@@ -511,7 +511,7 @@ fn stop_at_peer_section() {
     let mut parser = Parser::default();
 
     let mi = SectionBlock::parse(
-        &Preamble::new("== Section Title\n\nabc\n\n== Section 2\n\ndef"),
+        &BlockMetadata::new("== Section Title\n\nabc\n\n== Section 2\n\ndef"),
         &mut parser,
     )
     .unwrap()
@@ -587,7 +587,7 @@ fn stop_at_ancestor_section() {
     let mut parser = Parser::default();
 
     let mi = SectionBlock::parse(
-        &Preamble::new("=== Section Title\n\nabc\n\n== Section 2\n\ndef"),
+        &BlockMetadata::new("=== Section Title\n\nabc\n\n== Section 2\n\ndef"),
         &mut parser,
     )
     .unwrap()

--- a/parser/src/tests/blocks/simple.rs
+++ b/parser/src/tests/blocks/simple.rs
@@ -4,7 +4,7 @@ use pretty_assertions_sorted::assert_eq;
 
 use crate::{
     Parser,
-    blocks::{ContentModel, IsBlock, SimpleBlock, preamble::Preamble},
+    blocks::{ContentModel, IsBlock, SimpleBlock, metadata::BlockMetadata},
     span::content::SubstitutionGroup,
     tests::fixtures::{TSpan, blocks::TSimpleBlock, content::TContent},
 };
@@ -14,7 +14,7 @@ fn impl_clone() {
     // Silly test to mark the #[derive(...)] line as covered.
     let mut parser = Parser::default();
 
-    let b1 = SimpleBlock::parse(&Preamble::new("abc"), &mut parser).unwrap();
+    let b1 = SimpleBlock::parse(&BlockMetadata::new("abc"), &mut parser).unwrap();
 
     let b2 = b1.item.clone();
     assert_eq!(b1.item, b2);
@@ -23,19 +23,19 @@ fn impl_clone() {
 #[test]
 fn empty_source() {
     let mut parser = Parser::default();
-    assert!(SimpleBlock::parse(&Preamble::new(""), &mut parser).is_none());
+    assert!(SimpleBlock::parse(&BlockMetadata::new(""), &mut parser).is_none());
 }
 
 #[test]
 fn only_spaces() {
     let mut parser = Parser::default();
-    assert!(SimpleBlock::parse(&Preamble::new("    "), &mut parser).is_none());
+    assert!(SimpleBlock::parse(&BlockMetadata::new("    "), &mut parser).is_none());
 }
 
 #[test]
 fn single_line() {
     let mut parser = Parser::default();
-    let mi = SimpleBlock::parse(&Preamble::new("abc"), &mut parser).unwrap();
+    let mi = SimpleBlock::parse(&BlockMetadata::new("abc"), &mut parser).unwrap();
 
     assert_eq!(
         mi.item,
@@ -87,7 +87,7 @@ fn single_line() {
 #[test]
 fn multiple_lines() {
     let mut parser = Parser::default();
-    let mi = SimpleBlock::parse(&Preamble::new("abc\ndef"), &mut parser).unwrap();
+    let mi = SimpleBlock::parse(&BlockMetadata::new("abc\ndef"), &mut parser).unwrap();
 
     assert_eq!(
         mi.item,
@@ -127,7 +127,7 @@ fn multiple_lines() {
 #[test]
 fn consumes_blank_lines_after() {
     let mut parser = Parser::default();
-    let mi = SimpleBlock::parse(&Preamble::new("abc\n\ndef"), &mut parser).unwrap();
+    let mi = SimpleBlock::parse(&BlockMetadata::new("abc\n\ndef"), &mut parser).unwrap();
 
     assert_eq!(
         mi.item,


### PR DESCRIPTION
Preamble has a different definition in AsciiDoc documentation.