### PR TITLE
feat: Set derived author name attributes when :author: attribute is set in document header

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -3,7 +3,7 @@ use std::slice::Iter;
 use crate::{
     HasSpan, Parser, Span,
     content::{Content, SubstitutionGroup},
-    document::{Attribute, AuthorLine, RevisionLine},
+    document::{Attribute, Author, AuthorLine, RevisionLine},
     span::MatchedItem,
     warnings::{MatchAndWarnings, Warning, WarningType},
 };
@@ -54,6 +54,33 @@ impl<'src> Header<'src> {
             } else if line.starts_with(':')
                 && let Some(attr) = Attribute::parse(source, parser)
             {
+                // Special handling for :author: attribute to populate individual author
+                // attributes.
+                if attr.item.name().data().eq_ignore_ascii_case("author") {
+                    if let Some(raw_value) = attr.item.raw_value() {
+                        if let Some(author) = Author::parse(raw_value.data(), parser) {
+                            // Set individual author attributes.
+                            parser.set_attribute_by_value_from_header(
+                                "firstname",
+                                author.firstname(),
+                            );
+                            if let Some(middlename) = author.middlename() {
+                                parser.set_attribute_by_value_from_header("middlename", middlename);
+                            }
+                            if let Some(lastname) = author.lastname() {
+                                parser.set_attribute_by_value_from_header("lastname", lastname);
+                            }
+                            parser.set_attribute_by_value_from_header(
+                                "authorinitials",
+                                &author.initials(),
+                            );
+                            if let Some(email) = author.email() {
+                                parser.set_attribute_by_value_from_header("email", email);
+                            }
+                        }
+                    }
+                }
+
                 parser.set_attribute_from_header(&attr.item, &mut warnings);
                 attributes.push(attr.item);
                 source = attr.after;

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -56,28 +56,21 @@ impl<'src> Header<'src> {
             {
                 // Special handling for :author: attribute to populate individual author
                 // attributes.
-                if attr.item.name().data().eq_ignore_ascii_case("author") {
-                    if let Some(raw_value) = attr.item.raw_value() {
-                        if let Some(author) = Author::parse(raw_value.data(), parser) {
-                            // Set individual author attributes.
-                            parser.set_attribute_by_value_from_header(
-                                "firstname",
-                                author.firstname(),
-                            );
-                            if let Some(middlename) = author.middlename() {
-                                parser.set_attribute_by_value_from_header("middlename", middlename);
-                            }
-                            if let Some(lastname) = author.lastname() {
-                                parser.set_attribute_by_value_from_header("lastname", lastname);
-                            }
-                            parser.set_attribute_by_value_from_header(
-                                "authorinitials",
-                                &author.initials(),
-                            );
-                            if let Some(email) = author.email() {
-                                parser.set_attribute_by_value_from_header("email", email);
-                            }
-                        }
+                if attr.item.name().data().eq_ignore_ascii_case("author")
+                    && let Some(raw_value) = attr.item.raw_value()
+                    && let Some(author) = Author::parse(raw_value.data(), parser)
+                {
+                    // Set individual author attributes.
+                    parser.set_attribute_by_value_from_header("firstname", author.firstname());
+                    if let Some(middlename) = author.middlename() {
+                        parser.set_attribute_by_value_from_header("middlename", middlename);
+                    }
+                    if let Some(lastname) = author.lastname() {
+                        parser.set_attribute_by_value_from_header("lastname", lastname);
+                    }
+                    parser.set_attribute_by_value_from_header("authorinitials", author.initials());
+                    if let Some(email) = author.email() {
+                        parser.set_attribute_by_value_from_header("email", email);
                     }
                 }
 

--- a/parser/src/tests/document/header.rs
+++ b/parser/src/tests/document/header.rs
@@ -410,3 +410,24 @@ fn sets_author_attributes_from_author_attribute_single_name() {
     );
     assert_eq!(parser.attribute_value("email"), InterpretedValue::Unset);
 }
+
+#[test]
+fn sets_author_attributes_from_empty_string() {
+    let mut parser = Parser::default();
+    let _doc = parser.parse(":author:");
+
+    // Verify that individual author attributes are set.
+    assert_eq!(parser.attribute_value("firstname"), InterpretedValue::Unset);
+    assert_eq!(
+        parser.attribute_value("middlename"),
+        InterpretedValue::Unset
+    );
+    assert_eq!(parser.attribute_value("lastname"), InterpretedValue::Unset);
+    assert_eq!(
+        parser.attribute_value("authorinitials"),
+        InterpretedValue::Unset
+    );
+    assert_eq!(parser.attribute_value("email"), InterpretedValue::Unset);
+
+    assert_eq!(parser.attribute_value("author"), InterpretedValue::Set);
+}

--- a/parser/src/tests/document/header.rs
+++ b/parser/src/tests/document/header.rs
@@ -329,3 +329,84 @@ fn sets_doctitle_attribute() {
         InterpretedValue::Value("Document Title Goes Here")
     );
 }
+
+#[test]
+fn sets_author_attributes_from_author_attribute() {
+    let mut parser = Parser::default();
+    let _doc = parser.parse(":author: John Q. Smith <john@example.com>");
+
+    // Verify that individual author attributes are set.
+    assert_eq!(
+        parser.attribute_value("firstname"),
+        InterpretedValue::Value("John")
+    );
+    assert_eq!(
+        parser.attribute_value("middlename"),
+        InterpretedValue::Value("Q.")
+    );
+    assert_eq!(
+        parser.attribute_value("lastname"),
+        InterpretedValue::Value("Smith")
+    );
+    assert_eq!(
+        parser.attribute_value("authorinitials"),
+        InterpretedValue::Value("JQS")
+    );
+    assert_eq!(
+        parser.attribute_value("email"),
+        InterpretedValue::Value("john@example.com")
+    );
+
+    // Also verify the original author attribute is still set (with HTML encoding).
+    assert_eq!(
+        parser.attribute_value("author"),
+        InterpretedValue::Value("John Q. Smith &lt;john@example.com&gt;")
+    );
+}
+
+#[test]
+fn sets_author_attributes_from_author_attribute_two_names() {
+    let mut parser = Parser::default();
+    let _doc = parser.parse(":author: Jane Doe");
+
+    // Verify that individual author attributes are set.
+    assert_eq!(
+        parser.attribute_value("firstname"),
+        InterpretedValue::Value("Jane")
+    );
+    assert_eq!(
+        parser.attribute_value("middlename"),
+        InterpretedValue::Unset
+    );
+    assert_eq!(
+        parser.attribute_value("lastname"),
+        InterpretedValue::Value("Doe")
+    );
+    assert_eq!(
+        parser.attribute_value("authorinitials"),
+        InterpretedValue::Value("JD")
+    );
+    assert_eq!(parser.attribute_value("email"), InterpretedValue::Unset);
+}
+
+#[test]
+fn sets_author_attributes_from_author_attribute_single_name() {
+    let mut parser = Parser::default();
+    let _doc = parser.parse(":author: Cher");
+
+    // Verify that individual author attributes are set.
+    assert_eq!(
+        parser.attribute_value("firstname"),
+        InterpretedValue::Value("Cher")
+    );
+    assert_eq!(
+        parser.attribute_value("middlename"),
+        InterpretedValue::Unset
+    );
+    assert_eq!(parser.attribute_value("lastname"), InterpretedValue::Unset);
+    assert_eq!(
+        parser.attribute_value("authorinitials"),
+        InterpretedValue::Value("C")
+    );
+    assert_eq!(parser.attribute_value("email"), InterpretedValue::Unset);
+}


### PR DESCRIPTION
#sddbugfind: Found while working on #373.