### PR TITLE
chore: Fix SDD coverage for custom attributes page

### DIFF
--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -132,7 +132,7 @@ impl<'p> Parser<'p> {
         };
 
         self.attribute_values
-            .insert(name.as_ref().to_string(), attribute_value);
+            .insert(name.as_ref().to_lowercase(), attribute_value);
 
         self
     }
@@ -176,7 +176,7 @@ impl<'p> Parser<'p> {
         };
 
         self.attribute_values
-            .insert(name.as_ref().to_string(), attribute_value);
+            .insert(name.as_ref().to_lowercase(), attribute_value);
 
         self
     }
@@ -187,7 +187,7 @@ impl<'p> Parser<'p> {
         attr: &Attribute<'src>,
         warnings: &mut Vec<Warning<'src>>,
     ) {
-        let attr_name = attr.name().data().to_owned();
+        let attr_name = attr.name().data().to_lowercase();
 
         let existing_attr = self.attribute_values.get(&attr_name);
 
@@ -227,7 +227,7 @@ impl<'p> Parser<'p> {
         attr: &Attribute<'src>,
         warnings: &mut Vec<Warning<'src>>,
     ) {
-        let attr_name = attr.name().data().to_owned();
+        let attr_name = attr.name().data().to_lowercase();
 
         // Verify that we have permission to overwrite any existing attribute value.
         if let Some(existing_attr) = self.attribute_values.get(&attr_name)

--- a/parser/src/tests/asciidoc_lang/attributes/custom_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/custom_attributes.rs
@@ -174,55 +174,15 @@ A best practice is to only use lowercase letters in the name and avoid starting 
 
     #[test]
     fn may_contain_uppercase() {
-        // IMPORTANT: We've defined the lower-case normalization as out of scope for
-        // the parser crate for now.
-        let mi = Attribute::parse(Span::new(":URL:"), &Parser::default()).unwrap();
+        let mut parser = Parser::default();
+        parser.parse(":URL: /foo/bar");
+
+        assert_eq!(parser.attribute_value("URL"), TInterpretedValue::Unset);
 
         assert_eq!(
-            mi.item,
-            TAttribute {
-                name: TSpan {
-                    data: "URL",
-                    line: 1,
-                    col: 2,
-                    offset: 1,
-                },
-                value_source: None,
-                value: TInterpretedValue::Set,
-                source: TSpan {
-                    data: ":URL:",
-                    line: 1,
-                    col: 1,
-                    offset: 0,
-                },
-            }
+            parser.attribute_value("url"),
+            TInterpretedValue::Value("/foo/bar")
         );
-
-        assert_eq!(mi.item.value(), &InterpretedValue::Set);
-
-        let mi = Attribute::parse(Span::new(":Url:"), &Parser::default()).unwrap();
-
-        assert_eq!(
-            mi.item,
-            TAttribute {
-                name: TSpan {
-                    data: "Url",
-                    line: 1,
-                    col: 2,
-                    offset: 1,
-                },
-                value_source: None,
-                value: TInterpretedValue::Set,
-                source: TSpan {
-                    data: ":Url:",
-                    line: 1,
-                    col: 1,
-                    offset: 0,
-                },
-            }
-        );
-
-        assert_eq!(mi.item.value(), &InterpretedValue::Set);
     }
 }
 


### PR DESCRIPTION
#sddbugfind: We weren't normalizing attribute names to lower-case before storing them in the parser state.