### PR TITLE
fix: Allow comment lines between document start and title

### DIFF
--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -54,16 +54,14 @@ impl<'src> Document<'src> {
     /// [`warnings()`]: Self::warnings
     pub(crate) fn parse(source: &'src str, parser: &mut Parser) -> Self {
         let source = Span::new(source);
-        let i = source.discard_empty_lines();
-        let i = if i.is_empty() { source } else { i };
 
-        let mi = Header::parse(i, parser);
-        let i = mi.item.after;
+        let mi = Header::parse(source, parser);
+        let next = mi.item.after;
 
         let header = mi.item.item;
         let mut warnings = mi.warnings;
 
-        let mut maw_blocks = parse_blocks_until(i, |_| false, parser);
+        let mut maw_blocks = parse_blocks_until(next, |_| false, parser);
 
         if !maw_blocks.warnings.is_empty() {
             warnings.append(&mut maw_blocks.warnings);

--- a/parser/src/tests/asciidoc_lang/attributes/attribute_entries.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/attribute_entries.rs
@@ -120,6 +120,7 @@ At the end of the value, press kbd:[Enter].
                         offset: 10,
                     },
                 },],
+                comments: &[],
                 source: Span {
                     data: "= Testing\n:name-of-an-attribute: value of the attribute",
                     line: 1,
@@ -209,6 +210,7 @@ That means you don't need to escape special characters such in an HTML tag.
                         offset: 10,
                     },
                 },],
+                comments: &[],
                 source: Span {
                     data: "= Testing\n:lt-attribute: <",
                     line: 1,
@@ -320,6 +322,7 @@ Attribute references in the value of an attribute entry are resolved immediately
                         },
                     },
                 ],
+                comments: &[],
                 source: Span {
                     data: ":url-org: https://example.org/projects\n:url-project: {url-org}/project-name",
                     line: 1,
@@ -388,6 +391,7 @@ If you set a built-in attribute and leave its value empty, the AsciiDoc processo
                         offset: 0,
                     },
                 },],
+                comments: &[],
                 source: Span {
                     data: ":name-of-an-attribute:",
                     line: 1,

--- a/parser/src/tests/asciidoc_lang/attributes/element_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/element_attributes.rs
@@ -268,6 +268,7 @@ If this happens, append `+{empty}+` to the end of the line to disrupt the syntax
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -414,6 +415,7 @@ Specifically, it does not support named attributes, only the attribute shorthand
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/attributes/id.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/id.rs
@@ -560,6 +560,7 @@ The id (`#`) shorthand can be used on inline quoted text.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -623,6 +624,7 @@ The id (`#`) shorthand can be used on inline quoted text.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -701,6 +703,7 @@ According to the https://www.w3.org/TR/REC-xml/#NT-Name[XML Name] rules, a porta
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -750,6 +753,7 @@ According to the https://www.w3.org/TR/REC-xml/#NT-Name[XML Name] rules, a porta
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -799,6 +803,7 @@ According to the https://www.w3.org/TR/REC-xml/#NT-Name[XML Name] rules, a porta
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -848,6 +853,7 @@ According to the https://www.w3.org/TR/REC-xml/#NT-Name[XML Name] rules, a porta
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -906,6 +912,7 @@ The shorthand form in an attribute list does not impose this restriction.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -974,6 +981,7 @@ include::example$id.adoc[tag=block-id-shorthand]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1052,6 +1060,7 @@ include::example$id.adoc[tag=block-id-brackets]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1126,6 +1135,7 @@ include::example$id.adoc[tag=anchor-brackets]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1192,6 +1202,7 @@ include::example$id.adoc[tag=anchor-shorthand]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
@@ -416,6 +416,7 @@ Formatted text does not support a style, so the first and only positional attrib
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -490,6 +491,7 @@ A named attribute consists of a name and a value separated by an `=` character (
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -563,6 +565,7 @@ In all other cases, the surrounding quotes are optional.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -637,6 +640,7 @@ If enclosing quotes are used, they are dropped from the parsed value and the pre
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -713,6 +717,7 @@ If enclosing quotes are used, they are dropped from the parsed value and the pre
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -804,6 +809,7 @@ In these rules, `name` consists of a word character (letter or numeral) followed
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -903,6 +909,7 @@ In these rules, `name` consists of a word character (letter or numeral) followed
                             offset: 0,
                         },
                     },],
+                    comments: &[],
                     source: Span {
                         data: ":url: https://example.com",
                         line: 1,
@@ -983,6 +990,7 @@ In these rules, `name` consists of a word character (letter or numeral) followed
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1041,6 +1049,7 @@ For subsequent attributes, any leading space or tab characters are skipped.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1121,6 +1130,7 @@ Space and tab characters around the equals sign (=) and at the end of the value 
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1200,6 +1210,7 @@ Any space or tab characters at the boundaries of the value are ignored.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1284,6 +1295,7 @@ Any space or tab characters at the boundaries of the value are ignored.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1367,6 +1379,7 @@ Any space or tab characters at the boundaries of the value are ignored.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1458,6 +1471,7 @@ If there is a closing double quote, the enclosing double quote characters are re
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1541,6 +1555,7 @@ If there is a closing double quote, the enclosing double quote characters are re
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1632,6 +1647,7 @@ If there is a closing single quote, the enclosing single quote characters are re
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1716,6 +1732,7 @@ If there is a closing single quote, and the first character is not an escaped si
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1814,6 +1831,7 @@ That's because the parser already knows to look for the closing square bracket a
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1908,6 +1926,7 @@ There are some exceptions to this rule, such as a link macro in a footnote, whic
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/attributes/reference_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/reference_attributes.rs
@@ -133,6 +133,7 @@ Actually, please don't.
                         },
                     },
                 ],
+                comments: &[],
                 source: Span {
                     data: "= Ops Manual\n:disclaimer: Don't pet the wild Wolpertingers. We're not responsible for any loss \\\nof hair, chocolate, or purple socks.\n:url-repo: https://github.com/asciidoctor/asciidoctor",
                     line: 1,
@@ -232,6 +233,7 @@ Our servers don't like them either.
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,
@@ -347,6 +349,7 @@ In the path /items/\{id}, id is a path parameter.
                             offset: 0,
                         },
                     },],
+                    comments: &[],
                     source: Span {
                         data: ":id: foo",
                         line: 1,
@@ -407,6 +410,7 @@ If the syntax that follows the backslash does not match an attribute reference, 
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -503,6 +507,7 @@ In the path +/items/{id}+, id is a path parameter.
                             offset: 0,
                         },
                     },],
+                    comments: &[],
                     source: Span {
                         data: ":id: foo",
                         line: 1,
@@ -563,6 +568,7 @@ All the text between the passthrough enclosure will get passed through to the ou
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/blocks/build_basic_block.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/build_basic_block.rs
@@ -82,6 +82,7 @@ This is more content in the sidebar block.
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,

--- a/parser/src/tests/asciidoc_lang/blocks/paragraphs.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/paragraphs.rs
@@ -51,6 +51,7 @@ include::example$paragraph.adoc[tag=para]
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,

--- a/parser/src/tests/asciidoc_lang/blocks/troubleshoot_blocks.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/troubleshoot_blocks.rs
@@ -45,6 +45,7 @@ It will be styled as a sidebar.
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,
@@ -128,6 +129,7 @@ If you want the processor to recognize a closing delimiter, it must be the same 
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,

--- a/parser/src/tests/asciidoc_lang/macros/autolinks.rs
+++ b/parser/src/tests/asciidoc_lang/macros/autolinks.rs
@@ -44,6 +44,7 @@ AsciiDoc recognizes the following common URL schemes without the help of any mar
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -100,6 +101,7 @@ AsciiDoc recognizes the following common URL schemes without the help of any mar
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -156,6 +158,7 @@ AsciiDoc recognizes the following common URL schemes without the help of any mar
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -212,6 +215,7 @@ AsciiDoc recognizes the following common URL schemes without the help of any mar
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -269,6 +273,7 @@ AsciiDoc recognizes the following common URL schemes without the help of any mar
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -336,6 +341,7 @@ If you want to use xref:url-macro.adoc#link-text[custom link text], you must use
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -404,6 +410,7 @@ This allows the theming system (e.g., CSS) to recognize autolinks (and other bar
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -477,6 +484,7 @@ For email address which do not conform to these restriction, you can use the xre
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -552,6 +560,7 @@ The URL and email address will both be shown in plain text.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -641,6 +650,7 @@ The `subs` attribute is only recognized on a leaf block, such as a paragraph.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/macros/complex_urls.rs
+++ b/parser/src/tests/asciidoc_lang/macros/complex_urls.rs
@@ -59,6 +59,7 @@ include::partial$ts-url-format.adoc[tag=sb]
                         offset: 17,
                     },
                 },],
+                comments: &[],
                 source: Span {
                     data: "= Document Title\n:link-with-underscores: https://asciidoctor.org/now_this__link_works.html",
                     line: 1,
@@ -109,6 +110,7 @@ fn pass_macro() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,
@@ -160,6 +162,7 @@ fn double_plus_inline_macro() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,

--- a/parser/src/tests/asciidoc_lang/macros/icon_macro.rs
+++ b/parser/src/tests/asciidoc_lang/macros/icon_macro.rs
@@ -58,6 +58,7 @@ icon:heart[2x,role=red]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/macros/image_link.rs
+++ b/parser/src/tests/asciidoc_lang/macros/image_link.rs
@@ -53,6 +53,7 @@ image::logo.png[Logo]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -139,6 +140,7 @@ image::logo.png[Logo,link=https://example.org]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -220,6 +222,7 @@ image:apply.jpg[Apply,link=https://apply.example.org] today!
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -305,6 +308,7 @@ image::logo.png[Logo,link=https://example.org,window=_blank,opts=nofollow]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/macros/image_position.rs
+++ b/parser/src/tests/asciidoc_lang/macros/image_position.rs
@@ -66,6 +66,7 @@ include::example$image.adoc[tag=float]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -166,6 +167,7 @@ include::example$image.adoc[tag=in-float]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -251,6 +253,7 @@ include::example$image.adoc[tag=role]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -350,6 +353,7 @@ include::example$image.adoc[tag=in-role]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/macros/image_size.rs
+++ b/parser/src/tests/asciidoc_lang/macros/image_size.rs
@@ -51,6 +51,7 @@ image::flower.jpg[Flower,640,480]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -137,6 +138,7 @@ image::flower.jpg[alt=Flower,width=640,height=480]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/macros/image_url.rs
+++ b/parser/src/tests/asciidoc_lang/macros/image_url.rs
@@ -52,6 +52,7 @@ include::example$image.adoc[tag=url]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -146,6 +147,7 @@ include::example$image.adoc[tag=in-url]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/macros/images.rs
+++ b/parser/src/tests/asciidoc_lang/macros/images.rs
@@ -63,6 +63,7 @@ include::example$image.adoc[tag=base]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -186,6 +187,7 @@ include::example$image.adoc[tag=alt]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -268,6 +270,7 @@ You can also give the image an ID, title, set its dimensions and make it a link.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -360,6 +363,7 @@ include::example$image.adoc[tag=attr]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/macros/link_macro.rs
+++ b/parser/src/tests/asciidoc_lang/macros/link_macro.rs
@@ -51,6 +51,7 @@ the `<attrlist>` is the link text unless a named attribute is detected.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -141,6 +142,7 @@ The AsciiDoc processor will create a link to _report.pdf_ with the text "Get Rep
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -205,6 +207,7 @@ Note that when linking to a relative file, even if it's an HTML file, the link t
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -290,6 +293,7 @@ link:report.pdf[Get Report]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -363,6 +367,7 @@ link:pass:[My Documents/report.pdf][Get Report]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -424,6 +429,7 @@ link:My&#32;Documents/report.pdf[Get Report]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -485,6 +491,7 @@ link:My%20Documents/report.pdf[Get Report]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -558,6 +565,7 @@ link:Avengers%3A%20Endgame.html[]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -623,6 +631,7 @@ link:++https://example.org/now_this__link_works.html++[]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -686,6 +695,7 @@ In this case, the link macro prefix is required to increase the precedence so th
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -749,6 +759,7 @@ link:file:///home/username[Your files]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/macros/link_macro_attribute_parsing.rs
+++ b/parser/src/tests/asciidoc_lang/macros/link_macro_attribute_parsing.rs
@@ -47,6 +47,7 @@ https://chat.asciidoc.org[Discuss AsciiDoc]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -122,6 +123,7 @@ https://chat.asciidoc.org[Discuss AsciiDoc,role=resource,window=_blank]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -186,6 +188,7 @@ https://example.org["Google, DuckDuckGo, Ecosia",role=teal]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -249,6 +252,7 @@ https://example.org["1=2 posits the problem of inequality"]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -313,6 +317,7 @@ https://example.org["href=\"#top\" attribute"] creates link to top of page
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -386,6 +391,7 @@ https://chat.asciidoc.org[role=button,window=_blank,opts=nofollow]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -474,6 +480,7 @@ In the HTML output, the value of the `window` attribute is assigned to the `targ
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -543,6 +550,7 @@ If the target is `_blank`, the processor will automatically add the <<noopener a
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -620,6 +628,7 @@ https://asciidoctor.org[Asciidoctor,window=_blank]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -683,6 +692,7 @@ https://asciidoctor.org[Asciidoctor,window=read-later,opts=noopener]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -747,6 +757,7 @@ https://asciidoctor.org[Asciidoctor,window=_blank,opts=nofollow]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -811,6 +822,7 @@ https://asciidoctor.org[Asciidoctor,window=read-later,opts="noopener,nofollow"]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -873,6 +885,7 @@ link:post.html[My Post,opts=nofollow]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -941,6 +954,7 @@ include::example$url.adoc[tag=linkattrs-s]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1012,6 +1026,7 @@ https://example.org["Google, DuckDuckGo, Ecosia^",role=btn]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1073,6 +1088,7 @@ https://example.org[Google, DuckDuckGo, Ecosia^]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/macros/link_macro_ref.rs
+++ b/parser/src/tests/asciidoc_lang/macros/link_macro_ref.rs
@@ -38,6 +38,7 @@ fn id() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,
@@ -98,6 +99,7 @@ fn role() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,
@@ -158,6 +160,7 @@ fn title() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,
@@ -218,6 +221,7 @@ fn window() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,
@@ -280,6 +284,7 @@ fn window_shorthand() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,
@@ -339,6 +344,7 @@ fn opts() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,

--- a/parser/src/tests/asciidoc_lang/macros/links.rs
+++ b/parser/src/tests/asciidoc_lang/macros/links.rs
@@ -95,6 +95,7 @@ Depending on the capabilities of the web application, the space character can be
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -208,6 +209,7 @@ The prefix will still be present in the link target.
                             offset: 17,
                         },
                     },],
+                    comments: &[],
                     source: Span {
                         data: "= Document Title\n:hide-uri-scheme:",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/macros/mailto_macro.rs
+++ b/parser/src/tests/asciidoc_lang/macros/mailto_macro.rs
@@ -49,6 +49,7 @@ mailto:join@discuss.example.org[Subscribe]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -110,6 +111,7 @@ mailto:join@discuss.example.org[Subscribe,role=email]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -173,6 +175,7 @@ mailto:join@discuss.example.org["Click, subscribe, and participate!"]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -260,6 +263,7 @@ When the reader clicks the link, a conforming email client will fill in the subj
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -325,6 +329,7 @@ When the reader clicks the link, a conforming email client will fill in the body
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -387,6 +392,7 @@ mailto:join@discuss.example.org[,Subscribe me,I want to participate.]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -448,6 +454,7 @@ mailto:join@discuss.example.org[,Subscribe me]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -509,6 +516,7 @@ mailto:join@discuss.example.org[Subscribe,"I want to participate, so please subs
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/macros/url_macro.rs
+++ b/parser/src/tests/asciidoc_lang/macros/url_macro.rs
@@ -62,6 +62,7 @@ With the exception of the xref:mailto-macro.adoc[mailto macro], all the URL macr
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -128,6 +129,7 @@ The more typical reason, however, is to specify custom link text.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -207,6 +209,7 @@ include::example$url.adoc[tag=irc]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -270,6 +273,7 @@ include::example$url.adoc[tag=text]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -345,6 +349,7 @@ include::example$url.adoc[tag=css]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/root/document_structure.rs
+++ b/parser/src/tests/asciidoc_lang/root/document_structure.rs
@@ -50,6 +50,7 @@ This is a basic AsciiDoc document.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -119,6 +120,7 @@ This document contains two paragraphs.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -235,6 +237,7 @@ It also has a header that specifies the document title.
                             },
                         },
                     ],
+                comments: &[],
                     source: Span {
                         data: "= Document Title\n:reproducible:",
                         line: 1,
@@ -515,6 +518,7 @@ A single empty line separates the header from the body.
                             offset: 8,
                         },
                     },],
+                    comments: &[],
                     source: Span {
                         data: "= Title\n:name: value",
                         line: 1,

--- a/parser/src/tests/asciidoc_lang/root/key_concepts.rs
+++ b/parser/src/tests/asciidoc_lang/root/key_concepts.rs
@@ -109,6 +109,7 @@ image::sunset.jpg[Sunset]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -182,6 +183,7 @@ Click the button with the image:star.png[Star] to favorite the project.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/content/macros.rs
+++ b/parser/src/tests/content/macros.rs
@@ -18,6 +18,7 @@ mod inline_link {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -69,6 +70,7 @@ mod inline_link {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -119,6 +121,7 @@ mod inline_link {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -189,6 +192,7 @@ mod inline_link {
                             offset: 12,
                         },
                     },],
+                    comments: &[],
                     source: Span {
                         data: "= Test Page\n:hide-uri-scheme:",
                         line: 1,
@@ -241,6 +245,7 @@ mod inline_link {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -293,6 +298,7 @@ mod inline_link {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -364,6 +370,7 @@ mod inline_link {
                             offset: 7,
                         },
                     },],
+                    comments: &[],
                     source: Span {
                         data: "= Test\n:hide-uri-scheme:",
                         line: 1,
@@ -421,6 +428,7 @@ mod link_macro {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -471,6 +479,7 @@ mod link_macro {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -542,6 +551,7 @@ mod link_macro {
                             offset: 16,
                         },
                     },],
+                    comments: &[],
                     source: Span {
                         data: "= Test Document\n:hide-uri-scheme:",
                         line: 1,
@@ -613,6 +623,7 @@ mod link_macro {
                             offset: 16,
                         },
                     },],
+                    comments: &[],
                     source: Span {
                         data: "= Test Document\n:hide-uri-scheme:",
                         line: 1,
@@ -669,6 +680,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -719,6 +731,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -769,6 +782,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -819,6 +833,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -869,6 +884,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -919,6 +935,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -969,6 +986,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1019,6 +1037,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,
@@ -1069,6 +1088,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    comments: &[],
                     source: Span {
                         data: "",
                         line: 1,

--- a/parser/src/tests/document/document.rs
+++ b/parser/src/tests/document/document.rs
@@ -287,6 +287,84 @@ fn two_blocks_and_title() {
 }
 
 #[test]
+fn blank_lines_before_header() {
+    let doc = Parser::default().parse("\n\n= Example Title\n\nabc\n\ndef");
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: Some(Span {
+                    data: "Example Title",
+                    line: 3,
+                    col: 3,
+                    offset: 4,
+                },),
+                title: Some("Example Title",),
+                attributes: &[],
+                source: Span {
+                    data: "= Example Title",
+                    line: 3,
+                    col: 1,
+                    offset: 2,
+                },
+            },
+            blocks: &[
+                Block::Simple(SimpleBlock {
+                    content: Content {
+                        original: Span {
+                            data: "abc",
+                            line: 5,
+                            col: 1,
+                            offset: 19,
+                        },
+                        rendered: "abc",
+                    },
+                    source: Span {
+                        data: "abc",
+                        line: 5,
+                        col: 1,
+                        offset: 19,
+                    },
+                    title_source: None,
+                    title: None,
+                    anchor: None,
+                    attrlist: None,
+                },),
+                Block::Simple(SimpleBlock {
+                    content: Content {
+                        original: Span {
+                            data: "def",
+                            line: 7,
+                            col: 1,
+                            offset: 24,
+                        },
+                        rendered: "def",
+                    },
+                    source: Span {
+                        data: "def",
+                        line: 7,
+                        col: 1,
+                        offset: 24,
+                    },
+                    title_source: None,
+                    title: None,
+                    anchor: None,
+                    attrlist: None,
+                },),
+            ],
+            source: Span {
+                data: "\n\n= Example Title\n\nabc\n\ndef",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+        }
+    );
+}
+
+#[test]
 fn extra_space_before_title() {
     assert_eq!(
         Parser::default().parse("=   Example Title\n\nabc"),

--- a/parser/src/tests/document/document.rs
+++ b/parser/src/tests/document/document.rs
@@ -41,6 +41,7 @@ fn empty_source() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,
@@ -69,6 +70,7 @@ fn only_spaces() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,
@@ -98,6 +100,7 @@ fn one_simple_block() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,
@@ -148,6 +151,7 @@ fn two_simple_blocks() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "",
                     line: 1,
@@ -224,6 +228,7 @@ fn two_blocks_and_title() {
                 }),
                 title: Some("Example Title"),
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "= Example Title",
                     line: 1,
@@ -302,6 +307,7 @@ fn blank_lines_before_header() {
                 },),
                 title: Some("Example Title",),
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "= Example Title",
                     line: 3,
@@ -365,6 +371,90 @@ fn blank_lines_before_header() {
 }
 
 #[test]
+fn blank_lines_and_comment_before_header() {
+    let doc = Parser::default().parse("\n// ignore this comment\n= Example Title\n\nabc\n\ndef");
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: Some(Span {
+                    data: "Example Title",
+                    line: 3,
+                    col: 3,
+                    offset: 26,
+                },),
+                title: Some("Example Title",),
+                attributes: &[],
+                comments: &[Span {
+                    data: "// ignore this comment",
+                    line: 2,
+                    col: 1,
+                    offset: 1,
+                },],
+                source: Span {
+                    data: "= Example Title",
+                    line: 3,
+                    col: 1,
+                    offset: 24,
+                },
+            },
+            blocks: &[
+                Block::Simple(SimpleBlock {
+                    content: Content {
+                        original: Span {
+                            data: "abc",
+                            line: 5,
+                            col: 1,
+                            offset: 41,
+                        },
+                        rendered: "abc",
+                    },
+                    source: Span {
+                        data: "abc",
+                        line: 5,
+                        col: 1,
+                        offset: 41,
+                    },
+                    title_source: None,
+                    title: None,
+                    anchor: None,
+                    attrlist: None,
+                },),
+                Block::Simple(SimpleBlock {
+                    content: Content {
+                        original: Span {
+                            data: "def",
+                            line: 7,
+                            col: 1,
+                            offset: 46,
+                        },
+                        rendered: "def",
+                    },
+                    source: Span {
+                        data: "def",
+                        line: 7,
+                        col: 1,
+                        offset: 46,
+                    },
+                    title_source: None,
+                    title: None,
+                    anchor: None,
+                    attrlist: None,
+                },),
+            ],
+            source: Span {
+                data: "\n// ignore this comment\n= Example Title\n\nabc\n\ndef",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+        }
+    );
+}
+
+#[test]
 fn extra_space_before_title() {
     assert_eq!(
         Parser::default().parse("=   Example Title\n\nabc"),
@@ -378,6 +468,7 @@ fn extra_space_before_title() {
                 }),
                 title: Some("Example Title"),
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "=   Example Title",
                     line: 1,
@@ -431,6 +522,7 @@ fn err_bad_header() {
                 }),
                 title: Some("Title"),
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "= Title",
                     line: 1,
@@ -492,6 +584,7 @@ fn err_bad_header_and_bad_macro() {
                 }),
                 title: Some("Title"),
                 attributes: &[],
+                comments: &[],
                 source: Span {
                     data: "= Title",
                     line: 1,

--- a/parser/src/tests/document/header.rs
+++ b/parser/src/tests/document/header.rs
@@ -31,6 +31,7 @@ fn only_title() {
             }),
             title: Some("Just the Title"),
             attributes: &[],
+            comments: &[],
             source: Span {
                 data: "= Just the Title",
                 line: 1,
@@ -70,6 +71,7 @@ fn trims_leading_spaces_in_title() {
             }),
             title: Some("Just the Title"),
             attributes: &[],
+            comments: &[],
             source: Span {
                 data: "=    Just the Title",
                 line: 1,
@@ -107,6 +109,7 @@ fn trims_trailing_spaces_in_title() {
             }),
             title: Some("Just the Title"),
             attributes: &[],
+            comments: &[],
             source: Span {
                 data: "= Just the Title",
                 line: 1,
@@ -168,6 +171,7 @@ fn title_and_attribute() {
                     offset: 17,
                 }
             }],
+            comments: &[],
             source: Span {
                 data: "= Just the Title\n:foo: bar",
                 line: 1,
@@ -229,6 +233,7 @@ fn title_applies_header_substitutions() {
                     offset: 31,
                 }
             }],
+            comments: &[],
             source: Span {
                 data: "= The Title & Some{sp}Nonsense\n:foo: bar",
                 line: 1,
@@ -281,6 +286,7 @@ fn attribute_without_title() {
                     offset: 0,
                 }
             }],
+            comments: &[],
             source: Span {
                 data: ":foo: bar",
                 line: 1,

--- a/parser/src/tests/fixtures/document/header.rs
+++ b/parser/src/tests/fixtures/document/header.rs
@@ -10,6 +10,7 @@ pub(crate) struct Header {
     pub title_source: Option<Span>,
     pub title: Option<&'static str>,
     pub attributes: &'static [Attribute],
+    pub comments: &'static [Span],
     pub source: Span,
 }
 
@@ -19,6 +20,7 @@ impl fmt::Debug for Header {
             .field("title_source", &self.title_source)
             .field("title", &self.title)
             .field("attributes", &self.attributes)
+            .field("comments", &self.comments)
             .field("source", &self.source)
             .finish()
     }
@@ -77,6 +79,16 @@ fn fixture_eq_observed(fixture: &Header, observed: &crate::document::Header) -> 
         fixture.attributes.iter().zip(observed.attributes())
     {
         if fixture_attribute != observed_attribute {
+            return false;
+        }
+    }
+
+    if fixture.comments.len() != observed.comments().len() {
+        return false;
+    }
+
+    for (fixture_comment, observed_comment) in fixture.comments.iter().zip(observed.comments()) {
+        if fixture_comment != observed_comment {
             return false;
         }
     }


### PR DESCRIPTION
#sddbugfind: Found while reviewing "Document header" page