### PR TITLE
fix: Apply normal substitutions in `ElementAttribute::parse` but only when parsing attrlists for blocks and only when the value is single-quoted

### DIFF
--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -30,6 +30,7 @@ impl<'src> Attrlist<'src> {
     pub(crate) fn parse(
         source: Span<'src>,
         parser: &Parser,
+        attrlist_context: AttrlistContext,
     ) -> MatchAndWarnings<'src, MatchedItem<'src, Self>> {
         let mut attributes: Vec<ElementAttribute> = vec![];
         let mut parse_shorthand_items = true;
@@ -56,6 +57,7 @@ impl<'src> Attrlist<'src> {
                 index,
                 parser,
                 ParseShorthand(parse_shorthand_items),
+                attrlist_context,
             );
 
             // Because we do attribute value substitution early on in parsing, we can't
@@ -378,4 +380,11 @@ impl<'src> HasSpan<'src> for Attrlist<'src> {
     fn span(&self) -> Span<'src> {
         self.source
     }
+}
+
+/// Context for attribute list parsing.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AttrlistContext {
+    Block,
+    Inline,
 }

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -85,7 +85,7 @@ impl<'src> ElementAttribute<'src> {
                     let mut content = Content::from(span);
                     SubstitutionGroup::Normal.apply(&mut content, parser, None);
 
-                    if content.rendered.as_ref() != &new_value {
+                    if content.rendered.as_ref() != new_value {
                         new_value = content.rendered.to_string();
                     }
                 }

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -1,4 +1,11 @@
-use crate::{Parser, Span, span::MatchedItem, strings::CowStr, warnings::WarningType};
+use crate::{
+    Parser, Span,
+    attributes::AttrlistContext,
+    content::{Content, SubstitutionGroup},
+    span::MatchedItem,
+    strings::CowStr,
+    warnings::WarningType,
+};
 
 /// This struct represents a single element attribute.
 ///
@@ -18,8 +25,9 @@ impl<'src> ElementAttribute<'src> {
     pub(crate) fn parse(
         source_text: &CowStr<'src>,
         start_index: usize,
-        _parser: &Parser,
+        parser: &Parser,
         mut parse_shorthand: ParseShorthand,
+        attrlist_context: AttrlistContext,
     ) -> (Self, usize, Vec<WarningType>) {
         let mut warnings: Vec<WarningType> = vec![];
 
@@ -70,21 +78,22 @@ impl<'src> ElementAttribute<'src> {
                 && (first == '\'' || first == '\"')
             {
                 let escaped_quote = format!("\\{first}");
-                let new_value = value.replace(&escaped_quote, &first.to_string());
+                let mut new_value = value.replace(&escaped_quote, &first.to_string());
+
+                if first == '\'' && attrlist_context == AttrlistContext::Block {
+                    let span = Span::new(&new_value);
+                    let mut content = Content::from(span);
+                    SubstitutionGroup::Normal.apply(&mut content, parser, None);
+
+                    if content.rendered.as_ref() != &new_value {
+                        new_value = content.rendered.to_string();
+                    }
+                }
+
                 if new_value != *value {
                     value = CowStr::from(new_value);
                 }
             }
-
-            // TO DO: Redo this to support substitutions but only in correct circumstances.
-            // It doesn't apply in all cases.
-            // let value: CowStr<'_> = if value.item.data().contains(['<', '>', '&', '{']) {
-            //     let mut content = Content::from(value.item);
-            //     SubstitutionGroup::AttributeEntryValue.apply(&mut content, parser, None);
-            //     CowStr::from(content.rendered().to_string())
-            // } else {
-            //     cowstr_from_source_and_span(source_text, &value.item)
-            // };
 
             let shorthand_item_indices = if name.is_none() && parse_shorthand.0 {
                 parse_shorthand_items(&value, &mut warnings)

--- a/parser/src/attributes/mod.rs
+++ b/parser/src/attributes/mod.rs
@@ -5,6 +5,7 @@
 
 mod attrlist;
 pub use attrlist::Attrlist;
+pub(crate) use attrlist::AttrlistContext;
 
 pub(crate) mod element_attribute;
 pub use element_attribute::ElementAttribute;

--- a/parser/src/blocks/media.rs
+++ b/parser/src/blocks/media.rs
@@ -1,6 +1,6 @@
 use crate::{
     HasSpan, Parser, Span,
-    attributes::Attrlist,
+    attributes::{Attrlist, AttrlistContext},
     blocks::{ContentModel, IsBlock, metadata::BlockMetadata},
     span::MatchedItem,
     strings::CowStr,
@@ -103,7 +103,7 @@ impl<'src> MediaBlock<'src> {
         let attrlist = open_brace.after.slice(0..open_brace.after.len() - 1);
         // Note that we already checked that this line ends with a close brace.
 
-        let macro_attrlist = Attrlist::parse(attrlist, parser);
+        let macro_attrlist = Attrlist::parse(attrlist, parser, AttrlistContext::Inline);
 
         let source: Span = metadata.source.trim_remainder(line.after);
         let source = source.slice(0..source.trim().len());

--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -1,6 +1,6 @@
 use crate::{
     Parser, Span,
-    attributes::Attrlist,
+    attributes::{Attrlist, AttrlistContext},
     content::{Content, SubstitutionGroup},
     span::MatchedItem,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -203,7 +203,7 @@ fn parse_maybe_attrlist_line<'src>(
             after: _,
         },
         warnings,
-    } = Attrlist::parse(attrlist_src, parser);
+    } = Attrlist::parse(attrlist_src, parser, AttrlistContext::Block);
 
     Some(MatchAndWarnings {
         item: MatchedItem {

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -4,7 +4,7 @@ use regex::{Captures, Regex, Replacer};
 
 use crate::{
     Parser, Span,
-    attributes::Attrlist,
+    attributes::{Attrlist, AttrlistContext},
     content::{Content, SubstitutionGroup},
     parser::{QuoteScope, QuoteType},
 };
@@ -452,7 +452,7 @@ impl Replacer for PassthroughRestoreReplacer<'_> {
         if let Some(type_) = pass.type_ {
             let attrlist = pass.attrlist.as_ref().map(|attrlist_body| {
                 let span = Span::new(attrlist_body);
-                let maw = Attrlist::parse(span, self.1);
+                let maw = Attrlist::parse(span, self.1, AttrlistContext::Inline);
                 maw.item.item
             });
 

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -4,7 +4,7 @@ use regex::{Captures, Regex, RegexBuilder, Replacer};
 
 use crate::{
     Parser,
-    attributes::Attrlist,
+    attributes::{Attrlist, AttrlistContext},
     content::Content,
     document::InterpretedValue,
     internal::{LookaheadReplacer, LookaheadResult, replace_with_lookahead},
@@ -350,6 +350,7 @@ impl LookaheadReplacer for QuoteReplacer<'_> {
                                     Attrlist::parse(
                                         crate::Span::new(attrlist.as_str()),
                                         self.parser,
+                                        AttrlistContext::Inline,
                                     )
                                     .item
                                     .item,
@@ -385,9 +386,13 @@ impl LookaheadReplacer for QuoteReplacer<'_> {
 
                         (
                             Some(
-                                Attrlist::parse(crate::Span::new(attrlist.as_str()), self.parser)
-                                    .item
-                                    .item,
+                                Attrlist::parse(
+                                    crate::Span::new(attrlist.as_str()),
+                                    self.parser,
+                                    AttrlistContext::Inline,
+                                )
+                                .item
+                                .item,
                             ),
                             type_,
                         )

--- a/parser/src/tests/asciidoc_lang/attributes/element_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/element_attributes.rs
@@ -42,7 +42,9 @@ Unlike document attributes, element attributes are defined directly on the eleme
 mod attrlist {
     use pretty_assertions_sorted::assert_eq;
 
-    use crate::{HasSpan, Parser, blocks::MediaType, tests::prelude::*};
+    use crate::{
+        HasSpan, Parser, attributes::AttrlistContext, blocks::MediaType, tests::prelude::*,
+    };
 
     non_normative!(
         r#"
@@ -75,8 +77,13 @@ To learn more about how the attribute list is parsed, see xref:positional-and-na
             r#"first-positional,second-positional,named="value of named""#;
 
         let p = Parser::default();
-        let mi = crate::attributes::Attrlist::parse(crate::Span::new(ATTRLIST_EXAMPLE), &p)
-            .unwrap_if_no_warnings();
+
+        let mi = crate::attributes::Attrlist::parse(
+            crate::Span::new(ATTRLIST_EXAMPLE),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings();
 
         assert_eq!(
             mi.item,

--- a/parser/src/tests/attributes/attrlist.rs
+++ b/parser/src/tests/attributes/attrlist.rs
@@ -1,7 +1,8 @@
 use pretty_assertions_sorted::assert_eq;
 
 use crate::{
-    HasSpan, Parser, parser::ModificationContext, tests::prelude::*, warnings::WarningType,
+    HasSpan, Parser, attributes::AttrlistContext, parser::ModificationContext, tests::prelude::*,
+    warnings::WarningType,
 };
 
 #[test]
@@ -9,7 +10,8 @@ fn impl_clone() {
     // Silly test to mark the #[derive(...)] line as covered.
     let p = Parser::default();
     let b1 =
-        crate::attributes::Attrlist::parse(crate::Span::new("abc"), &p).unwrap_if_no_warnings();
+        crate::attributes::Attrlist::parse(crate::Span::new("abc"), &p, AttrlistContext::Inline)
+            .unwrap_if_no_warnings();
 
     let b2 = b1.item.clone();
     assert_eq!(b1.item, b2);
@@ -59,7 +61,10 @@ fn impl_default() {
 #[test]
 fn empty_source() {
     let p = Parser::default();
-    let mi = crate::attributes::Attrlist::parse(crate::Span::default(), &p).unwrap_if_no_warnings();
+
+    let mi =
+        crate::attributes::Attrlist::parse(crate::Span::default(), &p, AttrlistContext::Inline)
+            .unwrap_if_no_warnings();
 
     assert_eq!(
         mi.item,
@@ -111,8 +116,13 @@ fn empty_source() {
 #[test]
 fn empty_positional_attributes() {
     let p = Parser::default();
-    let mi = crate::attributes::Attrlist::parse(crate::Span::new(",300,400"), &p)
-        .unwrap_if_no_warnings();
+
+    let mi = crate::attributes::Attrlist::parse(
+        crate::Span::new(",300,400"),
+        &p,
+        AttrlistContext::Inline,
+    )
+    .unwrap_if_no_warnings();
 
     assert_eq!(
         mi.item,
@@ -232,8 +242,13 @@ fn empty_positional_attributes() {
 #[test]
 fn only_positional_attributes() {
     let p = Parser::default();
-    let mi = crate::attributes::Attrlist::parse(crate::Span::new("Sunset,300,400"), &p)
-        .unwrap_if_no_warnings();
+
+    let mi = crate::attributes::Attrlist::parse(
+        crate::Span::new("Sunset,300,400"),
+        &p,
+        AttrlistContext::Inline,
+    )
+    .unwrap_if_no_warnings();
 
     assert_eq!(
         mi.item,
@@ -353,8 +368,13 @@ fn only_positional_attributes() {
 #[test]
 fn trim_trailing_space() {
     let p = Parser::default();
-    let mi = crate::attributes::Attrlist::parse(crate::Span::new("Sunset ,300 , 400"), &p)
-        .unwrap_if_no_warnings();
+
+    let mi = crate::attributes::Attrlist::parse(
+        crate::Span::new("Sunset ,300 , 400"),
+        &p,
+        AttrlistContext::Inline,
+    )
+    .unwrap_if_no_warnings();
 
     assert_eq!(
         mi.item,
@@ -474,9 +494,13 @@ fn trim_trailing_space() {
 #[test]
 fn only_named_attributes() {
     let p = Parser::default();
-    let mi =
-        crate::attributes::Attrlist::parse(crate::Span::new("alt=Sunset,width=300,height=400"), &p)
-            .unwrap_if_no_warnings();
+
+    let mi = crate::attributes::Attrlist::parse(
+        crate::Span::new("alt=Sunset,width=300,height=400"),
+        &p,
+        AttrlistContext::Inline,
+    )
+    .unwrap_if_no_warnings();
 
     assert_eq!(
         mi.item,
@@ -601,6 +625,7 @@ fn ignore_named_attribute_with_none_value() {
     let mi = crate::attributes::Attrlist::parse(
         crate::Span::new("alt=Sunset,width=None,height=400"),
         &p,
+        AttrlistContext::Inline,
     )
     .unwrap_if_no_warnings();
 
@@ -704,7 +729,12 @@ fn ignore_named_attribute_with_none_value() {
 #[test]
 fn err_unparsed_remainder_after_value() {
     let p = Parser::default();
-    let maw = crate::attributes::Attrlist::parse(crate::Span::new("alt=\"Sunset\"width=300"), &p);
+
+    let maw = crate::attributes::Attrlist::parse(
+        crate::Span::new("alt=\"Sunset\"width=300"),
+        &p,
+        AttrlistContext::Inline,
+    );
 
     let mi = maw.item.clone();
 
@@ -752,7 +782,12 @@ fn err_unparsed_remainder_after_value() {
 #[test]
 fn propagates_error_from_element_attribute() {
     let p = Parser::default();
-    let maw = crate::attributes::Attrlist::parse(crate::Span::new("foo%#id"), &p);
+
+    let maw = crate::attributes::Attrlist::parse(
+        crate::Span::new("foo%#id"),
+        &p,
+        AttrlistContext::Inline,
+    );
 
     let mi = maw.item.clone();
 
@@ -800,13 +835,18 @@ fn propagates_error_from_element_attribute() {
 mod id {
     use pretty_assertions_sorted::assert_eq;
 
-    use crate::{HasSpan, Parser, tests::prelude::*};
+    use crate::{HasSpan, Parser, attributes::AttrlistContext, tests::prelude::*};
 
     #[test]
     fn via_shorthand_syntax() {
         let p = Parser::default();
-        let mi = crate::attributes::Attrlist::parse(crate::Span::new("#goals"), &p)
-            .unwrap_if_no_warnings();
+
+        let mi = crate::attributes::Attrlist::parse(
+            crate::Span::new("#goals"),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings();
 
         assert_eq!(
             mi.item,
@@ -856,8 +896,13 @@ mod id {
     #[test]
     fn via_named_attribute() {
         let p = Parser::default();
-        let mi = crate::attributes::Attrlist::parse(crate::Span::new("foo=bar,id=goals"), &p)
-            .unwrap_if_no_warnings();
+
+        let mi = crate::attributes::Attrlist::parse(
+            crate::Span::new("foo=bar,id=goals"),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings();
 
         assert_eq!(
             mi.item,
@@ -920,8 +965,13 @@ mod id {
     #[should_panic]
     fn via_block_anchor_syntax() {
         let p = Parser::default();
-        let _pr = crate::attributes::Attrlist::parse(crate::Span::new("[goals]"), &p)
-            .unwrap_if_no_warnings();
+
+        let _pr = crate::attributes::Attrlist::parse(
+            crate::Span::new("[goals]"),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings();
 
         // TO DO (#122): Parse block anchor syntax
     }
@@ -929,8 +979,13 @@ mod id {
     #[test]
     fn shorthand_only_first_attribute() {
         let p = Parser::default();
-        let mi = crate::attributes::Attrlist::parse(crate::Span::new("foo,blah#goals"), &p)
-            .unwrap_if_no_warnings();
+
+        let mi = crate::attributes::Attrlist::parse(
+            crate::Span::new("foo,blah#goals"),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings();
 
         assert_eq!(
             mi.item,
@@ -975,13 +1030,18 @@ mod id {
 mod roles {
     use pretty_assertions_sorted::assert_eq;
 
-    use crate::{HasSpan, Parser, tests::prelude::*};
+    use crate::{HasSpan, Parser, attributes::AttrlistContext, tests::prelude::*};
 
     #[test]
     fn via_shorthand_syntax() {
         let p = Parser::default();
-        let mi = crate::attributes::Attrlist::parse(crate::Span::new(".rolename"), &p)
-            .unwrap_if_no_warnings();
+
+        let mi = crate::attributes::Attrlist::parse(
+            crate::Span::new(".rolename"),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings();
 
         assert_eq!(
             mi.item,
@@ -1034,8 +1094,13 @@ mod roles {
     #[test]
     fn via_shorthand_syntax_trim_trailing_whitespace() {
         let p = Parser::default();
-        let mi = crate::attributes::Attrlist::parse(crate::Span::new(".rolename "), &p)
-            .unwrap_if_no_warnings();
+
+        let mi = crate::attributes::Attrlist::parse(
+            crate::Span::new(".rolename "),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings();
 
         assert_eq!(
             mi.item,
@@ -1061,8 +1126,7 @@ mod roles {
         let mut roles = roles.iter();
 
         assert_eq!(roles.next().unwrap(), &"rolename");
-
-        assert!(roles.next().is_none(),);
+        assert!(roles.next().is_none());
 
         assert_eq!(
             mi.item.span(),
@@ -1088,8 +1152,13 @@ mod roles {
     #[test]
     fn multiple_roles_via_shorthand_syntax() {
         let p = Parser::default();
-        let mi = crate::attributes::Attrlist::parse(crate::Span::new(".role1.role2.role3"), &p)
-            .unwrap_if_no_warnings();
+
+        let mi = crate::attributes::Attrlist::parse(
+            crate::Span::new(".role1.role2.role3"),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings();
 
         assert_eq!(
             mi.item,
@@ -1146,8 +1215,13 @@ mod roles {
     #[test]
     fn multiple_roles_via_shorthand_syntax_trim_whitespace() {
         let p = Parser::default();
-        let mi = crate::attributes::Attrlist::parse(crate::Span::new(".role1 .role2 .role3 "), &p)
-            .unwrap_if_no_warnings();
+
+        let mi = crate::attributes::Attrlist::parse(
+            crate::Span::new(".role1 .role2 .role3 "),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings();
 
         assert_eq!(
             mi.item,
@@ -1204,8 +1278,13 @@ mod roles {
     #[test]
     fn via_named_attribute() {
         let p = Parser::default();
-        let mi = crate::attributes::Attrlist::parse(crate::Span::new("foo=bar,role=role1"), &p)
-            .unwrap_if_no_warnings();
+
+        let mi = crate::attributes::Attrlist::parse(
+            crate::Span::new("foo=bar,role=role1"),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings();
 
         assert_eq!(
             mi.item,
@@ -1268,9 +1347,11 @@ mod roles {
     #[test]
     fn multiple_roles_via_named_attribute() {
         let p = Parser::default();
+
         let mi = crate::attributes::Attrlist::parse(
             crate::Span::new("foo=bar,role=role1 role2   role3 "),
             &p,
+            AttrlistContext::Inline,
         )
         .unwrap_if_no_warnings();
 
@@ -1338,9 +1419,11 @@ mod roles {
     #[test]
     fn shorthand_role_and_named_attribute_role() {
         let p = Parser::default();
+
         let mi = crate::attributes::Attrlist::parse(
             crate::Span::new("#foo.sh1.sh2,role=na1 na2   na3 "),
             &p,
+            AttrlistContext::Inline,
         )
         .unwrap_if_no_warnings();
 
@@ -1403,8 +1486,13 @@ mod roles {
     #[test]
     fn shorthand_only_first_attribute() {
         let p = Parser::default();
-        let mi = crate::attributes::Attrlist::parse(crate::Span::new("foo,blah.rolename"), &p)
-            .unwrap_if_no_warnings();
+
+        let mi = crate::attributes::Attrlist::parse(
+            crate::Span::new("foo,blah.rolename"),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings();
 
         assert_eq!(
             mi.item,
@@ -1448,13 +1536,18 @@ mod roles {
 mod options {
     use pretty_assertions_sorted::assert_eq;
 
-    use crate::{HasSpan, Parser, tests::prelude::*};
+    use crate::{HasSpan, Parser, attributes::AttrlistContext, tests::prelude::*};
 
     #[test]
     fn via_shorthand_syntax() {
         let p = Parser::default();
-        let mi = crate::attributes::Attrlist::parse(crate::Span::new("%option"), &p)
-            .unwrap_if_no_warnings();
+
+        let mi = crate::attributes::Attrlist::parse(
+            crate::Span::new("%option"),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings();
 
         assert_eq!(
             mi.item,
@@ -1510,9 +1603,13 @@ mod options {
     #[test]
     fn multiple_options_via_shorthand_syntax() {
         let p = Parser::default();
-        let mi =
-            crate::attributes::Attrlist::parse(crate::Span::new("%option1%option2%option3"), &p)
-                .unwrap_if_no_warnings();
+
+        let mi = crate::attributes::Attrlist::parse(
+            crate::Span::new("%option1%option2%option3"),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings();
 
         assert_eq!(
             mi.item,
@@ -1571,9 +1668,13 @@ mod options {
     #[test]
     fn via_options_attribute() {
         let p = Parser::default();
-        let mi =
-            crate::attributes::Attrlist::parse(crate::Span::new("foo=bar,options=option1"), &p)
-                .unwrap_if_no_warnings();
+
+        let mi = crate::attributes::Attrlist::parse(
+            crate::Span::new("foo=bar,options=option1"),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings();
 
         assert_eq!(
             mi.item,
@@ -1640,8 +1741,13 @@ mod options {
     #[test]
     fn via_opts_attribute() {
         let p = Parser::default();
-        let mi = crate::attributes::Attrlist::parse(crate::Span::new("foo=bar,opts=option1"), &p)
-            .unwrap_if_no_warnings();
+
+        let mi = crate::attributes::Attrlist::parse(
+            crate::Span::new("foo=bar,opts=option1"),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings();
 
         assert_eq!(
             mi.item,
@@ -1709,9 +1815,11 @@ mod options {
     #[test]
     fn multiple_options_via_named_attribute() {
         let p = Parser::default();
+
         let mi = crate::attributes::Attrlist::parse(
             crate::Span::new("foo=bar,options=\"option1,option2,option3\""),
             &p,
+            AttrlistContext::Inline,
         )
         .unwrap_if_no_warnings();
 
@@ -1784,9 +1892,11 @@ mod options {
     #[test]
     fn shorthand_option_and_named_attribute_option() {
         let p = Parser::default();
+
         let mi = crate::attributes::Attrlist::parse(
             crate::Span::new("#foo%sh1%sh2,options=\"na1,na2,na3\""),
             &p,
+            AttrlistContext::Inline,
         )
         .unwrap_if_no_warnings();
 
@@ -1857,8 +1967,13 @@ mod options {
     #[test]
     fn shorthand_only_first_attribute() {
         let p = Parser::default();
-        let mi = crate::attributes::Attrlist::parse(crate::Span::new("foo,blah%option"), &p)
-            .unwrap_if_no_warnings();
+
+        let mi = crate::attributes::Attrlist::parse(
+            crate::Span::new("foo,blah%option"),
+            &p,
+            AttrlistContext::Inline,
+        )
+        .unwrap_if_no_warnings();
 
         assert_eq!(
             mi.item,
@@ -1904,9 +2019,11 @@ mod options {
 #[test]
 fn err_double_comma() {
     let p = Parser::default();
+
     let maw = crate::attributes::Attrlist::parse(
         crate::Span::new("alt=Sunset,width=300,,height=400"),
         &p,
+        AttrlistContext::Inline,
     );
 
     let mi = maw.item.clone();
@@ -1972,8 +2089,12 @@ fn applies_attribute_substitution_before_parsing() {
         ModificationContext::Anywhere,
     );
 
-    let mi = crate::attributes::Attrlist::parse(crate::Span::new("Sunset,{sunset_dimensions}"), &p)
-        .unwrap_if_no_warnings();
+    let mi = crate::attributes::Attrlist::parse(
+        crate::Span::new("Sunset,{sunset_dimensions}"),
+        &p,
+        AttrlistContext::Inline,
+    )
+    .unwrap_if_no_warnings();
 
     assert_eq!(
         mi.item,
@@ -2098,9 +2219,12 @@ fn ignores_unknown_attribute_when_applying_attribution_substitution() {
         ModificationContext::Anywhere,
     );
 
-    let mi =
-        crate::attributes::Attrlist::parse(crate::Span::new("Sunset,{not_sunset_dimensions}"), &p)
-            .unwrap_if_no_warnings();
+    let mi = crate::attributes::Attrlist::parse(
+        crate::Span::new("Sunset,{not_sunset_dimensions}"),
+        &p,
+        AttrlistContext::Inline,
+    )
+    .unwrap_if_no_warnings();
 
     assert_eq!(
         mi.item,

--- a/parser/src/tests/attributes/element_attribute.rs
+++ b/parser/src/tests/attributes/element_attribute.rs
@@ -1,7 +1,10 @@
 use pretty_assertions_sorted::assert_eq;
 
 use crate::{
-    Parser, attributes::element_attribute::ParseShorthand, strings::CowStr, tests::prelude::*,
+    Parser,
+    attributes::{AttrlistContext, element_attribute::ParseShorthand},
+    strings::CowStr,
+    tests::prelude::*,
 };
 
 #[test]
@@ -14,6 +17,7 @@ fn impl_clone() {
         0,
         &p,
         ParseShorthand(false),
+        AttrlistContext::Inline,
     )
     .0;
 
@@ -26,8 +30,13 @@ fn impl_clone() {
 fn empty_source() {
     let p = Parser::default();
 
-    let (element_attr, offset, warning_types) =
-        crate::attributes::ElementAttribute::parse(&CowStr::from(""), 0, &p, ParseShorthand(false));
+    let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
+        &CowStr::from(""),
+        0,
+        &p,
+        ParseShorthand(false),
+        AttrlistContext::Inline,
+    );
 
     assert!(warning_types.is_empty());
 
@@ -58,6 +67,7 @@ fn only_spaces() {
         0,
         &p,
         ParseShorthand(false),
+        AttrlistContext::Inline,
     );
 
     assert!(warning_types.is_empty());
@@ -89,6 +99,7 @@ fn unquoted_and_unnamed_value() {
         0,
         &p,
         ParseShorthand(false),
+        AttrlistContext::Inline,
     );
 
     assert!(warning_types.is_empty());
@@ -120,6 +131,7 @@ fn unquoted_stops_at_comma() {
         0,
         &p,
         ParseShorthand(false),
+        AttrlistContext::Inline,
     );
 
     assert!(warning_types.is_empty());
@@ -146,7 +158,10 @@ mod quoted_string {
     use pretty_assertions_sorted::assert_eq;
 
     use crate::{
-        Parser, attributes::element_attribute::ParseShorthand, strings::CowStr, tests::prelude::*,
+        Parser,
+        attributes::{AttrlistContext, element_attribute::ParseShorthand},
+        strings::CowStr,
+        tests::prelude::*,
         warnings::WarningType,
     };
 
@@ -159,6 +174,7 @@ mod quoted_string {
             0,
             &p,
             ParseShorthand(false),
+            AttrlistContext::Inline,
         );
 
         assert_eq!(
@@ -193,6 +209,7 @@ mod quoted_string {
             0,
             &p,
             ParseShorthand(false),
+            AttrlistContext::Inline,
         );
 
         assert_eq!(
@@ -226,6 +243,7 @@ mod quoted_string {
             0,
             &p,
             ParseShorthand(false),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -257,6 +275,7 @@ mod quoted_string {
             0,
             &p,
             ParseShorthand(false),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -288,6 +307,7 @@ mod quoted_string {
             0,
             &p,
             ParseShorthand(false),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -319,6 +339,7 @@ mod quoted_string {
             0,
             &p,
             ParseShorthand(false),
+            AttrlistContext::Inline,
         );
 
         assert_eq!(
@@ -353,6 +374,7 @@ mod quoted_string {
             0,
             &p,
             ParseShorthand(false),
+            AttrlistContext::Inline,
         );
 
         assert_eq!(
@@ -386,6 +408,7 @@ mod quoted_string {
             0,
             &p,
             ParseShorthand(false),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -417,6 +440,7 @@ mod quoted_string {
             0,
             &p,
             ParseShorthand(false),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -448,6 +472,7 @@ mod quoted_string {
             0,
             &p,
             ParseShorthand(false),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -475,7 +500,10 @@ mod named {
     use pretty_assertions_sorted::assert_eq;
 
     use crate::{
-        Parser, attributes::element_attribute::ParseShorthand, strings::CowStr, tests::prelude::*,
+        Parser,
+        attributes::{AttrlistContext, element_attribute::ParseShorthand},
+        strings::CowStr,
+        tests::prelude::*,
     };
 
     #[test]
@@ -487,6 +515,7 @@ mod named {
             0,
             &p,
             ParseShorthand(false),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -518,6 +547,7 @@ mod named {
             0,
             &p,
             ParseShorthand(false),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -545,6 +575,7 @@ mod named {
             0,
             &p,
             ParseShorthand(false),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -576,6 +607,7 @@ mod named {
             0,
             &p,
             ParseShorthand(false),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -607,6 +639,7 @@ mod named {
             0,
             &p,
             ParseShorthand(false),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -638,6 +671,7 @@ mod named {
             0,
             &p,
             ParseShorthand(false),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -665,7 +699,10 @@ mod parse_with_shorthand {
     use pretty_assertions_sorted::assert_eq;
 
     use crate::{
-        Parser, attributes::element_attribute::ParseShorthand, strings::CowStr, tests::prelude::*,
+        Parser,
+        attributes::{AttrlistContext, element_attribute::ParseShorthand},
+        strings::CowStr,
+        tests::prelude::*,
         warnings::WarningType,
     };
 
@@ -678,6 +715,7 @@ mod parse_with_shorthand {
             0,
             &p,
             ParseShorthand(true),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -710,6 +748,7 @@ mod parse_with_shorthand {
             0,
             &p,
             ParseShorthand(true),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -742,6 +781,7 @@ mod parse_with_shorthand {
             0,
             &p,
             ParseShorthand(true),
+            AttrlistContext::Inline,
         );
 
         assert_eq!(
@@ -766,6 +806,7 @@ mod parse_with_shorthand {
             0,
             &p,
             ParseShorthand(true),
+            AttrlistContext::Inline,
         );
 
         assert_eq!(
@@ -790,6 +831,7 @@ mod parse_with_shorthand {
             0,
             &p,
             ParseShorthand(true),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -822,6 +864,7 @@ mod parse_with_shorthand {
             0,
             &p,
             ParseShorthand(true),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -854,6 +897,7 @@ mod parse_with_shorthand {
             0,
             &p,
             ParseShorthand(true),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -891,6 +935,7 @@ mod parse_with_shorthand {
             0,
             &p,
             ParseShorthand(true),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -923,6 +968,7 @@ mod parse_with_shorthand {
             0,
             &p,
             ParseShorthand(true),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -963,6 +1009,7 @@ mod parse_with_shorthand {
             0,
             &p,
             ParseShorthand(true),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());
@@ -998,6 +1045,7 @@ mod parse_with_shorthand {
             0,
             &p,
             ParseShorthand(true),
+            AttrlistContext::Inline,
         );
 
         assert!(warning_types.is_empty());

--- a/parser/src/tests/attributes/element_attribute.rs
+++ b/parser/src/tests/attributes/element_attribute.rs
@@ -160,6 +160,7 @@ mod quoted_string {
     use crate::{
         Parser,
         attributes::{AttrlistContext, element_attribute::ParseShorthand},
+        parser::ModificationContext,
         strings::CowStr,
         tests::prelude::*,
         warnings::WarningType,
@@ -493,6 +494,39 @@ mod quoted_string {
         assert!(element_attr.options().is_empty());
 
         assert_eq!(offset, 6);
+    }
+
+    #[test]
+    fn single_quoted_gets_substitions() {
+        let p =
+            Parser::default().with_intrinsic_attribute("foo", "bar", ModificationContext::Anywhere);
+
+        let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
+            &CowStr::from("'*abc* def {foo}'"),
+            0,
+            &p,
+            ParseShorthand(false),
+            AttrlistContext::Block,
+        );
+
+        assert!(warning_types.is_empty());
+
+        assert_eq!(
+            element_attr,
+            ElementAttribute {
+                name: None,
+                shorthand_items: &[],
+                value: "<strong>abc</strong> def bar"
+            }
+        );
+
+        assert!(element_attr.name().is_none());
+        assert!(element_attr.block_style().is_none());
+        assert!(element_attr.id().is_none());
+        assert!(element_attr.roles().is_empty());
+        assert!(element_attr.options().is_empty());
+
+        assert_eq!(offset, 17);
     }
 }
 


### PR DESCRIPTION
#sddbugfind: Found while working on #347.