### PR TITLE
fix: Quoted attribute value should unescape quotes inside the value

### DIFF
--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -72,7 +72,7 @@ impl<'src> ElementAttribute<'src> {
             {
                 let escaped_quote = format!("\\{first}");
                 let new_value = value.replace(&escaped_quote, &first.to_string());
-                if &new_value != &*value {
+                if new_value != *value {
                     value = CowStr::from(new_value);
                 }
             }

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -48,7 +48,9 @@ impl<'src> ElementAttribute<'src> {
 
             let after = after.take_whitespace_with_newline().after;
 
-            let value = match after.data().chars().next() {
+            let first_char = after.data().chars().next();
+
+            let value = match first_char {
                 Some('\'') | Some('"') => match after.take_quoted_string() {
                     Some(v) => {
                         parse_shorthand = ParseShorthand(false);
@@ -63,7 +65,17 @@ impl<'src> ElementAttribute<'src> {
             };
 
             let after = value.after;
-            let value = cowstr_from_source_and_span(source_text, &value.item);
+            let mut value = cowstr_from_source_and_span(source_text, &value.item);
+
+            if let Some(first) = first_char
+                && (first == '\'' || first == '\"')
+            {
+                let escaped_quote = format!("\\{first}");
+                let new_value = value.replace(&escaped_quote, &first.to_string());
+                if &new_value != &*value {
+                    value = CowStr::from(new_value);
+                }
+            }
 
             // TO DO: Redo this to support substitutions but only in correct circumstances.
             // It doesn't apply in all cases.

--- a/parser/src/tests/attributes/element_attribute.rs
+++ b/parser/src/tests/attributes/element_attribute.rs
@@ -219,7 +219,7 @@ mod quoted_string {
             ElementAttribute {
                 name: None,
                 shorthand_items: &[],
-                value: "a\\\"bc"
+                value: "a\"bc"
             }
         );
 
@@ -330,7 +330,7 @@ mod quoted_string {
             ElementAttribute {
                 name: None,
                 shorthand_items: &[],
-                value: "a\\'bc"
+                value: "a'bc"
             }
         );
 


### PR DESCRIPTION
#sddbugfind (found while working on #347)