### PR TITLE
chore: Add new method `MatchAndWarnings::unwrap_item_or_default`

### DIFF
--- a/parser/src/tests/warnings.rs
+++ b/parser/src/tests/warnings.rs
@@ -61,4 +61,26 @@ mod match_and_warnings {
         let _ = maw.unwrap_if_no_warnings();
         // There are warnings so this should panic.
     }
+
+    #[test]
+    fn unwrap_item_or_default() {
+        let maw = MatchAndWarnings {
+            item: Some("xyz".to_owned()),
+            warnings: vec![],
+        };
+
+        let item = maw.unwrap_item_or_default();
+        assert_eq!(item, "xyz");
+    }
+
+    #[test]
+    fn unwrap_item_or_default_none() {
+        let maw: MatchAndWarnings<'_, Option<String>> = MatchAndWarnings {
+            item: None,
+            warnings: vec![],
+        };
+
+        let item = maw.unwrap_item_or_default();
+        assert_eq!(item, "");
+    }
 }

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -77,6 +77,20 @@ pub(crate) struct MatchAndWarnings<'src, T> {
     pub(crate) warnings: Vec<Warning<'src>>,
 }
 
+impl<U> MatchAndWarnings<'_, Option<U>>
+where
+    U: Default,
+{
+    /// Unwrap the item if it's `Some(value)`, otherwise return `U::default()`.
+    ///
+    /// This method is only available when `T` is `Option<impl Default>`.
+    #[inline(always)]
+    #[allow(unused)] // TEMPORARY while building
+    pub(crate) fn unwrap_item_or_default(self) -> U {
+        self.item.unwrap_or_default()
+    }
+}
+
 impl<T> MatchAndWarnings<'_, T> {
     #[cfg(test)]
     #[inline(always)]


### PR DESCRIPTION
Convenience shortcut; only available when `T` is `Option<impl Default>`.