### PR TITLE
fix: Set `doctitle` attribute from document header title line

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -3,7 +3,7 @@ use std::slice::Iter;
 use crate::{
     HasSpan, Parser, Span,
     content::{Content, SubstitutionGroup},
-    document::{Attribute, AuthorLine, RevisionLine},
+    document::{Attribute, AuthorLine, InterpretedValue, RevisionLine},
     span::MatchedItem,
     warnings::{MatchAndWarnings, Warning, WarningType},
 };
@@ -59,7 +59,14 @@ impl<'src> Header<'src> {
                 source = attr.after;
             } else if title.is_none() && line.starts_with("= ") {
                 let title_span = line.discard(2).discard_whitespace();
-                title = Some(apply_header_subs(title_span.data(), parser));
+                let title_str = apply_header_subs(title_span.data(), parser);
+
+                parser.set_attribute_by_value_from_header(
+                    "doctitle",
+                    InterpretedValue::Value(title_str.clone()),
+                );
+
+                title = Some(title_str);
                 title_source = Some(title_span);
                 source = line_mi.after;
             } else if title.is_some() && author_line.is_none() {

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -269,6 +269,30 @@ impl<'p> Parser<'p> {
         self.attribute_values.insert(attr_name, attribute_value);
     }
 
+    /// Called from [`Header::parse()`] for a value that is derived from parsing
+    /// the header (except for attribute lines).
+    pub(crate) fn set_attribute_by_value_from_header<'src, N: AsRef<str>>(
+        &mut self,
+        name: N,
+        mut value: InterpretedValue,
+    ) {
+        let attr_name = name.as_ref().to_lowercase();
+
+        if let InterpretedValue::Set = value
+            && let Some(default_value) = self.default_attribute_values.get(&attr_name)
+        {
+            value = InterpretedValue::Value(default_value.clone());
+        }
+
+        let attribute_value = AttributeValue {
+            allowable_value: AllowableValue::Any,
+            modification_context: ModificationContext::Anywhere,
+            value,
+        };
+
+        self.attribute_values.insert(attr_name, attribute_value);
+    }
+
     /// Called from [`Block::parse()`] to accept or reject an attribute value
     /// from a document (body) attribute.
     pub(crate) fn set_attribute_from_body<'src>(

--- a/parser/src/tests/document/header.rs
+++ b/parser/src/tests/document/header.rs
@@ -318,3 +318,14 @@ fn attribute_without_title() {
         }
     );
 }
+
+#[test]
+fn sets_doctitle_attribute() {
+    let mut parser = Parser::default();
+    let _doc = parser.parse("= Document Title Goes Here");
+
+    assert_eq!(
+        parser.attribute_value("doctitle"),
+        InterpretedValue::Value("Document Title Goes Here")
+    );
+}


### PR DESCRIPTION
#sddbugfind: Found while working on #373.