### PR TITLE
feat: Split parsing from inline cross-reference resolution (#461)

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -8,7 +8,7 @@ use crate::{
         MediaBlock, Preamble, RawDelimitedBlock, SectionBlock, SimpleBlock,
         metadata::BlockMetadata,
     },
-    content::SubstitutionGroup,
+    content::{Content, SubstitutionGroup},
     document::{Attribute, RefType},
     parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning},
     span::MatchedItem,
@@ -442,60 +442,22 @@ impl<'src> Block<'src> {
     /// Resolve any deferred cross-references in this block and its descendants,
     /// using `resolver` to map targets to destinations and `renderer` to render
     /// the resulting links. Unresolved targets are reported in `warnings`.
+    ///
+    /// This drives the recursion uniformly via the [`IsBlock::content_mut`] and
+    /// [`IsBlock::nested_blocks_mut`] accessors, so it needs no per-block-type
+    /// special casing.
     pub(crate) fn resolve_references(
         &mut self,
         resolver: &dyn ReferenceResolver,
         renderer: &dyn InlineSubstitutionRenderer,
         warnings: &mut Vec<ReferenceWarning>,
     ) {
-        match self {
-            Self::Simple(b) => b
-                .content_mut()
-                .resolve_references(resolver, renderer, warnings),
+        if let Some(content) = self.content_mut() {
+            content.resolve_references(resolver, renderer, warnings);
+        }
 
-            Self::RawDelimited(b) => b
-                .content_mut()
-                .resolve_references(resolver, renderer, warnings),
-
-            Self::Section(b) => {
-                b.section_title_mut()
-                    .resolve_references(resolver, renderer, warnings);
-
-                for child in b.nested_blocks_mut() {
-                    child.resolve_references(resolver, renderer, warnings);
-                }
-            }
-
-            Self::List(b) => {
-                for item in b.items_mut() {
-                    item.resolve_references(resolver, renderer, warnings);
-                }
-            }
-
-            Self::ListItem(b) => {
-                if let Some(term) = b.marker_mut().term_mut() {
-                    term.resolve_references(resolver, renderer, warnings);
-                }
-
-                for child in b.nested_blocks_mut() {
-                    child.resolve_references(resolver, renderer, warnings);
-                }
-            }
-
-            Self::CompoundDelimited(b) => {
-                for child in b.nested_blocks_mut() {
-                    child.resolve_references(resolver, renderer, warnings);
-                }
-            }
-
-            Self::Preamble(b) => {
-                for child in b.nested_blocks_mut() {
-                    child.resolve_references(resolver, renderer, warnings);
-                }
-            }
-
-            // These block types carry no cross-reference-bearing content.
-            Self::Media(_) | Self::Break(_) | Self::DocumentAttribute(_) => {}
+        for child in self.nested_blocks_mut() {
+            child.resolve_references(resolver, renderer, warnings);
         }
     }
 }
@@ -558,6 +520,36 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::Preamble(b) => b.nested_blocks(),
             Self::Break(b) => b.nested_blocks(),
             Self::DocumentAttribute(b) => b.nested_blocks(),
+        }
+    }
+
+    fn nested_blocks_mut(&mut self) -> &mut [Block<'src>] {
+        match self {
+            Self::Simple(b) => b.nested_blocks_mut(),
+            Self::Media(b) => b.nested_blocks_mut(),
+            Self::Section(b) => b.nested_blocks_mut(),
+            Self::List(b) => b.nested_blocks_mut(),
+            Self::ListItem(b) => b.nested_blocks_mut(),
+            Self::RawDelimited(b) => b.nested_blocks_mut(),
+            Self::CompoundDelimited(b) => b.nested_blocks_mut(),
+            Self::Preamble(b) => b.nested_blocks_mut(),
+            Self::Break(b) => b.nested_blocks_mut(),
+            Self::DocumentAttribute(b) => b.nested_blocks_mut(),
+        }
+    }
+
+    fn content_mut(&mut self) -> Option<&mut Content<'src>> {
+        match self {
+            Self::Simple(b) => b.content_mut(),
+            Self::Media(b) => b.content_mut(),
+            Self::Section(b) => b.content_mut(),
+            Self::List(b) => b.content_mut(),
+            Self::ListItem(b) => b.content_mut(),
+            Self::RawDelimited(b) => b.content_mut(),
+            Self::CompoundDelimited(b) => b.content_mut(),
+            Self::Preamble(b) => b.content_mut(),
+            Self::Break(b) => b.content_mut(),
+            Self::DocumentAttribute(b) => b.content_mut(),
         }
     }
 

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -415,8 +415,7 @@ impl<'src> Block<'src> {
         warnings: &mut Vec<Warning<'src>>,
     ) {
         if let Some(id) = id
-            && let Some(catalog) = parser.catalog_mut()
-            && let Err(_duplicate_error) = catalog.register_ref(
+            && let Err(_duplicate_error) = parser.register_ref(
                 id,
                 title, // Use block title as reftext if available
                 RefType::Anchor,

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -460,6 +460,7 @@ impl<'src> Block<'src> {
             Self::Section(b) => {
                 b.section_title_mut()
                     .resolve_references(resolver, renderer, warnings);
+
                 for child in b.nested_blocks_mut() {
                     child.resolve_references(resolver, renderer, warnings);
                 }
@@ -475,6 +476,7 @@ impl<'src> Block<'src> {
                 if let Some(term) = b.marker_mut().term_mut() {
                     term.resolve_references(resolver, renderer, warnings);
                 }
+
                 for child in b.nested_blocks_mut() {
                     child.resolve_references(resolver, renderer, warnings);
                 }

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     content::SubstitutionGroup,
     document::{Attribute, RefType},
+    parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning},
     span::MatchedItem,
     strings::CowStr,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -435,6 +436,64 @@ impl<'src> Block<'src> {
         match self {
             Self::ListItem(li) => Some(li),
             _ => None,
+        }
+    }
+
+    /// Resolve any deferred cross-references in this block and its descendants,
+    /// using `resolver` to map targets to destinations and `renderer` to render
+    /// the resulting links. Unresolved targets are reported in `warnings`.
+    pub(crate) fn resolve_references(
+        &mut self,
+        resolver: &dyn ReferenceResolver,
+        renderer: &dyn InlineSubstitutionRenderer,
+        warnings: &mut Vec<ReferenceWarning>,
+    ) {
+        match self {
+            Self::Simple(b) => b
+                .content_mut()
+                .resolve_references(resolver, renderer, warnings),
+
+            Self::RawDelimited(b) => b
+                .content_mut()
+                .resolve_references(resolver, renderer, warnings),
+
+            Self::Section(b) => {
+                b.section_title_mut()
+                    .resolve_references(resolver, renderer, warnings);
+                for child in b.nested_blocks_mut() {
+                    child.resolve_references(resolver, renderer, warnings);
+                }
+            }
+
+            Self::List(b) => {
+                for item in b.items_mut() {
+                    item.resolve_references(resolver, renderer, warnings);
+                }
+            }
+
+            Self::ListItem(b) => {
+                if let Some(term) = b.marker_mut().term_mut() {
+                    term.resolve_references(resolver, renderer, warnings);
+                }
+                for child in b.nested_blocks_mut() {
+                    child.resolve_references(resolver, renderer, warnings);
+                }
+            }
+
+            Self::CompoundDelimited(b) => {
+                for child in b.nested_blocks_mut() {
+                    child.resolve_references(resolver, renderer, warnings);
+                }
+            }
+
+            Self::Preamble(b) => {
+                for child in b.nested_blocks_mut() {
+                    child.resolve_references(resolver, renderer, warnings);
+                }
+            }
+
+            // These block types carry no cross-reference-bearing content.
+            Self::Media(_) | Self::Break(_) | Self::DocumentAttribute(_) => {}
         }
     }
 }

--- a/parser/src/blocks/compound_delimited.rs
+++ b/parser/src/blocks/compound_delimited.rs
@@ -139,13 +139,6 @@ impl<'src> CompoundDelimitedBlock<'src> {
     }
 }
 
-impl<'src> CompoundDelimitedBlock<'src> {
-    /// Return a mutable slice of this block's child blocks.
-    pub(crate) fn nested_blocks_mut(&mut self) -> &mut [Block<'src>] {
-        &mut self.blocks
-    }
-}
-
 impl<'src> IsBlock<'src> for CompoundDelimitedBlock<'src> {
     fn content_model(&self) -> ContentModel {
         ContentModel::Compound
@@ -157,6 +150,10 @@ impl<'src> IsBlock<'src> for CompoundDelimitedBlock<'src> {
 
     fn nested_blocks(&'src self) -> Iter<'src, Block<'src>> {
         self.blocks.iter()
+    }
+
+    fn nested_blocks_mut(&mut self) -> &mut [Block<'src>] {
+        &mut self.blocks
     }
 
     fn title_source(&'src self) -> Option<Span<'src>> {

--- a/parser/src/blocks/compound_delimited.rs
+++ b/parser/src/blocks/compound_delimited.rs
@@ -139,6 +139,13 @@ impl<'src> CompoundDelimitedBlock<'src> {
     }
 }
 
+impl<'src> CompoundDelimitedBlock<'src> {
+    /// Return a mutable slice of this block's child blocks.
+    pub(crate) fn nested_blocks_mut(&mut self) -> &mut [Block<'src>] {
+        &mut self.blocks
+    }
+}
+
 impl<'src> IsBlock<'src> for CompoundDelimitedBlock<'src> {
     fn content_model(&self) -> ContentModel {
         ContentModel::Compound

--- a/parser/src/blocks/is_block.rs
+++ b/parser/src/blocks/is_block.rs
@@ -113,7 +113,8 @@ pub trait IsBlock<'src>: Debug + Eq + PartialEq {
         NO_BLOCKS.iter()
     }
 
-    /// Returns a mutable slice of the nested blocks contained within this block.
+    /// Returns a mutable slice of the nested blocks contained within this
+    /// block.
     ///
     /// This is the mutable counterpart of [`nested_blocks()`]. The default
     /// returns an empty slice; container blocks override it to expose their

--- a/parser/src/blocks/is_block.rs
+++ b/parser/src/blocks/is_block.rs
@@ -4,7 +4,7 @@ use crate::{
     Span,
     attributes::Attrlist,
     blocks::{Block, is_built_in_context},
-    content::SubstitutionGroup,
+    content::{Content, SubstitutionGroup},
     strings::CowStr,
 };
 
@@ -111,6 +111,26 @@ pub trait IsBlock<'src>: Debug + Eq + PartialEq {
     fn nested_blocks(&'src self) -> Iter<'src, Block<'src>> {
         const NO_BLOCKS: &[Block<'static>] = &[];
         NO_BLOCKS.iter()
+    }
+
+    /// Returns a mutable slice of the nested blocks contained within this block.
+    ///
+    /// This is the mutable counterpart of [`nested_blocks()`]. The default
+    /// returns an empty slice; container blocks override it to expose their
+    /// children for in-place passes such as cross-reference resolution.
+    ///
+    /// [`nested_blocks()`]: Self::nested_blocks
+    fn nested_blocks_mut(&mut self) -> &mut [Block<'src>] {
+        &mut []
+    }
+
+    /// Returns a mutable reference to this block's own resolvable content — its
+    /// body, section title, or description-list term — if any.
+    ///
+    /// The default returns `None`; content-bearing blocks override it. This is
+    /// used by in-place passes such as cross-reference resolution.
+    fn content_mut(&mut self) -> Option<&mut Content<'src>> {
+        None
     }
 
     /// Returns the ID for this block, if present.

--- a/parser/src/blocks/list.rs
+++ b/parser/src/blocks/list.rs
@@ -212,6 +212,13 @@ impl<'src> ListBlock<'src> {
     }
 }
 
+impl<'src> ListBlock<'src> {
+    /// Return a mutable slice of this list's items.
+    pub(crate) fn items_mut(&mut self) -> &mut [Block<'src>] {
+        &mut self.items
+    }
+}
+
 impl<'src> IsBlock<'src> for ListBlock<'src> {
     fn content_model(&self) -> ContentModel {
         ContentModel::Compound

--- a/parser/src/blocks/list.rs
+++ b/parser/src/blocks/list.rs
@@ -212,13 +212,6 @@ impl<'src> ListBlock<'src> {
     }
 }
 
-impl<'src> ListBlock<'src> {
-    /// Return a mutable slice of this list's items.
-    pub(crate) fn items_mut(&mut self) -> &mut [Block<'src>] {
-        &mut self.items
-    }
-}
-
 impl<'src> IsBlock<'src> for ListBlock<'src> {
     fn content_model(&self) -> ContentModel {
         ContentModel::Compound
@@ -230,6 +223,10 @@ impl<'src> IsBlock<'src> for ListBlock<'src> {
 
     fn nested_blocks(&'src self) -> Iter<'src, Block<'src>> {
         self.items.iter()
+    }
+
+    fn nested_blocks_mut(&mut self) -> &mut [Block<'src>] {
+        &mut self.items
     }
 
     fn title_source(&'src self) -> Option<Span<'src>> {

--- a/parser/src/blocks/list_item.rs
+++ b/parser/src/blocks/list_item.rs
@@ -449,6 +449,19 @@ impl<'src> ListItem<'src> {
     }
 }
 
+impl<'src> ListItem<'src> {
+    /// Return a mutable slice of this list item's child blocks.
+    pub(crate) fn nested_blocks_mut(&mut self) -> &mut [Block<'src>] {
+        &mut self.blocks
+    }
+
+    /// Return a mutable reference to this list item's marker (used to reach a
+    /// description-list term's content).
+    pub(crate) fn marker_mut(&mut self) -> &mut ListItemMarker<'src> {
+        &mut self.marker
+    }
+}
+
 impl<'src> IsBlock<'src> for ListItem<'src> {
     fn content_model(&self) -> ContentModel {
         ContentModel::Compound

--- a/parser/src/blocks/list_item.rs
+++ b/parser/src/blocks/list_item.rs
@@ -7,6 +7,7 @@ use crate::{
         Block, CompoundDelimitedBlock, ContentModel, IsBlock, ListBlock, ListItemMarker,
         RawDelimitedBlock, SimpleBlock, metadata::BlockMetadata,
     },
+    content::Content,
     internal::debug::DebugSliceReference,
     span::MatchedItem,
     strings::CowStr,
@@ -449,22 +450,18 @@ impl<'src> ListItem<'src> {
     }
 }
 
-impl<'src> ListItem<'src> {
-    /// Return a mutable slice of this list item's child blocks.
-    pub(crate) fn nested_blocks_mut(&mut self) -> &mut [Block<'src>] {
-        &mut self.blocks
-    }
-
-    /// Return a mutable reference to this list item's marker (used to reach a
-    /// description-list term's content).
-    pub(crate) fn marker_mut(&mut self) -> &mut ListItemMarker<'src> {
-        &mut self.marker
-    }
-}
-
 impl<'src> IsBlock<'src> for ListItem<'src> {
     fn content_model(&self) -> ContentModel {
         ContentModel::Compound
+    }
+
+    fn content_mut(&mut self) -> Option<&mut Content<'src>> {
+        // A description-list item's resolvable content is its term.
+        self.marker.term_mut()
+    }
+
+    fn nested_blocks_mut(&mut self) -> &mut [Block<'src>] {
+        &mut self.blocks
     }
 
     fn raw_context(&self) -> CowStr<'src> {

--- a/parser/src/blocks/list_item_marker.rs
+++ b/parser/src/blocks/list_item_marker.rs
@@ -206,9 +206,8 @@ impl<'src> ListItemMarker<'src> {
             });
 
             // Register the anchor in the catalog.
-            if let Some(catalog) = parser.catalog_mut()
-                && let Err(_duplicate_error) =
-                    catalog.register_ref(id, reftext.as_deref(), RefType::Anchor)
+            if let Err(_duplicate_error) =
+                parser.register_ref(id, reftext.as_deref(), RefType::Anchor)
             {
                 warnings.push(Warning {
                     source: term.original(),

--- a/parser/src/blocks/list_item_marker.rs
+++ b/parser/src/blocks/list_item_marker.rs
@@ -221,6 +221,15 @@ impl<'src> ListItemMarker<'src> {
     }
 
     /// Test for equality, disregarding span offsets.
+    /// Return a mutable reference to the term content of a description-list
+    /// marker, or `None` for other marker kinds.
+    pub(crate) fn term_mut(&mut self) -> Option<&mut Content<'src>> {
+        match self {
+            Self::DefinedTerm { term, .. } => Some(term),
+            _ => None,
+        }
+    }
+
     pub(crate) fn is_match_for(&self, other: &Self) -> bool {
         match self {
             Self::Hyphen(self_span) => match other {

--- a/parser/src/blocks/list_item_marker.rs
+++ b/parser/src/blocks/list_item_marker.rs
@@ -220,7 +220,6 @@ impl<'src> ListItemMarker<'src> {
         SubstitutionStep::Macros.apply(term, parser, None);
     }
 
-    /// Test for equality, disregarding span offsets.
     /// Return a mutable reference to the term content of a description-list
     /// marker, or `None` for other marker kinds.
     pub(crate) fn term_mut(&mut self) -> Option<&mut Content<'src>> {
@@ -230,6 +229,7 @@ impl<'src> ListItemMarker<'src> {
         }
     }
 
+    /// Test for equality, disregarding span offsets.
     pub(crate) fn is_match_for(&self, other: &Self) -> bool {
         match self {
             Self::Hyphen(self_span) => match other {

--- a/parser/src/blocks/preamble.rs
+++ b/parser/src/blocks/preamble.rs
@@ -33,6 +33,11 @@ impl<'src> Preamble<'src> {
             source: preamble_source,
         }
     }
+
+    /// Return a mutable slice of this preamble's child blocks.
+    pub(crate) fn nested_blocks_mut(&mut self) -> &mut [Block<'src>] {
+        &mut self.blocks
+    }
 }
 
 impl<'src> IsBlock<'src> for Preamble<'src> {

--- a/parser/src/blocks/preamble.rs
+++ b/parser/src/blocks/preamble.rs
@@ -33,11 +33,6 @@ impl<'src> Preamble<'src> {
             source: preamble_source,
         }
     }
-
-    /// Return a mutable slice of this preamble's child blocks.
-    pub(crate) fn nested_blocks_mut(&mut self) -> &mut [Block<'src>] {
-        &mut self.blocks
-    }
 }
 
 impl<'src> IsBlock<'src> for Preamble<'src> {
@@ -51,6 +46,10 @@ impl<'src> IsBlock<'src> for Preamble<'src> {
 
     fn nested_blocks(&'src self) -> Iter<'src, Block<'src>> {
         self.blocks.iter()
+    }
+
+    fn nested_blocks_mut(&mut self) -> &mut [Block<'src>] {
+        &mut self.blocks
     }
 
     fn title_source(&'src self) -> Option<Span<'src>> {

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -168,16 +168,15 @@ impl<'src> RawDelimitedBlock<'src> {
     pub fn content(&self) -> &Content<'src> {
         &self.content
     }
-
-    /// Return a mutable reference to the interpreted content of this block.
-    pub(crate) fn content_mut(&mut self) -> &mut Content<'src> {
-        &mut self.content
-    }
 }
 
 impl<'src> IsBlock<'src> for RawDelimitedBlock<'src> {
     fn content_model(&self) -> ContentModel {
         self.content_model
+    }
+
+    fn content_mut(&mut self) -> Option<&mut Content<'src>> {
+        Some(&mut self.content)
     }
 
     fn rendered_content(&self) -> Option<&str> {

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -168,6 +168,11 @@ impl<'src> RawDelimitedBlock<'src> {
     pub fn content(&self) -> &Content<'src> {
         &self.content
     }
+
+    /// Return a mutable reference to the interpreted content of this block.
+    pub(crate) fn content_mut(&mut self) -> &mut Content<'src> {
+        &mut self.content
+    }
 }
 
 impl<'src> IsBlock<'src> for RawDelimitedBlock<'src> {

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -109,28 +109,24 @@ impl<'src> SectionBlock<'src> {
             .and_then(|a| a.named_attribute("reftext").map(|a| a.value()))
             .unwrap_or_else(|| section_title.rendered());
 
-        let section_id = if let Some(catalog) = parser.catalog_mut() {
-            if sectids && manual_id.is_none() {
-                Some(catalog.generate_and_register_unique_id(
-                    &proposed_base_id,
-                    Some(reftext),
-                    RefType::Section,
-                ))
-            } else {
-                if let Some(manual_id) = manual_id
-                    && catalog
-                        .register_ref(manual_id, Some(reftext), RefType::Section)
-                        .is_err()
-                {
-                    warnings.push(Warning {
-                        source: metadata.source.trim_remainder(level_and_title.after),
-                        warning: WarningType::DuplicateId(manual_id.to_string()),
-                    });
-                }
-
-                None
-            }
+        let section_id = if sectids && manual_id.is_none() {
+            Some(parser.generate_and_register_unique_id(
+                &proposed_base_id,
+                Some(reftext),
+                RefType::Section,
+            ))
         } else {
+            if let Some(manual_id) = manual_id
+                && parser
+                    .register_ref(manual_id, Some(reftext), RefType::Section)
+                    .is_err()
+            {
+                warnings.push(Warning {
+                    source: metadata.source.trim_remainder(level_and_title.after),
+                    warning: WarningType::DuplicateId(manual_id.to_string()),
+                });
+            }
+
             None
         };
 

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -197,16 +197,6 @@ impl<'src> SectionBlock<'src> {
     pub fn section_number(&'src self) -> Option<&'src SectionNumber> {
         self.section_number.as_ref()
     }
-
-    /// Return a mutable reference to the section title content.
-    pub(crate) fn section_title_mut(&mut self) -> &mut Content<'src> {
-        &mut self.section_title
-    }
-
-    /// Return a mutable slice of this section's child blocks.
-    pub(crate) fn nested_blocks_mut(&mut self) -> &mut [Block<'src>] {
-        &mut self.blocks
-    }
 }
 
 impl<'src> IsBlock<'src> for SectionBlock<'src> {
@@ -214,8 +204,17 @@ impl<'src> IsBlock<'src> for SectionBlock<'src> {
         ContentModel::Compound
     }
 
+    fn content_mut(&mut self) -> Option<&mut Content<'src>> {
+        // The section title is the section's own resolvable content.
+        Some(&mut self.section_title)
+    }
+
     fn raw_context(&self) -> CowStr<'src> {
         "section".into()
+    }
+
+    fn nested_blocks_mut(&mut self) -> &mut [Block<'src>] {
+        &mut self.blocks
     }
 
     fn nested_blocks(&'src self) -> Iter<'src, Block<'src>> {

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -197,6 +197,16 @@ impl<'src> SectionBlock<'src> {
     pub fn section_number(&'src self) -> Option<&'src SectionNumber> {
         self.section_number.as_ref()
     }
+
+    /// Return a mutable reference to the section title content.
+    pub(crate) fn section_title_mut(&mut self) -> &mut Content<'src> {
+        &mut self.section_title
+    }
+
+    /// Return a mutable slice of this section's child blocks.
+    pub(crate) fn nested_blocks_mut(&mut self) -> &mut [Block<'src>] {
+        &mut self.blocks
+    }
 }
 
 impl<'src> IsBlock<'src> for SectionBlock<'src> {

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -202,6 +202,14 @@ impl<'src> SimpleBlock<'src> {
         &self.content
     }
 
+    /// Return a mutable reference to the interpreted content of this block.
+    ///
+    /// Used by the cross-reference resolution pass to splice resolved
+    /// references into the rendered content.
+    pub(crate) fn content_mut(&mut self) -> &mut Content<'src> {
+        &mut self.content
+    }
+
     /// Return the style of this block.
     pub fn style(&self) -> SimpleBlockStyle {
         self.style

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -202,14 +202,6 @@ impl<'src> SimpleBlock<'src> {
         &self.content
     }
 
-    /// Return a mutable reference to the interpreted content of this block.
-    ///
-    /// Used by the cross-reference resolution pass to splice resolved
-    /// references into the rendered content.
-    pub(crate) fn content_mut(&mut self) -> &mut Content<'src> {
-        &mut self.content
-    }
-
     /// Return the style of this block.
     pub fn style(&self) -> SimpleBlockStyle {
         self.style
@@ -442,6 +434,10 @@ fn parse_lines<'src>(
 impl<'src> IsBlock<'src> for SimpleBlock<'src> {
     fn content_model(&self) -> ContentModel {
         ContentModel::Simple
+    }
+
+    fn content_mut(&mut self) -> Option<&mut Content<'src>> {
+        Some(&mut self.content)
     }
 
     fn rendered_content(&self) -> Option<&str> {

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -3,7 +3,14 @@
 //!
 //! [substitutions]: https://docs.asciidoctor.org/asciidoc/latest/subs/
 
-use crate::{Span, strings::CowStr};
+use crate::{
+    Span,
+    parser::{
+        InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning, ReferenceWarningKind,
+        ResolutionContext, XrefRenderParams,
+    },
+    strings::CowStr,
+};
 
 /// Describes the annotated content of a block after any relevant
 /// [substitutions] have been performed.
@@ -11,17 +18,74 @@ use crate::{Span, strings::CowStr};
 /// This is typically used to represent the main body of block types that don't
 /// contain other blocks, such as [`SimpleBlock`] or [`RawDelimitedBlock`].
 ///
+/// # Deferred cross-references
+///
+/// Cross-references (`<<id>>`, `xref:id[…]`) cannot be resolved while a block
+/// is being parsed, because their target may be defined later in the document
+/// (or, for multi-document workflows, in another document entirely). The
+/// macros substitution therefore records each cross-reference as a deferred
+/// [`XrefSegment`] and leaves an opaque placeholder in the rendered text. The
+/// references are resolved in a later pass — see
+/// [`Document::resolve_references`] — at which point [`rendered()`] reflects the
+/// resolved links. Until then, [`rendered()`] shows an unresolved fallback, so
+/// it always returns clean text.
+///
 /// [substitutions]: https://docs.asciidoctor.org/asciidoc/latest/subs/
 /// [`SimpleBlock`]: crate::blocks::SimpleBlock
 /// [`RawDelimitedBlock`]: crate::blocks::RawDelimitedBlock
-#[derive(Clone, Debug, Eq, PartialEq)]
+/// [`Document::resolve_references`]: crate::Document::resolve_references
+/// [`rendered()`]: Self::rendered
+#[derive(Clone, Eq, PartialEq)]
 pub struct Content<'src> {
     /// The original [`Span`] from which this content was derived.
     original: Span<'src>,
 
     /// The possibly-modified text after substititions have been performed.
+    ///
+    /// This is always clean, user-facing text: when cross-references are still
+    /// unresolved it holds the unresolved fallback rendering, and after
+    /// resolution it holds the resolved rendering.
     pub(crate) rendered: CowStr<'src>,
+
+    /// Deferred cross-references discovered during substitution, awaiting
+    /// resolution against a (possibly cross-document) catalog.
+    ///
+    /// `None` for the overwhelming majority of content, which contains no
+    /// cross-references.
+    deferred: Option<Box<DeferredContent>>,
 }
+
+/// The deferred (cross-reference-bearing) portion of a [`Content`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct DeferredContent {
+    /// The locally-substituted text with opaque placeholder tokens marking
+    /// where each cross-reference will be spliced in. This is the source of
+    /// truth from which [`Content::rendered`] is (re)built, so resolution is
+    /// non-destructive and may be repeated.
+    template: String,
+
+    /// The cross-references, in placeholder order.
+    xrefs: Vec<XrefSegment>,
+}
+
+/// A single deferred cross-reference.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct XrefSegment {
+    /// The raw, uninterpreted target as written in the source.
+    pub(crate) target: String,
+
+    /// Explicit link text supplied in the cross-reference, if any.
+    pub(crate) provided_text: Option<String>,
+
+    /// The resolved destination, filled in by resolution; `None` until then.
+    pub(crate) resolved: Option<crate::parser::ResolvedReference>,
+}
+
+/// Sentinel codepoints (Unicode Private Use Area) bracketing a placeholder
+/// index in [`DeferredContent::template`]. These cannot collide with user text
+/// and are inert to the remaining substitution steps.
+const XREF_PLACEHOLDER_START: char = '\u{E000}';
+const XREF_PLACEHOLDER_END: char = '\u{E001}';
 
 impl<'src> Content<'src> {
     /// Constructs a `Content` from a source `Span` and a potentially-filtered
@@ -30,6 +94,7 @@ impl<'src> Content<'src> {
         Self {
             original: span,
             rendered: filtered.as_ref().to_string().into(),
+            deferred: None,
         }
     }
 
@@ -49,6 +114,138 @@ impl<'src> Content<'src> {
     pub fn is_empty(&self) -> bool {
         self.rendered.as_ref().is_empty()
     }
+
+    /// Returns `true` if this content contains one or more cross-references that
+    /// have not yet been resolved to a destination.
+    pub fn has_unresolved_refs(&self) -> bool {
+        self.deferred
+            .as_ref()
+            .is_some_and(|d| d.xrefs.iter().any(|x| x.resolved.is_none()))
+    }
+
+    /// Records the cross-references discovered for this content during the
+    /// macros substitution step. The placeholder tokens for these references
+    /// must already have been written into [`Content::rendered`], in the same
+    /// order as `xrefs`.
+    pub(crate) fn set_deferred_xrefs(&mut self, xrefs: Vec<XrefSegment>) {
+        if xrefs.is_empty() {
+            return;
+        }
+
+        self.deferred = Some(Box::new(DeferredContent {
+            template: String::new(),
+            xrefs,
+        }));
+    }
+
+    /// Returns the placeholder token for the cross-reference at `index`.
+    pub(crate) fn xref_placeholder(index: usize) -> String {
+        format!("{XREF_PLACEHOLDER_START}{index}{XREF_PLACEHOLDER_END}")
+    }
+
+    /// Finalizes any deferred cross-references at the end of substitution.
+    ///
+    /// At this point [`Content::rendered`] holds the placeholder-bearing text;
+    /// it is captured as the template and `rendered` is rebuilt as the
+    /// unresolved fallback so it is immediately clean for callers that read it
+    /// before resolution.
+    pub(crate) fn finalize_deferred(&mut self, renderer: &dyn InlineSubstitutionRenderer) {
+        if self.deferred.is_none() {
+            return;
+        }
+
+        let template = self.rendered.as_ref().to_string();
+
+        if let Some(deferred) = self.deferred.as_mut() {
+            deferred.template = template;
+        }
+
+        self.rebuild_rendered(renderer);
+    }
+
+    /// Resolves any deferred cross-references using `resolver`, then rebuilds
+    /// the rendered text.
+    ///
+    /// This is non-destructive: the placeholder template is retained, so a
+    /// document may be resolved more than once (e.g. for incremental builds or
+    /// multiple output targets).
+    ///
+    /// Any target that the resolver cannot resolve is reported in `warnings`.
+    pub(crate) fn resolve_references(
+        &mut self,
+        resolver: &dyn ReferenceResolver,
+        renderer: &dyn InlineSubstitutionRenderer,
+        warnings: &mut Vec<ReferenceWarning>,
+    ) {
+        if let Some(deferred) = self.deferred.as_mut() {
+            for xref in deferred.xrefs.iter_mut() {
+                xref.resolved = resolver.resolve(&ResolutionContext {
+                    target: &xref.target,
+                    provided_text: xref.provided_text.as_deref(),
+                });
+
+                if xref.resolved.is_none() {
+                    warnings.push(ReferenceWarning {
+                        target: xref.target.clone(),
+                        kind: ReferenceWarningKind::Unresolved,
+                    });
+                }
+            }
+        }
+
+        self.rebuild_rendered(renderer);
+    }
+
+    /// Rebuilds [`Content::rendered`] from the deferred template and the current
+    /// (resolved or unresolved) state of its cross-references.
+    fn rebuild_rendered(&mut self, renderer: &dyn InlineSubstitutionRenderer) {
+        let Some(deferred) = self.deferred.as_ref() else {
+            return;
+        };
+
+        self.rendered = render_template(&deferred.template, &deferred.xrefs, renderer).into();
+    }
+}
+
+/// Splices resolved (or fallback) cross-reference renderings into a placeholder
+/// template, producing the final rendered text.
+fn render_template(
+    template: &str,
+    xrefs: &[XrefSegment],
+    renderer: &dyn InlineSubstitutionRenderer,
+) -> String {
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+
+    while let Some(start) = rest.find(XREF_PLACEHOLDER_START) {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + XREF_PLACEHOLDER_START.len_utf8()..];
+
+        let Some(end) = after.find(XREF_PLACEHOLDER_END) else {
+            // Malformed placeholder; emit the sentinel literally and continue.
+            out.push(XREF_PLACEHOLDER_START);
+            rest = after;
+            continue;
+        };
+
+        if let Ok(index) = after[..end].parse::<usize>()
+            && let Some(xref) = xrefs.get(index)
+        {
+            renderer.render_xref(
+                &XrefRenderParams {
+                    target: &xref.target,
+                    provided_text: xref.provided_text.as_deref(),
+                    resolved: xref.resolved.as_ref(),
+                },
+                &mut out,
+            );
+        }
+
+        rest = &after[end + XREF_PLACEHOLDER_END.len_utf8()..];
+    }
+
+    out.push_str(rest);
+    out
 }
 
 impl<'src> From<Span<'src>> for Content<'src> {
@@ -56,7 +253,26 @@ impl<'src> From<Span<'src>> for Content<'src> {
         Self {
             original: span,
             rendered: CowStr::from(span.data()),
+            deferred: None,
         }
+    }
+}
+
+impl std::fmt::Debug for Content<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The deferred cross-reference state is an internal implementation
+        // detail. It is omitted from the debug output unless present, so that
+        // the (very common) cross-reference-free content debugs identically to
+        // a plain `original` + `rendered` pair.
+        let mut s = f.debug_struct("Content");
+        s.field("original", &self.original);
+        s.field("rendered", &self.rendered);
+
+        if let Some(deferred) = self.deferred.as_ref() {
+            s.field("deferred", deferred);
+        }
+
+        s.finish()
     }
 }
 

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -26,9 +26,9 @@ use crate::{
 /// macros substitution therefore records each cross-reference as a deferred
 /// [`XrefSegment`] and leaves an opaque placeholder in the rendered text. The
 /// references are resolved in a later pass — see
-/// [`Document::resolve_references`] — at which point [`rendered()`] reflects the
-/// resolved links. Until then, [`rendered()`] shows an unresolved fallback, so
-/// it always returns clean text.
+/// [`Document::resolve_references`] — at which point [`rendered()`] reflects
+/// the resolved links. Until then, [`rendered()`] shows an unresolved fallback,
+/// so it always returns clean text.
 ///
 /// [substitutions]: https://docs.asciidoctor.org/asciidoc/latest/subs/
 /// [`SimpleBlock`]: crate::blocks::SimpleBlock
@@ -115,8 +115,8 @@ impl<'src> Content<'src> {
         self.rendered.as_ref().is_empty()
     }
 
-    /// Returns `true` if this content contains one or more cross-references that
-    /// have not yet been resolved to a destination.
+    /// Returns `true` if this content contains one or more cross-references
+    /// that have not yet been resolved to a destination.
     pub fn has_unresolved_refs(&self) -> bool {
         self.deferred
             .as_ref()
@@ -207,8 +207,8 @@ impl<'src> Content<'src> {
         self.rebuild_rendered(renderer);
     }
 
-    /// Rebuilds [`Content::rendered`] from the deferred template and the current
-    /// (resolved or unresolved) state of its cross-references.
+    /// Rebuilds [`Content::rendered`] from the deferred template and the
+    /// current (resolved or unresolved) state of its cross-references.
     fn rebuild_rendered(&mut self, renderer: &dyn InlineSubstitutionRenderer) {
         let Some(deferred) = self.deferred.as_ref() else {
             return;

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -127,10 +127,21 @@ impl<'src> Content<'src> {
     /// macros substitution step. The placeholder tokens for these references
     /// must already have been written into [`Content::rendered`], in the same
     /// order as `xrefs`.
+    ///
+    /// This must be called at most once per `Content`: the placeholder indices
+    /// already embedded in [`Content::rendered`] are positions into this single
+    /// `xrefs` vector. The macros substitution runs once per content, so this
+    /// holds in practice; the assertion guards against a future caller breaking
+    /// it.
     pub(crate) fn set_deferred_xrefs(&mut self, xrefs: Vec<XrefSegment>) {
         if xrefs.is_empty() {
             return;
         }
+
+        debug_assert!(
+            self.deferred.is_none(),
+            "set_deferred_xrefs must be called at most once per Content"
+        );
 
         self.deferred = Some(Box::new(DeferredContent {
             template: String::new(),
@@ -228,20 +239,36 @@ fn render_template(
             continue;
         };
 
-        if let Ok(index) = after[..end].parse::<usize>()
-            && let Some(xref) = xrefs.get(index)
-        {
-            renderer.render_xref(
-                &XrefRenderParams {
-                    target: &xref.target,
-                    provided_text: xref.provided_text.as_deref(),
-                    resolved: xref.resolved.as_ref(),
-                },
-                &mut out,
-            );
-        }
-
+        let body = &after[..end];
         rest = &after[end + XREF_PLACEHOLDER_END.len_utf8()..];
+
+        match body
+            .parse::<usize>()
+            .ok()
+            .and_then(|index| xrefs.get(index))
+        {
+            Some(xref) => {
+                renderer.render_xref(
+                    &XrefRenderParams {
+                        target: &xref.target,
+                        provided_text: xref.provided_text.as_deref(),
+                        resolved: xref.resolved.as_ref(),
+                    },
+                    &mut out,
+                );
+            }
+
+            None => {
+                // Unreachable while `template` and `xrefs` come from the same
+                // `Content` (indices are assigned sequentially). If that
+                // invariant is ever broken, emit the raw placeholder rather than
+                // silently dropping the span, so the breakage is visible.
+                debug_assert!(false, "xref placeholder index {body:?} out of range");
+                out.push(XREF_PLACEHOLDER_START);
+                out.push_str(body);
+                out.push(XREF_PLACEHOLDER_END);
+            }
+        }
     }
 
     out.push_str(rest);

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -23,8 +23,8 @@ use crate::{
 /// Cross-references (`<<id>>`, `xref:id[…]`) cannot be resolved while a block
 /// is being parsed, because their target may be defined later in the document
 /// (or, for multi-document workflows, in another document entirely). The
-/// macros substitution therefore records each cross-reference as a deferred
-/// [`XrefSegment`] and leaves an opaque placeholder in the rendered text. The
+/// macros substitution therefore records each cross-reference in a deferred
+/// form and leaves an opaque placeholder in the rendered text. The
 /// references are resolved in a later pass — see
 /// [`Document::resolve_references`] — at which point [`rendered()`] reflects
 /// the resolved links. Until then, [`rendered()`] shows an unresolved fallback,

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -99,10 +99,9 @@ pub(super) fn apply_macros(content: &mut Content<'_>, parser: &Parser) {
     if text.contains("&lt;&lt;") || (found_macroish && text.contains("xref:")) {
         let mut xrefs: Vec<XrefSegment> = vec![];
 
-        let replaced = match INLINE_XREF.replace_all(
-            content.rendered(),
-            InlineXrefReplacer { xrefs: &mut xrefs },
-        ) {
+        let replaced = match INLINE_XREF
+            .replace_all(content.rendered(), InlineXrefReplacer { xrefs: &mut xrefs })
+        {
             Cow::Owned(new_result) => Some(new_result),
             Cow::Borrowed(_) => None,
         };

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -6,7 +6,7 @@ use regex::{Captures, Regex, Replacer};
 use crate::{
     Parser, Span,
     attributes::{Attrlist, AttrlistContext},
-    content::Content,
+    content::{Content, content::XrefSegment},
     parser::{IconRenderParams, ImageRenderParams, LinkRenderParams, LinkRenderType},
 };
 
@@ -87,14 +87,34 @@ pub(super) fn apply_macros(content: &mut Content<'_>, parser: &Parser) {
         }
     }
 
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/476):
-    // Handle double-angle-bracket cross-reference syntax.
-    /*
-    if (text.contains('&') && text.contains(";&l") || (found_macroish && text.contains("xref:"))) {
-        todo!("Port cross-reference macro");
-        // Port Ruby Asciidoctor's implementation from lines 742..840.
+    // Cross-references (`<<id>>`, `<<id,text>>`, `xref:id[]`, `xref:id[text]`).
+    //
+    // By the time the macros step runs, the special-characters step has already
+    // turned `<<` / `>>` into `&lt;&lt;` / `&gt;&gt;`. We do NOT resolve the
+    // reference here, because its target may be defined later in the document
+    // (or, for multi-document workflows, in another document). Instead each
+    // cross-reference is recorded as a deferred `XrefSegment` and a placeholder
+    // is left in the rendered text; resolution happens later via
+    // `Document::resolve_references`.
+    if text.contains("&lt;&lt;") || (found_macroish && text.contains("xref:")) {
+        let mut xrefs: Vec<XrefSegment> = vec![];
+
+        let replaced = match INLINE_XREF.replace_all(
+            content.rendered(),
+            InlineXrefReplacer { xrefs: &mut xrefs },
+        ) {
+            Cow::Owned(new_result) => Some(new_result),
+            Cow::Borrowed(_) => None,
+        };
+
+        if let Some(new_result) = replaced {
+            content.rendered = new_result.into();
+        }
+
+        content.set_deferred_xrefs(xrefs);
     }
 
+    /*
     if found_macroish && text.contains("tnote") {
         todo!("Port footnote macro");
         // Port Ruby Asciidoctor's implementation from lines 842..884.
@@ -787,6 +807,80 @@ impl Replacer for InlineAnchorReplacer<'_> {
             .register_ref(id, reftext.as_deref(), crate::document::RefType::Anchor);
 
         self.0.renderer.render_anchor(id, reftext, dest);
+    }
+}
+
+/// Matches a cross-reference, in either the double-angle-bracket shorthand or
+/// the `xref:` macro form.
+///
+/// Note that the special-characters substitution runs before macros, so by this
+/// point `<<` and `>>` have already become `&lt;&lt;` and `&gt;&gt;`.
+///
+/// ## Examples
+///
+/// * `<<idname>>` (seen here as `&lt;&lt;idname&gt;&gt;`)
+/// * `<<idname,Reference Text>>`
+/// * `xref:idname[]`
+/// * `xref:idname[Reference Text]`
+static INLINE_XREF: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(
+        r#"(?xs)
+        (\\)?                           # (1) optional escape backslash
+        (?:
+            &lt;&lt;                     #   shorthand: << (post special-chars)
+              ( .*? )                    # (2) refid plus optional ", reftext"
+            &gt;&gt;                     #   >>
+          |
+            xref:                        #   'xref:' macro form
+              ( [^:\s\[] [^\s\[]* )      # (3) target
+            \[                           #   opening '['
+              ( | .*?[^\\] )             # (4) reftext: empty or ends non-escaped
+            \]                           #   closing ']'
+        )
+        "#,
+    )
+    .unwrap()
+});
+
+#[derive(Debug)]
+struct InlineXrefReplacer<'x> {
+    /// Accumulates the cross-references discovered during replacement, in the
+    /// same order as the placeholders emitted into the output.
+    xrefs: &'x mut Vec<XrefSegment>,
+}
+
+impl Replacer for InlineXrefReplacer<'_> {
+    fn replace_append(&mut self, caps: &Captures<'_>, dest: &mut String) {
+        if caps.get(1).is_some() {
+            // Honor the escape: emit the reference literally (sans backslash).
+            dest.push_str(&caps[0][1..]);
+            return;
+        }
+
+        let (target, provided_text) = if let Some(inner) = caps.get(2) {
+            // Shorthand form: split an optional ", reftext" off the id.
+            match inner.as_str().split_once(',') {
+                Some((id, text)) => (id.trim().to_string(), Some(text.trim().to_string())),
+                None => (inner.as_str().trim().to_string(), None),
+            }
+        } else {
+            let target = caps[3].to_string();
+            let text = caps
+                .get(4)
+                .map(|m| m.as_str().to_string())
+                .filter(|s| !s.is_empty());
+            (target, text)
+        };
+
+        let index = self.xrefs.len();
+        self.xrefs.push(XrefSegment {
+            target,
+            provided_text,
+            resolved: None,
+        });
+
+        dest.push_str(&Content::xref_placeholder(index));
     }
 }
 

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -778,6 +778,14 @@ impl Replacer for InlineAnchorReplacer<'_> {
             )
         };
 
+        // Register the inline anchor so that later cross-references can resolve
+        // against it. A duplicate ID here is non-fatal (first registration
+        // wins); block- and section-level registration paths surface duplicate
+        // warnings, so we don't double-report them for inline anchors.
+        let _ = self
+            .0
+            .register_ref(id, reftext.as_deref(), crate::document::RefType::Anchor);
+
         self.0.renderer.render_anchor(id, reftext, dest);
     }
 }
@@ -1574,7 +1582,17 @@ mod tests {
                     },
                     warnings: &[],
                     source_map: SourceMap(&[]),
-                    catalog: Catalog::default(),
+                    catalog: Catalog {
+                        refs: HashMap::from([(
+                            "tigers",
+                            RefEntry {
+                                id: "tigers",
+                                reftext: None,
+                                ref_type: crate::document::RefType::Anchor,
+                            },
+                        )]),
+                        reftext_to_id: HashMap::new(),
+                    },
                 }
             );
         }
@@ -1631,7 +1649,17 @@ mod tests {
                     },
                     warnings: &[],
                     source_map: SourceMap(&[]),
-                    catalog: Catalog::default(),
+                    catalog: Catalog {
+                        refs: HashMap::from([(
+                            "tigers",
+                            RefEntry {
+                                id: "tigers",
+                                reftext: None,
+                                ref_type: crate::document::RefType::Anchor,
+                            },
+                        )]),
+                        reftext_to_id: HashMap::new(),
+                    },
                 }
             );
         }
@@ -1688,7 +1716,17 @@ mod tests {
                     },
                     warnings: &[],
                     source_map: SourceMap(&[]),
-                    catalog: Catalog::default(),
+                    catalog: Catalog {
+                        refs: HashMap::from([(
+                            "tigers",
+                            RefEntry {
+                                id: "tigers",
+                                reftext: Some("Tigers"),
+                                ref_type: crate::document::RefType::Anchor,
+                            },
+                        )]),
+                        reftext_to_id: HashMap::from([("Tigers", "tigers")]),
+                    },
                 }
             );
         }
@@ -1746,7 +1784,17 @@ mod tests {
                     },
                     warnings: &[],
                     source_map: SourceMap(&[]),
-                    catalog: Catalog::default(),
+                    catalog: Catalog {
+                        refs: HashMap::from([(
+                            "tigers",
+                            RefEntry {
+                                id: "tigers",
+                                reftext: Some("Tigers"),
+                                ref_type: crate::document::RefType::Anchor,
+                            },
+                        )]),
+                        reftext_to_id: HashMap::from([("Tigers", "tigers")]),
+                    },
                 }
             );
         }
@@ -1804,7 +1852,51 @@ mod tests {
                     },
                     warnings: &[],
                     source_map: SourceMap(&[]),
-                    catalog: Catalog::default(),
+                    catalog: Catalog {
+                        refs: HashMap::from([
+                            (
+                                "one",
+                                RefEntry {
+                                    id: "one",
+                                    reftext: None,
+                                    ref_type: crate::document::RefType::Anchor,
+                                },
+                            ),
+                            (
+                                "two",
+                                RefEntry {
+                                    id: "two",
+                                    reftext: None,
+                                    ref_type: crate::document::RefType::Anchor,
+                                },
+                            ),
+                            (
+                                "three",
+                                RefEntry {
+                                    id: "three",
+                                    reftext: None,
+                                    ref_type: crate::document::RefType::Anchor,
+                                },
+                            ),
+                            (
+                                "four",
+                                RefEntry {
+                                    id: "four",
+                                    reftext: None,
+                                    ref_type: crate::document::RefType::Anchor,
+                                },
+                            ),
+                            (
+                                "five",
+                                RefEntry {
+                                    id: "five",
+                                    reftext: None,
+                                    ref_type: crate::document::RefType::Anchor,
+                                },
+                            ),
+                        ]),
+                        reftext_to_id: HashMap::new(),
+                    },
                 }
             );
         }
@@ -1861,7 +1953,17 @@ mod tests {
                     },
                     warnings: &[],
                     source_map: SourceMap(&[]),
-                    catalog: Catalog::default(),
+                    catalog: Catalog {
+                        refs: HashMap::from([(
+                            ":idname",
+                            RefEntry {
+                                id: ":idname",
+                                reftext: None,
+                                ref_type: crate::document::RefType::Anchor,
+                            },
+                        )]),
+                        reftext_to_id: HashMap::new(),
+                    },
                 }
             );
         }

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -184,6 +184,12 @@ impl SubstitutionGroup {
         if let Some(passthroughs) = passthroughs {
             passthroughs.restore_to(content, parser);
         }
+
+        // Capture any deferred cross-references as a placeholder template and
+        // render the unresolved fallback, so `rendered()` is clean even before
+        // references are resolved. This is a no-op when no cross-references were
+        // found.
+        content.finalize_deferred(&*parser.renderer);
     }
 
     pub(crate) fn override_via_attrlist(&self, attrlist: Option<&Attrlist>) -> Self {

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -17,6 +17,12 @@ pub struct Catalog {
     pub(crate) reftext_to_id: HashMap<String, String>,
 }
 
+impl Default for Catalog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Catalog {
     pub(crate) fn new() -> Self {
         Self {

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -10,7 +10,9 @@ use crate::{
     blocks::{Block, ContentModel, IsBlock, Preamble, parse_utils::parse_blocks_until},
     document::{Catalog, Header},
     internal::debug::DebugSliceReference,
-    parser::SourceMap,
+    parser::{
+        CatalogResolver, InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning, SourceMap,
+    },
     strings::CowStr,
     warnings::Warning,
 };
@@ -151,6 +153,53 @@ impl<'src> Document<'src> {
     /// Return the document catalog for accessing referenceable elements.
     pub fn catalog(&self) -> &Catalog {
         &self.internal.borrow_dependent().catalog
+    }
+
+    /// Resolve the document's deferred cross-references using a caller-supplied
+    /// [`ReferenceResolver`] and [`InlineSubstitutionRenderer`].
+    ///
+    /// This is the entry point for multi-document workflows: parse each document
+    /// with [`Parser::parse_deferred`], then call this with a resolver that
+    /// resolves targets against whatever combined index the caller has built
+    /// (this crate does not merge catalogs). The resolver binds the "from"
+    /// document, so a single shared resolver can be parametrized per call site.
+    ///
+    /// Resolution is non-destructive and may be repeated (e.g. for incremental
+    /// builds or multiple output targets). Targets that cannot be resolved are
+    /// returned as [`ReferenceWarning`]s.
+    pub fn resolve_references(
+        &mut self,
+        resolver: &dyn ReferenceResolver,
+        renderer: &dyn InlineSubstitutionRenderer,
+    ) -> Vec<ReferenceWarning> {
+        let mut warnings = Vec::new();
+
+        self.internal.with_dependent_mut(|_owner, dependent| {
+            for block in dependent.blocks.iter_mut() {
+                block.resolve_references(resolver, renderer, &mut warnings);
+            }
+        });
+
+        warnings
+    }
+
+    /// Resolve the document's deferred cross-references against its own catalog.
+    ///
+    /// This is the single-document convenience path used by [`Parser::parse`].
+    pub(crate) fn resolve_against_own_catalog(
+        &mut self,
+        renderer: &dyn InlineSubstitutionRenderer,
+    ) -> Vec<ReferenceWarning> {
+        let mut warnings = Vec::new();
+
+        self.internal.with_dependent_mut(|_owner, dependent| {
+            let resolver = CatalogResolver::new(&dependent.catalog);
+            for block in dependent.blocks.iter_mut() {
+                block.resolve_references(&resolver, renderer, &mut warnings);
+            }
+        });
+
+        warnings
     }
 }
 

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -165,8 +165,19 @@ impl<'src> Document<'src> {
     /// document, so a single shared resolver can be parametrized per call site.
     ///
     /// Resolution is non-destructive and may be repeated (e.g. for incremental
-    /// builds or multiple output targets). Targets that cannot be resolved are
-    /// returned as [`ReferenceWarning`]s.
+    /// builds or multiple output targets): the original target text is retained,
+    /// so re-resolving is always possible.
+    ///
+    /// Each call is a **full, independent resolution sweep**. Every
+    /// cross-reference is re-resolved against `resolver`, overwriting any result
+    /// from a previous pass, and the returned [`ReferenceWarning`]s reflect only
+    /// what *this* `resolver` could not resolve — a prior pass having resolved a
+    /// target does not suppress a warning here. Consequently, resolving with a
+    /// resolver that knows fewer targets than an earlier pass (for example,
+    /// calling this after [`Parser::parse`] has already auto-resolved against the
+    /// document's own catalog) will re-report those now-unknown targets as
+    /// unresolved. Multi-document pipelines should therefore start from
+    /// [`Parser::parse_deferred`], which does not auto-resolve.
     pub fn resolve_references(
         &mut self,
         resolver: &dyn ReferenceResolver,

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -158,25 +158,27 @@ impl<'src> Document<'src> {
     /// Resolve the document's deferred cross-references using a caller-supplied
     /// [`ReferenceResolver`] and [`InlineSubstitutionRenderer`].
     ///
-    /// This is the entry point for multi-document workflows: parse each document
-    /// with [`Parser::parse_deferred`], then call this with a resolver that
-    /// resolves targets against whatever combined index the caller has built
-    /// (this crate does not merge catalogs). The resolver binds the "from"
-    /// document, so a single shared resolver can be parametrized per call site.
+    /// This is the entry point for multi-document workflows: parse each
+    /// document with [`Parser::parse_deferred`], then call this with a
+    /// resolver that resolves targets against whatever combined index the
+    /// caller has built (this crate does not merge catalogs). The resolver
+    /// binds the "from" document, so a single shared resolver can be
+    /// parametrized per call site.
     ///
     /// Resolution is non-destructive and may be repeated (e.g. for incremental
-    /// builds or multiple output targets): the original target text is retained,
-    /// so re-resolving is always possible.
+    /// builds or multiple output targets): the original target text is
+    /// retained, so re-resolving is always possible.
     ///
     /// Each call is a **full, independent resolution sweep**. Every
-    /// cross-reference is re-resolved against `resolver`, overwriting any result
-    /// from a previous pass, and the returned [`ReferenceWarning`]s reflect only
-    /// what *this* `resolver` could not resolve — a prior pass having resolved a
-    /// target does not suppress a warning here. Consequently, resolving with a
-    /// resolver that knows fewer targets than an earlier pass (for example,
-    /// calling this after [`Parser::parse`] has already auto-resolved against the
-    /// document's own catalog) will re-report those now-unknown targets as
-    /// unresolved. Multi-document pipelines should therefore start from
+    /// cross-reference is re-resolved against `resolver`, overwriting any
+    /// result from a previous pass, and the returned [`ReferenceWarning`]s
+    /// reflect only what *this* `resolver` could not resolve — a prior pass
+    /// having resolved a target does not suppress a warning here.
+    /// Consequently, resolving with a resolver that knows fewer targets
+    /// than an earlier pass (for example, calling this after
+    /// [`Parser::parse`] has already auto-resolved against the document's
+    /// own catalog) will re-report those now-unknown targets as unresolved.
+    /// Multi-document pipelines should therefore start from
     /// [`Parser::parse_deferred`], which does not auto-resolve.
     pub fn resolve_references(
         &mut self,
@@ -194,7 +196,8 @@ impl<'src> Document<'src> {
         warnings
     }
 
-    /// Resolve the document's deferred cross-references against its own catalog.
+    /// Resolve the document's deferred cross-references against its own
+    /// catalog.
     ///
     /// This is the single-document convenience path used by [`Parser::parse`].
     pub(crate) fn resolve_against_own_catalog(

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -2,7 +2,7 @@ use std::{fmt::Debug, sync::LazyLock};
 
 use regex::Regex;
 
-use crate::{Parser, attributes::Attrlist};
+use crate::{Parser, attributes::Attrlist, parser::ResolvedReference};
 
 /// An implementation of `InlineSubstitutionRenderer` is used when converting
 /// the basic raw text of a simple block to the format which will ultimately be
@@ -149,6 +149,14 @@ pub trait InlineSubstitutionRenderer: Debug {
     /// The rendered should write an appropriate rendering of the specified
     /// anchor with ID and possible ref text (only used by some renderers).
     fn render_anchor(&self, id: &str, reftext: Option<String>, dest: &mut String);
+
+    /// Renders a cross-reference.
+    ///
+    /// When [`XrefRenderParams::resolved`] is `Some`, the reference resolved to
+    /// a destination; the renderer should link to it. When it is `None`, the
+    /// reference could not be resolved and the renderer should emit a sensible
+    /// fallback (e.g. a link to the raw target with bracketed text).
+    fn render_xref(&self, params: &XrefRenderParams, dest: &mut String);
 }
 
 /// Specifies which special character is being replaced in a call to
@@ -324,6 +332,19 @@ pub struct LinkRenderParams<'a> {
 pub enum LinkRenderType {
     /// TEMPORARY: I don't know the different types of links yet.
     Link,
+}
+
+/// Provides parameters for rendering a cross-reference.
+#[derive(Clone, Debug)]
+pub struct XrefRenderParams<'a> {
+    /// The raw, uninterpreted cross-reference target as written in the source.
+    pub target: &'a str,
+
+    /// Explicit link text supplied in the cross-reference, if any.
+    pub provided_text: Option<&'a str>,
+
+    /// The resolved destination, or `None` if the reference is unresolved.
+    pub resolved: Option<&'a ResolvedReference>,
 }
 
 /// Implementation of [`InlineSubstitutionRenderer`] that renders substitutions
@@ -689,6 +710,37 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
 
     fn render_anchor(&self, id: &str, _reftext: Option<String>, dest: &mut String) {
         dest.push_str(&format!("<a id=\"{id}\"></a>"));
+    }
+
+    fn render_xref(&self, params: &XrefRenderParams, dest: &mut String) {
+        match params.resolved {
+            Some(resolved) => {
+                let text = params
+                    .provided_text
+                    .map(str::to_string)
+                    .or_else(|| resolved.text.clone())
+                    .unwrap_or_else(|| format!("[{target}]", target = params.target));
+
+                dest.push_str(&format!(
+                    r#"<a href="{href}">{text}</a>"#,
+                    href = resolved.href
+                ));
+            }
+
+            None => {
+                // Unresolved: link to the raw target and show bracketed text,
+                // mirroring Asciidoctor's behavior for a missing reference.
+                let text = params
+                    .provided_text
+                    .map(str::to_string)
+                    .unwrap_or_else(|| format!("[{target}]", target = params.target));
+
+                dest.push_str(&format!(
+                    r##"<a href="#{target}">{text}</a>"##,
+                    target = params.target
+                ));
+            }
+        }
     }
 }
 

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -14,7 +14,7 @@ mod inline_substitution_renderer;
 pub use inline_substitution_renderer::{
     CharacterReplacementType, HtmlSubstitutionRenderer, IconRenderParams, ImageRenderParams,
     InlineSubstitutionRenderer, LinkRenderParams, LinkRenderType, QuoteScope, QuoteType,
-    SpecialCharacter,
+    SpecialCharacter, XrefRenderParams,
 };
 
 mod parser;
@@ -24,6 +24,12 @@ mod path_resolver;
 pub use path_resolver::PathResolver;
 
 pub(crate) mod preprocessor;
+
+mod reference_resolver;
+pub use reference_resolver::{
+    CatalogResolver, ReferenceResolver, ReferenceWarning, ReferenceWarningKind, ResolutionContext,
+    ResolvedReference,
+};
 
 mod source_map;
 pub use source_map::{SourceLine, SourceMap};

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -264,7 +264,9 @@ impl Parser {
         reftext: Option<&str>,
         ref_type: RefType,
     ) -> Result<(), crate::document::DuplicateIdError> {
-        self.catalog.borrow_mut().register_ref(id, reftext, ref_type)
+        self.catalog
+            .borrow_mut()
+            .register_ref(id, reftext, ref_type)
     }
 
     /// Generate a unique ID derived from `base_id` and register it in the
@@ -709,11 +711,7 @@ mod tests {
             dest.push_str(&format!("[ANCHOR:{}]", id));
         }
 
-        fn render_xref(
-            &self,
-            params: &crate::parser::XrefRenderParams,
-            dest: &mut String,
-        ) {
+        fn render_xref(&self, params: &crate::parser::XrefRenderParams, dest: &mut String) {
             dest.push_str(&format!("[XREF:{}]", params.target));
         }
     }

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -118,6 +118,32 @@ impl Parser {
     /// [`warnings()`]: Document::warnings
     /// [`attribute_value()`]: Self::attribute_value
     pub fn parse(&mut self, source: &str) -> Document<'static> {
+        let mut document = self.parse_deferred(source);
+
+        // Resolve cross-references against this document's own catalog. For
+        // multi-document workflows, use `parse_deferred` and resolve later with
+        // a caller-supplied resolver via `Document::resolve_references`.
+        document.resolve_against_own_catalog(&*self.renderer);
+
+        document
+    }
+
+    /// Parse a UTF-8 string as an AsciiDoc document, leaving cross-references
+    /// unresolved.
+    ///
+    /// This behaves like [`parse()`], except it does not resolve
+    /// cross-references (`<<id>>`, `xref:id[…]`). The returned [`Document`]
+    /// carries its references in a deferred state; resolve them later with
+    /// [`Document::resolve_references`].
+    ///
+    /// This is the entry point for multi-document workflows (e.g. Antora-style
+    /// site generation): parse every document with this method, build a combined
+    /// index from each document's [`catalog()`], then resolve each document
+    /// against that index. This crate does not merge catalogs itself.
+    ///
+    /// [`parse()`]: Self::parse
+    /// [`catalog()`]: Document::catalog
+    pub fn parse_deferred(&mut self, source: &str) -> Document<'static> {
         let (preprocessed_source, source_map) = preprocess(source, self);
 
         // NOTE: `Document::parse` will transfer the catalog to itself at the end of the
@@ -681,6 +707,14 @@ mod tests {
 
         fn render_anchor(&self, id: &str, _reftext: Option<String>, dest: &mut String) {
             dest.push_str(&format!("[ANCHOR:{}]", id));
+        }
+
+        fn render_xref(
+            &self,
+            params: &crate::parser::XrefRenderParams,
+            dest: &mut String,
+        ) {
+            dest.push_str(&format!("[XREF:{}]", params.target));
         }
     }
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1,9 +1,9 @@
-use std::{collections::HashMap, rc::Rc};
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use crate::{
     Document, HasSpan,
     blocks::{SectionNumber, SectionType},
-    document::{Attribute, Catalog, InterpretedValue},
+    document::{Attribute, Catalog, InterpretedValue, RefType},
     parser::{
         AllowableValue, AttributeValue, HtmlSubstitutionRenderer, IncludeFileHandler,
         InlineSubstitutionRenderer, ModificationContext, PathResolver,
@@ -43,7 +43,12 @@ pub struct Parser {
     /// Document catalog for tracking referenceable elements during parsing.
     /// This is created during parsing and transferred to the Document when
     /// complete.
-    catalog: Option<Catalog>,
+    ///
+    /// Wrapped in a [`RefCell`] so that anchors and references discovered deep
+    /// inside inline substitution (where only a shared `&Parser` is available,
+    /// e.g. within a regex [`Replacer`](regex::Replacer)) can still be
+    /// registered.
+    catalog: RefCell<Catalog>,
 
     /// Most recently-assigned section number.
     pub(crate) last_section_number: SectionNumber,
@@ -68,7 +73,7 @@ impl Default for Parser {
             primary_file_name: None,
             path_resolver: PathResolver::default(),
             include_file_handler: None,
-            catalog: Some(Catalog::new()),
+            catalog: RefCell::new(Catalog::new()),
             last_section_number: SectionNumber::default(),
             last_appendix_section_number: SectionNumber {
                 section_type: SectionType::Appendix,
@@ -116,10 +121,8 @@ impl Parser {
         let (preprocessed_source, source_map) = preprocess(source, self);
 
         // NOTE: `Document::parse` will transfer the catalog to itself at the end of the
-        // parsing operation.
-        if self.catalog.is_none() {
-            self.catalog = Some(Catalog::new());
-        }
+        // parsing operation. Start each parse with a fresh catalog.
+        *self.catalog.borrow_mut() = Catalog::new();
 
         // Reset section numbering for each new document.
         self.last_section_number = SectionNumber::default();
@@ -223,29 +226,41 @@ impl Parser {
         self
     }
 
-    /// Returns a mutable reference to the document catalog.
+    /// Register a referenceable element (anchor, section, bibliography entry) in
+    /// the document catalog.
     ///
-    /// This is used during parsing to allow code within `Document::parse` to
-    /// register and access referenceable elements. The catalog should only be
-    /// available during active parsing.
-    ///
-    /// # Example usage during parsing
-    /// ```ignore
-    /// // Within block parsing code:
-    /// if let Some(catalog) = parser.catalog_mut() {
-    ///     catalog.register_ref("my-anchor", Some(span), Some("My Anchor"), RefType::Anchor)?;
-    /// }
-    /// ```
-    pub(crate) fn catalog_mut(&mut self) -> Option<&mut Catalog> {
-        self.catalog.as_mut()
+    /// This takes `&self` (rather than `&mut self`) so that it can be called
+    /// from inline-substitution code paths that only hold a shared reference to
+    /// the parser, such as a regex [`Replacer`](regex::Replacer).
+    pub(crate) fn register_ref(
+        &self,
+        id: &str,
+        reftext: Option<&str>,
+        ref_type: RefType,
+    ) -> Result<(), crate::document::DuplicateIdError> {
+        self.catalog.borrow_mut().register_ref(id, reftext, ref_type)
     }
 
-    /// Takes the catalog from the parser, transferring ownership.
+    /// Generate a unique ID derived from `base_id` and register it in the
+    /// document catalog, returning the ID that was assigned.
+    pub(crate) fn generate_and_register_unique_id(
+        &self,
+        base_id: &str,
+        reftext: Option<&str>,
+        ref_type: RefType,
+    ) -> String {
+        self.catalog
+            .borrow_mut()
+            .generate_and_register_unique_id(base_id, reftext, ref_type)
+    }
+
+    /// Takes the catalog from the parser, transferring ownership and leaving an
+    /// empty catalog in its place.
     ///
     /// This is used by `Document::parse` to transfer the catalog from the
     /// parser to the document at the end of parsing.
     pub(crate) fn take_catalog(&mut self) -> Catalog {
-        self.catalog.take().unwrap_or_else(Catalog::new)
+        std::mem::take(&mut *self.catalog.borrow_mut())
     }
 
     /* Comment out until we're prepared to use and test this.
@@ -585,7 +600,9 @@ mod tests {
         let catalog = doc.catalog();
         assert!(catalog.is_empty());
 
-        assert!(parser.catalog.is_none());
+        // The catalog was transferred to the document, leaving the parser with
+        // an empty catalog.
+        assert!(parser.catalog.borrow().is_empty());
     }
 
     #[test]

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -137,9 +137,10 @@ impl Parser {
     /// [`Document::resolve_references`].
     ///
     /// This is the entry point for multi-document workflows (e.g. Antora-style
-    /// site generation): parse every document with this method, build a combined
-    /// index from each document's [`catalog()`], then resolve each document
-    /// against that index. This crate does not merge catalogs itself.
+    /// site generation): parse every document with this method, build a
+    /// combined index from each document's [`catalog()`], then resolve each
+    /// document against that index. This crate does not merge catalogs
+    /// itself.
     ///
     /// [`parse()`]: Self::parse
     /// [`catalog()`]: Document::catalog
@@ -252,8 +253,8 @@ impl Parser {
         self
     }
 
-    /// Register a referenceable element (anchor, section, bibliography entry) in
-    /// the document catalog.
+    /// Register a referenceable element (anchor, section, bibliography entry)
+    /// in the document catalog.
     ///
     /// This takes `&self` (rather than `&mut self`) so that it can be called
     /// from inline-substitution code paths that only hold a shared reference to

--- a/parser/src/parser/reference_resolver.rs
+++ b/parser/src/parser/reference_resolver.rs
@@ -29,8 +29,8 @@ pub struct ResolvedReference {
 /// A warning produced while resolving cross-references.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReferenceWarning {
-    /// The cross-reference target that could not be resolved, exactly as written
-    /// in the source.
+    /// The cross-reference target that could not be resolved, exactly as
+    /// written in the source.
     pub target: String,
 
     /// The kind of problem encountered.
@@ -72,7 +72,8 @@ pub trait ReferenceResolver {
     fn resolve(&self, context: &ResolutionContext<'_>) -> Option<ResolvedReference>;
 }
 
-/// The default single-document [`ReferenceResolver`], backed by one [`Catalog`].
+/// The default single-document [`ReferenceResolver`], backed by one
+/// [`Catalog`].
 ///
 /// It resolves bare IDs and natural cross-references (by reference text) to
 /// `#id` fragments. Targets that carry a path component (detected by the

--- a/parser/src/parser/reference_resolver.rs
+++ b/parser/src/parser/reference_resolver.rs
@@ -1,0 +1,198 @@
+//! Cross-reference resolution.
+//!
+//! Parsing leaves cross-references (`<<id>>`, `xref:id[…]`) unresolved so they
+//! can be resolved later, once the full document — or, for multi-document
+//! workflows such as Antora, the full corpus — has been parsed and its catalog
+//! of referenceable elements is complete.
+//!
+//! Resolution is performed through the [`ReferenceResolver`] trait. This crate
+//! ships [`CatalogResolver`], a single-document resolver backed by one
+//! [`Catalog`]. A host that resolves references across many documents supplies
+//! its own implementation (binding the "from" document when it constructs the
+//! resolver), and this crate makes no attempt to merge catalogs.
+
+use crate::document::Catalog;
+
+/// The resolved destination of a cross-reference.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolvedReference {
+    /// The hyperlink destination. For a same-document reference this is a
+    /// fragment such as `#section-id`; a cross-document resolver may return a
+    /// full or relative URL.
+    pub href: String,
+
+    /// The display text to use when the cross-reference did not specify its own
+    /// text. This is typically the target's reference text (reftext).
+    pub text: Option<String>,
+}
+
+/// A warning produced while resolving cross-references.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReferenceWarning {
+    /// The cross-reference target that could not be resolved, exactly as written
+    /// in the source.
+    pub target: String,
+
+    /// The kind of problem encountered.
+    pub kind: ReferenceWarningKind,
+}
+
+/// The kind of problem described by a [`ReferenceWarning`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ReferenceWarningKind {
+    /// The target could not be resolved to any destination.
+    Unresolved,
+}
+
+/// Describes a single cross-reference that needs to be resolved.
+///
+/// This carries only information the crate itself knows about the reference. A
+/// multi-document host that needs to know which document a reference originates
+/// from binds that "from" context when it constructs its [`ReferenceResolver`],
+/// rather than receiving it here — keeping this seam free of any host-specific
+/// coordinate system.
+#[non_exhaustive]
+pub struct ResolutionContext<'a> {
+    /// The raw, uninterpreted cross-reference target, exactly as written in the
+    /// source (e.g. `"section-id"`, a reftext, or `"other-page.adoc#frag"`).
+    pub target: &'a str,
+
+    /// Explicit link text supplied in the cross-reference, if any.
+    pub provided_text: Option<&'a str>,
+}
+
+/// Resolves cross-reference targets to their destinations.
+///
+/// Implementations map a [`ResolutionContext`] to a [`ResolvedReference`], or
+/// return `None` when the target cannot be resolved (the caller then renders an
+/// unresolved-reference fallback and may emit a warning).
+pub trait ReferenceResolver {
+    /// Resolve a single cross-reference.
+    fn resolve(&self, context: &ResolutionContext<'_>) -> Option<ResolvedReference>;
+}
+
+/// The default single-document [`ReferenceResolver`], backed by one [`Catalog`].
+///
+/// It resolves bare IDs and natural cross-references (by reference text) to
+/// `#id` fragments. Targets that carry a path component (detected by the
+/// presence of `#`, e.g. `other-page.adoc#frag`) are treated as inter-document
+/// references and left unresolved — resolving those is the responsibility of a
+/// host-supplied resolver.
+#[derive(Clone, Copy, Debug)]
+pub struct CatalogResolver<'a> {
+    catalog: &'a Catalog,
+}
+
+impl<'a> CatalogResolver<'a> {
+    /// Construct a resolver backed by the given catalog.
+    pub fn new(catalog: &'a Catalog) -> Self {
+        Self { catalog }
+    }
+}
+
+impl ReferenceResolver for CatalogResolver<'_> {
+    fn resolve(&self, context: &ResolutionContext<'_>) -> Option<ResolvedReference> {
+        let target = context.target;
+
+        // Path-bearing (inter-document) targets are a host concern.
+        if target.contains('#') {
+            return None;
+        }
+
+        // Direct ID match.
+        if let Some(entry) = self.catalog.get_ref(target) {
+            return Some(ResolvedReference {
+                href: format!("#{target}"),
+                text: entry.reftext.clone(),
+            });
+        }
+
+        // Natural cross-reference: match on reference text.
+        if let Some(id) = self.catalog.resolve_id(target) {
+            let text = self.catalog.get_ref(&id).and_then(|e| e.reftext.clone());
+            return Some(ResolvedReference {
+                href: format!("#{id}"),
+                text,
+            });
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+    use crate::document::RefType;
+
+    fn catalog_with(id: &str, reftext: Option<&str>, ref_type: RefType) -> Catalog {
+        let mut catalog = Catalog::new();
+        catalog.register_ref(id, reftext, ref_type).unwrap();
+        catalog
+    }
+
+    #[test]
+    fn resolves_by_id() {
+        let catalog = catalog_with("later", Some("The Later Section"), RefType::Section);
+        let resolver = CatalogResolver::new(&catalog);
+
+        let resolved = resolver
+            .resolve(&ResolutionContext {
+                target: "later",
+                provided_text: None,
+            })
+            .unwrap();
+
+        assert_eq!(resolved.href, "#later");
+        assert_eq!(resolved.text.as_deref(), Some("The Later Section"));
+    }
+
+    #[test]
+    fn resolves_by_reftext() {
+        let catalog = catalog_with("later", Some("The Later Section"), RefType::Section);
+        let resolver = CatalogResolver::new(&catalog);
+
+        let resolved = resolver
+            .resolve(&ResolutionContext {
+                target: "The Later Section",
+                provided_text: None,
+            })
+            .unwrap();
+
+        assert_eq!(resolved.href, "#later");
+        assert_eq!(resolved.text.as_deref(), Some("The Later Section"));
+    }
+
+    #[test]
+    fn unresolved_returns_none() {
+        let catalog = Catalog::new();
+        let resolver = CatalogResolver::new(&catalog);
+
+        assert!(
+            resolver
+                .resolve(&ResolutionContext {
+                    target: "missing",
+                    provided_text: None,
+                })
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn path_bearing_target_left_unresolved() {
+        let catalog = catalog_with("frag", Some("Fragment"), RefType::Anchor);
+        let resolver = CatalogResolver::new(&catalog);
+
+        assert!(
+            resolver
+                .resolve(&ResolutionContext {
+                    target: "other-page.adoc#frag",
+                    provided_text: None,
+                })
+                .is_none()
+        );
+    }
+}

--- a/parser/src/tests/asciidoc_lang/attributes/id.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/id.rs
@@ -891,14 +891,24 @@ The id (`#`) shorthand can be used on inline quoted text.
                 },
                 warnings: &[],
                 source_map: SourceMap(&[]),
-                catalog: Catalog::default(),
+                catalog: Catalog {
+                    refs: HashMap::from([(
+                        "free_the_world",
+                        RefEntry {
+                            id: "free_the_world",
+                            reftext: None,
+                            ref_type: crate::document::RefType::Anchor,
+                        },
+                    )]),
+                    reftext_to_id: HashMap::default(),
+                },
             }
         );
     }
 }
 
 mod anchor {
-    use crate::{document::RefType, tests::prelude::*};
+    use crate::tests::prelude::*;
 
     non_normative!(
         r#"
@@ -973,7 +983,17 @@ According to the https://www.w3.org/TR/REC-xml/#NT-Name[XML Name] rules, a porta
                 },
                 warnings: &[],
                 source_map: SourceMap(&[]),
-                catalog: Catalog::default(),
+                catalog: Catalog {
+                    refs: HashMap::from([(
+                        "start_with_letter",
+                        RefEntry {
+                            id: "start_with_letter",
+                            reftext: None,
+                            ref_type: crate::document::RefType::Anchor,
+                        },
+                    )]),
+                    reftext_to_id: HashMap::default(),
+                },
             }
         );
 
@@ -1029,7 +1049,17 @@ According to the https://www.w3.org/TR/REC-xml/#NT-Name[XML Name] rules, a porta
                 },
                 warnings: &[],
                 source_map: SourceMap(&[]),
-                catalog: Catalog::default(),
+                catalog: Catalog {
+                    refs: HashMap::from([(
+                        "_start_with_underscore",
+                        RefEntry {
+                            id: "_start_with_underscore",
+                            reftext: None,
+                            ref_type: crate::document::RefType::Anchor,
+                        },
+                    )]),
+                    reftext_to_id: HashMap::default(),
+                },
             }
         );
 
@@ -1085,7 +1115,17 @@ According to the https://www.w3.org/TR/REC-xml/#NT-Name[XML Name] rules, a porta
                 },
                 warnings: &[],
                 source_map: SourceMap(&[]),
-                catalog: Catalog::default(),
+                catalog: Catalog {
+                    refs: HashMap::from([(
+                        ":start_with_colon",
+                        RefEntry {
+                            id: ":start_with_colon",
+                            reftext: None,
+                            ref_type: crate::document::RefType::Anchor,
+                        },
+                    )]),
+                    reftext_to_id: HashMap::default(),
+                },
             }
         );
 
@@ -1300,7 +1340,7 @@ include::example$id.adoc[tag=block-id-shorthand]
                         RefEntry {
                             id: "notice",
                             reftext: None,
-                            ref_type: RefType::Anchor,
+                            ref_type: crate::document::RefType::Anchor,
                         }
                     ),]),
                     reftext_to_id: HashMap::default(),
@@ -1387,7 +1427,7 @@ include::example$id.adoc[tag=block-id-brackets]
                         RefEntry {
                             id: "notice",
                             reftext: None,
-                            ref_type: RefType::Anchor,
+                            ref_type: crate::document::RefType::Anchor,
                         }
                     ),]),
                     reftext_to_id: HashMap::default(),
@@ -1467,7 +1507,17 @@ include::example$id.adoc[tag=anchor-brackets]
                 },
                 warnings: &[],
                 source_map: SourceMap(&[]),
-                catalog: Catalog::default(),
+                catalog: Catalog {
+                    refs: HashMap::from([(
+                        "bookmark-a",
+                        RefEntry {
+                            id: "bookmark-a",
+                            reftext: None,
+                            ref_type: crate::document::RefType::Anchor,
+                        },
+                    )]),
+                    reftext_to_id: HashMap::default(),
+                },
             }
         );
     }

--- a/parser/src/tests/asciidoc_lang/directives/include_multiple_times_in_same_document.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include_multiple_times_in_same_document.rs
@@ -144,7 +144,7 @@ The single quotes around the variable name in the assignment are required to for
                                         col: 1,
                                         offset: 81,
                                     },
-                                    rendered: "See xref:chain-operation[].",
+                                    rendered: "See <a href=\"#chain-operation\">Chain</a>.",
                                 },
                                 source: Span {
                                     data: "See xref:chain-{chapter}[].",
@@ -254,7 +254,7 @@ The single quotes around the variable name in the assignment are required to for
                                     col: 1,
                                     offset: 180,
                                 },
-                                rendered: "See xref:chain-maintenance[].",
+                                rendered: "See <a href=\"#chain-maintenance\">Chain</a>.",
                             },
                             source: Span {
                                 data: "See xref:chain-{chapter}[].",

--- a/parser/src/tests/asciidoc_lang/sections/custom_ids.rs
+++ b/parser/src/tests/asciidoc_lang/sections/custom_ids.rs
@@ -497,16 +497,34 @@ Here's how to register auxiliary IDs using inline anchors when using an autogene
             warnings: &[],
             source_map: SourceMap(&[]),
             catalog: Catalog {
-                refs: HashMap::from([(
-                    "_section_title",
-                    RefEntry {
-                        id: "_section_title",
-                        reftext: Some(
-                            "<a id=\"secondary-id\"></a><a id=\"tertiary-id\"></a>Section Title",
-                        ),
-                        ref_type: RefType::Section,
-                    },
-                ),]),
+                refs: HashMap::from([
+                    (
+                        "_section_title",
+                        RefEntry {
+                            id: "_section_title",
+                            reftext: Some(
+                                "<a id=\"secondary-id\"></a><a id=\"tertiary-id\"></a>Section Title",
+                            ),
+                            ref_type: RefType::Section,
+                        },
+                    ),
+                    (
+                        "secondary-id",
+                        RefEntry {
+                            id: "secondary-id",
+                            reftext: None,
+                            ref_type: RefType::Anchor,
+                        },
+                    ),
+                    (
+                        "tertiary-id",
+                        RefEntry {
+                            id: "tertiary-id",
+                            reftext: None,
+                            ref_type: RefType::Anchor,
+                        },
+                    ),
+                ]),
                 reftext_to_id: HashMap::from([(
                     "<a id=\"secondary-id\"></a><a id=\"tertiary-id\"></a>Section Title",
                     "_section_title"
@@ -584,16 +602,34 @@ fn assign_auxiliary_ids_2() {
             warnings: &[],
             source_map: SourceMap(&[]),
             catalog: Catalog {
-                refs: HashMap::from([(
-                    "_section_title",
-                    RefEntry {
-                        id: "_section_title",
-                        reftext: Some(
-                            "Section Title<a id=\"secondary-id\"></a><a id=\"tertiary-id\"></a>",
-                        ),
-                        ref_type: RefType::Section,
-                    }
-                ),]),
+                refs: HashMap::from([
+                    (
+                        "_section_title",
+                        RefEntry {
+                            id: "_section_title",
+                            reftext: Some(
+                                "Section Title<a id=\"secondary-id\"></a><a id=\"tertiary-id\"></a>",
+                            ),
+                            ref_type: RefType::Section,
+                        },
+                    ),
+                    (
+                        "secondary-id",
+                        RefEntry {
+                            id: "secondary-id",
+                            reftext: None,
+                            ref_type: RefType::Anchor,
+                        },
+                    ),
+                    (
+                        "tertiary-id",
+                        RefEntry {
+                            id: "tertiary-id",
+                            reftext: None,
+                            ref_type: RefType::Anchor,
+                        },
+                    ),
+                ]),
                 reftext_to_id: HashMap::from([(
                     "Section Title<a id=\"secondary-id\"></a><a id=\"tertiary-id\"></a>",
                     "_section_title"
@@ -696,16 +732,34 @@ These additional anchor points don't interfere with the declaration of the prima
             warnings: &[],
             source_map: SourceMap(&[]),
             catalog: Catalog {
-                refs: HashMap::from([(
-                    "primary-id",
-                    RefEntry {
-                        id: "primary-id",
-                        reftext: Some(
-                            "<a id=\"secondary-id\"></a><a id=\"tertiary-id\"></a>Section Title",
-                        ),
-                        ref_type: RefType::Section,
-                    }
-                ),]),
+                refs: HashMap::from([
+                    (
+                        "primary-id",
+                        RefEntry {
+                            id: "primary-id",
+                            reftext: Some(
+                                "<a id=\"secondary-id\"></a><a id=\"tertiary-id\"></a>Section Title",
+                            ),
+                            ref_type: RefType::Section,
+                        },
+                    ),
+                    (
+                        "secondary-id",
+                        RefEntry {
+                            id: "secondary-id",
+                            reftext: None,
+                            ref_type: RefType::Anchor,
+                        },
+                    ),
+                    (
+                        "tertiary-id",
+                        RefEntry {
+                            id: "tertiary-id",
+                            reftext: None,
+                            ref_type: RefType::Anchor,
+                        },
+                    ),
+                ]),
                 reftext_to_id: HashMap::from([(
                     "<a id=\"secondary-id\"></a><a id=\"tertiary-id\"></a>Section Title",
                     "primary-id"

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -828,37 +828,44 @@ mod bulleted_lists {
         }
 
         #[test]
-        #[ignore]
-        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/461):
-        // Enable this test when xref replacement refactoring is complete.
         fn should_discover_anchor_at_start_of_unordered_list_item_text_and_register_it_as_a_reference()
          {
-            let _doc = Parser::default().parse("The highest peak in the Front Range is <<grays-peak>>, which tops <<mount-evans>> by just a few feet.\n\n* [[mount-evans,Mount Evans]]At 14,271 feet, Mount Evans is the highest summit of the Chicago Peaks in the Front Range of the Rocky Mountains.\n* [[grays-peak,Grays Peak]]\nGrays Peak rises to 14,278 feet, making it the highest summit in the Front Range of the Rocky Mountains.\n* Longs Peak is a 14,259-foot high, prominent mountain summit in the northern Front Range of the Rocky Mountains.\n* Pikes Peak is the highest summit of the southern Front Range of the Rocky Mountains at 14,115 feet.\n");
-            todo!("doc.catalog[:refs] check");
-            todo!(
-                "assert_xpath: '(//p)[1]/a[@href=\"#grays-peak\"][text()=\"Grays Peak\"]', output, 1"
+            let doc = Parser::default().parse("The highest peak in the Front Range is <<grays-peak>>, which tops <<mount-evans>> by just a few feet.\n\n* [[mount-evans,Mount Evans]]At 14,271 feet, Mount Evans is the highest summit of the Chicago Peaks in the Front Range of the Rocky Mountains.\n* [[grays-peak,Grays Peak]]\nGrays Peak rises to 14,278 feet, making it the highest summit in the Front Range of the Rocky Mountains.\n* Longs Peak is a 14,259-foot high, prominent mountain summit in the northern Front Range of the Rocky Mountains.\n* Pikes Peak is the highest summit of the southern Front Range of the Rocky Mountains at 14,115 feet.\n");
+
+            // The inline anchors at the start of the list items were registered.
+            assert!(doc.catalog().contains_id("mount-evans"));
+            assert!(doc.catalog().contains_id("grays-peak"));
+
+            // The forward cross-references in the first paragraph resolved
+            // against those later-defined anchors.
+            assert_xpath(
+                &doc,
+                "(//p)[1]/a[@href=\"#grays-peak\"][text()=\"Grays Peak\"]",
+                1,
             );
-            todo!(
-                "assert_xpath: '(//p)[1]/a[@href=\"#mount-evans\"][text()=\"Mount Evans\"]', output, 1"
+            assert_xpath(
+                &doc,
+                "(//p)[1]/a[@href=\"#mount-evans\"][text()=\"Mount Evans\"]",
+                1,
             );
         }
 
         #[test]
-        #[ignore]
-        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/461):
-        // Enable this test when xref replacement refactoring is complete.
         fn should_discover_anchor_at_start_of_ordered_list_item_text_and_register_it_as_a_reference()
          {
-            let _doc = Parser::default().parse("This is a cross-reference to <<step-2>>.\nThis is a cross-reference to <<step-4>>.\n\n. Ordered list, item 1, without anchor\n. [[step-2,Step 2]]Ordered list, item 2, with anchor\n. Ordered list, item 3, without anchor\n. [[step-4,Step 4]]Ordered list, item 4, with anchor\n");
-            todo!("doc.catalog[:refs] check");
-            todo!("assert_xpath: '(//p)[1]/a[@href=\"#step-2\"][text()=\"Step 2\"]', output, 1");
-            todo!("assert_xpath: '(//p)[1]/a[@href=\"#step-4\"][text()=\"Step 4\"]', output, 1");
+            let doc = Parser::default().parse("This is a cross-reference to <<step-2>>.\nThis is a cross-reference to <<step-4>>.\n\n. Ordered list, item 1, without anchor\n. [[step-2,Step 2]]Ordered list, item 2, with anchor\n. Ordered list, item 3, without anchor\n. [[step-4,Step 4]]Ordered list, item 4, with anchor\n");
+
+            assert!(doc.catalog().contains_id("step-2"));
+            assert!(doc.catalog().contains_id("step-4"));
+
+            assert_xpath(&doc, "(//p)[1]/a[@href=\"#step-2\"][text()=\"Step 2\"]", 1);
+            assert_xpath(&doc, "(//p)[1]/a[@href=\"#step-4\"][text()=\"Step 4\"]", 1);
         }
 
         #[test]
         #[ignore]
-        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/461):
-        // Enable this test when xref replacement refactoring is complete.
+        // Cross-reference resolution (#461) is implemented, but this scenario
+        // also depends on callout lists.
         // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311):
         // Enable this test when callouts are implemented.
         fn should_discover_anchor_at_start_of_callout_list_item_text_and_register_it_as_a_reference()

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -4,6 +4,10 @@
 //! documents for testing purposes. It maps AsciiDoc block structures to their
 //! HTML equivalents, enabling XPath-like queries for test assertions.
 
+use std::sync::LazyLock;
+
+use regex::Regex;
+
 use crate::{
     Document, HasSpan,
     blocks::{
@@ -111,7 +115,49 @@ fn try_parse_element(text: &str, pos: usize) -> Option<(VirtualNode, usize)> {
         VirtualNode::new(tag_name).with_text(content)
     };
 
+    // Capture the opening tag's attributes (id, class, href, etc.) so that
+    // attribute predicates like `[@href="#x"]` can match inline elements.
+    let element = apply_tag_attributes(element, tag_content);
+
     Some((element, after_closing))
+}
+
+/// Matches `name="value"` attribute pairs in an opening tag. Renderer output
+/// always uses double quotes, so single-quoted values are not handled.
+static HTML_ATTR: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(r#"([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*"([^"]*)""#).unwrap()
+});
+
+/// Parses the attributes from an opening tag's content and applies them to
+/// `node`, routing `id` and `class` to their dedicated fields and everything
+/// else into the generic attribute map.
+fn apply_tag_attributes(mut node: VirtualNode, tag_content: &str) -> VirtualNode {
+    // Skip the tag name; only the remainder can contain attributes.
+    let attrs = tag_content
+        .trim()
+        .split_once(char::is_whitespace)
+        .map(|(_, rest)| rest)
+        .unwrap_or("");
+
+    for caps in HTML_ATTR.captures_iter(attrs) {
+        let name = &caps[1];
+        let value = caps[2].to_string();
+
+        match name {
+            "id" => node.id = Some(value),
+            "class" => {
+                for class in value.split_whitespace() {
+                    node.classes.push(class.to_string());
+                }
+            }
+            _ => {
+                node.attributes.insert(name.to_string(), value);
+            }
+        }
+    }
+
+    node
 }
 
 /// Extracts the tag name from an opening tag string (without the < and >).

--- a/parser/src/tests/mod.rs
+++ b/parser/src/tests/mod.rs
@@ -9,3 +9,4 @@ pub(crate) mod assert_dom;
 pub(crate) mod fixtures;
 pub(crate) mod prelude;
 pub(crate) mod sdd;
+mod xref;

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -1,0 +1,206 @@
+//! Integration tests for cross-reference resolution (issue #461).
+//!
+//! These exercise the parse/resolution split: parsing records cross-references
+//! as deferred, and a later pass resolves them against a complete catalog —
+//! including the cross-document (Antora-style) workflow via
+//! [`Parser::parse_deferred`] and [`Document::resolve_references`].
+//!
+//! Expected outputs were verified against Ruby Asciidoctor 2.0.
+
+use std::collections::HashMap;
+
+use crate::{
+    Document, Parser,
+    blocks::{Block, IsBlock, SimpleBlock},
+    parser::{
+        CatalogResolver, HtmlSubstitutionRenderer, ReferenceResolver, ResolutionContext,
+        ResolvedReference,
+    },
+};
+
+/// Returns the first `SimpleBlock` found in document order (recursing into
+/// nested blocks).
+fn first_simple<'a>(doc: &'a Document<'a>) -> &'a SimpleBlock<'a> {
+    fn walk<'a>(mut blocks: impl Iterator<Item = &'a Block<'a>>) -> Option<&'a SimpleBlock<'a>> {
+        blocks.find_map(|block| {
+            if let Block::Simple(simple) = block {
+                Some(simple)
+            } else {
+                walk(block.nested_blocks())
+            }
+        })
+    }
+
+    walk(doc.nested_blocks()).expect("expected at least one simple block")
+}
+
+/// Returns the rendered text of the first paragraph in `doc`.
+fn first_paragraph<'a>(doc: &'a Document<'a>) -> &'a str {
+    first_simple(doc).content().rendered()
+}
+
+#[test]
+fn forward_reference_resolves() {
+    let doc = Parser::default().parse("See <<later>>.\n\n[#later]\n== Later\n");
+    assert_eq!(first_paragraph(&doc), "See <a href=\"#later\">Later</a>.");
+}
+
+#[test]
+fn backward_reference_resolves() {
+    let doc =
+        Parser::default().parse("[#first]\n== First\n\nText.\n\n== Second\n\nBack to <<first>>.\n");
+
+    // The "Back to ..." paragraph lives in the second section.
+    let mut paragraphs = vec![];
+    fn collect<'a>(blocks: impl Iterator<Item = &'a Block<'a>>, out: &mut Vec<String>) {
+        for block in blocks {
+            if let Block::Simple(simple) = block {
+                out.push(simple.content().rendered().to_string());
+            }
+            collect(block.nested_blocks(), out);
+        }
+    }
+    collect(doc.nested_blocks(), &mut paragraphs);
+
+    assert!(
+        paragraphs
+            .iter()
+            .any(|p| p == "Back to <a href=\"#first\">First</a>."),
+        "paragraphs were {paragraphs:?}"
+    );
+}
+
+#[test]
+fn reference_with_explicit_text() {
+    let doc = Parser::default().parse("<<sec,Custom Label>>\n\n[#sec]\n== Section\n");
+    assert_eq!(first_paragraph(&doc), "<a href=\"#sec\">Custom Label</a>");
+}
+
+#[test]
+fn natural_reference_by_reftext() {
+    let doc = Parser::default().parse("See <<The Beginning>>.\n\n== The Beginning\n");
+    assert_eq!(
+        first_paragraph(&doc),
+        "See <a href=\"#_the_beginning\">The Beginning</a>."
+    );
+}
+
+#[test]
+fn xref_macro_form_resolves() {
+    let doc = Parser::default().parse("See xref:later[].\n\n[#later]\n== Later\n");
+    assert_eq!(first_paragraph(&doc), "See <a href=\"#later\">Later</a>.");
+}
+
+#[test]
+fn unresolved_reference_falls_back_and_warns() {
+    // Parse without resolving, then resolve against the document's own catalog
+    // (cloned so it does not alias the `&mut doc` borrow).
+    let mut doc = Parser::default().parse_deferred("See <<nope>>.\n");
+
+    // Before resolution, the reference is pending.
+    assert!(first_simple(&doc).content().has_unresolved_refs());
+
+    let catalog = doc.catalog().clone();
+    let resolver = CatalogResolver::new(&catalog);
+    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0].target, "nope");
+
+    // Unresolved references still render a sensible fallback.
+    assert_eq!(first_paragraph(&doc), "See <a href=\"#nope\">[nope]</a>.");
+}
+
+#[test]
+fn escaped_reference_is_not_a_cross_reference() {
+    // A backslash-escaped shorthand is emitted literally and is not deferred.
+    let doc = Parser::default().parse("See \\<<later>>.\n\n[#later]\n== Later\n");
+    assert!(!first_simple(&doc).content().has_unresolved_refs());
+    assert_eq!(first_paragraph(&doc), "See &lt;&lt;later&gt;&gt;.");
+}
+
+/// A resolver backed by a combined, cross-document index — the shape a host
+/// such as Antora would supply. The crate itself never merges catalogs.
+struct CrossDocResolver {
+    index: HashMap<String, ResolvedReference>,
+}
+
+impl ReferenceResolver for CrossDocResolver {
+    fn resolve(&self, context: &ResolutionContext<'_>) -> Option<ResolvedReference> {
+        self.index.get(context.target).cloned()
+    }
+}
+
+#[test]
+fn cross_document_resolution() {
+    let mut parser = Parser::default();
+
+    // Two documents parsed independently; references left unresolved.
+    let mut doc_a = parser.parse_deferred("See <<b-topic>> for details.\n");
+    let doc_b = parser.parse_deferred("[#b-topic]\n== B Topic\n\nContent.\n");
+
+    // The host builds a combined index from each document's catalog, assigning
+    // its own cross-document hrefs.
+    let mut index = HashMap::new();
+    for id in ["b-topic"] {
+        if let Some(entry) = doc_b.catalog().get_ref(id) {
+            index.insert(
+                entry.id.clone(),
+                ResolvedReference {
+                    href: format!("doc-b.html#{id}"),
+                    text: entry.reftext.clone(),
+                },
+            );
+        }
+    }
+    let resolver = CrossDocResolver { index };
+
+    // Document A still has the pending reference until we resolve it.
+    assert!(first_simple(&doc_a).content().has_unresolved_refs());
+
+    let warnings = doc_a.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    assert!(warnings.is_empty());
+
+    assert_eq!(
+        first_paragraph(&doc_a),
+        "See <a href=\"doc-b.html#b-topic\">B Topic</a> for details."
+    );
+    assert!(!first_simple(&doc_a).content().has_unresolved_refs());
+}
+
+#[test]
+fn resolution_is_repeatable() {
+    // Resolving twice against different resolvers yields the second result —
+    // resolution is non-destructive.
+    let mut doc = Parser::default().parse_deferred("See <<topic>>.\n");
+
+    let first = CrossDocResolver {
+        index: HashMap::from([(
+            "topic".to_string(),
+            ResolvedReference {
+                href: "first.html#topic".to_string(),
+                text: Some("First".to_string()),
+            },
+        )]),
+    };
+    doc.resolve_references(&first, &HtmlSubstitutionRenderer {});
+    assert_eq!(
+        first_paragraph(&doc),
+        "See <a href=\"first.html#topic\">First</a>."
+    );
+
+    let second = CrossDocResolver {
+        index: HashMap::from([(
+            "topic".to_string(),
+            ResolvedReference {
+                href: "second.html#topic".to_string(),
+                text: Some("Second".to_string()),
+            },
+        )]),
+    };
+    doc.resolve_references(&second, &HtmlSubstitutionRenderer {});
+    assert_eq!(
+        first_paragraph(&doc),
+        "See <a href=\"second.html#topic\">Second</a>."
+    );
+}

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -204,3 +204,38 @@ fn resolution_is_repeatable() {
         "See <a href=\"second.html#topic\">Second</a>."
     );
 }
+
+#[test]
+fn re_resolution_is_a_full_independent_sweep() {
+    // Each call re-resolves every reference against the given resolver. A
+    // resolver that no longer knows a target re-reports it as unresolved and
+    // reverts the rendering to the fallback, even though an earlier pass had
+    // resolved it.
+    let mut doc = Parser::default().parse_deferred("See <<topic>>.\n");
+
+    let knows_topic = CrossDocResolver {
+        index: HashMap::from([(
+            "topic".to_string(),
+            ResolvedReference {
+                href: "first.html#topic".to_string(),
+                text: Some("Topic".to_string()),
+            },
+        )]),
+    };
+    let warnings = doc.resolve_references(&knows_topic, &HtmlSubstitutionRenderer {});
+    assert!(warnings.is_empty());
+    assert_eq!(
+        first_paragraph(&doc),
+        "See <a href=\"first.html#topic\">Topic</a>."
+    );
+
+    // A second pass with an empty resolver re-reports the target and reverts to
+    // the unresolved fallback.
+    let knows_nothing = CrossDocResolver {
+        index: HashMap::new(),
+    };
+    let warnings = doc.resolve_references(&knows_nothing, &HtmlSubstitutionRenderer {});
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0].target, "topic");
+    assert_eq!(first_paragraph(&doc), "See <a href=\"#topic\">[topic]</a>.");
+}


### PR DESCRIPTION
## Summary

Implements the parse/inline-resolution split proposed in #461. Cross-reference resolution was previously impossible because substitution ran **eagerly, interleaved with parsing**: when a block was substituted, anchors defined later in the document weren't in the catalog yet, so `<<id>>` could never resolve to a forward target — and inline anchors weren't registered at all.

The fix separates **local substitution (parse-time)** from **global cross-reference resolution (a deferred pass)**, keeping point-in-time attribute semantics intact (verified against Ruby Asciidoctor — an attribute redefined mid-document still affects only text after the redefinition).

See the [design comment on #461](https://github.com/asciidoc-rs/asciidoc-parser/issues/461#issuecomment-4742942002) for the full rationale.

## What changed

**1. `RefCell` catalog + inline-anchor registration** (`e4f4c03`)
- The parser's catalog is interior-mutable so anchors discovered inside inline substitution (where only a shared `&Parser` is available, e.g. a regex `Replacer`) can register.
- Inline anchors (`[[id]]`, `anchor:id[]`) are now recorded in the catalog, closing a latent gap where they rendered but were never registered. (Also unblocks the image/link registration TODOs, #335.)

**2. Defer + resolve cross-references** (`c22db2e`)
- `Content` stores cross-references structurally and rebuilds its rendered text **non-destructively**, so resolution is repeatable. `rendered()` stays a clean `&str` (unresolved references show a fallback until resolved).
- Parsing records each `<<id>>` / `xref:id[]` as deferred instead of resolving eagerly.
- `ReferenceResolver` is the pluggable seam; `CatalogResolver` is the default single-document resolver; `InlineSubstitutionRenderer` gains `render_xref`.
- `Document::resolve_references(resolver, renderer) -> Vec<ReferenceWarning>` resolves against a caller-supplied (possibly cross-document) resolver. `Parser::parse` auto-resolves against the document's own catalog (unchanged signature/behavior); `Parser::parse_deferred` returns an unresolved document for multi-document (Antora-style) workflows.

**3. Tests** (`c440f67`)
- Enables the two list-anchor acceptance tests from #461 (forward references to inline anchors defined later in unordered/ordered list items). The callout-list variant stays ignored pending callout support (#311).
- New `tests/xref.rs`: forward / backward / natural-reftext / explicit-text / `xref:` macro / escaped / unresolved references, plus the cross-document workflow (`parse_deferred` + host-supplied resolver) and repeatable non-destructive resolution.
- Teaches the test virtual-DOM HTML parser to capture element attributes (`id`/`class`/`href`/…), so predicates like `a[@href="#x"]` match inline elements.

## Multi-document (Antora) support

`parse_deferred` + `Document::resolve_references` enable resolving references across many documents against a host-built combined index. This crate ships single-document defaults and the resolver seam only — **it does not merge catalogs**; coordinate systems and URL construction live in the host's `ReferenceResolver`. A follow-up tracking issue for the cross-document workflow is worth filing separately (not done here).

## Notes / scope

- The deferred representation is a structured side-table + opaque placeholder template rather than a literal `Vec<ContentSegment>`, because the substitution pipeline mutates a flat `rendered` string throughout. Semantically equivalent (structured, non-destructive, re-resolvable) with far less churn and zero behavior change to existing snapshot tests.
- Bibliography (`[[[id]]]`) registration is **not** included — there is no bibliography-reference parsing in the crate yet, so it's a separate feature. Such targets pass through the resolver untouched.

## Verification

- Full suite green: **1884 passed, 0 failed, 95 ignored**; clippy (all targets) clean; rustfmt clean; doctests pass.
- All rendered outputs diffed against Ruby Asciidoctor 2.0.23 and match exactly (forward/backward/natural/explicit-text/unresolved, and attribute-substituted xref targets).

Closes #461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
