### PR TITLE
fix: Attribute value with unmatched initial quote ends at next comma or EOF instead

### DIFF
--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -51,7 +51,7 @@ impl<'src> Attrlist<'src> {
         let mut index = 0;
 
         let after_index = loop {
-            let (maybe_attr, warning_types) = ElementAttribute::parse(
+            let (attr, new_index, warning_types) = ElementAttribute::parse(
                 &source_cow,
                 index,
                 parser,
@@ -68,10 +68,6 @@ impl<'src> Attrlist<'src> {
                     warning: warning_type,
                 });
             }
-
-            let Some((attr, new_index)) = maybe_attr else {
-                break index;
-            };
 
             if attr.name().is_none() {
                 parse_shorthand_items = false;

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -58,7 +58,7 @@ impl<'src> ElementAttribute<'src> {
                     }
                     None => {
                         warnings.push(WarningType::AttributeValueMissingTerminatingQuote);
-                        return (None, warnings);
+                        after.take_while(|c| c != ',').trim_item_trailing_spaces()
                     }
                 },
                 _ => after.take_while(|c| c != ',').trim_item_trailing_spaces(),

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -20,7 +20,7 @@ impl<'src> ElementAttribute<'src> {
         start_index: usize,
         _parser: &Parser,
         mut parse_shorthand: ParseShorthand,
-    ) -> (Option<(Self, usize)>, Vec<WarningType>) {
+    ) -> (Self, usize, Vec<WarningType>) {
         let mut warnings: Vec<WarningType> = vec![];
 
         let (name, value, shorthand_item_indices, offset) = {
@@ -47,7 +47,6 @@ impl<'src> ElementAttribute<'src> {
             };
 
             let after = after.take_whitespace_with_newline().after;
-
             let first_char = after.data().chars().next();
 
             let value = match first_char {
@@ -99,14 +98,12 @@ impl<'src> ElementAttribute<'src> {
         };
 
         (
-            Some((
-                Self {
-                    name,
-                    value,
-                    shorthand_item_indices,
-                },
-                offset,
-            )),
+            Self {
+                name,
+                value,
+                shorthand_item_indices,
+            },
+            offset,
             warnings,
         )
     }

--- a/parser/src/tests/attributes/element_attribute.rs
+++ b/parser/src/tests/attributes/element_attribute.rs
@@ -15,8 +15,6 @@ fn impl_clone() {
         &p,
         ParseShorthand(false),
     )
-    .0
-    .unwrap()
     .0;
 
     let b2 = b1.clone();
@@ -27,10 +25,10 @@ fn impl_clone() {
 #[test]
 fn empty_source() {
     let p = Parser::default();
-    let (maybe_mi, warning_types) =
+
+    let (element_attr, offset, warning_types) =
         crate::attributes::ElementAttribute::parse(&CowStr::from(""), 0, &p, ParseShorthand(false));
 
-    let (element_attr, offset) = maybe_mi.unwrap();
     assert!(warning_types.is_empty());
 
     assert_eq!(
@@ -54,14 +52,14 @@ fn empty_source() {
 #[test]
 fn only_spaces() {
     let p = Parser::default();
-    let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+    let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
         &CowStr::from("   "),
         0,
         &p,
         ParseShorthand(false),
     );
 
-    let (element_attr, offset) = maybe_mi.unwrap();
     assert!(warning_types.is_empty());
 
     assert_eq!(
@@ -85,14 +83,14 @@ fn only_spaces() {
 #[test]
 fn unquoted_and_unnamed_value() {
     let p = Parser::default();
-    let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+    let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
         &CowStr::from("abc"),
         0,
         &p,
         ParseShorthand(false),
     );
 
-    let (element_attr, offset) = maybe_mi.unwrap();
     assert!(warning_types.is_empty());
 
     assert_eq!(
@@ -116,14 +114,14 @@ fn unquoted_and_unnamed_value() {
 #[test]
 fn unquoted_stops_at_comma() {
     let p = Parser::default();
-    let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+    let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
         &CowStr::from("abc,def"),
         0,
         &p,
         ParseShorthand(false),
     );
 
-    let (element_attr, offset) = maybe_mi.unwrap();
     assert!(warning_types.is_empty());
 
     assert_eq!(
@@ -155,14 +153,13 @@ mod quoted_string {
     #[test]
     fn err_unterminated_double_quote() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("\"xyz"),
             0,
             &p,
             ParseShorthand(false),
         );
-
-        let (element_attr, offset) = maybe_mi.unwrap();
 
         assert_eq!(
             element_attr,
@@ -190,14 +187,13 @@ mod quoted_string {
     #[test]
     fn err_unterminated_double_quote_ends_at_comma() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("\"xyz,abc"),
             0,
             &p,
             ParseShorthand(false),
         );
-
-        let (element_attr, offset) = maybe_mi.unwrap();
 
         assert_eq!(
             element_attr,
@@ -224,14 +220,14 @@ mod quoted_string {
     #[test]
     fn double_quoted_string() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("\"abc\"def"),
             0,
             &p,
             ParseShorthand(false),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -255,14 +251,14 @@ mod quoted_string {
     #[test]
     fn double_quoted_with_escape() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("\"a\\\"bc\"def"),
             0,
             &p,
             ParseShorthand(false),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -286,14 +282,14 @@ mod quoted_string {
     #[test]
     fn double_quoted_with_single_quote() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("\"a'bc\"def"),
             0,
             &p,
             ParseShorthand(false),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -317,14 +313,13 @@ mod quoted_string {
     #[test]
     fn err_unterminated_single_quote() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("\'xyz"),
             0,
             &p,
             ParseShorthand(false),
         );
-
-        let (element_attr, offset) = maybe_mi.unwrap();
 
         assert_eq!(
             element_attr,
@@ -352,14 +347,13 @@ mod quoted_string {
     #[test]
     fn err_unterminated_single_quote_ends_at_comma() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("\'xyz,abc"),
             0,
             &p,
             ParseShorthand(false),
         );
-
-        let (element_attr, offset) = maybe_mi.unwrap();
 
         assert_eq!(
             element_attr,
@@ -386,14 +380,14 @@ mod quoted_string {
     #[test]
     fn single_quoted_string() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("'abc'def"),
             0,
             &p,
             ParseShorthand(false),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -417,14 +411,14 @@ mod quoted_string {
     #[test]
     fn single_quoted_with_escape() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("'a\\'bc'def"),
             0,
             &p,
             ParseShorthand(false),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -448,14 +442,14 @@ mod quoted_string {
     #[test]
     fn single_quoted_with_double_quote() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("'a\"bc'def"),
             0,
             &p,
             ParseShorthand(false),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -487,14 +481,14 @@ mod named {
     #[test]
     fn simple_named_value() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("abc=def"),
             0,
             &p,
             ParseShorthand(false),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -518,14 +512,14 @@ mod named {
     #[test]
     fn ignores_spaces_around_equals() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("abc =  def"),
             0,
             &p,
             ParseShorthand(false),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -545,14 +539,14 @@ mod named {
     #[test]
     fn numeric_name() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("94-x =def"),
             0,
             &p,
             ParseShorthand(false),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -576,14 +570,14 @@ mod named {
     #[test]
     fn quoted_value() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("abc='def'g"),
             0,
             &p,
             ParseShorthand(false),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -607,14 +601,14 @@ mod named {
     #[test]
     fn fallback_if_no_value() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("abc="),
             0,
             &p,
             ParseShorthand(false),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -638,14 +632,14 @@ mod named {
     #[test]
     fn fallback_if_immediate_comma() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("abc=,def"),
             0,
             &p,
             ParseShorthand(false),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -678,14 +672,14 @@ mod parse_with_shorthand {
     #[test]
     fn block_style_only() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("abc"),
             0,
             &p,
             ParseShorthand(true),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -710,14 +704,14 @@ mod parse_with_shorthand {
     #[test]
     fn ignore_if_named_attribute() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("name=block_style#id"),
             0,
             &p,
             ParseShorthand(true),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -742,14 +736,13 @@ mod parse_with_shorthand {
     #[test]
     fn error_empty_id() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("abc#"),
             0,
             &p,
             ParseShorthand(true),
         );
-
-        let (element_attr, offset) = maybe_mi.unwrap();
 
         assert_eq!(
             element_attr,
@@ -767,14 +760,13 @@ mod parse_with_shorthand {
     #[test]
     fn error_duplicate_delimiter() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("abc##id"),
             0,
             &p,
             ParseShorthand(true),
         );
-
-        let (element_attr, offset) = maybe_mi.unwrap();
 
         assert_eq!(
             element_attr,
@@ -792,14 +784,14 @@ mod parse_with_shorthand {
     #[test]
     fn id_only() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("#xyz"),
             0,
             &p,
             ParseShorthand(true),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -824,14 +816,14 @@ mod parse_with_shorthand {
     #[test]
     fn one_role_only() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from(".role1"),
             0,
             &p,
             ParseShorthand(true),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -856,14 +848,14 @@ mod parse_with_shorthand {
     #[test]
     fn multiple_roles() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from(".role1.role2.role3"),
             0,
             &p,
             ParseShorthand(true),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -893,14 +885,14 @@ mod parse_with_shorthand {
     #[test]
     fn one_option_only() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("%option1"),
             0,
             &p,
             ParseShorthand(true),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -925,14 +917,14 @@ mod parse_with_shorthand {
     #[test]
     fn multiple_options() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("%option1%option2%option3"),
             0,
             &p,
             ParseShorthand(true),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -965,14 +957,14 @@ mod parse_with_shorthand {
     #[test]
     fn block_style_and_id() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("appendix#custom-id"),
             0,
             &p,
             ParseShorthand(true),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(
@@ -1000,14 +992,14 @@ mod parse_with_shorthand {
     #[test]
     fn id_role_and_option() {
         let p = Parser::default();
-        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
             &CowStr::from("#rules.prominent%incremental"),
             0,
             &p,
             ParseShorthand(true),
         );
 
-        let (element_attr, offset) = maybe_mi.unwrap();
         assert!(warning_types.is_empty());
 
         assert_eq!(

--- a/parser/src/tests/attributes/element_attribute.rs
+++ b/parser/src/tests/attributes/element_attribute.rs
@@ -156,14 +156,65 @@ mod quoted_string {
     fn err_unterminated_double_quote() {
         let p = Parser::default();
         let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
-            &CowStr::from("\"xxx"),
+            &CowStr::from("\"xyz"),
             0,
             &p,
             ParseShorthand(false),
         );
 
-        assert!(maybe_mi.is_none());
+        let (element_attr, offset) = maybe_mi.unwrap();
 
+        assert_eq!(
+            element_attr,
+            ElementAttribute {
+                name: None,
+                shorthand_items: &[],
+                value: "\"xyz"
+            }
+        );
+
+        assert!(element_attr.name().is_none());
+        assert!(element_attr.block_style().is_none());
+        assert!(element_attr.id().is_none());
+        assert!(element_attr.roles().is_empty());
+        assert!(element_attr.options().is_empty());
+
+        assert_eq!(offset, 4);
+
+        assert_eq!(
+            warning_types,
+            vec![WarningType::AttributeValueMissingTerminatingQuote]
+        );
+    }
+
+    #[test]
+    fn err_unterminated_double_quote_ends_at_comma() {
+        let p = Parser::default();
+        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+            &CowStr::from("\"xyz,abc"),
+            0,
+            &p,
+            ParseShorthand(false),
+        );
+
+        let (element_attr, offset) = maybe_mi.unwrap();
+
+        assert_eq!(
+            element_attr,
+            ElementAttribute {
+                name: None,
+                shorthand_items: &[],
+                value: "\"xyz"
+            }
+        );
+
+        assert!(element_attr.name().is_none());
+        assert!(element_attr.block_style().is_none());
+        assert!(element_attr.id().is_none());
+        assert!(element_attr.roles().is_empty());
+        assert!(element_attr.options().is_empty());
+
+        assert_eq!(offset, 4);
         assert_eq!(
             warning_types,
             vec![WarningType::AttributeValueMissingTerminatingQuote]
@@ -267,14 +318,65 @@ mod quoted_string {
     fn err_unterminated_single_quote() {
         let p = Parser::default();
         let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
-            &CowStr::from("\'xxx"),
+            &CowStr::from("\'xyz"),
             0,
             &p,
             ParseShorthand(false),
         );
 
-        assert!(maybe_mi.is_none());
+        let (element_attr, offset) = maybe_mi.unwrap();
 
+        assert_eq!(
+            element_attr,
+            ElementAttribute {
+                name: None,
+                shorthand_items: &[],
+                value: "\'xyz"
+            }
+        );
+
+        assert!(element_attr.name().is_none());
+        assert!(element_attr.block_style().is_none());
+        assert!(element_attr.id().is_none());
+        assert!(element_attr.roles().is_empty());
+        assert!(element_attr.options().is_empty());
+
+        assert_eq!(offset, 4);
+
+        assert_eq!(
+            warning_types,
+            vec![WarningType::AttributeValueMissingTerminatingQuote]
+        );
+    }
+
+    #[test]
+    fn err_unterminated_single_quote_ends_at_comma() {
+        let p = Parser::default();
+        let (maybe_mi, warning_types) = crate::attributes::ElementAttribute::parse(
+            &CowStr::from("\'xyz,abc"),
+            0,
+            &p,
+            ParseShorthand(false),
+        );
+
+        let (element_attr, offset) = maybe_mi.unwrap();
+
+        assert_eq!(
+            element_attr,
+            ElementAttribute {
+                name: None,
+                shorthand_items: &[],
+                value: "\'xyz"
+            }
+        );
+
+        assert!(element_attr.name().is_none());
+        assert!(element_attr.block_style().is_none());
+        assert!(element_attr.id().is_none());
+        assert!(element_attr.roles().is_empty());
+        assert!(element_attr.options().is_empty());
+
+        assert_eq!(offset, 4);
         assert_eq!(
             warning_types,
             vec![WarningType::AttributeValueMissingTerminatingQuote]


### PR DESCRIPTION
#sddbugfix: Found while working on #347.