### PR TITLE
chore: Swap the pretty-print and "normal" `Debug` implementations for `CowStr`

### DIFF
--- a/parser/src/strings.rs
+++ b/parser/src/strings.rs
@@ -109,8 +109,9 @@ impl fmt::Display for InlineStr {
 /// It is three words long.
 ///
 /// NOTE: The [`Debug`] implementation for this struct elides the storage
-/// mechanism that is chosen. To obtain that information, use the alternate
-/// debug formatting as shown below:
+/// mechanism that is chosen when pretty printing (as occurs when using the
+/// `dbg!()` macro. To obtain that information, use the “normal” debug
+/// formatting as shown below:
 ///
 /// ```
 /// # use asciidoc_parser::strings::CowStr;
@@ -118,8 +119,8 @@ impl fmt::Display for InlineStr {
 /// let s: &'static str = "0123456789abcdefghijklm";
 /// let s: CowStr = s.into();
 /// assert_eq!(
-///     format!("{s:#?}"),
-///     "CowStr::Borrowed(\n    \"0123456789abcdefghijklm\",\n)"
+///     format!("{s:?}"),
+///     "CowStr::Borrowed(\"0123456789abcdefghijklm\")"
 /// );
 /// ```
 #[derive(Eq)]
@@ -244,13 +245,13 @@ impl fmt::Display for CowStr<'_> {
 impl fmt::Debug for CowStr<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
+            write!(f, "{:?}", self.as_ref())
+        } else {
             match self {
                 Self::Boxed(b) => f.debug_tuple("CowStr::Boxed").field(b).finish(),
                 Self::Borrowed(b) => f.debug_tuple("CowStr::Borrowed").field(b).finish(),
                 Self::Inlined(s) => f.debug_tuple("CowStr::Inlined").field(s).finish(),
             }
-        } else {
-            write!(f, "{:?}", self.as_ref())
         }
     }
 }

--- a/parser/src/tests/strings.rs
+++ b/parser/src/tests/strings.rs
@@ -241,11 +241,38 @@ mod cow_str {
     }
 
     #[test]
+    fn impl_debug_pretty_print_for_inline() {
+        let c = '藏';
+        let s: CowStr = c.into();
+
+        assert_eq!(format!("{s:#?}"), r#""藏""#);
+    }
+
+    #[test]
+    fn impl_debug_pretty_print_for_boxed() {
+        let s = "blah blah blah".to_string();
+        let s: CowStr = s.into();
+
+        assert_eq!(format!("{s:#?}"), r#""blah blah blah""#);
+    }
+
+    #[test]
+    fn impl_debug_pretty_print_for_borrowed() {
+        let s: &'static str = "0123456789abcdefghijklm";
+        let s: CowStr = s.into();
+
+        assert_eq!(format!("{s:#?}"), r#""0123456789abcdefghijklm""#);
+    }
+
+    #[test]
     fn impl_debug_for_inline() {
         let c = '藏';
         let s: CowStr = c.into();
 
-        assert_eq!(format!("{s:?}"), r#""藏""#);
+        assert_eq!(
+            format!("{s:?}"),
+            "CowStr::Inlined(InlineStr { inner: [232, 151, 143, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], len: 3 })"
+        );
     }
 
     #[test]
@@ -253,7 +280,7 @@ mod cow_str {
         let s = "blah blah blah".to_string();
         let s: CowStr = s.into();
 
-        assert_eq!(format!("{s:?}"), r#""blah blah blah""#);
+        assert_eq!(format!("{s:?}"), "CowStr::Boxed(\"blah blah blah\")");
     }
 
     #[test]
@@ -261,67 +288,9 @@ mod cow_str {
         let s: &'static str = "0123456789abcdefghijklm";
         let s: CowStr = s.into();
 
-        assert_eq!(format!("{s:?}"), r#""0123456789abcdefghijklm""#);
-    }
-
-    #[test]
-    fn impl_debug_alt_for_inline() {
-        let c = '藏';
-        let s: CowStr = c.into();
-
         assert_eq!(
-            format!("{s:#?}"),
-            r#"CowStr::Inlined(
-    InlineStr {
-        inner: [
-            232,
-            151,
-            143,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-        ],
-        len: 3,
-    },
-)"#
-        );
-    }
-
-    #[test]
-    fn impl_debug_alt_for_boxed() {
-        let s = "blah blah blah".to_string();
-        let s: CowStr = s.into();
-
-        assert_eq!(
-            format!("{s:#?}"),
-            "CowStr::Boxed(\n    \"blah blah blah\",\n)"
-        );
-    }
-
-    #[test]
-    fn impl_debug_alt_for_borrowed() {
-        let s: &'static str = "0123456789abcdefghijklm";
-        let s: CowStr = s.into();
-
-        assert_eq!(
-            format!("{s:#?}"),
-            "CowStr::Borrowed(\n    \"0123456789abcdefghijklm\",\n)"
+            format!("{s:?}"),
+            "CowStr::Borrowed(\"0123456789abcdefghijklm\")"
         );
     }
 


### PR DESCRIPTION
(What I really wanted in #351 was to impact the implementation for the `dbg!()` macro.)