### PR TITLE
feat: Refactor document header parsing

### DIFF
--- a/parser/src/tests/asciidoc_lang/attributes/attribute_entries.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/attribute_entries.rs
@@ -120,6 +120,7 @@ At the end of the value, press kbd:[Enter].
                         offset: 10,
                     },
                 },],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "= Testing\n:name-of-an-attribute: value of the attribute",
@@ -210,6 +211,7 @@ That means you don't need to escape special characters such in an HTML tag.
                         offset: 10,
                     },
                 },],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "= Testing\n:lt-attribute: <",
@@ -322,6 +324,7 @@ Attribute references in the value of an attribute entry are resolved immediately
                         },
                     },
                 ],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: ":url-org: https://example.org/projects\n:url-project: {url-org}/project-name",
@@ -391,6 +394,7 @@ If you set a built-in attribute and leave its value empty, the AsciiDoc processo
                         offset: 0,
                     },
                 },],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: ":name-of-an-attribute:",

--- a/parser/src/tests/asciidoc_lang/attributes/element_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/element_attributes.rs
@@ -268,6 +268,7 @@ If this happens, append `+{empty}+` to the end of the line to disrupt the syntax
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -415,6 +416,7 @@ Specifically, it does not support named attributes, only the attribute shorthand
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/asciidoc_lang/attributes/id.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/id.rs
@@ -560,6 +560,7 @@ The id (`#`) shorthand can be used on inline quoted text.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -624,6 +625,7 @@ The id (`#`) shorthand can be used on inline quoted text.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -703,6 +705,7 @@ According to the https://www.w3.org/TR/REC-xml/#NT-Name[XML Name] rules, a porta
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -753,6 +756,7 @@ According to the https://www.w3.org/TR/REC-xml/#NT-Name[XML Name] rules, a porta
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -803,6 +807,7 @@ According to the https://www.w3.org/TR/REC-xml/#NT-Name[XML Name] rules, a porta
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -853,6 +858,7 @@ According to the https://www.w3.org/TR/REC-xml/#NT-Name[XML Name] rules, a porta
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -912,6 +918,7 @@ The shorthand form in an attribute list does not impose this restriction.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -981,6 +988,7 @@ include::example$id.adoc[tag=block-id-shorthand]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1060,6 +1068,7 @@ include::example$id.adoc[tag=block-id-brackets]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1135,6 +1144,7 @@ include::example$id.adoc[tag=anchor-brackets]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1202,6 +1212,7 @@ include::example$id.adoc[tag=anchor-shorthand]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
@@ -416,6 +416,7 @@ Formatted text does not support a style, so the first and only positional attrib
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -491,6 +492,7 @@ A named attribute consists of a name and a value separated by an `=` character (
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -565,6 +567,7 @@ In all other cases, the surrounding quotes are optional.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -640,6 +643,7 @@ If enclosing quotes are used, they are dropped from the parsed value and the pre
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -717,6 +721,7 @@ If enclosing quotes are used, they are dropped from the parsed value and the pre
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -809,6 +814,7 @@ In these rules, `name` consists of a word character (letter or numeral) followed
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -909,6 +915,7 @@ In these rules, `name` consists of a word character (letter or numeral) followed
                             offset: 0,
                         },
                     },],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: ":url: https://example.com",
@@ -990,6 +997,7 @@ In these rules, `name` consists of a word character (letter or numeral) followed
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1049,6 +1057,7 @@ For subsequent attributes, any leading space or tab characters are skipped.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1130,6 +1139,7 @@ Space and tab characters around the equals sign (=) and at the end of the value 
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1210,6 +1220,7 @@ Any space or tab characters at the boundaries of the value are ignored.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1295,6 +1306,7 @@ Any space or tab characters at the boundaries of the value are ignored.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1379,6 +1391,7 @@ Any space or tab characters at the boundaries of the value are ignored.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1471,6 +1484,7 @@ If there is a closing double quote, the enclosing double quote characters are re
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1555,6 +1569,7 @@ If there is a closing double quote, the enclosing double quote characters are re
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1647,6 +1662,7 @@ If there is a closing single quote, the enclosing single quote characters are re
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1732,6 +1748,7 @@ If there is a closing single quote, and the first character is not an escaped si
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1831,6 +1848,7 @@ That's because the parser already knows to look for the closing square bracket a
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1926,6 +1944,7 @@ There are some exceptions to this rule, such as a link macro in a footnote, whic
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/asciidoc_lang/attributes/reference_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/reference_attributes.rs
@@ -133,6 +133,7 @@ Actually, please don't.
                         },
                     },
                 ],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "= Ops Manual\n:disclaimer: Don't pet the wild Wolpertingers. We're not responsible for any loss \\\nof hair, chocolate, or purple socks.\n:url-repo: https://github.com/asciidoctor/asciidoctor",
@@ -233,6 +234,7 @@ Our servers don't like them either.
                 title_source: None,
                 title: None,
                 attributes: &[],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "",
@@ -349,6 +351,7 @@ In the path /items/\{id}, id is a path parameter.
                             offset: 0,
                         },
                     },],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: ":id: foo",
@@ -410,6 +413,7 @@ If the syntax that follows the backslash does not match an attribute reference, 
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -507,6 +511,7 @@ In the path +/items/{id}+, id is a path parameter.
                             offset: 0,
                         },
                     },],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: ":id: foo",
@@ -568,6 +573,7 @@ All the text between the passthrough enclosure will get passed through to the ou
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/asciidoc_lang/blocks/build_basic_block.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/build_basic_block.rs
@@ -82,6 +82,7 @@ This is more content in the sidebar block.
                 title_source: None,
                 title: None,
                 attributes: &[],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "",

--- a/parser/src/tests/asciidoc_lang/blocks/paragraphs.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/paragraphs.rs
@@ -51,6 +51,7 @@ include::example$paragraph.adoc[tag=para]
                 title_source: None,
                 title: None,
                 attributes: &[],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "",

--- a/parser/src/tests/asciidoc_lang/blocks/troubleshoot_blocks.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/troubleshoot_blocks.rs
@@ -45,6 +45,7 @@ It will be styled as a sidebar.
                 title_source: None,
                 title: None,
                 attributes: &[],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "",
@@ -129,6 +130,7 @@ If you want the processor to recognize a closing delimiter, it must be the same 
                 title_source: None,
                 title: None,
                 attributes: &[],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "",

--- a/parser/src/tests/asciidoc_lang/macros/autolinks.rs
+++ b/parser/src/tests/asciidoc_lang/macros/autolinks.rs
@@ -44,6 +44,7 @@ AsciiDoc recognizes the following common URL schemes without the help of any mar
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -101,6 +102,7 @@ AsciiDoc recognizes the following common URL schemes without the help of any mar
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -158,6 +160,7 @@ AsciiDoc recognizes the following common URL schemes without the help of any mar
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -215,6 +218,7 @@ AsciiDoc recognizes the following common URL schemes without the help of any mar
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -273,6 +277,7 @@ AsciiDoc recognizes the following common URL schemes without the help of any mar
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -341,6 +346,7 @@ If you want to use xref:url-macro.adoc#link-text[custom link text], you must use
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -410,6 +416,7 @@ This allows the theming system (e.g., CSS) to recognize autolinks (and other bar
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -484,6 +491,7 @@ For email address which do not conform to these restriction, you can use the xre
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -560,6 +568,7 @@ The URL and email address will both be shown in plain text.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -650,6 +659,7 @@ The `subs` attribute is only recognized on a leaf block, such as a paragraph.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/asciidoc_lang/macros/complex_urls.rs
+++ b/parser/src/tests/asciidoc_lang/macros/complex_urls.rs
@@ -59,6 +59,7 @@ include::partial$ts-url-format.adoc[tag=sb]
                         offset: 17,
                     },
                 },],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "= Document Title\n:link-with-underscores: https://asciidoctor.org/now_this__link_works.html",
@@ -110,6 +111,7 @@ fn pass_macro() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "",
@@ -162,6 +164,7 @@ fn double_plus_inline_macro() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "",

--- a/parser/src/tests/asciidoc_lang/macros/icon_macro.rs
+++ b/parser/src/tests/asciidoc_lang/macros/icon_macro.rs
@@ -58,6 +58,7 @@ icon:heart[2x,role=red]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/asciidoc_lang/macros/image_link.rs
+++ b/parser/src/tests/asciidoc_lang/macros/image_link.rs
@@ -53,6 +53,7 @@ image::logo.png[Logo]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -140,6 +141,7 @@ image::logo.png[Logo,link=https://example.org]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -222,6 +224,7 @@ image:apply.jpg[Apply,link=https://apply.example.org] today!
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -308,6 +311,7 @@ image::logo.png[Logo,link=https://example.org,window=_blank,opts=nofollow]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/asciidoc_lang/macros/image_position.rs
+++ b/parser/src/tests/asciidoc_lang/macros/image_position.rs
@@ -66,6 +66,7 @@ include::example$image.adoc[tag=float]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -167,6 +168,7 @@ include::example$image.adoc[tag=in-float]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -253,6 +255,7 @@ include::example$image.adoc[tag=role]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -353,6 +356,7 @@ include::example$image.adoc[tag=in-role]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/asciidoc_lang/macros/image_size.rs
+++ b/parser/src/tests/asciidoc_lang/macros/image_size.rs
@@ -51,6 +51,7 @@ image::flower.jpg[Flower,640,480]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -138,6 +139,7 @@ image::flower.jpg[alt=Flower,width=640,height=480]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/asciidoc_lang/macros/image_url.rs
+++ b/parser/src/tests/asciidoc_lang/macros/image_url.rs
@@ -52,6 +52,7 @@ include::example$image.adoc[tag=url]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -147,6 +148,7 @@ include::example$image.adoc[tag=in-url]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/asciidoc_lang/macros/images.rs
+++ b/parser/src/tests/asciidoc_lang/macros/images.rs
@@ -63,6 +63,7 @@ include::example$image.adoc[tag=base]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -187,6 +188,7 @@ include::example$image.adoc[tag=alt]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -270,6 +272,7 @@ You can also give the image an ID, title, set its dimensions and make it a link.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -363,6 +366,7 @@ include::example$image.adoc[tag=attr]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/asciidoc_lang/macros/link_macro.rs
+++ b/parser/src/tests/asciidoc_lang/macros/link_macro.rs
@@ -51,6 +51,7 @@ the `<attrlist>` is the link text unless a named attribute is detected.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -142,6 +143,7 @@ The AsciiDoc processor will create a link to _report.pdf_ with the text "Get Rep
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -207,6 +209,7 @@ Note that when linking to a relative file, even if it's an HTML file, the link t
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -293,6 +296,7 @@ link:report.pdf[Get Report]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -367,6 +371,7 @@ link:pass:[My Documents/report.pdf][Get Report]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -429,6 +434,7 @@ link:My&#32;Documents/report.pdf[Get Report]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -491,6 +497,7 @@ link:My%20Documents/report.pdf[Get Report]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -565,6 +572,7 @@ link:Avengers%3A%20Endgame.html[]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -631,6 +639,7 @@ link:++https://example.org/now_this__link_works.html++[]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -695,6 +704,7 @@ In this case, the link macro prefix is required to increase the precedence so th
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -759,6 +769,7 @@ link:file:///home/username[Your files]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/asciidoc_lang/macros/link_macro_attribute_parsing.rs
+++ b/parser/src/tests/asciidoc_lang/macros/link_macro_attribute_parsing.rs
@@ -47,6 +47,7 @@ https://chat.asciidoc.org[Discuss AsciiDoc]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -123,6 +124,7 @@ https://chat.asciidoc.org[Discuss AsciiDoc,role=resource,window=_blank]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -188,6 +190,7 @@ https://example.org["Google, DuckDuckGo, Ecosia",role=teal]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -252,6 +255,7 @@ https://example.org["1=2 posits the problem of inequality"]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -317,6 +321,7 @@ https://example.org["href=\"#top\" attribute"] creates link to top of page
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -391,6 +396,7 @@ https://chat.asciidoc.org[role=button,window=_blank,opts=nofollow]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -480,6 +486,7 @@ In the HTML output, the value of the `window` attribute is assigned to the `targ
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -550,6 +557,7 @@ If the target is `_blank`, the processor will automatically add the <<noopener a
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -628,6 +636,7 @@ https://asciidoctor.org[Asciidoctor,window=_blank]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -692,6 +701,7 @@ https://asciidoctor.org[Asciidoctor,window=read-later,opts=noopener]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -757,6 +767,7 @@ https://asciidoctor.org[Asciidoctor,window=_blank,opts=nofollow]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -822,6 +833,7 @@ https://asciidoctor.org[Asciidoctor,window=read-later,opts="noopener,nofollow"]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -885,6 +897,7 @@ link:post.html[My Post,opts=nofollow]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -954,6 +967,7 @@ include::example$url.adoc[tag=linkattrs-s]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1026,6 +1040,7 @@ https://example.org["Google, DuckDuckGo, Ecosia^",role=btn]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1088,6 +1103,7 @@ https://example.org[Google, DuckDuckGo, Ecosia^]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/asciidoc_lang/macros/link_macro_ref.rs
+++ b/parser/src/tests/asciidoc_lang/macros/link_macro_ref.rs
@@ -38,6 +38,7 @@ fn id() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "",
@@ -99,6 +100,7 @@ fn role() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "",
@@ -160,6 +162,7 @@ fn title() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "",
@@ -221,6 +224,7 @@ fn window() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "",
@@ -284,6 +288,7 @@ fn window_shorthand() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "",
@@ -344,6 +349,7 @@ fn opts() {
                 title_source: None,
                 title: None,
                 attributes: &[],
+                author_line: None,
                 comments: &[],
                 source: Span {
                     data: "",

--- a/parser/src/tests/asciidoc_lang/macros/links.rs
+++ b/parser/src/tests/asciidoc_lang/macros/links.rs
@@ -95,6 +95,7 @@ Depending on the capabilities of the web application, the space character can be
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -209,6 +210,7 @@ The prefix will still be present in the link target.
                             offset: 17,
                         },
                     },],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "= Document Title\n:hide-uri-scheme:",

--- a/parser/src/tests/asciidoc_lang/macros/mailto_macro.rs
+++ b/parser/src/tests/asciidoc_lang/macros/mailto_macro.rs
@@ -49,6 +49,7 @@ mailto:join@discuss.example.org[Subscribe]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -111,6 +112,7 @@ mailto:join@discuss.example.org[Subscribe,role=email]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -175,6 +177,7 @@ mailto:join@discuss.example.org["Click, subscribe, and participate!"]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -263,6 +266,7 @@ When the reader clicks the link, a conforming email client will fill in the subj
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -329,6 +333,7 @@ When the reader clicks the link, a conforming email client will fill in the body
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -392,6 +397,7 @@ mailto:join@discuss.example.org[,Subscribe me,I want to participate.]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -454,6 +460,7 @@ mailto:join@discuss.example.org[,Subscribe me]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -516,6 +523,7 @@ mailto:join@discuss.example.org[Subscribe,"I want to participate, so please subs
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/asciidoc_lang/macros/url_macro.rs
+++ b/parser/src/tests/asciidoc_lang/macros/url_macro.rs
@@ -62,6 +62,7 @@ With the exception of the xref:mailto-macro.adoc[mailto macro], all the URL macr
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -129,6 +130,7 @@ The more typical reason, however, is to specify custom link text.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -209,6 +211,7 @@ include::example$url.adoc[tag=irc]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -273,6 +276,7 @@ include::example$url.adoc[tag=text]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -349,6 +353,7 @@ include::example$url.adoc[tag=css]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/asciidoc_lang/root/document_structure.rs
+++ b/parser/src/tests/asciidoc_lang/root/document_structure.rs
@@ -50,6 +50,7 @@ This is a basic AsciiDoc document.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -120,6 +121,7 @@ This document contains two paragraphs.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -237,6 +239,7 @@ It also has a header that specifies the document title.
                             },
                         },
                     ],
+                author_line: None,
                 comments: &[],
                     source: Span {
                         data: "= Document Title\n:reproducible:",
@@ -518,6 +521,7 @@ A single empty line separates the header from the body.
                             offset: 8,
                         },
                     },],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "= Title\n:name: value",

--- a/parser/src/tests/asciidoc_lang/root/key_concepts.rs
+++ b/parser/src/tests/asciidoc_lang/root/key_concepts.rs
@@ -109,6 +109,7 @@ image::sunset.jpg[Sunset]
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -183,6 +184,7 @@ Click the button with the image:star.png[Star] to favorite the project.
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/content/macros.rs
+++ b/parser/src/tests/content/macros.rs
@@ -18,6 +18,7 @@ mod inline_link {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -70,6 +71,7 @@ mod inline_link {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -121,6 +123,7 @@ mod inline_link {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -192,6 +195,7 @@ mod inline_link {
                             offset: 12,
                         },
                     },],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "= Test Page\n:hide-uri-scheme:",
@@ -245,6 +249,7 @@ mod inline_link {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -298,6 +303,7 @@ mod inline_link {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -370,6 +376,7 @@ mod inline_link {
                             offset: 7,
                         },
                     },],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "= Test\n:hide-uri-scheme:",
@@ -428,6 +435,7 @@ mod link_macro {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -479,6 +487,7 @@ mod link_macro {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -551,6 +560,7 @@ mod link_macro {
                             offset: 16,
                         },
                     },],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "= Test Document\n:hide-uri-scheme:",
@@ -623,6 +633,7 @@ mod link_macro {
                             offset: 16,
                         },
                     },],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "= Test Document\n:hide-uri-scheme:",
@@ -680,6 +691,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -731,6 +743,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -782,6 +795,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -833,6 +847,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -884,6 +899,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -935,6 +951,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -986,6 +1003,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1037,6 +1055,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",
@@ -1088,6 +1107,7 @@ mod inline_anchor {
                     title_source: None,
                     title: None,
                     attributes: &[],
+                    author_line: None,
                     comments: &[],
                     source: Span {
                         data: "",

--- a/parser/src/tests/document/header.rs
+++ b/parser/src/tests/document/header.rs
@@ -31,6 +31,7 @@ fn only_title() {
             }),
             title: Some("Just the Title"),
             attributes: &[],
+            author_line: None,
             comments: &[],
             source: Span {
                 data: "= Just the Title",
@@ -71,6 +72,7 @@ fn trims_leading_spaces_in_title() {
             }),
             title: Some("Just the Title"),
             attributes: &[],
+            author_line: None,
             comments: &[],
             source: Span {
                 data: "=    Just the Title",
@@ -109,6 +111,7 @@ fn trims_trailing_spaces_in_title() {
             }),
             title: Some("Just the Title"),
             attributes: &[],
+            author_line: None,
             comments: &[],
             source: Span {
                 data: "= Just the Title",
@@ -171,6 +174,7 @@ fn title_and_attribute() {
                     offset: 17,
                 }
             }],
+            author_line: None,
             comments: &[],
             source: Span {
                 data: "= Just the Title\n:foo: bar",
@@ -233,6 +237,7 @@ fn title_applies_header_substitutions() {
                     offset: 31,
                 }
             }],
+            author_line: None,
             comments: &[],
             source: Span {
                 data: "= The Title & Some{sp}Nonsense\n:foo: bar",
@@ -286,6 +291,7 @@ fn attribute_without_title() {
                     offset: 0,
                 }
             }],
+            author_line: None,
             comments: &[],
             source: Span {
                 data: ":foo: bar",

--- a/parser/src/tests/fixtures/document/header.rs
+++ b/parser/src/tests/fixtures/document/header.rs
@@ -2,7 +2,10 @@ use std::{cmp::PartialEq, fmt};
 
 use crate::{
     HasSpan,
-    tests::fixtures::{Span, document::Attribute},
+    tests::fixtures::{
+        Span,
+        document::{Attribute, AuthorLine},
+    },
 };
 
 #[derive(Eq, PartialEq)]
@@ -10,6 +13,7 @@ pub(crate) struct Header {
     pub title_source: Option<Span>,
     pub title: Option<&'static str>,
     pub attributes: &'static [Attribute],
+    pub author_line: Option<AuthorLine>,
     pub comments: &'static [Span],
     pub source: Span,
 }
@@ -20,6 +24,7 @@ impl fmt::Debug for Header {
             .field("title_source", &self.title_source)
             .field("title", &self.title)
             .field("attributes", &self.attributes)
+            .field("author_line", &self.author_line)
             .field("comments", &self.comments)
             .field("source", &self.source)
             .finish()
@@ -81,6 +86,17 @@ fn fixture_eq_observed(fixture: &Header, observed: &crate::document::Header) -> 
         if fixture_attribute != observed_attribute {
             return false;
         }
+    }
+
+    if fixture.author_line.is_some() != observed.author_line().is_some() {
+        return false;
+    }
+
+    if let Some(fixture_author_line) = &fixture.author_line
+        && let Some(observed_author_line) = observed.author_line()
+        && fixture_author_line != observed_author_line
+    {
+        return false;
     }
 
     if fixture.comments.len() != observed.comments().len() {


### PR DESCRIPTION
Now supports comments and blank lines before the title and also supports author lines.