### PR TITLE
feat: Add support for tables

### DIFF
--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -41,12 +41,12 @@ impl<'src> ElementAttribute<'src> {
                     match space.after.take_prefix("=") {
                         Some(equals) => {
                             let space = equals.after.take_whitespace_with_newline();
-                            if space.after.is_empty() || space.after.starts_with(',') {
-                                // TO DO: Is this a warning? Possible spec ambiguity.
-                                (None, source)
-                            } else {
-                                (Some(name.item), space.after)
-                            }
+                            // `name=` with nothing (or only a comma) after the `=`
+                            // is a named attribute with an empty value, not a
+                            // positional one. The empty value falls out of the
+                            // value scan below (`take_while(c != ',')` yields the
+                            // empty string), so the name is all we need to keep.
+                            (Some(name.item), space.after)
                         }
                         None => (None, source),
                     }
@@ -1141,9 +1141,12 @@ mod tests {
         }
 
         #[test]
-        fn fallback_if_no_value() {
+        fn named_with_empty_value() {
             let p = Parser::default();
 
+            // `name=` with nothing after the `=` is a named attribute whose value
+            // is the empty string (e.g. `[caption=]` clears a label), not a
+            // positional attribute with the literal value "abc=".
             let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
                 &CowStr::from("abc="),
                 0,
@@ -1157,13 +1160,13 @@ mod tests {
             assert_eq!(
                 element_attr,
                 ElementAttribute {
-                    name: None,
+                    name: Some("abc"),
                     shorthand_items: &[],
-                    value: "abc="
+                    value: ""
                 }
             );
 
-            assert!(element_attr.name().is_none());
+            assert_eq!(element_attr.name(), Some("abc"));
             assert!(element_attr.block_style().is_none());
             assert!(element_attr.id().is_none());
             assert!(element_attr.roles().is_empty());
@@ -1173,9 +1176,12 @@ mod tests {
         }
 
         #[test]
-        fn fallback_if_immediate_comma() {
+        fn named_with_empty_value_before_comma() {
             let p = Parser::default();
 
+            // `name=` immediately followed by a comma is likewise a named
+            // attribute with an empty value; parsing stops at the comma so the
+            // next attribute can be read separately.
             let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
                 &CowStr::from("abc=,def"),
                 0,
@@ -1189,13 +1195,13 @@ mod tests {
             assert_eq!(
                 element_attr,
                 ElementAttribute {
-                    name: None,
+                    name: Some("abc"),
                     shorthand_items: &[],
-                    value: "abc="
+                    value: ""
                 }
             );
 
-            assert!(element_attr.name().is_none());
+            assert_eq!(element_attr.name(), Some("abc"));
             assert!(element_attr.block_style().is_none());
             assert!(element_attr.id().is_none());
             assert!(element_attr.roles().is_empty());

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -5,7 +5,7 @@ use crate::{
     attributes::Attrlist,
     blocks::{
         Break, CompoundDelimitedBlock, ContentModel, IsBlock, ListBlock, ListItem, ListItemMarker,
-        MediaBlock, Preamble, RawDelimitedBlock, SectionBlock, SimpleBlock,
+        MediaBlock, Preamble, RawDelimitedBlock, SectionBlock, SimpleBlock, TableBlock,
         metadata::BlockMetadata,
     },
     content::{Content, SubstitutionGroup},
@@ -61,6 +61,9 @@ pub enum Block<'src> {
     /// A delimited block that can contain other blocks.
     CompoundDelimited(CompoundDelimitedBlock<'src>),
 
+    /// A table block arranges content into a grid of rows and columns.
+    Table(TableBlock<'src>),
+
     /// Content between the end of the document header and the first section
     /// title in the document body is called the preamble.
     Preamble(Preamble<'src>),
@@ -90,6 +93,8 @@ impl<'src> std::fmt::Debug for Block<'src> {
                 .debug_tuple("Block::CompoundDelimited")
                 .field(block)
                 .finish(),
+
+            Block::Table(block) => f.debug_tuple("Block::Table").field(block).finish(),
 
             Block::Preamble(block) => f.debug_tuple("Block::Preamble").field(block).finish(),
             Block::Break(break_) => f.debug_tuple("Block::Break").field(break_).finish(),
@@ -153,6 +158,7 @@ impl<'src> Block<'src> {
             )
             && !first_line.contains("::")
             && !first_line.contains(";;")
+            && !TableBlock::is_table_delimiter(&first_line)
             && !ListItemMarker::starts_with_marker(first_line)
             && parent_list_markers.is_none()
             && let Some(MatchedItem {
@@ -252,6 +258,32 @@ impl<'src> Block<'src> {
                     item: Some(MatchedItem {
                         item: block,
                         after: cdb.after,
+                    }),
+                    warnings,
+                };
+            }
+
+            if let Some(mut table_maw) = TableBlock::parse(&metadata, parser)
+                && let Some(table) = table_maw.item
+            {
+                if !table_maw.warnings.is_empty() {
+                    warnings.append(&mut table_maw.warnings);
+                }
+
+                let block = Self::Table(table.item);
+
+                Self::register_block_id(
+                    block.id(),
+                    block.title(),
+                    block.span(),
+                    parser,
+                    &mut warnings,
+                );
+
+                return MatchAndWarnings {
+                    item: Some(MatchedItem {
+                        item: block,
+                        after: table.after,
                     }),
                     warnings,
                 };
@@ -456,6 +488,12 @@ impl<'src> Block<'src> {
             content.resolve_references(resolver, renderer, warnings);
         }
 
+        // Tables hold their resolvable content in cells rather than in a single
+        // `content_mut()` value, so they are resolved explicitly here.
+        if let Self::Table(table) = self {
+            table.resolve_references(resolver, renderer, warnings);
+        }
+
         for child in self.nested_blocks_mut() {
             child.resolve_references(resolver, renderer, warnings);
         }
@@ -472,6 +510,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.content_model(),
             Self::RawDelimited(b) => b.content_model(),
             Self::CompoundDelimited(b) => b.content_model(),
+            Self::Table(b) => b.content_model(),
             Self::Preamble(b) => b.content_model(),
             Self::Break(b) => b.content_model(),
             Self::DocumentAttribute(b) => b.content_model(),
@@ -487,6 +526,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.rendered_content(),
             Self::RawDelimited(b) => b.rendered_content(),
             Self::CompoundDelimited(b) => b.rendered_content(),
+            Self::Table(b) => b.rendered_content(),
             Self::Preamble(b) => b.rendered_content(),
             Self::Break(b) => b.rendered_content(),
             Self::DocumentAttribute(b) => b.rendered_content(),
@@ -502,6 +542,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.raw_context(),
             Self::RawDelimited(b) => b.raw_context(),
             Self::CompoundDelimited(b) => b.raw_context(),
+            Self::Table(b) => b.raw_context(),
             Self::Preamble(b) => b.raw_context(),
             Self::Break(b) => b.raw_context(),
             Self::DocumentAttribute(b) => b.raw_context(),
@@ -517,6 +558,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.nested_blocks(),
             Self::RawDelimited(b) => b.nested_blocks(),
             Self::CompoundDelimited(b) => b.nested_blocks(),
+            Self::Table(b) => b.nested_blocks(),
             Self::Preamble(b) => b.nested_blocks(),
             Self::Break(b) => b.nested_blocks(),
             Self::DocumentAttribute(b) => b.nested_blocks(),
@@ -532,6 +574,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.nested_blocks_mut(),
             Self::RawDelimited(b) => b.nested_blocks_mut(),
             Self::CompoundDelimited(b) => b.nested_blocks_mut(),
+            Self::Table(b) => b.nested_blocks_mut(),
             Self::Preamble(b) => b.nested_blocks_mut(),
             Self::Break(b) => b.nested_blocks_mut(),
             Self::DocumentAttribute(b) => b.nested_blocks_mut(),
@@ -547,6 +590,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.content_mut(),
             Self::RawDelimited(b) => b.content_mut(),
             Self::CompoundDelimited(b) => b.content_mut(),
+            Self::Table(b) => b.content_mut(),
             Self::Preamble(b) => b.content_mut(),
             Self::Break(b) => b.content_mut(),
             Self::DocumentAttribute(b) => b.content_mut(),
@@ -562,6 +606,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.title_source(),
             Self::RawDelimited(b) => b.title_source(),
             Self::CompoundDelimited(b) => b.title_source(),
+            Self::Table(b) => b.title_source(),
             Self::Preamble(b) => b.title_source(),
             Self::Break(b) => b.title_source(),
             Self::DocumentAttribute(b) => b.title_source(),
@@ -577,6 +622,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.title(),
             Self::RawDelimited(b) => b.title(),
             Self::CompoundDelimited(b) => b.title(),
+            Self::Table(b) => b.title(),
             Self::Preamble(b) => b.title(),
             Self::Break(b) => b.title(),
             Self::DocumentAttribute(b) => b.title(),
@@ -592,6 +638,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.anchor(),
             Self::RawDelimited(b) => b.anchor(),
             Self::CompoundDelimited(b) => b.anchor(),
+            Self::Table(b) => b.anchor(),
             Self::Preamble(b) => b.anchor(),
             Self::Break(b) => b.anchor(),
             Self::DocumentAttribute(b) => b.anchor(),
@@ -607,6 +654,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.anchor_reftext(),
             Self::RawDelimited(b) => b.anchor_reftext(),
             Self::CompoundDelimited(b) => b.anchor_reftext(),
+            Self::Table(b) => b.anchor_reftext(),
             Self::Preamble(b) => b.anchor_reftext(),
             Self::Break(b) => b.anchor_reftext(),
             Self::DocumentAttribute(b) => b.anchor_reftext(),
@@ -622,6 +670,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.attrlist(),
             Self::RawDelimited(b) => b.attrlist(),
             Self::CompoundDelimited(b) => b.attrlist(),
+            Self::Table(b) => b.attrlist(),
             Self::Preamble(b) => b.attrlist(),
             Self::Break(b) => b.attrlist(),
             Self::DocumentAttribute(b) => b.attrlist(),
@@ -637,6 +686,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.substitution_group(),
             Self::RawDelimited(b) => b.substitution_group(),
             Self::CompoundDelimited(b) => b.substitution_group(),
+            Self::Table(b) => b.substitution_group(),
             Self::Preamble(b) => b.substitution_group(),
             Self::Break(b) => b.substitution_group(),
             Self::DocumentAttribute(b) => b.substitution_group(),
@@ -654,6 +704,7 @@ impl<'src> HasSpan<'src> for Block<'src> {
             Self::ListItem(b) => b.span(),
             Self::RawDelimited(b) => b.span(),
             Self::CompoundDelimited(b) => b.span(),
+            Self::Table(b) => b.span(),
             Self::Preamble(b) => b.span(),
             Self::Break(b) => b.span(),
             Self::DocumentAttribute(b) => b.span(),

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -95,7 +95,6 @@ impl<'src> std::fmt::Debug for Block<'src> {
                 .finish(),
 
             Block::Table(block) => f.debug_tuple("Block::Table").field(block).finish(),
-
             Block::Preamble(block) => f.debug_tuple("Block::Preamble").field(block).finish(),
             Block::Break(break_) => f.debug_tuple("Block::Break").field(break_).finish(),
 

--- a/parser/src/blocks/mod.rs
+++ b/parser/src/blocks/mod.rs
@@ -64,5 +64,8 @@ pub use section::{SectionBlock, SectionNumber, SectionType};
 mod simple;
 pub use simple::{SimpleBlock, SimpleBlockStyle};
 
+mod table;
+pub use table::{TableBlock, TableCell, TableColumn, TableRow};
+
 #[cfg(test)]
 mod tests;

--- a/parser/src/blocks/mod.rs
+++ b/parser/src/blocks/mod.rs
@@ -66,7 +66,8 @@ pub use simple::{SimpleBlock, SimpleBlockStyle};
 
 mod table;
 pub use table::{
-    HorizontalAlignment, TableBlock, TableCell, TableColumn, TableRow, VerticalAlignment,
+    ColumnStyle, HorizontalAlignment, TableBlock, TableCell, TableCellContent, TableColumn,
+    TableRow, VerticalAlignment,
 };
 
 #[cfg(test)]

--- a/parser/src/blocks/mod.rs
+++ b/parser/src/blocks/mod.rs
@@ -66,8 +66,8 @@ pub use simple::{SimpleBlock, SimpleBlockStyle};
 
 mod table;
 pub use table::{
-    ColumnStyle, Frame, Grid, HorizontalAlignment, TableBlock, TableCell, TableCellContent,
-    TableColumn, TableRow, VerticalAlignment,
+    ColumnStyle, Frame, Grid, HorizontalAlignment, Stripes, TableBlock, TableCell,
+    TableCellContent, TableColumn, TableRow, VerticalAlignment,
 };
 
 #[cfg(test)]

--- a/parser/src/blocks/mod.rs
+++ b/parser/src/blocks/mod.rs
@@ -66,8 +66,8 @@ pub use simple::{SimpleBlock, SimpleBlockStyle};
 
 mod table;
 pub use table::{
-    ColumnStyle, HorizontalAlignment, TableBlock, TableCell, TableCellContent, TableColumn,
-    TableRow, VerticalAlignment,
+    ColumnStyle, Frame, Grid, HorizontalAlignment, TableBlock, TableCell, TableCellContent,
+    TableColumn, TableRow, VerticalAlignment,
 };
 
 #[cfg(test)]

--- a/parser/src/blocks/mod.rs
+++ b/parser/src/blocks/mod.rs
@@ -66,7 +66,7 @@ pub use simple::{SimpleBlock, SimpleBlockStyle};
 
 mod table;
 pub use table::{
-    ColumnStyle, Frame, Grid, HorizontalAlignment, Stripes, TableBlock, TableCell,
+    ColumnStyle, DataFormat, Frame, Grid, HorizontalAlignment, Stripes, TableBlock, TableCell,
     TableCellContent, TableColumn, TableRow, VerticalAlignment,
 };
 

--- a/parser/src/blocks/mod.rs
+++ b/parser/src/blocks/mod.rs
@@ -65,7 +65,9 @@ mod simple;
 pub use simple::{SimpleBlock, SimpleBlockStyle};
 
 mod table;
-pub use table::{TableBlock, TableCell, TableColumn, TableRow};
+pub use table::{
+    HorizontalAlignment, TableBlock, TableCell, TableColumn, TableRow, VerticalAlignment,
+};
 
 #[cfg(test)]
 mod tests;

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -64,6 +64,10 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 /// the border around the table and the [`grid`](Self::grid) attribute controls
 /// the borders between cells. Each falls back to a document-level default
 /// (`table-frame` / `table-grid`) and then to `all`.
+///
+/// Zebra striping is supported via the [`stripes`](Self::stripes) attribute,
+/// which falls back to the `table-stripes` document attribute and then to
+/// `none`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -76,6 +80,7 @@ pub struct TableBlock<'src> {
     caption: Option<String>,
     frame: Frame,
     grid: Grid,
+    stripes: Stripes,
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
@@ -238,14 +243,18 @@ impl<'src> TableBlock<'src> {
             None
         };
 
-        // The `frame` and `grid` attributes control the table's borders. Each
-        // defaults to `all`; the default can be changed for the whole document
-        // with the `table-frame` / `table-grid` attribute, and an explicit
-        // attribute on the table overrides both. The value is resolved here
-        // (while `parser` is borrowed only immutably) and stored on the block so
-        // the accessors need no further document lookup.
-        let frame = resolve_border::<Frame>(metadata, parser, "frame", "table-frame");
-        let grid = resolve_border::<Grid>(metadata, parser, "grid", "table-grid");
+        // The `frame` and `grid` attributes control the table's borders, and the
+        // `stripes` attribute controls zebra striping. The borders each default
+        // to `all` and stripes defaults to `none`; the default can be changed for
+        // the whole document with the `table-frame` / `table-grid` /
+        // `table-stripes` attribute, and an explicit attribute on the table
+        // overrides both. Each value is resolved here (while `parser` is borrowed
+        // only immutably) and stored on the block so the accessors need no further
+        // document lookup.
+        let frame = resolve_table_attribute::<Frame>(metadata, parser, "frame", "table-frame");
+        let grid = resolve_table_attribute::<Grid>(metadata, parser, "grid", "table-grid");
+        let stripes =
+            resolve_table_attribute::<Stripes>(metadata, parser, "stripes", "table-stripes");
 
         // Scan every cell in the table, in document order, then partition into
         // rows by walking the grid: a cell's span (colspan/rowspan) governs how
@@ -394,6 +403,7 @@ impl<'src> TableBlock<'src> {
                     caption,
                     frame,
                     grid,
+                    stripes,
                     anchor: metadata.anchor,
                     anchor_reftext: metadata.anchor_reftext,
                     attrlist: metadata.attrlist.clone(),
@@ -475,6 +485,24 @@ impl<'src> TableBlock<'src> {
     /// absent it defaults to [`Grid::All`].
     pub fn grid(&self) -> Grid {
         self.grid
+    }
+
+    /// Returns the [`Stripes`] that control which rows of this table are shaded
+    /// to create a zebra-striping effect.
+    ///
+    /// The stripes come from the `stripes` attribute on the table, which
+    /// accepts `none`, `even`, `odd`, `all`, or `hover`. When the attribute
+    /// is absent the value is taken from the `table-stripes` document
+    /// attribute, and when that too is absent it defaults to
+    /// [`Stripes::None`].
+    ///
+    /// As a shorthand, a `stripes-<value>` role on the table (e.g.
+    /// `[.stripes-even]`) applies the same CSS class directly without setting
+    /// the `stripes` attribute. That shorthand does not affect this value
+    /// (which remains [`Stripes::None`]); the role is instead reported
+    /// among the table's [roles](crate::attributes::Attrlist::roles).
+    pub fn stripes(&self) -> Stripes {
+        self.stripes
     }
 
     /// Returns the header row of this table, if one was declared.
@@ -785,16 +813,51 @@ pub enum Grid {
     None,
 }
 
-/// A table border value ([`Frame`] or [`Grid`]) that can be parsed from an
-/// attribute value and has a default of `all`.
-trait BorderValue: Copy + Default {
-    /// Parse the value of a `frame` / `grid` attribute (or its document-level
-    /// `table-frame` / `table-grid` counterpart). An unrecognized value yields
-    /// the default.
+/// The zebra striping applied to the rows of a [`TableBlock`].
+///
+/// Striping shades the specified rows with a background color to create a zebra
+/// effect. It is set with the `stripes` attribute on the table (or,
+/// document-wide, the `table-stripes` attribute). The default is
+/// [`None`](Self::None).
+///
+/// Under the covers, a converter applies the CSS class `stripes-<value>` to the
+/// table; the actual shading depends on the stylesheet. As a shorthand, the
+/// same class can be applied directly with a role (e.g. `[.stripes-even]`)
+/// rather than the `stripes` attribute. A role does not set this value (see
+/// [`TableBlock::stripes`]).
+///
+/// An unrecognized value falls back to [`None`](Self::None). (Asciidoctor
+/// instead passes an unrecognized value straight through to a CSS class, which
+/// the stylesheet ignores; this parser models only the five documented values.)
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum Stripes {
+    /// No rows are shaded (the `none` value). This is the default.
+    #[default]
+    None,
+
+    /// Even rows are shaded (the `even` value).
+    Even,
+
+    /// Odd rows are shaded (the `odd` value).
+    Odd,
+
+    /// All rows are shaded (the `all` value).
+    All,
+
+    /// The row under the mouse cursor is shaded (the `hover` value). This has
+    /// an effect only in HTML output.
+    Hover,
+}
+
+/// A table-level attribute value ([`Frame`], [`Grid`], or [`Stripes`]) that can
+/// be parsed from an attribute value and has a default.
+trait TableAttributeValue: Copy + Default {
+    /// Parse the value of the table attribute (or its document-level
+    /// `table-<name>` counterpart). An unrecognized value yields the default.
     fn from_attr_value(value: &str) -> Self;
 }
 
-impl BorderValue for Frame {
+impl TableAttributeValue for Frame {
     fn from_attr_value(value: &str) -> Self {
         match value.trim() {
             // `topbot` is the older synonym for `ends`.
@@ -807,7 +870,7 @@ impl BorderValue for Frame {
     }
 }
 
-impl BorderValue for Grid {
+impl TableAttributeValue for Grid {
     fn from_attr_value(value: &str) -> Self {
         match value.trim() {
             "rows" => Grid::Rows,
@@ -819,12 +882,25 @@ impl BorderValue for Grid {
     }
 }
 
-/// Resolve a table border attribute ([`Frame`] or [`Grid`]).
+impl TableAttributeValue for Stripes {
+    fn from_attr_value(value: &str) -> Self {
+        match value.trim() {
+            "even" => Stripes::Even,
+            "odd" => Stripes::Odd,
+            "all" => Stripes::All,
+            "hover" => Stripes::Hover,
+            // `none` and any unrecognized value.
+            _ => Stripes::None,
+        }
+    }
+}
+
+/// Resolve a table-level attribute ([`Frame`], [`Grid`], or [`Stripes`]).
 ///
 /// An explicit attribute on the table (`attr_name`) wins; otherwise the
 /// document-level default (`doc_attr_name`) is consulted; otherwise the value
-/// defaults to `all`.
-fn resolve_border<B: BorderValue>(
+/// falls back to the type's default.
+fn resolve_table_attribute<B: TableAttributeValue>(
     metadata: &BlockMetadata<'_>,
     parser: &Parser,
     attr_name: &str,

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -33,13 +33,15 @@ use crate::{
 ///
 /// * The CSV, TSV, and DSV data formats (and the `,===` / `:===` shorthand
 ///   delimiters).
-/// * Cell specifiers (spans, duplication, per-cell alignment and style); the
-///   per-cell style operator that overrides a column's style operator is not
-///   yet recognized.
+/// * Cell specifier span (`+`) and duplication (`*`) operators and the per-cell
+///   style operator: these are recognized in a cell specifier (so the cell
+///   separator is still located correctly) but their layout and styling effects
+///   are not yet applied.
 ///
 /// Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, and `s`
 /// operators) are supported, along with proportional width and the horizontal
-/// and vertical alignment operators.
+/// and vertical alignment operators. Per-cell horizontal and vertical alignment
+/// operators are supported and override the column's alignment.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -205,17 +207,18 @@ impl<'src> TableBlock<'src> {
 
         let mut cells = Vec::with_capacity(raw_cells.len());
         for (idx, raw) in raw_cells.into_iter().enumerate() {
-            let style = if idx < header_len {
-                ColumnStyle::Default
-            } else {
-                // `idx % ncols` is in bounds whenever `ncols > 0`; an empty table
-                // (`ncols == 0`) has no columns, so the cell falls back to the
-                // default style.
-                columns
-                    .get(idx % ncols.max(1))
-                    .map_or(ColumnStyle::Default, |column| column.style)
-            };
-            cells.push(TableCell::parse(raw, style, parser, &mut warnings));
+            // `idx % ncols` is in bounds whenever `ncols > 0`; an empty table
+            // (`ncols == 0`) has no columns, so the cell falls back to the
+            // default column (default style and alignment).
+            let column = columns.get(idx % ncols.max(1)).cloned().unwrap_or_default();
+            let is_header = idx < header_len;
+            cells.push(TableCell::parse(
+                raw,
+                &column,
+                is_header,
+                parser,
+                &mut warnings,
+            ));
         }
         let mut cells = cells.into_iter();
 
@@ -532,12 +535,21 @@ impl<'src> TableRow<'src> {
 /// A single cell in a [`TableBlock`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableCell<'src> {
+    h_align: HorizontalAlignment,
+    v_align: VerticalAlignment,
     content: TableCellContent<'src>,
 }
 
 impl<'src> TableCell<'src> {
     /// Build a cell from the raw (untrimmed) span of its content, processing it
-    /// according to the [style](ColumnStyle) of the column the cell belongs to.
+    /// according to the [style](ColumnStyle) of the `column` the cell belongs
+    /// to.
+    ///
+    /// The cell's horizontal and vertical alignment come from the alignment
+    /// operators on its [specifier](RawCell::spec) when present; otherwise they
+    /// are inherited from the column. A header cell (`is_header`) is always
+    /// processed as plain header content, regardless of the column's style
+    /// operator.
     ///
     /// Leading and trailing whitespace is always stripped. For every style but
     /// [`AsciiDoc`](ColumnStyle::AsciiDoc) the cell holds inline
@@ -547,14 +559,28 @@ impl<'src> TableCell<'src> {
     /// [`AsciiDoc`](ColumnStyle::AsciiDoc) cell instead parses its content as a
     /// nested sequence of [blocks](TableCellContent::AsciiDoc).
     fn parse(
-        raw: Span<'src>,
-        style: ColumnStyle,
+        raw: RawCell<'src>,
+        column: &TableColumn,
+        is_header: bool,
         parser: &mut Parser,
         warnings: &mut Vec<Warning<'src>>,
     ) -> Self {
-        let trimmed = trim_surrounding_whitespace(raw);
+        // A cell's own alignment operator overrides the column's alignment; with
+        // no operator, the cell inherits the column's alignment.
+        let h_align = raw.spec.h_align.unwrap_or(column.h_align);
+        let v_align = raw.spec.v_align.unwrap_or(column.v_align);
 
-        if style == ColumnStyle::AsciiDoc {
+        // The header row is always processed as plain header content, so a
+        // column's style operator never affects a header cell.
+        let style = if is_header {
+            ColumnStyle::Default
+        } else {
+            column.style
+        };
+
+        let trimmed = trim_surrounding_whitespace(raw.content);
+
+        let content = if style == ColumnStyle::AsciiDoc {
             // The AsciiDoc style effectively creates a nested, standalone
             // AsciiDoc document in the cell. It inherits the parent document's
             // attributes, but any attribute it defines is scoped to the cell and
@@ -566,29 +592,51 @@ impl<'src> TableCell<'src> {
             let mut maw = parse_blocks_until(trimmed, |_| false, parser);
             parser.attribute_values = saved_attributes;
             warnings.append(&mut maw.warnings);
-            return Self {
-                content: TableCellContent::AsciiDoc(maw.item.item),
+            TableCellContent::AsciiDoc(maw.item.item)
+        } else {
+            let data = trimmed.data();
+
+            let mut content = if data.contains("\\|") {
+                Content::from_filtered(trimmed, data.replace("\\|", "|"))
+            } else {
+                Content::from(trimmed)
             };
-        }
 
-        let data = trimmed.data();
+            let substitutions = if style == ColumnStyle::Literal {
+                SubstitutionGroup::Verbatim
+            } else {
+                SubstitutionGroup::Normal
+            };
+            substitutions.apply(&mut content, parser, None);
 
-        let mut content = if data.contains("\\|") {
-            Content::from_filtered(trimmed, data.replace("\\|", "|"))
-        } else {
-            Content::from(trimmed)
+            TableCellContent::Simple(content)
         };
-
-        let substitutions = if style == ColumnStyle::Literal {
-            SubstitutionGroup::Verbatim
-        } else {
-            SubstitutionGroup::Normal
-        };
-        substitutions.apply(&mut content, parser, None);
 
         Self {
-            content: TableCellContent::Simple(content),
+            h_align,
+            v_align,
+            content,
         }
+    }
+
+    /// Returns the horizontal alignment of this cell's content.
+    ///
+    /// The alignment comes from a horizontal alignment operator (`<`, `>`, or
+    /// `^`) on the cell's specifier, which overrides the column's alignment. A
+    /// cell with no horizontal alignment operator inherits its column's
+    /// [`h_align`](TableColumn::h_align).
+    pub fn h_align(&self) -> HorizontalAlignment {
+        self.h_align
+    }
+
+    /// Returns the vertical alignment of this cell's content.
+    ///
+    /// The alignment comes from a vertical alignment operator (`.<`, `.>`, or
+    /// `.^`) on the cell's specifier, which overrides the column's alignment. A
+    /// cell with no vertical alignment operator inherits its column's
+    /// [`v_align`](TableColumn::v_align).
+    pub fn v_align(&self) -> VerticalAlignment {
+        self.v_align
     }
 
     /// Returns the interpreted content of this cell.
@@ -750,34 +798,84 @@ fn parse_col_spec(spec: &str) -> TableColumn {
     }
 }
 
-/// Scan a region for PSV cell boundaries, returning the raw (untrimmed) span of
-/// each cell's content.
+/// The alignment overrides parsed from a [cell specifier](RawCell::spec).
+///
+/// Each field is `None` when the corresponding alignment operator is absent
+/// from the specifier, in which case the cell inherits that alignment from its
+/// column.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct CellSpec {
+    h_align: Option<HorizontalAlignment>,
+    v_align: Option<VerticalAlignment>,
+}
+
+/// A single PSV cell as located by [`scan_cells`]: the alignment operators from
+/// its specifier together with the raw (untrimmed) span of its content.
+struct RawCell<'src> {
+    spec: CellSpec,
+    content: Span<'src>,
+}
+
+/// Scan a region for PSV cell boundaries, returning the [specifier](CellSpec)
+/// and raw (untrimmed) content span of each cell.
 ///
 /// A cell boundary is a vertical bar (`|`) that appears at the start of a line
-/// or is preceded by whitespace. Content before the first boundary is ignored.
+/// or is preceded by whitespace, optionally with a [cell specifier](CellSpec)
+/// (e.g. `^`, `2+`, `.>`) directly in front of the `|`. The token immediately
+/// preceding a `|` is taken to be a specifier when it parses as one (see
+/// [`parse_cell_spec`]); a token that doesn't parse as a specifier means the
+/// `|` is not a cell boundary. Content before the first boundary is ignored.
 ///
-/// An escaped separator (`\|`) is preceded by a backslash — neither a line
-/// start nor whitespace — so it already fails the boundary test and needs no
-/// special handling here; the backslash is stripped later in
-/// [`TableCell::parse`].
-fn scan_cells(region: Span<'_>) -> Vec<Span<'_>> {
-    let bytes = region.data().as_bytes();
+/// An escaped separator (`\|`) is preceded by a backslash, which is not a valid
+/// specifier, so the `|` already fails the boundary test and needs no special
+/// handling here; the backslash is stripped later in [`TableCell::parse`].
+fn scan_cells(region: Span<'_>) -> Vec<RawCell<'_>> {
+    let data = region.data();
+    let bytes = data.as_bytes();
     let len = bytes.len();
 
-    let mut cells: Vec<Span<'_>> = vec![];
+    let mut cells: Vec<RawCell<'_>> = vec![];
+    // The content start and specifier of the cell currently being accumulated.
     let mut content_start: Option<usize> = None;
+    let mut cur_spec = CellSpec::default();
     let mut i = 0;
 
     while i < len {
-        if bytes.get(i) == Some(&b'|') {
-            let prev = i.checked_sub(1).and_then(|p| bytes.get(p)).copied();
-            let at_line_start = prev.is_none() || prev == Some(b'\n');
-            let after_space = prev == Some(b' ') || prev == Some(b'\t');
+        if bytes.get(i).copied() == Some(b'|') {
+            // Walk back to the start of the token directly preceding this `|`.
+            // The token (a possible cell specifier) runs back to the previous
+            // whitespace, tab, or newline, or to the start of the region; either
+            // way the token is anchored at a line start or after whitespace, as a
+            // cell boundary requires. (When `tok_start == i` the token is empty
+            // and the separator is plain.)
+            let mut tok_start = i;
+            while tok_start > 0
+                && !matches!(
+                    bytes.get(tok_start - 1).copied(),
+                    Some(b' ' | b'\t' | b'\n')
+                )
+            {
+                tok_start -= 1;
+            }
 
-            if at_line_start || after_space {
+            let token = data.get(tok_start..i).unwrap_or_default();
+            let spec = if token.is_empty() {
+                Some(CellSpec::default())
+            } else {
+                parse_cell_spec(token)
+            };
+
+            if let Some(spec) = spec {
                 if let Some(start) = content_start {
-                    cells.push(region.slice(start..i));
+                    // The previous cell's content ends at the start of this
+                    // cell's specifier; the separating whitespace, included in
+                    // the slice, is trimmed later in `TableCell::parse`.
+                    cells.push(RawCell {
+                        spec: cur_spec,
+                        content: region.slice(start..tok_start),
+                    });
                 }
+                cur_spec = spec;
                 content_start = Some(i + 1);
             }
         }
@@ -786,10 +884,103 @@ fn scan_cells(region: Span<'_>) -> Vec<Span<'_>> {
     }
 
     if let Some(start) = content_start {
-        cells.push(region.slice(start..len));
+        cells.push(RawCell {
+            spec: cur_spec,
+            content: region.slice(start..len),
+        });
     }
 
     cells
+}
+
+/// Parse a cell specifier, returning its [alignment overrides](CellSpec), or
+/// `None` if `token` is not a valid cell specifier.
+///
+/// A cell specifier is positional and every part is optional, but the whole
+/// token must be consumed for it to be valid:
+///
+/// ```text
+/// <factor><span or duplication operator><horizontal><vertical><style>
+/// ```
+///
+/// * The factor and span/duplication operator are an optional count (e.g. `2`,
+///   `2.3`, `.3`) that, when present, must be followed by `+` (span) or `*`
+///   (duplication). These operators are recognized so the cell separator is
+///   located correctly, but their layout effect is not yet applied.
+/// * The horizontal alignment operator is `<`, `>`, or `^`.
+/// * The vertical alignment operator is a dot followed by `<`, `>`, or `^`.
+/// * The style operator is a single lowercase letter. It is recognized (so the
+///   separator is located) but its styling effect is not yet applied.
+fn parse_cell_spec(token: &str) -> Option<CellSpec> {
+    let b = token.as_bytes();
+    let mut i = 0;
+
+    // Optional span/duplication: an optional count followed by `+` or `*`. The
+    // count is committed only when the operator that must follow it is present;
+    // otherwise leading digits remain and the token fails below.
+    let mut j = i;
+    while matches!(b.get(j).copied(), Some(c) if c.is_ascii_digit()) {
+        j += 1;
+    }
+    if b.get(j).copied() == Some(b'.') {
+        j += 1;
+        while matches!(b.get(j).copied(), Some(c) if c.is_ascii_digit()) {
+            j += 1;
+        }
+    }
+    if matches!(b.get(j).copied(), Some(b'+' | b'*')) {
+        i = j + 1;
+    }
+
+    // Optional horizontal alignment operator.
+    let mut h_align = None;
+    match b.get(i).copied() {
+        Some(b'<') => {
+            h_align = Some(HorizontalAlignment::Left);
+            i += 1;
+        }
+        Some(b'>') => {
+            h_align = Some(HorizontalAlignment::Right);
+            i += 1;
+        }
+        Some(b'^') => {
+            h_align = Some(HorizontalAlignment::Center);
+            i += 1;
+        }
+        _ => {}
+    }
+
+    // Optional vertical alignment operator, introduced by a dot.
+    let mut v_align = None;
+    if b.get(i).copied() == Some(b'.') {
+        match b.get(i + 1).copied() {
+            Some(b'<') => {
+                v_align = Some(VerticalAlignment::Top);
+                i += 2;
+            }
+            Some(b'>') => {
+                v_align = Some(VerticalAlignment::Bottom);
+                i += 2;
+            }
+            Some(b'^') => {
+                v_align = Some(VerticalAlignment::Middle);
+                i += 2;
+            }
+            _ => {}
+        }
+    }
+
+    // Optional style operator: a single lowercase letter in the last position.
+    if matches!(b.get(i).copied(), Some(c) if c.is_ascii_lowercase()) {
+        i += 1;
+    }
+
+    // The token is a cell specifier only if it was consumed in its entirety.
+    if i == b.len() {
+        Some(CellSpec { h_align, v_align })
+    } else {
+        None
+    }
 }
 
 /// Return the subspan of `s` with surrounding whitespace (including newlines)

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -12,6 +12,16 @@ use crate::{
     warnings::{MatchAndWarnings, Warning, WarningType},
 };
 
+/// Attributes that an AsciiDoc table cell may modify even when they are set in
+/// the parent document.
+///
+/// An AsciiDoc cell inherits the parent's attributes and cannot modify them,
+/// but the AsciiDoc specification carves out a handful of exceptions:
+/// `doctype`, `toc`, `notitle` (and its complement, `showtitle`), and
+/// `compat-mode`.
+const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
+    &["doctype", "toc", "notitle", "showtitle", "compat-mode"];
+
 /// A table is a delimited block that arranges content into a grid of rows and
 /// columns.
 ///
@@ -33,15 +43,16 @@ use crate::{
 ///
 /// * The CSV, TSV, and DSV data formats (and the `,===` / `:===` shorthand
 ///   delimiters).
-/// * Cell specifier span (`+`) and duplication (`*`) operators and the per-cell
-///   style operator: these are recognized in a cell specifier (so the cell
-///   separator is still located correctly) but their layout and styling effects
-///   are not yet applied.
+/// * Cell specifier span (`+`) and duplication (`*`) operators: these are
+///   recognized in a cell specifier (so the cell separator is still located
+///   correctly) but their layout effect is not yet applied.
 ///
 /// Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, and `s`
 /// operators) are supported, along with proportional width and the horizontal
 /// and vertical alignment operators. Per-cell horizontal and vertical alignment
-/// operators are supported and override the column's alignment.
+/// operators are supported and override the column's alignment, and a per-cell
+/// style operator (in the last position of the cell specifier) is supported and
+/// overrides the column's style.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -537,6 +548,7 @@ impl<'src> TableRow<'src> {
 pub struct TableCell<'src> {
     h_align: HorizontalAlignment,
     v_align: VerticalAlignment,
+    style: ColumnStyle,
     content: TableCellContent<'src>,
 }
 
@@ -547,9 +559,11 @@ impl<'src> TableCell<'src> {
     ///
     /// The cell's horizontal and vertical alignment come from the alignment
     /// operators on its [specifier](RawCell::spec) when present; otherwise they
-    /// are inherited from the column. A header cell (`is_header`) is always
-    /// processed as plain header content, regardless of the column's style
-    /// operator.
+    /// are inherited from the column. Likewise, a style operator on the cell's
+    /// specifier overrides the column's [style](ColumnStyle); with no cell
+    /// style operator, the cell is processed with the column's style. A
+    /// header cell (`is_header`) is always processed as plain header
+    /// content, regardless of any style operator on the column or the cell.
     ///
     /// Leading and trailing whitespace is always stripped. For every style but
     /// [`AsciiDoc`](ColumnStyle::AsciiDoc) the cell holds inline
@@ -570,12 +584,14 @@ impl<'src> TableCell<'src> {
         let h_align = raw.spec.h_align.unwrap_or(column.h_align);
         let v_align = raw.spec.v_align.unwrap_or(column.v_align);
 
-        // The header row is always processed as plain header content, so a
-        // column's style operator never affects a header cell.
+        // A cell's own style operator overrides the column's style; with no
+        // operator, the cell is processed with the column's style. The header
+        // row is always processed as plain header content, so neither a column
+        // nor a cell style operator ever affects a header cell.
         let style = if is_header {
             ColumnStyle::Default
         } else {
-            column.style
+            raw.spec.style.unwrap_or(column.style)
         };
 
         let trimmed = trim_surrounding_whitespace(raw.content);
@@ -589,7 +605,28 @@ impl<'src> TableCell<'src> {
             // (matching Asciidoctor, where a `:foo:` set inside a cell is not
             // visible after the table).
             let saved_attributes = parser.attribute_values.clone();
+
+            // An attribute that is set in the parent document cannot be modified
+            // inside the cell. Lock every inherited attribute that currently
+            // holds a value for the duration of the cell (other than the handful
+            // of exceptions the spec carves out), so a body assignment to one of
+            // them is ignored. An attribute that is unset in the parent is not
+            // locked: the cell may assign it (matching Asciidoctor, which here
+            // diverges from the spec's "set or explicitly unset" wording). The
+            // lock set is saved and restored so it applies only within the cell
+            // and nests correctly.
+            let saved_locks = parser.locked_attribute_names.clone();
+            for (name, value) in saved_attributes.iter() {
+                if !matches!(value.value, InterpretedValue::Unset)
+                    && !ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES.contains(&name.as_str())
+                {
+                    parser.locked_attribute_names.insert(name.clone());
+                }
+            }
+
             let mut maw = parse_blocks_until(trimmed, |_| false, parser);
+
+            parser.locked_attribute_names = saved_locks;
             parser.attribute_values = saved_attributes;
             warnings.append(&mut maw.warnings);
             TableCellContent::AsciiDoc(maw.item.item)
@@ -615,6 +652,7 @@ impl<'src> TableCell<'src> {
         Self {
             h_align,
             v_align,
+            style,
             content,
         }
     }
@@ -637,6 +675,18 @@ impl<'src> TableCell<'src> {
     /// [`v_align`](TableColumn::v_align).
     pub fn v_align(&self) -> VerticalAlignment {
         self.v_align
+    }
+
+    /// Returns the [style](ColumnStyle) applied to this cell's content.
+    ///
+    /// The style comes from a style operator in the last position of the cell's
+    /// specifier (`a`, `d`, `e`, `h`, `l`, `m`, or `s`), which overrides the
+    /// column's style. A cell with no style operator inherits its column's
+    /// [`style`](TableColumn::style). A header cell is always
+    /// [`Default`](ColumnStyle::Default), because the header row ignores style
+    /// operators on both column and cell specifiers.
+    pub fn style(&self) -> ColumnStyle {
+        self.style
     }
 
     /// Returns the interpreted content of this cell.
@@ -798,15 +848,17 @@ fn parse_col_spec(spec: &str) -> TableColumn {
     }
 }
 
-/// The alignment overrides parsed from a [cell specifier](RawCell::spec).
+/// The alignment and style overrides parsed from a
+/// [cell specifier](RawCell::spec).
 ///
-/// Each field is `None` when the corresponding alignment operator is absent
-/// from the specifier, in which case the cell inherits that alignment from its
-/// column.
+/// Each field is `None` when the corresponding operator is absent from the
+/// specifier, in which case the cell inherits that alignment (or style) from
+/// its column.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 struct CellSpec {
     h_align: Option<HorizontalAlignment>,
     v_align: Option<VerticalAlignment>,
+    style: Option<ColumnStyle>,
 }
 
 /// A single PSV cell as located by [`scan_cells`]: the alignment operators from
@@ -909,8 +961,12 @@ fn scan_cells(region: Span<'_>) -> Vec<RawCell<'_>> {
 ///   located correctly, but their layout effect is not yet applied.
 /// * The horizontal alignment operator is `<`, `>`, or `^`.
 /// * The vertical alignment operator is a dot followed by `<`, `>`, or `^`.
-/// * The style operator is a single lowercase letter. It is recognized (so the
-///   separator is located) but its styling effect is not yet applied.
+/// * The style operator is a single lowercase letter in the last position. A
+///   recognized operator (`a`, `d`, `e`, `h`, `l`, `m`, or `s`) overrides the
+///   column's style on this cell. Any other single lowercase letter still
+///   locates the separator but leaves the style at `None`, so the cell inherits
+///   its column's style (matching Asciidoctor, which ignores an unrecognized
+///   style operator).
 fn parse_cell_spec(token: &str) -> Option<CellSpec> {
     let b = token.as_bytes();
     let mut i = 0;
@@ -971,13 +1027,33 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
     }
 
     // Optional style operator: a single lowercase letter in the last position.
-    if matches!(b.get(i).copied(), Some(c) if c.is_ascii_lowercase()) {
+    // A recognized letter overrides the column's style; any other lowercase
+    // letter is consumed (so the separator is still located) but leaves the
+    // style at `None`, so the cell inherits its column's style.
+    let mut style = None;
+    if let Some(c) = b.get(i).copied()
+        && c.is_ascii_lowercase()
+    {
+        style = match c {
+            b'a' => Some(ColumnStyle::AsciiDoc),
+            b'd' => Some(ColumnStyle::Default),
+            b'e' => Some(ColumnStyle::Emphasis),
+            b'h' => Some(ColumnStyle::Header),
+            b'l' => Some(ColumnStyle::Literal),
+            b'm' => Some(ColumnStyle::Monospace),
+            b's' => Some(ColumnStyle::Strong),
+            _ => None,
+        };
         i += 1;
     }
 
     // The token is a cell specifier only if it was consumed in its entirety.
     if i == b.len() {
-        Some(CellSpec { h_align, v_align })
+        Some(CellSpec {
+            h_align,
+            v_align,
+            style,
+        })
     } else {
         None
     }

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -3,6 +3,7 @@ use crate::{
     attributes::Attrlist,
     blocks::{ContentModel, IsBlock, metadata::BlockMetadata},
     content::{Content, SubstitutionGroup},
+    document::InterpretedValue,
     parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning},
     span::MatchedItem,
     strings::CowStr,
@@ -44,6 +45,7 @@ pub struct TableBlock<'src> {
     source: Span<'src>,
     title_source: Option<Span<'src>>,
     title: Option<String>,
+    caption: Option<String>,
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
@@ -136,6 +138,26 @@ impl<'src> TableBlock<'src> {
             !line1.after.is_empty() && line1.after.take_line().item.data().trim().is_empty();
         let has_header = opts_header || (!line1_blank && line2_blank);
 
+        // A titled table is given an automatic caption (e.g. "Table 1. ") that
+        // a processor prepends to the title. The label comes from the
+        // `table-caption` attribute (which defaults to "Table"); each captioned
+        // table consumes the next value of a document-wide table counter. When
+        // `table-caption` is unset, no caption (and no number) is assigned.
+        //
+        // Computed before the cell iterator below borrows `parser` immutably, so
+        // that the mutable counter update does not conflict with that borrow.
+        let caption = if metadata.title.is_some() {
+            match parser.attribute_value("table-caption") {
+                InterpretedValue::Value(label) if !label.is_empty() => {
+                    let number = parser.assign_table_number();
+                    Some(format!("{label} {number}. "))
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
+
         // Scan every cell in the table, in document order, then partition into
         // rows of `ncols` cells each.
         let mut cells = scan_cells(inside)
@@ -188,6 +210,7 @@ impl<'src> TableBlock<'src> {
                     source,
                     title_source: metadata.title_source,
                     title: metadata.title.clone(),
+                    caption,
                     anchor: metadata.anchor,
                     anchor_reftext: metadata.anchor_reftext,
                     attrlist: metadata.attrlist.clone(),
@@ -196,6 +219,16 @@ impl<'src> TableBlock<'src> {
             }),
             warnings,
         })
+    }
+
+    /// Returns the automatic caption assigned to this table, if any.
+    ///
+    /// A titled table is captioned with a label and number (e.g. `"Table 1. "`)
+    /// that a processor prepends to the [`title`](IsBlock::title). The caption
+    /// is absent when the table has no title or when the `table-caption`
+    /// attribute has been unset.
+    pub fn caption(&self) -> Option<&str> {
+        self.caption.as_deref()
     }
 
     /// Returns the columns of this table.

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -144,11 +144,13 @@ impl<'src> TableBlock<'src> {
         // An explicit `caption` attribute on the table sets the label verbatim
         // (including any trailing whitespace) and is used as-is, with no
         // automatically incremented number; it applies even when
-        // `table-caption` has been unset. Otherwise the label comes from the
-        // `table-caption` attribute (which defaults to "Table"), and each such
-        // captioned table consumes the next value of a document-wide table
-        // counter. When `table-caption` is unset and no explicit `caption` is
-        // given, no caption (and no number) is assigned.
+        // `table-caption` has been unset. An explicitly empty `caption` (e.g.
+        // `[caption=]`) removes the label entirely, so the title renders with no
+        // prefix. Otherwise the label comes from the `table-caption` attribute
+        // (which defaults to "Table"), and each such captioned table consumes
+        // the next value of a document-wide table counter. When `table-caption`
+        // is unset and no explicit `caption` is given, no caption (and no
+        // number) is assigned.
         //
         // Computed before the cell iterator below borrows `parser` immutably, so
         // that the mutable counter update does not conflict with that borrow.
@@ -158,6 +160,7 @@ impl<'src> TableBlock<'src> {
                 .as_ref()
                 .and_then(|a| a.named_attribute("caption"))
             {
+                Some(attr) if attr.value().is_empty() => None,
                 Some(attr) => Some(attr.value().to_string()),
                 None => match parser.attribute_value("table-caption") {
                     InterpretedValue::Value(label) if !label.is_empty() => {
@@ -240,9 +243,10 @@ impl<'src> TableBlock<'src> {
     /// the [`title`](IsBlock::title). By default the label combines the
     /// `table-caption` attribute and an automatically incremented number (e.g.
     /// `"Table 1. "`). An explicit `caption` attribute on the table overrides
-    /// this with a verbatim label and no number. The caption is absent when the
-    /// table has no title, or when `table-caption` has been unset and no
-    /// explicit `caption` is given.
+    /// this with a verbatim label and no number; an explicitly empty `caption`
+    /// (e.g. `[caption=]`) removes the label entirely. The caption is absent
+    /// when the table has no title, when `table-caption` has been unset and no
+    /// explicit `caption` is given, or when an empty `caption` was supplied.
     pub fn caption(&self) -> Option<&str> {
         self.caption.as_deref()
     }

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1,3 +1,7 @@
+use std::sync::Arc;
+
+use self_cell::self_cell;
+
 use crate::{
     HasSpan, Parser, Span,
     attributes::Attrlist,
@@ -6,7 +10,10 @@ use crate::{
     },
     content::{Content, SubstitutionGroup},
     document::InterpretedValue,
-    parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning},
+    parser::{
+        InlineSubstitutionRenderer, ModificationContext, ReferenceResolver, ReferenceWarning,
+        preprocessor::preprocess,
+    },
     span::MatchedItem,
     strings::CowStr,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -217,7 +224,22 @@ impl<'src> TableBlock<'src> {
         let line1_blank = line1.item.data().trim().is_empty();
         let line2_blank =
             !line1.after.is_empty() && line1.after.take_line().item.data().trim().is_empty();
-        let has_header = opts_header || (!opts_noheader && !line1_blank && line2_blank);
+
+        // An implicit header additionally requires that the first row be complete
+        // on the first line. If the first cell spans multiple lines — for PSV,
+        // the first non-blank line after the blank gap continues the cell instead
+        // of starting a new one; for CSV/TSV, the first line opens a quoted value
+        // that is not closed on that line — there is no implicit header (matching
+        // Asciidoctor, which cancels the implicit header in these cases).
+        let first_row_complete = match data_format {
+            DataFormat::Psv => first_nonblank_line(line1.after)
+                .is_none_or(|line| psv_line_starts_cell(line.data(), separator.as_str())),
+            DataFormat::Csv | DataFormat::Tsv => !line_has_unclosed_quote(line1.item.data()),
+            DataFormat::Dsv => true,
+        };
+
+        let has_header =
+            opts_header || (!opts_noheader && !line1_blank && line2_blank && first_row_complete);
 
         // A titled table is given a caption (e.g. "Table 1. ") that a processor
         // prepends to the title.
@@ -1041,6 +1063,7 @@ fn build_psv_table<'src>(
     // single-column slots (one per clone).
     let first_line_cells: usize =
         scan_cells(inside.discard_empty_lines().take_line().item, separator)
+            .0
             .iter()
             .map(|c| c.spec.colspan.max(1) * c.spec.repeat.min(MAX_DUPLICATION_FACTOR))
             .sum();
@@ -1053,7 +1076,14 @@ fn build_psv_table<'src>(
 
     let columns = finalize_columns(cols_attr, ncols, autowidth);
 
-    let raw_cells = expand_duplicates(scan_cells(inside, separator));
+    let (raw_cells, recovered_first_cell) = scan_cells(inside, separator);
+    if let Some(source) = recovered_first_cell {
+        warnings.push(Warning {
+            source,
+            warning: WarningType::TableMissingLeadingSeparator,
+        });
+    }
+    let raw_cells = expand_duplicates(raw_cells);
 
     // A table can never have more rows than it has cells, so a row span is
     // clamped to the cell count for the `active_rowspans` bookkeeping below: a
@@ -1116,10 +1146,15 @@ fn build_psv_table<'src>(
             }
         }
 
-        // A trailing incomplete row (one that never reached `ncols`) is still
-        // emitted, matching the existing handling of short final rows.
-        if !current_row.is_empty() {
-            raw_rows.push(current_row);
+        // If the table ends mid-row, the cells accumulated since the last
+        // complete row never filled `ncols`. Matching Asciidoctor's
+        // `close_table`, that incomplete row is dropped and an error is logged
+        // against its last cell.
+        if let Some(last) = current_row.last() {
+            warnings.push(Warning {
+                source: last.content,
+                warning: WarningType::TableDroppingIncompleteRowAtEndOfTable,
+            });
         }
     }
 
@@ -1176,7 +1211,7 @@ fn build_data_table<'src>(
     let (fields, first_row_len) = if data_format == DataFormat::Dsv {
         parse_dsv_fields(inside, separator)
     } else {
-        parse_csv_fields(inside, separator)
+        parse_csv_fields(inside, separator, warnings)
     };
 
     let ncols = if cols_attr.is_empty() {
@@ -1238,7 +1273,11 @@ struct DataField<'src> {
 /// value. As a result a value whose opening quote is never properly closed (or
 /// that has trailing characters after its closing quote) keeps its quotes and
 /// absorbs the following separators, rather than being treated as enclosed.
-fn parse_csv_fields<'src>(region: Span<'src>, separator: &str) -> (Vec<DataField<'src>>, usize) {
+fn parse_csv_fields<'src>(
+    region: Span<'src>,
+    separator: &str,
+    warnings: &mut Vec<Warning<'src>>,
+) -> (Vec<DataField<'src>>, usize) {
     let data = region.data();
     let n = data.len();
     let sep_len = separator.len().max(1);
@@ -1279,7 +1318,7 @@ fn parse_csv_fields<'src>(region: Span<'src>, separator: &str) -> (Vec<DataField
         // blank cell that follows a separator on a populated line is kept.
         let blank_skip = (at_nl || at_eof) && fields_in_row == 0 && raw.trim().is_empty();
         if !blank_skip {
-            fields.push(make_csv_field(region, cell_start, i));
+            fields.push(make_csv_field(region, cell_start, i, warnings));
             fields_in_row += 1;
             if !first_row_done {
                 first_row_len = fields_in_row;
@@ -1312,37 +1351,42 @@ fn parse_csv_fields<'src>(region: Span<'src>, separator: &str) -> (Vec<DataField
 /// applying Asciidoctor's `close_cell` value processing.
 ///
 /// The value is stripped of surrounding whitespace; then, if it is enclosed in
-/// double quotes, the quotes are removed and the inner value is stripped again;
-/// finally any run of consecutive double quotes is collapsed to one (so an
-/// escaped `""` becomes a single `"`). A value that is not enclosed (no leading
-/// quote, an unclosed quote, or trailing characters after the closing quote)
-/// keeps its quotes and is only collapsed.
-fn make_csv_field<'src>(region: Span<'src>, start: usize, end: usize) -> DataField<'src> {
+/// double quotes, the quotes are removed and the inner value is stripped again,
+/// so the field's [content](DataField::content) span points at the actual value
+/// (this matters for an AsciiDoc cell, which parses that span). Finally any run
+/// of consecutive double quotes is collapsed to one (so an escaped `""` becomes
+/// a single `"`). A value that is not enclosed (no leading quote, or trailing
+/// characters after the closing quote) keeps its quotes and is only collapsed.
+///
+/// A lone double quote is an unclosed quoted value: it logs an error and the
+/// cell is set to empty (matching Asciidoctor).
+fn make_csv_field<'src>(
+    region: Span<'src>,
+    start: usize,
+    end: usize,
+    warnings: &mut Vec<Warning<'src>>,
+) -> DataField<'src> {
     let trimmed = trim_surrounding_whitespace(region.slice(start..end));
-    let value = csv_cell_value(trimmed.data());
-    let replacement = (value != trimmed.data()).then_some(value);
-    DataField {
-        content: trimmed,
-        replacement,
-    }
-}
+    let data = trimmed.data();
 
-/// Apply Asciidoctor's CSV value processing to an already-stripped cell value:
-/// unquote an enclosed value and collapse escaped double quotes (`""` -> `"`).
-fn csv_cell_value(text: &str) -> String {
-    if text.is_empty() || !text.contains('"') {
-        return text.to_string();
-    }
-
-    // An enclosed value (leading and trailing quote) has its quotes removed and
-    // is stripped again; a lone `"` becomes empty. Anything else keeps its text.
-    if text.starts_with('"') && text.ends_with('"') {
-        match text.get(1..text.len() - 1) {
-            Some(inner) => squeeze_quotes(inner.trim()),
-            None => String::new(),
-        }
+    let content = if data == "\"" {
+        warnings.push(Warning {
+            source: trimmed,
+            warning: WarningType::TableCsvDataHasUnclosedQuote,
+        });
+        trimmed.slice(0..0)
+    } else if data.len() >= 2 && data.starts_with('"') && data.ends_with('"') {
+        trim_surrounding_whitespace(trimmed.slice(1..data.len() - 1))
     } else {
-        squeeze_quotes(text)
+        trimmed
+    };
+
+    let value = squeeze_quotes(content.data());
+    let replacement = (value != content.data()).then_some(value);
+
+    DataField {
+        content,
+        replacement,
     }
 }
 
@@ -1544,28 +1588,68 @@ fn process_content<'src>(
         // cell may assign it (matching Asciidoctor, which here diverges from the
         // spec's "set or explicitly unset" wording). The lock set is saved and
         // restored so it applies only within the cell and nests correctly.
+        // An attribute set in the parent is locked, as is one hard set or unset
+        // through the API (its modification context is `ApiOnly`) even though it
+        // is unset — matching Asciidoctor, where an API-controlled attribute can
+        // never be overridden in a cell. An attribute merely unset in the parent
+        // document is not locked, so the cell may assign it.
         let saved_locks = parser.locked_attribute_names.clone();
         for (name, value) in saved_attributes.iter() {
-            if !matches!(value.value, InterpretedValue::Unset)
+            let api_locked = value.modification_context == ModificationContext::ApiOnly;
+            if (!matches!(value.value, InterpretedValue::Unset) || api_locked)
                 && !ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES.contains(&name.as_str())
             {
                 parser.locked_attribute_names.insert(name.clone());
             }
         }
 
-        // Mark that we are inside an AsciiDoc cell (a nested document) for the
-        // duration of the cell, so a table found within defaults its cell
-        // separator to `!` rather than `|` (matching Asciidoctor's
-        // `Document#nested?`). The depth is restored afterward so the marker is
-        // scoped to the cell and nests correctly.
-        parser.nested_document_depth += 1;
-        let mut maw = parse_blocks_until(trimmed, |_| false, parser);
-        parser.nested_document_depth -= 1;
+        // The modifiable attributes may always be changed inside a cell, even
+        // when the parent or the API set them with a restrictive modification
+        // context. Relax their context for the duration of the cell so a body
+        // assignment is honored; the snapshot restore reverts it afterward.
+        for name in ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES {
+            if let Some(attr) = parser.attribute_values.get_mut(*name) {
+                attr.modification_context = ModificationContext::Anywhere;
+            }
+        }
+
+        // A cell does not inherit the parent's doctype; it resets to the default
+        // (`article`). The cell body may still set its own doctype, and the
+        // derived `backend-html5-doctype-*` attribute is refreshed to match.
+        parser.force_doctype("article");
+
+        // A cell whose content holds a preprocessor directive (an `include::`)
+        // is parsed from an owned, expanded source the cell carries; every other
+        // cell is parsed in place from the parent document's source, which keeps
+        // its spans (and line numbers) and avoids a copy.
+        let cell = if content_has_directive(trimmed.data()) {
+            let (expanded, _source_map) = preprocess(trimmed.data(), parser);
+            let owned = OwnedCell::new(expanded, |source| {
+                // Warnings from the owned parse borrow the owned source and so
+                // cannot escape it; the include path is rare and currently
+                // warning-free, so they are dropped here.
+                let mut owned_warnings: Vec<Warning<'_>> = vec![];
+                let (title, inline, blocks) =
+                    parse_asciidoc_cell_body(Span::new(source), parser, &mut owned_warnings);
+                OwnedCellInner {
+                    title,
+                    inline,
+                    blocks,
+                }
+            });
+            AsciiDocCell::Owned(Arc::new(owned))
+        } else {
+            let (title, inline, blocks) = parse_asciidoc_cell_body(trimmed, parser, warnings);
+            AsciiDocCell::Borrowed(BorrowedCell {
+                title,
+                inline,
+                blocks,
+            })
+        };
 
         parser.locked_attribute_names = saved_locks;
         parser.attribute_values = saved_attributes;
-        warnings.append(&mut maw.warnings);
-        TableCellContent::AsciiDoc(maw.item.item)
+        TableCellContent::AsciiDoc(cell)
     } else {
         let mut content = match replacement {
             Some(replacement) => Content::from_filtered(trimmed, replacement),
@@ -1581,6 +1665,63 @@ fn process_content<'src>(
 
         TableCellContent::Simple(content)
     }
+}
+
+/// Parses the body of an AsciiDoc table cell — a nested, standalone AsciiDoc
+/// document — returning its (shown) title, whether its doctype is `inline`, and
+/// its blocks.
+///
+/// A leading level-0 title line (`= Title`) is the nested document's title
+/// rather than a section, so it is split off and rendered here (a level-0
+/// heading is otherwise rejected in block parsing). The render-time decisions
+/// (`inline`, and whether the title is shown) depend on the cell's now-mutated
+/// attribute state, so they are resolved before the caller restores the
+/// parent's attribute snapshot.
+fn parse_asciidoc_cell_body<'src>(
+    content: Span<'src>,
+    parser: &mut Parser,
+    warnings: &mut Vec<Warning<'src>>,
+) -> (Option<String>, bool, Vec<Block<'src>>) {
+    let first_line = content.take_line();
+    let (title_source, body) = if first_line.item.data().starts_with("= ") {
+        (
+            Some(first_line.item.discard(2).discard_whitespace()),
+            first_line.after,
+        )
+    } else {
+        (None, content)
+    };
+
+    // Mark that we are inside an AsciiDoc cell (a nested document) for the
+    // duration of the parse, so a table found within defaults its cell separator
+    // to `!` rather than `|` (matching Asciidoctor's `Document#nested?`).
+    parser.nested_document_depth += 1;
+    let mut maw = parse_blocks_until(body, |_| false, parser);
+    parser.nested_document_depth -= 1;
+    warnings.append(&mut maw.warnings);
+
+    let inline = matches!(
+        parser.attribute_value("doctype"),
+        InterpretedValue::Value(ref v) if v == "inline"
+    );
+    let title = if parser.resolve_show_title(true) {
+        title_source.map(|span| {
+            let mut content = Content::from(span);
+            SubstitutionGroup::Header.apply(&mut content, parser, None);
+            content.rendered().to_string()
+        })
+    } else {
+        None
+    };
+
+    (title, inline, maw.item.item)
+}
+
+/// Returns `true` when the cell content holds an `include::` preprocessor
+/// directive at the start of a line, which must be expanded before the cell is
+/// parsed.
+fn content_has_directive(content: &str) -> bool {
+    content.starts_with("include::") || content.contains("\ninclude::")
 }
 
 /// A row of cells in a [`TableBlock`].
@@ -1605,6 +1746,7 @@ pub struct TableCell<'src> {
     colspan: usize,
     rowspan: usize,
     content: TableCellContent<'src>,
+    source: Span<'src>,
 }
 
 impl<'src> TableCell<'src> {
@@ -1651,7 +1793,7 @@ impl<'src> TableCell<'src> {
             raw.spec.style.unwrap_or(column.style)
         };
 
-        let trimmed = trim_surrounding_whitespace(raw.content);
+        let trimmed = trim_cell_content(raw.content, style);
 
         // An escaped cell separator (a backslash in front of the table's
         // separator, e.g. `\|` or `\!`) is unescaped to the bare separator. Only
@@ -1675,6 +1817,10 @@ impl<'src> TableCell<'src> {
             colspan: raw.spec.colspan.max(1),
             rowspan: raw.spec.rowspan.max(1),
             content,
+            // The cell's source begins at its content, immediately after the
+            // separator (before any trimming), so the cell's reported line is
+            // the separator's line.
+            source: raw.content,
         }
     }
 
@@ -1701,6 +1847,7 @@ impl<'src> TableCell<'src> {
             column.style
         };
 
+        let source = field.content;
         let content = process_content(field.content, field.replacement, style, parser, warnings);
 
         Self {
@@ -1710,6 +1857,7 @@ impl<'src> TableCell<'src> {
             colspan: 1,
             rowspan: 1,
             content,
+            source,
         }
     }
 
@@ -1781,12 +1929,19 @@ impl<'src> TableCell<'src> {
             TableCellContent::Simple(content) => {
                 content.resolve_references(resolver, renderer, warnings);
             }
-            TableCellContent::AsciiDoc(blocks) => {
-                for block in blocks.iter_mut() {
-                    block.resolve_references(resolver, renderer, warnings);
-                }
+            TableCellContent::AsciiDoc(cell) => {
+                cell.resolve_references(resolver, renderer, warnings);
             }
         }
+    }
+}
+
+impl<'src> HasSpan<'src> for TableCell<'src> {
+    /// Returns the cell's source span, which begins at the cell's content
+    /// immediately after its separator. Its [line](Span::line) is therefore the
+    /// line on which the cell starts.
+    fn span(&self) -> Span<'src> {
+        self.source
     }
 }
 
@@ -1805,26 +1960,168 @@ pub enum TableCellContent<'src> {
 
     /// Block content: the cell's text parsed as a nested, standalone AsciiDoc
     /// document. Produced by the [`AsciiDoc`](ColumnStyle::AsciiDoc) style.
-    AsciiDoc(Vec<Block<'src>>),
+    AsciiDoc(AsciiDocCell<'src>),
 }
 
-/// Parse the value of the `cols` attribute into a list of columns.
+/// The content of an [`AsciiDoc`](TableCellContent::AsciiDoc) table cell: a
+/// nested, standalone AsciiDoc document.
 ///
-/// The value is a comma-separated list of column specifiers. A specifier may be
-/// preceded by a multiplier (`<n>*`) that repeats the column `n` times. The
-/// alignment operators and proportional width of a specifier are interpreted;
-/// the style operator is not yet.
-fn parse_cols(value: &str) -> Vec<TableColumn> {
-    let mut columns: Vec<TableColumn> = vec![];
+/// Because the cell behaves like its own document, a few render-time decisions
+/// depend on attribute state that is scoped to the cell and gone by the time
+/// the document is rendered. They are therefore resolved while the cell is
+/// parsed and captured here: whether the cell's nested document title is shown
+/// (and its rendered text), and whether the cell's `doctype` is `inline` (in
+/// which case a lone paragraph renders without the usual block wrapper).
+///
+/// A cell whose content has no preprocessor directives is parsed in place from
+/// the parent document's source ([`Borrowed`](Self::Borrowed)). A cell that
+/// expands an `include::` directive owns its preprocessed source
+/// ([`Owned`](Self::Owned)); the owned store is shared behind an [`Arc`] so the
+/// cell stays cheaply cloneable.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AsciiDocCell<'src> {
+    /// Parsed in place from the parent document's source.
+    Borrowed(BorrowedCell<'src>),
 
-    for part in value.split(',') {
-        let part = part.trim();
-        if part.is_empty() {
-            continue;
+    /// Parsed from an owned, include-expanded source the cell carries.
+    Owned(Arc<OwnedCell>),
+}
+
+impl<'src> AsciiDocCell<'src> {
+    /// Returns the cell's nested-document title, rendered to its display text.
+    ///
+    /// This is `Some` only when the cell began with a level-0 title line
+    /// (`= Title`) *and* the cell's effective `showtitle`/`notitle` state means
+    /// that title is shown; otherwise it is `None`.
+    pub fn title(&self) -> Option<&str> {
+        match self {
+            Self::Borrowed(cell) => cell.title.as_deref(),
+            Self::Owned(cell) => cell.borrow_dependent().title.as_deref(),
         }
+    }
 
-        if let Some((count, spec)) = part.split_once('*') {
-            let repeat = count.trim().parse::<usize>().unwrap_or(1).max(1);
+    /// Returns `true` when the cell's `doctype` resolves to `inline`.
+    ///
+    /// An `inline` document renders a lone paragraph as bare inline content,
+    /// without the enclosing block wrapper.
+    pub fn is_inline(&self) -> bool {
+        match self {
+            Self::Borrowed(cell) => cell.inline,
+            Self::Owned(cell) => cell.borrow_dependent().inline,
+        }
+    }
+
+    /// Returns the blocks parsed from the cell's content.
+    pub fn blocks(&self) -> &[Block<'_>] {
+        match self {
+            Self::Borrowed(cell) => &cell.blocks,
+            Self::Owned(cell) => &cell.borrow_dependent().blocks,
+        }
+    }
+
+    /// Resolves any deferred cross-references in the cell's blocks.
+    fn resolve_references(
+        &mut self,
+        resolver: &dyn ReferenceResolver,
+        renderer: &dyn InlineSubstitutionRenderer,
+        warnings: &mut Vec<ReferenceWarning>,
+    ) {
+        match self {
+            Self::Borrowed(cell) => {
+                for block in &mut cell.blocks {
+                    block.resolve_references(resolver, renderer, warnings);
+                }
+            }
+            // The owned store is shared behind an `Arc`, but references are
+            // resolved immediately after parsing while the cell is still its sole
+            // owner, so `get_mut` succeeds.
+            Self::Owned(cell) => {
+                if let Some(cell) = Arc::get_mut(cell) {
+                    cell.with_dependent_mut(|_, dependent| {
+                        for block in &mut dependent.blocks {
+                            block.resolve_references(resolver, renderer, warnings);
+                        }
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// An [`AsciiDoc`](TableCellContent::AsciiDoc) cell parsed in place from the
+/// parent document's source.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BorrowedCell<'src> {
+    title: Option<String>,
+    inline: bool,
+    blocks: Vec<Block<'src>>,
+}
+
+self_cell! {
+    /// An [`AsciiDoc`](TableCellContent::AsciiDoc) cell that owns its
+    /// (include-expanded) source, with the parsed blocks borrowing from it.
+    pub struct OwnedCell {
+        owner: String,
+
+        #[covariant]
+        dependent: OwnedCellInner,
+    }
+
+    impl {Debug, Eq, PartialEq}
+}
+
+/// The parsed contents of an [`OwnedCell`], borrowing its owned source.
+#[derive(Debug, Eq, PartialEq)]
+struct OwnedCellInner<'src> {
+    title: Option<String>,
+    inline: bool,
+    blocks: Vec<Block<'src>>,
+}
+
+/// Parse the value of the `cols` attribute into a list of columns, mirroring
+/// Asciidoctor's `parse_colspecs`.
+///
+/// All spaces are first removed from the value. A wholly blank value yields no
+/// columns (the caller then takes the column count from the first row), and a
+/// lone integer (the deprecated `cols="3"` form) yields that many default
+/// columns. Otherwise the value is a list of column specifiers separated by
+/// commas, or by semicolons when no comma is present. An empty record (e.g. the
+/// trailing field of `cols="1,,1"`) contributes a default column, and a
+/// specifier may be preceded by a multiplier (`<n>*`) that repeats the column
+/// `n` times. Each specifier's alignment operators, proportional width, and
+/// [style operator](parse_col_spec) are interpreted.
+fn parse_cols(value: &str) -> Vec<TableColumn> {
+    // Asciidoctor strips every space from the cols value before parsing, so
+    // `cols=" 1, 1 "` is equivalent to `cols="1,1"`.
+    let records: String = value.chars().filter(|c| !c.is_whitespace()).collect();
+
+    // A wholly blank cols value is ignored: the caller falls back to the column
+    // count of the first row.
+    if records.is_empty() {
+        return vec![];
+    }
+
+    // Deprecated single-integer form: `cols=3` is equivalent to `cols="3*"` and
+    // produces that many equally sized columns.
+    if let Ok(count) = records.parse::<usize>() {
+        return vec![TableColumn::default(); count];
+    }
+
+    // Split on commas when present, otherwise on semicolons (Asciidoctor accepts
+    // either as the column-spec separator, but not a mix). Empty records are
+    // kept: each one contributes a default column.
+    let parts: Vec<&str> = if records.contains(',') {
+        records.split(',').collect()
+    } else {
+        records.split(';').collect()
+    };
+
+    let mut columns: Vec<TableColumn> = vec![];
+    for part in parts {
+        if part.is_empty() {
+            columns.push(TableColumn::default());
+        } else if let Some((count, spec)) = part.split_once('*') {
+            let repeat = count.parse::<usize>().unwrap_or(1).max(1);
             let column = parse_col_spec(spec);
             for _ in 0..repeat {
                 columns.push(column.clone());
@@ -2019,21 +2316,27 @@ fn expand_duplicates(cells: Vec<RawCell<'_>>) -> Vec<RawCell<'_>> {
 /// Scan a region for PSV cell boundaries, returning the [specifier](CellSpec)
 /// and raw (untrimmed) content span of each cell.
 ///
-/// A cell boundary is the table's `separator` (the vertical bar (`|`) by
-/// default, the exclamation mark (`!`) for a nested table, or any string set
-/// with the `separator` attribute, e.g. the broken bar `¦`) that appears at the
-/// start of a line or is preceded by whitespace, optionally with a
-/// [cell specifier](CellSpec) (e.g. `^`, `2+`, `.>`) directly in front of the
-/// separator. The token immediately preceding a separator is taken to be a
-/// specifier when it parses as one (see [`parse_cell_spec`]); a token that
-/// doesn't parse as a specifier means the separator is not a cell boundary.
-/// Content before the first boundary is ignored.
+/// Every unescaped occurrence of the table's `separator` (the vertical bar
+/// (`|`) by default, the exclamation mark (`!`) for a nested table, or any
+/// string set with the `separator` attribute, e.g. the broken bar `¦`) is a
+/// cell boundary, matching Asciidoctor. The token immediately preceding a
+/// separator is treated as that cell's [specifier](CellSpec) (e.g. `^`, `2+`,
+/// `.>`) only when it parses as one (see [`parse_cell_spec`]) *and* is anchored
+/// at the line start or preceded by whitespace; otherwise the token is ordinary
+/// content of the preceding cell and the separator is a plain boundary (so the
+/// `a` in `|a|b` is content, not a style operator). Content before the first
+/// boundary is ignored.
 ///
-/// An escaped separator (e.g. `\|`) is preceded by a backslash, which is not a
-/// valid specifier, so the separator already fails the boundary test and needs
-/// no special handling here; the backslash is stripped later in
-/// [`TableCell::parse`].
-fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
+/// A separator immediately preceded by a backslash (e.g. `\|`) is escaped: it
+/// is literal content rather than a boundary, and the backslash is stripped
+/// later in [`TableCell::parse`]. Only the single byte before the separator is
+/// inspected, so `\\|` is also read as an escaped separator — matching
+/// Asciidoctor, whose check is likewise the single-character
+/// `pre_match.end_with? '\'`.
+fn scan_cells<'src>(
+    region: Span<'src>,
+    separator: &str,
+) -> (Vec<RawCell<'src>>, Option<Span<'src>>) {
     let data = region.data();
     let bytes = data.as_bytes();
     let len = bytes.len();
@@ -2045,6 +2348,9 @@ fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
     // The content start and specifier of the cell currently being accumulated.
     let mut content_start: Option<usize> = None;
     let mut cur_spec = CellSpec::default();
+    // The span of a cell recovered from content that precedes the first
+    // separator (see below); `Some` drives a missing-leading-separator warning.
+    let mut recovered: Option<Span<'src>> = None;
     let mut i = 0;
 
     while i < len {
@@ -2052,12 +2358,18 @@ fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
             .get(i..)
             .is_some_and(|rest| rest.starts_with(separator))
         {
+            // A separator immediately preceded by a backslash is escaped: it is
+            // literal content, not a cell boundary. The backslash is stripped
+            // from the rendered cell later (see `TableCell::parse`).
+            if i > 0 && bytes.get(i - 1).copied() == Some(b'\\') {
+                i += sep_len;
+                continue;
+            }
+
             // Walk back to the start of the token directly preceding this
             // separator. The token (a possible cell specifier) runs back to the
             // previous whitespace, tab, or newline, or to the start of the
-            // region; either way the token is anchored at a line start or after
-            // whitespace, as a cell boundary requires. (When `tok_start == i`
-            // the token is empty and the separator is plain.)
+            // region.
             let mut tok_start = i;
             while tok_start > 0
                 && !matches!(
@@ -2075,21 +2387,47 @@ fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
                 parse_cell_spec(token)
             };
 
-            if let Some(spec) = spec {
-                if let Some(start) = content_start {
-                    // The previous cell's content ends at the start of this
-                    // cell's specifier; the separating whitespace, included in
-                    // the slice, is trimmed later in `TableCell::parse`.
+            // Every unescaped separator is a cell boundary (matching
+            // Asciidoctor). When the token is empty or a valid specifier it
+            // belongs to the *next* cell, so the previous cell's content ends
+            // before the token. Otherwise the token is ordinary content of the
+            // previous cell (e.g. the `a` in `|a|b`, where `a` is not preceded
+            // by whitespace and so is not a specifier), the separator is plain,
+            // and the next cell takes the default specifier.
+            let (content_end, next_spec) = match spec {
+                Some(spec) => (tok_start, spec),
+                None => (i, CellSpec::default()),
+            };
+
+            match content_start {
+                Some(start) => {
+                    // The separating whitespace, included in the slice, is
+                    // trimmed later in `TableCell::parse`.
                     cells.push(RawCell {
                         spec: cur_spec,
-                        content: region.slice(start..tok_start),
+                        content: region.slice(start..content_end),
                     });
                 }
-                cur_spec = spec;
-                content_start = Some(i + sep_len);
-                i += sep_len;
-                continue;
+                None => {
+                    // No cell has been opened yet, so this is the table's first
+                    // separator. Non-blank content in front of it means the first
+                    // cell is missing its leading separator; recover that content
+                    // as the first cell (with the default specifier) and record
+                    // its span so the caller can warn, matching Asciidoctor.
+                    let leading = region.slice(0..content_end);
+                    if !leading.data().trim().is_empty() {
+                        cells.push(RawCell {
+                            spec: CellSpec::default(),
+                            content: leading,
+                        });
+                        recovered = Some(leading);
+                    }
+                }
             }
+            cur_spec = next_spec;
+            content_start = Some(i + sep_len);
+            i += sep_len;
+            continue;
         }
 
         i += 1;
@@ -2102,7 +2440,7 @@ fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
         });
     }
 
-    cells
+    (cells, recovered)
 }
 
 /// Parse a cell specifier, returning its [span and overrides](CellSpec), or
@@ -2275,4 +2613,126 @@ fn trim_surrounding_whitespace(s: Span<'_>) -> Span<'_> {
     let start = data.len() - data.trim_start().len();
     let len = data.trim().len();
     s.slice(start..start + len)
+}
+
+/// Trim a PSV cell's content according to its [style](ColumnStyle), matching
+/// Asciidoctor's `Table::Cell` initializer:
+///
+/// * A [`Literal`](ColumnStyle::Literal) cell has its trailing whitespace
+///   removed and any leading blank lines stripped, but the leading indentation
+///   of its first content line is preserved (so an indented literal cell keeps
+///   its indentation).
+/// * An [`AsciiDoc`](ColumnStyle::AsciiDoc) cell likewise removes trailing
+///   whitespace; if the remaining content begins with a newline it strips the
+///   leading blank lines (preserving the first content line's indentation, so a
+///   leading-indented line is interpreted as a literal block), otherwise it
+///   strips the leading whitespace.
+/// * Every other style has all surrounding whitespace removed.
+fn trim_cell_content(s: Span<'_>, style: ColumnStyle) -> Span<'_> {
+    let data = s.data();
+    match style {
+        ColumnStyle::Literal => {
+            let end = data.trim_end().len();
+            let mut start = 0;
+            while data[start..end].starts_with('\n') {
+                start += 1;
+            }
+            s.slice(start..end)
+        }
+        ColumnStyle::AsciiDoc => {
+            let end = data.trim_end().len();
+            if data[..end].starts_with('\n') {
+                let mut start = 0;
+                while data[start..end].starts_with('\n') {
+                    start += 1;
+                }
+                s.slice(start..end)
+            } else {
+                let start = end - data[..end].trim_start().len();
+                s.slice(start..end)
+            }
+        }
+        _ => trim_surrounding_whitespace(s),
+    }
+}
+
+/// Returns the first non-blank line in `rest`, or `None` when every remaining
+/// line is blank (or `rest` is empty).
+fn first_nonblank_line(mut rest: Span<'_>) -> Option<Span<'_>> {
+    while !rest.is_empty() {
+        let line = rest.take_line();
+        if !line.item.data().trim().is_empty() {
+            return Some(line.item);
+        }
+        rest = line.after;
+    }
+    None
+}
+
+/// Returns `true` when `line` begins a new PSV cell, i.e. it contains the
+/// separator and the text before the first separator (after any leading
+/// whitespace) is either empty or a valid cell specifier. A line that continues
+/// the previous cell returns `false`.
+fn psv_line_starts_cell(line: &str, separator: &str) -> bool {
+    match line.find(separator) {
+        Some(pos) => {
+            let prefix = line[..pos].trim_start();
+            prefix.is_empty() || parse_cell_spec(prefix).is_some()
+        }
+        None => false,
+    }
+}
+
+/// Returns `true` when `line` contains an odd number of double quotes, i.e. it
+/// opens a quoted CSV/TSV value that is not closed on the same line.
+fn line_has_unclosed_quote(line: &str) -> bool {
+    line.bytes().filter(|&b| b == b'"').count() % 2 == 1
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::{AsciiDocCell, OwnedCell, OwnedCellInner};
+    use crate::parser::{
+        HtmlSubstitutionRenderer, ReferenceResolver, ResolutionContext, ResolvedReference,
+    };
+
+    /// A resolver that resolves nothing; the owned-cell resolution path under
+    /// test carries no references, so it is never actually consulted.
+    struct NoopResolver;
+
+    impl ReferenceResolver for NoopResolver {
+        fn resolve(&self, _context: &ResolutionContext<'_>) -> Option<ResolvedReference> {
+            None
+        }
+    }
+
+    /// When an owned (include-expanded) AsciiDoc cell is shared behind more
+    /// than one `Arc` reference, `resolve_references` cannot obtain a
+    /// mutable borrow of the store and leaves it untouched rather than
+    /// panicking. Production code resolves while the cell is its sole
+    /// owner, so this defensive branch is exercised here by deliberately
+    /// holding a second reference.
+    #[test]
+    fn resolve_references_skips_shared_owned_cell() {
+        let mut cell = AsciiDocCell::Owned(Arc::new(OwnedCell::new(String::new(), |_source| {
+            OwnedCellInner {
+                title: None,
+                inline: false,
+                blocks: vec![],
+            }
+        })));
+
+        // Hold a second reference to the same store so `Arc::get_mut` fails.
+        let shared = cell.clone();
+
+        let mut warnings = vec![];
+        cell.resolve_references(&NoopResolver, &HtmlSubstitutionRenderer {}, &mut warnings);
+
+        // Resolution was skipped silently: no warnings, and the two references
+        // still describe the same (unmodified) cell.
+        assert!(warnings.is_empty());
+        assert_eq!(cell, shared);
+    }
 }

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -128,11 +128,17 @@ impl<'src> TableBlock<'src> {
 
         // The first row is an (implicit) header row when the line directly after
         // the opening delimiter is non-empty and is itself followed by an empty
-        // line. The `header` option forces the same interpretation.
+        // line. The `header` option forces the same interpretation; the
+        // `noheader` option suppresses only the implicit detection, so an
+        // explicit `header` still wins when both are present.
         let opts_header = metadata
             .attrlist
             .as_ref()
             .is_some_and(|a| a.has_option("header"));
+        let opts_noheader = metadata
+            .attrlist
+            .as_ref()
+            .is_some_and(|a| a.has_option("noheader"));
 
         // The blank line must genuinely exist after the first row; the end of the
         // table (an empty remainder) does not count, so a single-row table is not
@@ -141,7 +147,7 @@ impl<'src> TableBlock<'src> {
         let line1_blank = line1.item.data().trim().is_empty();
         let line2_blank =
             !line1.after.is_empty() && line1.after.take_line().item.data().trim().is_empty();
-        let has_header = opts_header || (!line1_blank && line2_blank);
+        let has_header = opts_header || (!opts_noheader && !line1_blank && line2_blank);
 
         // A titled table is given a caption (e.g. "Table 1. ") that a processor
         // prepends to the title.

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -43,9 +43,6 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 ///
 /// * The CSV, TSV, and DSV data formats (and the `,===` / `:===` shorthand
 ///   delimiters).
-/// * The cell specifier duplication (`*`) operator: it is recognized in a cell
-///   specifier (so the cell separator is still located correctly) but its
-///   layout effect is not yet applied.
 ///
 /// Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, and `s`
 /// operators) are supported, along with proportional width and the horizontal
@@ -54,7 +51,9 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 /// style operator (in the last position of the cell specifier) is supported and
 /// overrides the column's style. The per-cell span (`+`) operator is supported:
 /// a cell can span multiple columns (`<n>+`), multiple rows (`.<n>+`), or a
-/// block of both (`<n>.<n>+`).
+/// block of both (`<n>.<n>+`). The per-cell duplication (`*`) operator is
+/// supported: a cell with a duplication factor (`<n>*`) clones its content and
+/// properties into `<n>` consecutive cells.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -128,10 +127,11 @@ impl<'src> TableBlock<'src> {
 
         // When the column count is implicit, it is the number of column slots in
         // the first non-empty line: a cell that spans columns (`<n>+`) counts as
-        // `<n>` slots, not one.
+        // `<n>` slots, not one, and a cell duplicated `<n>` times (`<n>*`) counts
+        // as `<n>` single-column slots (one per clone).
         let first_line_cells: usize = scan_cells(inside.discard_empty_lines().take_line().item)
             .iter()
-            .map(|c| c.spec.colspan.max(1))
+            .map(|c| c.spec.colspan.max(1) * c.spec.repeat.min(MAX_DUPLICATION_FACTOR))
             .sum();
 
         let ncols = if columns.is_empty() {
@@ -228,8 +228,12 @@ impl<'src> TableBlock<'src> {
         // matching Asciidoctor. A row whose columns are entirely pre-filled by
         // carried slots has no cells of its own to close it, so the next cell
         // overruns and is dropped together with that pre-filled row.
+        // A duplicated cell (`<n>*`) is expanded into `<n>` independent cells —
+        // each carrying the original's content, alignment, and style — before the
+        // grid walk, so each clone occupies its own column slot exactly like an
+        // ordinary cell. A duplication factor of zero drops the cell entirely.
         let mut warnings: Vec<Warning<'src>> = vec![];
-        let raw_cells = scan_cells(inside);
+        let raw_cells = expand_duplicates(scan_cells(inside));
 
         // A table can never have more rows than it has cells, so a row span is
         // clamped to the cell count for the `active_rowspans` bookkeeping below: a
@@ -949,7 +953,9 @@ fn parse_col_spec(spec: &str) -> TableColumn {
 /// Each alignment and style field is `None` when the corresponding operator is
 /// absent from the specifier, in which case the cell inherits that alignment
 /// (or style) from its column. `colspan` and `rowspan` are the number of
-/// columns and rows the cell spans; they default to `1` (no span).
+/// columns and rows the cell spans; they default to `1` (no span). `repeat` is
+/// the duplication factor — the number of consecutive cells the content is
+/// cloned into — and defaults to `1` (no duplication).
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct CellSpec {
     h_align: Option<HorizontalAlignment>,
@@ -957,6 +963,7 @@ struct CellSpec {
     style: Option<ColumnStyle>,
     colspan: usize,
     rowspan: usize,
+    repeat: usize,
 }
 
 impl Default for CellSpec {
@@ -967,15 +974,56 @@ impl Default for CellSpec {
             style: None,
             colspan: 1,
             rowspan: 1,
+            repeat: 1,
         }
     }
 }
 
 /// A single PSV cell as located by [`scan_cells`]: the alignment operators from
 /// its specifier together with the raw (untrimmed) span of its content.
+#[derive(Clone, Copy)]
 struct RawCell<'src> {
     spec: CellSpec,
     content: Span<'src>,
+}
+
+/// The largest number of cells a single duplication factor (`<n>*`) is allowed
+/// to expand into.
+///
+/// A duplicated cell is materialized as `<n>` independent cells, so the factor
+/// is an amplification: a dozen source bytes such as `1000000000*` would
+/// otherwise request a billion `RawCell`s (a multi-gigabyte allocation).
+/// Capping the per-specifier factor bounds that amplification while leaving any
+/// realistic table — which never duplicates a cell more than a handful of times
+/// — untouched. (This is the one point where the implementation diverges from
+/// Asciidoctor, which expands the literal factor however large.)
+const MAX_DUPLICATION_FACTOR: usize = 1_000;
+
+/// Expand each duplicated cell into the `<n>` independent cells it represents.
+///
+/// A cell specifier with a duplication factor (`<n>*`) clones the cell's
+/// content and properties into `<n>` consecutive cells. Each clone is an
+/// ordinary single-slot cell (colspan and rowspan of 1), so expanding here —
+/// before the grid is walked — lets the clones flow into rows exactly like
+/// cells the author typed out by hand. A duplication factor of zero produces no
+/// cells, dropping the original (matching Asciidoctor). A cell with no
+/// duplication factor has a `repeat` of 1 and so passes through unchanged. The
+/// factor is clamped to [`MAX_DUPLICATION_FACTOR`] so a hostile specifier can't
+/// trigger a runaway allocation.
+fn expand_duplicates(cells: Vec<RawCell<'_>>) -> Vec<RawCell<'_>> {
+    // The common case is no duplication at all, so only the clones beyond the
+    // first add to the count.
+    let extra: usize = cells
+        .iter()
+        .map(|c| c.spec.repeat.min(MAX_DUPLICATION_FACTOR).saturating_sub(1))
+        .sum();
+    let mut expanded = Vec::with_capacity(cells.len() + extra);
+    for cell in cells {
+        for _ in 0..cell.spec.repeat.min(MAX_DUPLICATION_FACTOR) {
+            expanded.push(cell);
+        }
+    }
+    expanded
 }
 
 /// Scan a region for PSV cell boundaries, returning the [specifier](CellSpec)
@@ -1068,9 +1116,10 @@ fn scan_cells(region: Span<'_>) -> Vec<RawCell<'_>> {
 /// * The factor and span/duplication operator are an optional count (e.g. `2`,
 ///   `2.3`, `.3`) that, when present, must be followed by `+` (span) or `*`
 ///   (duplication). For a span the factor is interpreted as the cell's colspan
-///   and rowspan (a missing column or row count defaults to 1). The duplication
-///   operator is recognized so the cell separator is located correctly, but its
-///   layout effect is not yet applied.
+///   and rowspan (a missing column or row count defaults to 1). For a
+///   duplication the column part of the factor is the duplication count — the
+///   number of consecutive cells the content is cloned into — and any row part
+///   is ignored; a duplicated cell keeps a colspan and rowspan of 1.
 /// * The horizontal alignment operator is `<`, `>`, or `^`.
 /// * The vertical alignment operator is a dot followed by `<`, `>`, or `^`.
 /// * The style operator is a single lowercase letter in the last position. A
@@ -1090,6 +1139,7 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
     // leading digits remain and the token fails the full-consumption check below.
     let mut colspan = 1;
     let mut rowspan = 1;
+    let mut repeat = 1;
     let col_start = i;
     let mut j = i;
     while matches!(b.get(j).copied(), Some(c) if c.is_ascii_digit()) {
@@ -1126,9 +1176,17 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
             }
             i = j + 1;
         }
-        // Duplication: recognized so the cell separator is still located, but its
-        // layout effect (and so its factor) is not yet applied.
+        // Duplication: the factor is interpreted as a duplication count, so the
+        // cell's content and properties are cloned into `<n>` consecutive cells.
+        // Only the column part of the factor is the count; any row part (`<n>.`)
+        // is ignored, matching Asciidoctor. A missing column count defaults to 1.
+        // Unlike a span, a duplication leaves `colspan` and `rowspan` at 1: each
+        // clone is an ordinary single-slot cell.
         Some(b'*') => {
+            let col_digits = token.get(col_start..col_end).unwrap_or_default();
+            if !col_digits.is_empty() {
+                repeat = col_digits.parse().unwrap_or(1);
+            }
             i = j + 1;
         }
         _ => {}
@@ -1201,6 +1259,7 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
             style,
             colspan,
             rowspan,
+            repeat,
         })
     } else {
         None

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1,7 +1,9 @@
 use crate::{
     HasSpan, Parser, Span,
     attributes::Attrlist,
-    blocks::{ContentModel, IsBlock, metadata::BlockMetadata},
+    blocks::{
+        Block, ContentModel, IsBlock, metadata::BlockMetadata, parse_utils::parse_blocks_until,
+    },
     content::{Content, SubstitutionGroup},
     document::InterpretedValue,
     parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning},
@@ -31,12 +33,14 @@ use crate::{
 ///
 /// * The CSV, TSV, and DSV data formats (and the `,===` / `:===` shorthand
 ///   delimiters).
-/// * Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, `s`,
-///   and `v` operators); proportional width and the horizontal and vertical
-///   alignment operators are supported.
-/// * Cell specifiers (spans, duplication, per-cell alignment and style, and the
-///   `a` AsciiDoc style that nests block content inside a cell).
+/// * Cell specifiers (spans, duplication, per-cell alignment and style); the
+///   per-cell style operator that overrides a column's style operator is not
+///   yet recognized.
 /// * Footer rows.
+///
+/// Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, and `s`
+/// operators) are supported, along with proportional width and the horizontal
+/// and vertical alignment operators.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -177,9 +181,30 @@ impl<'src> TableBlock<'src> {
 
         // Scan every cell in the table, in document order, then partition into
         // rows of `ncols` cells each.
-        let mut cells = scan_cells(inside)
-            .into_iter()
-            .map(|raw| TableCell::parse(raw, parser));
+        //
+        // Each cell is processed according to the style of the column it falls
+        // in. The header row (when present) is the first `ncols` cells and is
+        // always processed as plain header content, regardless of the column
+        // styles, so that a style operator doesn't affect the header row.
+        let mut warnings: Vec<Warning<'src>> = vec![];
+        let raw_cells = scan_cells(inside);
+        let header_len = if has_header { ncols } else { 0 };
+
+        let mut cells = Vec::with_capacity(raw_cells.len());
+        for (idx, raw) in raw_cells.into_iter().enumerate() {
+            let style = if idx < header_len {
+                ColumnStyle::Default
+            } else {
+                // `idx % ncols` is in bounds whenever `ncols > 0`; an empty table
+                // (`ncols == 0`) has no columns, so the cell falls back to the
+                // default style.
+                columns
+                    .get(idx % ncols.max(1))
+                    .map_or(ColumnStyle::Default, |column| column.style)
+            };
+            cells.push(TableCell::parse(raw, style, parser, &mut warnings));
+        }
+        let mut cells = cells.into_iter();
 
         let header_row = if has_header && ncols > 0 {
             let row: Vec<TableCell<'src>> = cells.by_ref().take(ncols).collect();
@@ -208,14 +233,12 @@ impl<'src> TableBlock<'src> {
             .trim_remainder(closing_delimiter.discard_all())
             .trim_trailing_whitespace();
 
-        let warnings = if closing_delimiter.is_empty() {
-            vec![Warning {
+        if closing_delimiter.is_empty() {
+            warnings.push(Warning {
                 source: delimiter.item,
                 warning: WarningType::UnterminatedDelimitedBlock,
-            }]
-        } else {
-            vec![]
-        };
+            });
+        }
 
         Some(MatchAndWarnings {
             item: Some(MatchedItem {
@@ -287,8 +310,7 @@ impl<'src> TableBlock<'src> {
 
         for row in rows {
             for cell in row.cells.iter_mut() {
-                cell.content
-                    .resolve_references(resolver, renderer, warnings);
+                cell.resolve_references(resolver, renderer, warnings);
             }
         }
     }
@@ -332,14 +354,15 @@ impl<'src> HasSpan<'src> for TableBlock<'src> {
 
 /// A column in a [`TableBlock`].
 ///
-/// A column carries its proportional width and the horizontal and vertical
-/// alignment applied to its cells' content. Style operators on the `cols`
-/// specifier are not yet modeled.
+/// A column carries its proportional width, the horizontal and vertical
+/// alignment applied to its cells' content, and the [style](ColumnStyle) used
+/// to process and render that content.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableColumn {
     width: usize,
     h_align: HorizontalAlignment,
     v_align: VerticalAlignment,
+    style: ColumnStyle,
 }
 
 impl TableColumn {
@@ -366,6 +389,15 @@ impl TableColumn {
     pub fn v_align(&self) -> VerticalAlignment {
         self.v_align
     }
+
+    /// Returns the [style](ColumnStyle) applied to this column's content.
+    ///
+    /// The style comes from a style operator in the last position of the
+    /// column's specifier (`a`, `d`, `e`, `h`, `l`, `m`, or `s`) and defaults
+    /// to [`ColumnStyle::Default`].
+    pub fn style(&self) -> ColumnStyle {
+        self.style
+    }
 }
 
 impl Default for TableColumn {
@@ -374,8 +406,55 @@ impl Default for TableColumn {
             width: 1,
             h_align: HorizontalAlignment::Left,
             v_align: VerticalAlignment::Top,
+            style: ColumnStyle::Default,
         }
     }
+}
+
+/// The style applied to the content of a [column](TableColumn) (and, by
+/// extension, to each body cell in that column).
+///
+/// A style is specified by a style operator in the last position of a column
+/// specifier. When no style operator is present, [`Default`](Self::Default) is
+/// assigned and the column is processed as paragraph text.
+///
+/// The style governs both how a cell's content is parsed and how it is
+/// rendered: most styles leave the content as inline markup (changing only the
+/// surrounding formatting), [`Literal`](Self::Literal) processes the content
+/// verbatim, and [`AsciiDoc`](Self::AsciiDoc) parses the content as a nested,
+/// standalone AsciiDoc document.
+///
+/// The verse operator (`v`) recognized by older versions of AsciiDoc has been
+/// deprecated and is not modeled here.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ColumnStyle {
+    /// Block elements (lists, delimited blocks, and block macros) are
+    /// supported; the content is parsed as a nested, standalone AsciiDoc
+    /// document (the `a` operator).
+    AsciiDoc,
+
+    /// All of the markup permitted in a paragraph (inline formatting and inline
+    /// macros) is supported (the `d` operator). This is the default style,
+    /// assigned automatically when no style operator is present.
+    #[default]
+    Default,
+
+    /// Text is italicized (the `e` operator).
+    Emphasis,
+
+    /// The header semantics and styles are applied to the text and cell borders
+    /// (the `h` operator).
+    Header,
+
+    /// Content is treated as if it were inside a literal block (the `l`
+    /// operator).
+    Literal,
+
+    /// Text is rendered using a monospace font (the `m` operator).
+    Monospace,
+
+    /// Text is bold (the `s` operator).
+    Strong,
 }
 
 /// The horizontal alignment of a column's content.
@@ -435,16 +514,45 @@ impl<'src> TableRow<'src> {
 /// A single cell in a [`TableBlock`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableCell<'src> {
-    content: Content<'src>,
+    content: TableCellContent<'src>,
 }
 
 impl<'src> TableCell<'src> {
-    /// Build a cell from the raw (untrimmed) span of its content.
+    /// Build a cell from the raw (untrimmed) span of its content, processing it
+    /// according to the [style](ColumnStyle) of the column the cell belongs to.
     ///
-    /// Leading and trailing whitespace is stripped, escaped cell separators
-    /// (`\|`) are unescaped, and normal inline substitutions are applied.
-    fn parse(raw: Span<'src>, parser: &Parser) -> Self {
+    /// Leading and trailing whitespace is always stripped. For every style but
+    /// [`AsciiDoc`](ColumnStyle::AsciiDoc) the cell holds inline
+    /// [`Content`](TableCellContent::Simple): escaped cell separators (`\|`)
+    /// are unescaped and substitutions are applied — the verbatim group for
+    /// [`Literal`](ColumnStyle::Literal), the normal group otherwise. An
+    /// [`AsciiDoc`](ColumnStyle::AsciiDoc) cell instead parses its content as a
+    /// nested sequence of [blocks](TableCellContent::AsciiDoc).
+    fn parse(
+        raw: Span<'src>,
+        style: ColumnStyle,
+        parser: &mut Parser,
+        warnings: &mut Vec<Warning<'src>>,
+    ) -> Self {
         let trimmed = trim_surrounding_whitespace(raw);
+
+        if style == ColumnStyle::AsciiDoc {
+            // The AsciiDoc style effectively creates a nested, standalone
+            // AsciiDoc document in the cell. It inherits the parent document's
+            // attributes, but any attribute it defines is scoped to the cell and
+            // must not leak back into the parent. Snapshot the attribute set
+            // before parsing and restore it afterward to enforce that boundary
+            // (matching Asciidoctor, where a `:foo:` set inside a cell is not
+            // visible after the table).
+            let saved_attributes = parser.attribute_values.clone();
+            let mut maw = parse_blocks_until(trimmed, |_| false, parser);
+            parser.attribute_values = saved_attributes;
+            warnings.append(&mut maw.warnings);
+            return Self {
+                content: TableCellContent::AsciiDoc(maw.item.item),
+            };
+        }
+
         let data = trimmed.data();
 
         let mut content = if data.contains("\\|") {
@@ -453,15 +561,59 @@ impl<'src> TableCell<'src> {
             Content::from(trimmed)
         };
 
-        SubstitutionGroup::Normal.apply(&mut content, parser, None);
+        let substitutions = if style == ColumnStyle::Literal {
+            SubstitutionGroup::Verbatim
+        } else {
+            SubstitutionGroup::Normal
+        };
+        substitutions.apply(&mut content, parser, None);
 
-        Self { content }
+        Self {
+            content: TableCellContent::Simple(content),
+        }
     }
 
     /// Returns the interpreted content of this cell.
-    pub fn content(&self) -> &Content<'src> {
+    pub fn content(&self) -> &TableCellContent<'src> {
         &self.content
     }
+
+    /// Resolves any deferred cross-references in this cell's content.
+    fn resolve_references(
+        &mut self,
+        resolver: &dyn ReferenceResolver,
+        renderer: &dyn InlineSubstitutionRenderer,
+        warnings: &mut Vec<ReferenceWarning>,
+    ) {
+        match &mut self.content {
+            TableCellContent::Simple(content) => {
+                content.resolve_references(resolver, renderer, warnings);
+            }
+            TableCellContent::AsciiDoc(blocks) => {
+                for block in blocks.iter_mut() {
+                    block.resolve_references(resolver, renderer, warnings);
+                }
+            }
+        }
+    }
+}
+
+/// The interpreted content of a [`TableCell`].
+///
+/// The variant is determined by the [style](ColumnStyle) of the cell's column:
+/// an [`AsciiDoc`](ColumnStyle::AsciiDoc) column produces
+/// [`AsciiDoc`](Self::AsciiDoc) content, and every other style produces
+/// [`Simple`](Self::Simple) inline content.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TableCellContent<'src> {
+    /// Inline content: the cell's text after its substitutions (normal for most
+    /// styles, verbatim for [`Literal`](ColumnStyle::Literal)) have been
+    /// applied.
+    Simple(Content<'src>),
+
+    /// Block content: the cell's text parsed as a nested, standalone AsciiDoc
+    /// document. Produced by the [`AsciiDoc`](ColumnStyle::AsciiDoc) style.
+    AsciiDoc(Vec<Block<'src>>),
 }
 
 /// Parse the value of the `cols` attribute into a list of columns.
@@ -493,21 +645,20 @@ fn parse_cols(value: &str) -> Vec<TableColumn> {
     columns
 }
 
-/// Parse a single column specifier, extracting its alignment and proportional
-/// width.
+/// Parse a single column specifier, extracting its alignment, proportional
+/// width, and style.
 ///
 /// A column specifier is positional: an optional horizontal alignment operator
 /// (`<`, `>`, or `^`) comes first, followed by an optional vertical alignment
 /// operator (`.<`, `.>`, or `.^`), followed by the width, and finally an
-/// optional style operator. When a multiplier (`<n>*`) is present, the
-/// operators follow the multiplier, so the `spec` passed here is the portion
-/// after the `*`.
+/// optional style operator in the last position. When a multiplier (`<n>*`) is
+/// present, the operators follow the multiplier, so the `spec` passed here is
+/// the portion after the `*`.
 ///
 /// The width is the first contiguous run of digits after any alignment
-/// operators; a spec with no digits falls back to the default width. Taking the
-/// first run — rather than concatenating every digit — keeps the width from
-/// fusing with digits in an as-yet-unmodeled style operator. The style operator
-/// is otherwise ignored.
+/// operators; a spec with no digits falls back to the default width. The style
+/// operator is the trailing letter (`a`, `d`, `e`, `h`, `l`, `m`, or `s`); an
+/// unrecognized trailing letter leaves the style at its default.
 fn parse_col_spec(spec: &str) -> TableColumn {
     let mut rest = spec.trim();
 
@@ -555,11 +706,29 @@ fn parse_col_spec(spec: &str) -> TableColumn {
         Ok(width) if width > 0 => width,
         _ => TableColumn::default().width,
     };
+    rest = &rest[digits.len()..];
+
+    // The style operator, if present, occupies the last position on the
+    // specifier, so it is the entire remainder after the width. Matching the
+    // whole remainder (rather than just its first byte) means a malformed spec
+    // with trailing junk — e.g. `1em` — falls back to the default style instead
+    // of silently honoring the first letter and discarding the rest.
+    let style = match rest.trim() {
+        "a" => ColumnStyle::AsciiDoc,
+        "d" => ColumnStyle::Default,
+        "e" => ColumnStyle::Emphasis,
+        "h" => ColumnStyle::Header,
+        "l" => ColumnStyle::Literal,
+        "m" => ColumnStyle::Monospace,
+        "s" => ColumnStyle::Strong,
+        _ => ColumnStyle::Default,
+    };
 
     TableColumn {
         width,
         h_align,
         v_align,
+        style,
     }
 }
 

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -25,11 +25,14 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 /// A table is a delimited block that arranges content into a grid of rows and
 /// columns.
 ///
-/// A table is introduced by a table delimiter (`|===`) and closed by a matching
-/// delimiter. Cells are separated using prefix-separated value (PSV) syntax: a
-/// vertical bar (`|`) at the start of a line or preceded by whitespace begins a
-/// new cell. Cells flow, in document order, into rows whose length is fixed by
-/// the number of columns.
+/// A table is introduced by a table delimiter (`|===`, or `!===` for a nested
+/// table) and closed by a matching delimiter. Cells are separated using
+/// prefix-separated value (PSV) syntax: the table's cell separator — a vertical
+/// bar (`|`) by default — at the start of a line or preceded by whitespace
+/// begins a new cell. Cells flow, in document order, into rows whose length is
+/// fixed by the number of columns. (The separator defaults to `!` inside a
+/// nested table and can be overridden with the `separator` attribute; see
+/// below.)
 ///
 /// The number of columns is determined either by the `cols` attribute or,
 /// implicitly, by the number of cells found in the first non-empty line after
@@ -68,6 +71,13 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 /// Zebra striping is supported via the [`stripes`](Self::stripes) attribute,
 /// which falls back to the `table-stripes` document attribute and then to
 /// `none`.
+///
+/// Nested tables are supported: an [`AsciiDoc`](ColumnStyle::AsciiDoc) cell may
+/// contain its own table. The cell separator defaults to the vertical bar (`|`)
+/// but switches to the exclamation mark (`!`) inside an AsciiDoc cell, so a
+/// nested table is opened with `!===` and separates its cells with `!`. The
+/// `separator` attribute overrides the default separator with an explicit
+/// character at any level.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -89,17 +99,20 @@ pub struct TableBlock<'src> {
 impl<'src> TableBlock<'src> {
     /// Returns `true` if `line` is a table delimiter.
     ///
-    /// A table delimiter is a vertical bar (`|`) followed by three or more
-    /// equals signs (`===`).
+    /// A table delimiter is a vertical bar (`|`) or an exclamation mark (`!`)
+    /// followed by three or more equals signs (`===`). The `!===` form opens a
+    /// table whose default cell separator is the exclamation mark, which lets a
+    /// nested table be distinguished from the `|`-separated table that encloses
+    /// it.
     ///
-    /// **NOTE:** The `,===` (CSV), `:===` (DSV), and `!===` (nested) shorthand
-    /// delimiters are not yet recognized.
+    /// **NOTE:** The `,===` (CSV) and `:===` (DSV) shorthand delimiters are not
+    /// yet recognized.
     pub(crate) fn is_table_delimiter(line: &Span<'src>) -> bool {
         let data = line.data();
-        // `len() >= 4` plus the leading `|` guarantees `rest` holds at least three
-        // bytes, so the closure only needs to confirm they are all `=`.
+        // `len() >= 4` plus the leading `|`/`!` guarantees `rest` holds at least
+        // three bytes, so the closure only needs to confirm they are all `=`.
         data.len() >= 4
-            && data.starts_with('|')
+            && (data.starts_with('|') || data.starts_with('!'))
             && data
                 .get(1..)
                 .is_some_and(|rest| rest.bytes().all(|b| b == b'='))
@@ -133,6 +146,14 @@ impl<'src> TableBlock<'src> {
 
         let inside = delimiter.after.trim_remainder(closing_delimiter);
 
+        // The cell separator partitions each row into cells. It defaults to the
+        // vertical bar (`|`), except inside an AsciiDoc table cell — a nested,
+        // standalone document — where it defaults to the exclamation mark (`!`)
+        // so a nested table is distinguished from the `|`-separated table that
+        // encloses it. The `separator` attribute overrides the default with an
+        // explicit character; an empty `separator` falls back to the default.
+        let separator = resolve_separator(metadata, parser);
+
         // Determine the number of columns, either from the `cols` attribute or
         // implicitly from the number of cells in the first non-empty line.
         let columns: Vec<TableColumn> = metadata
@@ -146,10 +167,11 @@ impl<'src> TableBlock<'src> {
         // the first non-empty line: a cell that spans columns (`<n>+`) counts as
         // `<n>` slots, not one, and a cell duplicated `<n>` times (`<n>*`) counts
         // as `<n>` single-column slots (one per clone).
-        let first_line_cells: usize = scan_cells(inside.discard_empty_lines().take_line().item)
-            .iter()
-            .map(|c| c.spec.colspan.max(1) * c.spec.repeat.min(MAX_DUPLICATION_FACTOR))
-            .sum();
+        let first_line_cells: usize =
+            scan_cells(inside.discard_empty_lines().take_line().item, separator)
+                .iter()
+                .map(|c| c.spec.colspan.max(1) * c.spec.repeat.min(MAX_DUPLICATION_FACTOR))
+                .sum();
 
         let ncols = if columns.is_empty() {
             first_line_cells
@@ -276,7 +298,7 @@ impl<'src> TableBlock<'src> {
         // grid walk, so each clone occupies its own column slot exactly like an
         // ordinary cell. A duplication factor of zero drops the cell entirely.
         let mut warnings: Vec<Warning<'src>> = vec![];
-        let raw_cells = expand_duplicates(scan_cells(inside));
+        let raw_cells = expand_duplicates(scan_cells(inside, separator));
 
         // A table can never have more rows than it has cells, so a row span is
         // clamped to the cell count for the `active_rowspans` bookkeeping below: a
@@ -362,6 +384,7 @@ impl<'src> TableBlock<'src> {
                     raw,
                     &column,
                     is_header,
+                    separator,
                     parser,
                     &mut warnings,
                 ));
@@ -919,6 +942,34 @@ fn resolve_table_attribute<B: TableAttributeValue>(
     }
 }
 
+/// Resolve the cell separator byte for a table.
+///
+/// The separator defaults to the vertical bar (`|`), except inside an AsciiDoc
+/// table cell — a nested, standalone document — where it defaults to the
+/// exclamation mark (`!`), so a nested table is distinguished from the
+/// `|`-separated table that encloses it. An explicit `separator` attribute on
+/// the table overrides the default with its first byte; an empty `separator`
+/// value (e.g. `[separator=]`) falls back to the default. A non-ASCII first
+/// character is ignored (the byte-oriented cell scanner only recognizes a
+/// single-byte separator), so it too falls back to the default.
+fn resolve_separator(metadata: &BlockMetadata<'_>, parser: &Parser) -> u8 {
+    let default = if parser.nested_document_depth > 0 {
+        b'!'
+    } else {
+        b'|'
+    };
+
+    metadata
+        .attrlist
+        .as_ref()
+        .and_then(|a| a.named_attribute("separator"))
+        .map(|attr| attr.value())
+        .filter(|value| !value.is_empty())
+        .and_then(|value| value.chars().next())
+        .filter(char::is_ascii)
+        .map_or(default, |c| c as u8)
+}
+
 /// A row of cells in a [`TableBlock`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableRow<'src> {
@@ -958,8 +1009,9 @@ impl<'src> TableCell<'src> {
     ///
     /// Leading and trailing whitespace is always stripped. For every style but
     /// [`AsciiDoc`](ColumnStyle::AsciiDoc) the cell holds inline
-    /// [`Content`](TableCellContent::Simple): escaped cell separators (`\|`)
-    /// are unescaped and substitutions are applied — the verbatim group for
+    /// [`Content`](TableCellContent::Simple): escaped cell separators (the
+    /// table's `separator` character preceded by a backslash, e.g. `\|`) are
+    /// unescaped and substitutions are applied — the verbatim group for
     /// [`Literal`](ColumnStyle::Literal), the normal group otherwise. An
     /// [`AsciiDoc`](ColumnStyle::AsciiDoc) cell instead parses its content as a
     /// nested sequence of [blocks](TableCellContent::AsciiDoc).
@@ -967,6 +1019,7 @@ impl<'src> TableCell<'src> {
         raw: RawCell<'src>,
         column: &TableColumn,
         is_header: bool,
+        separator: u8,
         parser: &mut Parser,
         warnings: &mut Vec<Warning<'src>>,
     ) -> Self {
@@ -1015,7 +1068,14 @@ impl<'src> TableCell<'src> {
                 }
             }
 
+            // Mark that we are inside an AsciiDoc cell (a nested document) for the
+            // duration of the cell, so a table found within defaults its cell
+            // separator to `!` rather than `|` (matching Asciidoctor's
+            // `Document#nested?`). The depth is restored afterward so the marker
+            // is scoped to the cell and nests correctly.
+            parser.nested_document_depth += 1;
             let mut maw = parse_blocks_until(trimmed, |_| false, parser);
+            parser.nested_document_depth -= 1;
 
             parser.locked_attribute_names = saved_locks;
             parser.attribute_values = saved_attributes;
@@ -1024,8 +1084,16 @@ impl<'src> TableCell<'src> {
         } else {
             let data = trimmed.data();
 
-            let mut content = if data.contains("\\|") {
-                Content::from_filtered(trimmed, data.replace("\\|", "|"))
+            // An escaped cell separator (a backslash in front of the table's
+            // separator character, e.g. `\|` or `\!`) is unescaped to the bare
+            // separator. Only the active separator is unescaped, so a `\|` in a
+            // `!`-separated table is left untouched.
+            let escaped = format!("\\{}", separator as char);
+            let mut content = if data.contains(&escaped) {
+                Content::from_filtered(
+                    trimmed,
+                    data.replace(&escaped, &(separator as char).to_string()),
+                )
             } else {
                 Content::from(trimmed)
             };
@@ -1356,17 +1424,20 @@ fn expand_duplicates(cells: Vec<RawCell<'_>>) -> Vec<RawCell<'_>> {
 /// Scan a region for PSV cell boundaries, returning the [specifier](CellSpec)
 /// and raw (untrimmed) content span of each cell.
 ///
-/// A cell boundary is a vertical bar (`|`) that appears at the start of a line
-/// or is preceded by whitespace, optionally with a [cell specifier](CellSpec)
-/// (e.g. `^`, `2+`, `.>`) directly in front of the `|`. The token immediately
-/// preceding a `|` is taken to be a specifier when it parses as one (see
-/// [`parse_cell_spec`]); a token that doesn't parse as a specifier means the
-/// `|` is not a cell boundary. Content before the first boundary is ignored.
+/// A cell boundary is the table's `separator` byte (the vertical bar (`|`) by
+/// default, or the exclamation mark (`!`) for a nested table) that appears at
+/// the start of a line or is preceded by whitespace, optionally with a
+/// [cell specifier](CellSpec) (e.g. `^`, `2+`, `.>`) directly in front of the
+/// separator. The token immediately preceding a separator is taken to be a
+/// specifier when it parses as one (see [`parse_cell_spec`]); a token that
+/// doesn't parse as a specifier means the separator is not a cell boundary.
+/// Content before the first boundary is ignored.
 ///
-/// An escaped separator (`\|`) is preceded by a backslash, which is not a valid
-/// specifier, so the `|` already fails the boundary test and needs no special
-/// handling here; the backslash is stripped later in [`TableCell::parse`].
-fn scan_cells(region: Span<'_>) -> Vec<RawCell<'_>> {
+/// An escaped separator (e.g. `\|`) is preceded by a backslash, which is not a
+/// valid specifier, so the separator already fails the boundary test and needs
+/// no special handling here; the backslash is stripped later in
+/// [`TableCell::parse`].
+fn scan_cells(region: Span<'_>, separator: u8) -> Vec<RawCell<'_>> {
     let data = region.data();
     let bytes = data.as_bytes();
     let len = bytes.len();
@@ -1378,13 +1449,13 @@ fn scan_cells(region: Span<'_>) -> Vec<RawCell<'_>> {
     let mut i = 0;
 
     while i < len {
-        if bytes.get(i).copied() == Some(b'|') {
-            // Walk back to the start of the token directly preceding this `|`.
-            // The token (a possible cell specifier) runs back to the previous
-            // whitespace, tab, or newline, or to the start of the region; either
-            // way the token is anchored at a line start or after whitespace, as a
-            // cell boundary requires. (When `tok_start == i` the token is empty
-            // and the separator is plain.)
+        if bytes.get(i).copied() == Some(separator) {
+            // Walk back to the start of the token directly preceding this
+            // separator. The token (a possible cell specifier) runs back to the
+            // previous whitespace, tab, or newline, or to the start of the
+            // region; either way the token is anchored at a line start or after
+            // whitespace, as a cell boundary requires. (When `tok_start == i`
+            // the token is empty and the separator is plain.)
             let mut tok_start = i;
             while tok_start > 0
                 && !matches!(

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -138,21 +138,34 @@ impl<'src> TableBlock<'src> {
             !line1.after.is_empty() && line1.after.take_line().item.data().trim().is_empty();
         let has_header = opts_header || (!line1_blank && line2_blank);
 
-        // A titled table is given an automatic caption (e.g. "Table 1. ") that
-        // a processor prepends to the title. The label comes from the
-        // `table-caption` attribute (which defaults to "Table"); each captioned
-        // table consumes the next value of a document-wide table counter. When
-        // `table-caption` is unset, no caption (and no number) is assigned.
+        // A titled table is given a caption (e.g. "Table 1. ") that a processor
+        // prepends to the title.
+        //
+        // An explicit `caption` attribute on the table sets the label verbatim
+        // (including any trailing whitespace) and is used as-is, with no
+        // automatically incremented number; it applies even when
+        // `table-caption` has been unset. Otherwise the label comes from the
+        // `table-caption` attribute (which defaults to "Table"), and each such
+        // captioned table consumes the next value of a document-wide table
+        // counter. When `table-caption` is unset and no explicit `caption` is
+        // given, no caption (and no number) is assigned.
         //
         // Computed before the cell iterator below borrows `parser` immutably, so
         // that the mutable counter update does not conflict with that borrow.
         let caption = if metadata.title.is_some() {
-            match parser.attribute_value("table-caption") {
-                InterpretedValue::Value(label) if !label.is_empty() => {
-                    let number = parser.assign_table_number();
-                    Some(format!("{label} {number}. "))
-                }
-                _ => None,
+            match metadata
+                .attrlist
+                .as_ref()
+                .and_then(|a| a.named_attribute("caption"))
+            {
+                Some(attr) => Some(attr.value().to_string()),
+                None => match parser.attribute_value("table-caption") {
+                    InterpretedValue::Value(label) if !label.is_empty() => {
+                        let number = parser.assign_table_number();
+                        Some(format!("{label} {number}. "))
+                    }
+                    _ => None,
+                },
             }
         } else {
             None
@@ -221,12 +234,15 @@ impl<'src> TableBlock<'src> {
         })
     }
 
-    /// Returns the automatic caption assigned to this table, if any.
+    /// Returns the caption assigned to this table, if any.
     ///
-    /// A titled table is captioned with a label and number (e.g. `"Table 1. "`)
-    /// that a processor prepends to the [`title`](IsBlock::title). The caption
-    /// is absent when the table has no title or when the `table-caption`
-    /// attribute has been unset.
+    /// A titled table is captioned with a label that a processor prepends to
+    /// the [`title`](IsBlock::title). By default the label combines the
+    /// `table-caption` attribute and an automatically incremented number (e.g.
+    /// `"Table 1. "`). An explicit `caption` attribute on the table overrides
+    /// this with a verbatim label and no number. The caption is absent when the
+    /// table has no title, or when `table-caption` has been unset and no
+    /// explicit `caption` is given.
     pub fn caption(&self) -> Option<&str> {
         self.caption.as_deref()
     }

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1,0 +1,445 @@
+use crate::{
+    HasSpan, Parser, Span,
+    attributes::Attrlist,
+    blocks::{ContentModel, IsBlock, metadata::BlockMetadata},
+    content::{Content, SubstitutionGroup},
+    parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning},
+    span::MatchedItem,
+    strings::CowStr,
+    warnings::{MatchAndWarnings, Warning, WarningType},
+};
+
+/// A table is a delimited block that arranges content into a grid of rows and
+/// columns.
+///
+/// A table is introduced by a table delimiter (`|===`) and closed by a matching
+/// delimiter. Cells are separated using prefix-separated value (PSV) syntax: a
+/// vertical bar (`|`) at the start of a line or preceded by whitespace begins a
+/// new cell. Cells flow, in document order, into rows whose length is fixed by
+/// the number of columns.
+///
+/// The number of columns is determined either by the `cols` attribute or,
+/// implicitly, by the number of cells found in the first non-empty line after
+/// the opening delimiter.
+///
+/// # Not yet supported
+///
+/// This is an initial implementation covering the basic PSV table. The
+/// following table features are recognized by the wider AsciiDoc specification
+/// but are not yet implemented:
+///
+/// * The CSV, TSV, and DSV data formats (and the `,===` / `:===` shorthand
+///   delimiters).
+/// * Column specifiers and multipliers beyond a proportional width (alignment
+///   and style operators).
+/// * Cell specifiers (spans, duplication, per-cell alignment and style, and the
+///   `a` AsciiDoc style that nests block content inside a cell).
+/// * Footer rows.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TableBlock<'src> {
+    columns: Vec<TableColumn>,
+    header_row: Option<TableRow<'src>>,
+    body_rows: Vec<TableRow<'src>>,
+    footer_row: Option<TableRow<'src>>,
+    source: Span<'src>,
+    title_source: Option<Span<'src>>,
+    title: Option<String>,
+    anchor: Option<Span<'src>>,
+    anchor_reftext: Option<Span<'src>>,
+    attrlist: Option<Attrlist<'src>>,
+}
+
+impl<'src> TableBlock<'src> {
+    /// Returns `true` if `line` is a table delimiter.
+    ///
+    /// A table delimiter is a vertical bar (`|`) followed by three or more
+    /// equals signs (`===`).
+    ///
+    /// **NOTE:** The `,===` (CSV), `:===` (DSV), and `!===` (nested) shorthand
+    /// delimiters are not yet recognized.
+    pub(crate) fn is_table_delimiter(line: &Span<'src>) -> bool {
+        let data = line.data();
+        // `len() >= 4` plus the leading `|` guarantees `rest` holds at least three
+        // bytes, so the closure only needs to confirm they are all `=`.
+        data.len() >= 4
+            && data.starts_with('|')
+            && data
+                .get(1..)
+                .is_some_and(|rest| rest.bytes().all(|b| b == b'='))
+    }
+
+    pub(crate) fn parse(
+        metadata: &BlockMetadata<'src>,
+        parser: &mut Parser,
+    ) -> Option<MatchAndWarnings<'src, Option<MatchedItem<'src, Self>>>> {
+        let delimiter = metadata.block_start.take_normalized_line();
+
+        if !Self::is_table_delimiter(&delimiter.item) {
+            return None;
+        }
+
+        let delimiter_text = delimiter.item.data();
+
+        // Find the matching closing delimiter.
+        let mut next = delimiter.after;
+        let (closing_delimiter, after) = loop {
+            if next.is_empty() {
+                break (next, next);
+            }
+
+            let line = next.take_normalized_line();
+            if line.item.data() == delimiter_text {
+                break (line.item, line.after);
+            }
+            next = line.after;
+        };
+
+        let inside = delimiter.after.trim_remainder(closing_delimiter);
+
+        // Determine the number of columns, either from the `cols` attribute or
+        // implicitly from the number of cells in the first non-empty line.
+        let columns: Vec<TableColumn> = metadata
+            .attrlist
+            .as_ref()
+            .and_then(|a| a.named_attribute("cols"))
+            .map(|attr| parse_cols(attr.value()))
+            .unwrap_or_default();
+
+        let first_line_cells = scan_cells(inside.discard_empty_lines().take_line().item).len();
+
+        let ncols = if columns.is_empty() {
+            first_line_cells
+        } else {
+            columns.len()
+        };
+
+        let columns = if columns.is_empty() {
+            (0..ncols).map(|_| TableColumn::default()).collect()
+        } else {
+            columns
+        };
+
+        // The first row is an (implicit) header row when the line directly after
+        // the opening delimiter is non-empty and is itself followed by an empty
+        // line. The `header` option forces the same interpretation.
+        let opts_header = metadata
+            .attrlist
+            .as_ref()
+            .is_some_and(|a| a.has_option("header"));
+
+        // The blank line must genuinely exist after the first row; the end of the
+        // table (an empty remainder) does not count, so a single-row table is not
+        // mistaken for an all-header table.
+        let line1 = inside.take_line();
+        let line1_blank = line1.item.data().trim().is_empty();
+        let line2_blank =
+            !line1.after.is_empty() && line1.after.take_line().item.data().trim().is_empty();
+        let has_header = opts_header || (!line1_blank && line2_blank);
+
+        // Scan every cell in the table, in document order, then partition into
+        // rows of `ncols` cells each.
+        let mut cells = scan_cells(inside)
+            .into_iter()
+            .map(|raw| TableCell::parse(raw, parser));
+
+        let header_row = if has_header && ncols > 0 {
+            let row: Vec<TableCell<'src>> = cells.by_ref().take(ncols).collect();
+            if row.is_empty() {
+                None
+            } else {
+                Some(TableRow { cells: row })
+            }
+        } else {
+            None
+        };
+
+        let mut body_rows: Vec<TableRow<'src>> = vec![];
+        if ncols > 0 {
+            loop {
+                let row: Vec<TableCell<'src>> = cells.by_ref().take(ncols).collect();
+                if row.is_empty() {
+                    break;
+                }
+                body_rows.push(TableRow { cells: row });
+            }
+        }
+
+        let source = metadata
+            .source
+            .trim_remainder(closing_delimiter.discard_all())
+            .trim_trailing_whitespace();
+
+        let warnings = if closing_delimiter.is_empty() {
+            vec![Warning {
+                source: delimiter.item,
+                warning: WarningType::UnterminatedDelimitedBlock,
+            }]
+        } else {
+            vec![]
+        };
+
+        Some(MatchAndWarnings {
+            item: Some(MatchedItem {
+                item: Self {
+                    columns,
+                    header_row,
+                    body_rows,
+                    footer_row: None,
+                    source,
+                    title_source: metadata.title_source,
+                    title: metadata.title.clone(),
+                    anchor: metadata.anchor,
+                    anchor_reftext: metadata.anchor_reftext,
+                    attrlist: metadata.attrlist.clone(),
+                },
+                after,
+            }),
+            warnings,
+        })
+    }
+
+    /// Returns the columns of this table.
+    pub fn columns(&self) -> &[TableColumn] {
+        &self.columns
+    }
+
+    /// Returns the header row of this table, if one was declared.
+    pub fn header_row(&self) -> Option<&TableRow<'src>> {
+        self.header_row.as_ref()
+    }
+
+    /// Returns the body rows of this table.
+    pub fn body_rows(&self) -> &[TableRow<'src>] {
+        &self.body_rows
+    }
+
+    /// Returns the footer row of this table, if one was declared.
+    pub fn footer_row(&self) -> Option<&TableRow<'src>> {
+        self.footer_row.as_ref()
+    }
+
+    /// Resolves any deferred cross-references in this table's cells.
+    pub(crate) fn resolve_references(
+        &mut self,
+        resolver: &dyn ReferenceResolver,
+        renderer: &dyn InlineSubstitutionRenderer,
+        warnings: &mut Vec<ReferenceWarning>,
+    ) {
+        let rows = self
+            .header_row
+            .iter_mut()
+            .chain(self.body_rows.iter_mut())
+            .chain(self.footer_row.iter_mut());
+
+        for row in rows {
+            for cell in row.cells.iter_mut() {
+                cell.content
+                    .resolve_references(resolver, renderer, warnings);
+            }
+        }
+    }
+}
+
+impl<'src> IsBlock<'src> for TableBlock<'src> {
+    fn content_model(&self) -> ContentModel {
+        ContentModel::Table
+    }
+
+    fn raw_context(&self) -> CowStr<'src> {
+        "table".into()
+    }
+
+    fn title_source(&'src self) -> Option<Span<'src>> {
+        self.title_source
+    }
+
+    fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    fn anchor(&'src self) -> Option<Span<'src>> {
+        self.anchor
+    }
+
+    fn anchor_reftext(&'src self) -> Option<Span<'src>> {
+        self.anchor_reftext
+    }
+
+    fn attrlist(&'src self) -> Option<&'src Attrlist<'src>> {
+        self.attrlist.as_ref()
+    }
+}
+
+impl<'src> HasSpan<'src> for TableBlock<'src> {
+    fn span(&self) -> Span<'src> {
+        self.source
+    }
+}
+
+/// A column in a [`TableBlock`].
+///
+/// For now a column carries only its proportional width. Alignment and style
+/// operators on the `cols` specifier are not yet modeled.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TableColumn {
+    width: usize,
+}
+
+impl TableColumn {
+    /// Returns the proportional width of this column relative to the other
+    /// columns in the table.
+    pub fn width(&self) -> usize {
+        self.width
+    }
+}
+
+impl Default for TableColumn {
+    fn default() -> Self {
+        Self { width: 1 }
+    }
+}
+
+/// A row of cells in a [`TableBlock`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TableRow<'src> {
+    cells: Vec<TableCell<'src>>,
+}
+
+impl<'src> TableRow<'src> {
+    /// Returns the cells in this row.
+    pub fn cells(&self) -> &[TableCell<'src>] {
+        &self.cells
+    }
+}
+
+/// A single cell in a [`TableBlock`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TableCell<'src> {
+    content: Content<'src>,
+}
+
+impl<'src> TableCell<'src> {
+    /// Build a cell from the raw (untrimmed) span of its content.
+    ///
+    /// Leading and trailing whitespace is stripped, escaped cell separators
+    /// (`\|`) are unescaped, and normal inline substitutions are applied.
+    fn parse(raw: Span<'src>, parser: &Parser) -> Self {
+        let trimmed = trim_surrounding_whitespace(raw);
+        let data = trimmed.data();
+
+        let mut content = if data.contains("\\|") {
+            Content::from_filtered(trimmed, data.replace("\\|", "|"))
+        } else {
+            Content::from(trimmed)
+        };
+
+        SubstitutionGroup::Normal.apply(&mut content, parser, None);
+
+        Self { content }
+    }
+
+    /// Returns the interpreted content of this cell.
+    pub fn content(&self) -> &Content<'src> {
+        &self.content
+    }
+}
+
+/// Parse the value of the `cols` attribute into a list of columns.
+///
+/// The value is a comma-separated list of column specifiers. A specifier may be
+/// preceded by a multiplier (`<n>*`) that repeats the column `n` times. Only
+/// the proportional width portion of a specifier is currently interpreted.
+fn parse_cols(value: &str) -> Vec<TableColumn> {
+    let mut columns: Vec<TableColumn> = vec![];
+
+    for part in value.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+
+        if let Some((count, spec)) = part.split_once('*') {
+            let repeat = count.trim().parse::<usize>().unwrap_or(1).max(1);
+            let column = parse_col_spec(spec);
+            for _ in 0..repeat {
+                columns.push(column.clone());
+            }
+        } else {
+            columns.push(parse_col_spec(part));
+        }
+    }
+
+    columns
+}
+
+/// Parse a single column specifier, extracting its proportional width.
+///
+/// In a full column specifier the width is the single numeric token, optionally
+/// preceded by alignment operators and followed by a style operator (neither of
+/// which is interpreted yet). The width is therefore the first contiguous run
+/// of digits; a spec with no digits falls back to the default width. Taking the
+/// first run — rather than concatenating every digit in the spec — keeps
+/// unrelated digit groups from fusing once those operators are supported.
+fn parse_col_spec(spec: &str) -> TableColumn {
+    let digits: String = spec
+        .chars()
+        .skip_while(|c| !c.is_ascii_digit())
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+
+    match digits.parse::<usize>() {
+        Ok(width) if width > 0 => TableColumn { width },
+        _ => TableColumn::default(),
+    }
+}
+
+/// Scan a region for PSV cell boundaries, returning the raw (untrimmed) span of
+/// each cell's content.
+///
+/// A cell boundary is a vertical bar (`|`) that appears at the start of a line
+/// or is preceded by whitespace. Content before the first boundary is ignored.
+///
+/// An escaped separator (`\|`) is preceded by a backslash — neither a line
+/// start nor whitespace — so it already fails the boundary test and needs no
+/// special handling here; the backslash is stripped later in
+/// [`TableCell::parse`].
+fn scan_cells(region: Span<'_>) -> Vec<Span<'_>> {
+    let bytes = region.data().as_bytes();
+    let len = bytes.len();
+
+    let mut cells: Vec<Span<'_>> = vec![];
+    let mut content_start: Option<usize> = None;
+    let mut i = 0;
+
+    while i < len {
+        if bytes.get(i) == Some(&b'|') {
+            let prev = i.checked_sub(1).and_then(|p| bytes.get(p)).copied();
+            let at_line_start = prev.is_none() || prev == Some(b'\n');
+            let after_space = prev == Some(b' ') || prev == Some(b'\t');
+
+            if at_line_start || after_space {
+                if let Some(start) = content_start {
+                    cells.push(region.slice(start..i));
+                }
+                content_start = Some(i + 1);
+            }
+        }
+
+        i += 1;
+    }
+
+    if let Some(start) = content_start {
+        cells.push(region.slice(start..len));
+    }
+
+    cells
+}
+
+/// Return the subspan of `s` with surrounding whitespace (including newlines)
+/// removed.
+fn trim_surrounding_whitespace(s: Span<'_>) -> Span<'_> {
+    let data = s.data();
+    let start = data.len() - data.trim_start().len();
+    let len = data.trim().len();
+    s.slice(start..start + len)
+}

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -31,8 +31,9 @@ use crate::{
 ///
 /// * The CSV, TSV, and DSV data formats (and the `,===` / `:===` shorthand
 ///   delimiters).
-/// * Column specifiers and multipliers beyond a proportional width (alignment
-///   and style operators).
+/// * Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, `s`,
+///   and `v` operators); proportional width and the horizontal and vertical
+///   alignment operators are supported.
 /// * Cell specifiers (spans, duplication, per-cell alignment and style, and the
 ///   `a` AsciiDoc style that nests block content inside a cell).
 /// * Footer rows.
@@ -331,11 +332,14 @@ impl<'src> HasSpan<'src> for TableBlock<'src> {
 
 /// A column in a [`TableBlock`].
 ///
-/// For now a column carries only its proportional width. Alignment and style
-/// operators on the `cols` specifier are not yet modeled.
+/// A column carries its proportional width and the horizontal and vertical
+/// alignment applied to its cells' content. Style operators on the `cols`
+/// specifier are not yet modeled.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableColumn {
     width: usize,
+    h_align: HorizontalAlignment,
+    v_align: VerticalAlignment,
 }
 
 impl TableColumn {
@@ -344,12 +348,75 @@ impl TableColumn {
     pub fn width(&self) -> usize {
         self.width
     }
+
+    /// Returns the horizontal alignment applied to this column's content.
+    ///
+    /// The alignment comes from a horizontal alignment operator (`<`, `>`, or
+    /// `^`) on the column's specifier and defaults to
+    /// [`HorizontalAlignment::Left`].
+    pub fn h_align(&self) -> HorizontalAlignment {
+        self.h_align
+    }
+
+    /// Returns the vertical alignment applied to this column's content.
+    ///
+    /// The alignment comes from a vertical alignment operator (`.<`, `.>`, or
+    /// `.^`) on the column's specifier and defaults to
+    /// [`VerticalAlignment::Top`].
+    pub fn v_align(&self) -> VerticalAlignment {
+        self.v_align
+    }
 }
 
 impl Default for TableColumn {
     fn default() -> Self {
-        Self { width: 1 }
+        Self {
+            width: 1,
+            h_align: HorizontalAlignment::Left,
+            v_align: VerticalAlignment::Top,
+        }
     }
+}
+
+/// The horizontal alignment of a column's content.
+///
+/// Specified by a horizontal alignment operator at the start of a
+/// [column specifier](TableColumn): the less-than sign (`<`) for
+/// [`Left`](Self::Left), the greater-than sign (`>`) for
+/// [`Right`](Self::Right), and the caret (`^`) for [`Center`](Self::Center).
+/// The default is [`Left`](Self::Left).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HorizontalAlignment {
+    /// Content is aligned to the left side of the column (the `<` operator).
+    /// This is the default horizontal alignment.
+    Left,
+
+    /// Content is centered horizontally in the column (the `^` operator).
+    Center,
+
+    /// Content is aligned to the right side of the column (the `>` operator).
+    Right,
+}
+
+/// The vertical alignment of a column's content.
+///
+/// Specified by a vertical alignment operator on a
+/// [column specifier](TableColumn), always introduced by a dot (`.`): `.<` for
+/// [`Top`](Self::Top), `.>` for [`Bottom`](Self::Bottom), and `.^` for
+/// [`Middle`](Self::Middle). The default is [`Top`](Self::Top).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum VerticalAlignment {
+    /// Content is aligned to the top of the column's cells (the `.<` operator).
+    /// This is the default vertical alignment.
+    Top,
+
+    /// Content is centered vertically in the column's cells (the `.^`
+    /// operator).
+    Middle,
+
+    /// Content is aligned to the bottom of the column's cells (the `.>`
+    /// operator).
+    Bottom,
 }
 
 /// A row of cells in a [`TableBlock`].
@@ -400,8 +467,9 @@ impl<'src> TableCell<'src> {
 /// Parse the value of the `cols` attribute into a list of columns.
 ///
 /// The value is a comma-separated list of column specifiers. A specifier may be
-/// preceded by a multiplier (`<n>*`) that repeats the column `n` times. Only
-/// the proportional width portion of a specifier is currently interpreted.
+/// preceded by a multiplier (`<n>*`) that repeats the column `n` times. The
+/// alignment operators and proportional width of a specifier are interpreted;
+/// the style operator is not yet.
 fn parse_cols(value: &str) -> Vec<TableColumn> {
     let mut columns: Vec<TableColumn> = vec![];
 
@@ -425,24 +493,73 @@ fn parse_cols(value: &str) -> Vec<TableColumn> {
     columns
 }
 
-/// Parse a single column specifier, extracting its proportional width.
+/// Parse a single column specifier, extracting its alignment and proportional
+/// width.
 ///
-/// In a full column specifier the width is the single numeric token, optionally
-/// preceded by alignment operators and followed by a style operator (neither of
-/// which is interpreted yet). The width is therefore the first contiguous run
-/// of digits; a spec with no digits falls back to the default width. Taking the
-/// first run — rather than concatenating every digit in the spec — keeps
-/// unrelated digit groups from fusing once those operators are supported.
+/// A column specifier is positional: an optional horizontal alignment operator
+/// (`<`, `>`, or `^`) comes first, followed by an optional vertical alignment
+/// operator (`.<`, `.>`, or `.^`), followed by the width, and finally an
+/// optional style operator. When a multiplier (`<n>*`) is present, the
+/// operators follow the multiplier, so the `spec` passed here is the portion
+/// after the `*`.
+///
+/// The width is the first contiguous run of digits after any alignment
+/// operators; a spec with no digits falls back to the default width. Taking the
+/// first run — rather than concatenating every digit — keeps the width from
+/// fusing with digits in an as-yet-unmodeled style operator. The style operator
+/// is otherwise ignored.
 fn parse_col_spec(spec: &str) -> TableColumn {
-    let digits: String = spec
-        .chars()
-        .skip_while(|c| !c.is_ascii_digit())
-        .take_while(|c| c.is_ascii_digit())
-        .collect();
+    let mut rest = spec.trim();
 
-    match digits.parse::<usize>() {
-        Ok(width) if width > 0 => TableColumn { width },
-        _ => TableColumn::default(),
+    // Horizontal alignment operator (if present) always comes first.
+    let mut h_align = HorizontalAlignment::Left;
+    match rest.as_bytes().first() {
+        Some(b'<') => {
+            h_align = HorizontalAlignment::Left;
+            rest = &rest[1..];
+        }
+        Some(b'>') => {
+            h_align = HorizontalAlignment::Right;
+            rest = &rest[1..];
+        }
+        Some(b'^') => {
+            h_align = HorizontalAlignment::Center;
+            rest = &rest[1..];
+        }
+        _ => {}
+    }
+
+    // Vertical alignment operator (if present) follows, introduced by a dot.
+    let mut v_align = VerticalAlignment::Top;
+    if let Some(after_dot) = rest.strip_prefix('.') {
+        match after_dot.as_bytes().first() {
+            Some(b'<') => {
+                v_align = VerticalAlignment::Top;
+                rest = &after_dot[1..];
+            }
+            Some(b'>') => {
+                v_align = VerticalAlignment::Bottom;
+                rest = &after_dot[1..];
+            }
+            Some(b'^') => {
+                v_align = VerticalAlignment::Middle;
+                rest = &after_dot[1..];
+            }
+            _ => {}
+        }
+    }
+
+    // Width is the first run of digits after the alignment operators.
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    let width = match digits.parse::<usize>() {
+        Ok(width) if width > 0 => width,
+        _ => TableColumn::default().width,
+    };
+
+    TableColumn {
+        width,
+        h_align,
+        v_align,
     }
 }
 

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1010,13 +1010,17 @@ fn finalize_columns(
 struct TableBody<'src> {
     /// The region between the opening and closing delimiters.
     inside: Span<'src>,
+
     /// The resolved cell separator.
     separator: String,
+
     /// Columns parsed from the `cols` attribute (empty when the attribute is
     /// absent, in which case the column count is implicit).
     cols_attr: Vec<TableColumn>,
+
     /// Whether the table carries the `autowidth` option.
     autowidth: bool,
+
     /// Whether the first row is a header row.
     has_header: bool,
 }
@@ -1055,6 +1059,7 @@ fn build_psv_table<'src>(
         autowidth,
         has_header,
     } = body;
+
     let separator = separator.as_str();
 
     // When the column count is implicit, it is the number of column slots in the
@@ -1083,6 +1088,7 @@ fn build_psv_table<'src>(
             warning: WarningType::TableMissingLeadingSeparator,
         });
     }
+
     let raw_cells = expand_duplicates(raw_cells);
 
     // A table can never have more rows than it has cells, so a row span is
@@ -1097,6 +1103,7 @@ fn build_psv_table<'src>(
     let max_rowspan = raw_cells.len().saturating_add(1);
 
     let mut raw_rows: Vec<Vec<RawCell<'src>>> = vec![];
+
     if ncols > 0 {
         // A queue: each completed row consumes the slots carried into it from the
         // front (`pop_front`), while a multi-row cell reserves slots in the rows it
@@ -1207,6 +1214,7 @@ fn build_data_table<'src>(
         autowidth,
         has_header,
     } = body;
+
     let separator = separator.as_str();
 
     // DSV is parsed by its own, simpler rules; CSV and TSV share their rules and
@@ -1490,6 +1498,7 @@ fn parse_dsv_fields<'src>(region: Span<'src>, separator: &str) -> (Vec<DataField
         let mut fields_in_row = 0usize;
         let mut field_start = i;
         let mut p = i;
+
         while p < line_end {
             // A backslash that escapes the separator (`\:`) is not a boundary;
             // skip past both so the separator stays in the value.
@@ -1637,11 +1646,13 @@ fn process_content<'src>(
                 let mut owned_warnings: Vec<Warning<'_>> = vec![];
                 let (title, inline, blocks) =
                     parse_asciidoc_cell_body(Span::new(source), parser, &mut owned_warnings);
+
                 debug_assert!(
                     owned_warnings.is_empty(),
                     "warnings from an include-expanded AsciiDoc cell are dropped; \
                      propagate them before adding any to this path"
                 );
+
                 OwnedCellInner {
                     title,
                     inline,
@@ -1715,6 +1726,7 @@ fn parse_asciidoc_cell_body<'src>(
         parser.attribute_value("doctype"),
         InterpretedValue::Value(ref v) if v == "inline"
     );
+
     let title = if parser.resolve_show_title(true) {
         title_source.map(|span| {
             let mut content = Content::from(span);
@@ -2043,6 +2055,7 @@ impl<'src> AsciiDocCell<'src> {
                     block.resolve_references(resolver, renderer, warnings);
                 }
             }
+
             // The owned store is shared behind an `Arc`, but references are
             // resolved immediately after parsing while the cell is still its sole
             // owner, so `get_mut` succeeds.
@@ -2170,14 +2183,17 @@ fn parse_col_spec(spec: &str) -> TableColumn {
             h_align = HorizontalAlignment::Left;
             rest = &rest[1..];
         }
+
         Some(b'>') => {
             h_align = HorizontalAlignment::Right;
             rest = &rest[1..];
         }
+
         Some(b'^') => {
             h_align = HorizontalAlignment::Center;
             rest = &rest[1..];
         }
+
         _ => {}
     }
 
@@ -2189,14 +2205,17 @@ fn parse_col_spec(spec: &str) -> TableColumn {
                 v_align = VerticalAlignment::Top;
                 rest = &after_dot[1..];
             }
+
             Some(b'>') => {
                 v_align = VerticalAlignment::Bottom;
                 rest = &after_dot[1..];
             }
+
             Some(b'^') => {
                 v_align = VerticalAlignment::Middle;
                 rest = &after_dot[1..];
             }
+
             _ => {}
         }
     }
@@ -2315,12 +2334,14 @@ fn expand_duplicates(cells: Vec<RawCell<'_>>) -> Vec<RawCell<'_>> {
         .iter()
         .map(|c| c.spec.repeat.min(MAX_DUPLICATION_FACTOR).saturating_sub(1))
         .sum();
+
     let mut expanded = Vec::with_capacity(cells.len() + extra);
     for cell in cells {
         for _ in 0..cell.spec.repeat.min(MAX_DUPLICATION_FACTOR) {
             expanded.push(cell);
         }
     }
+
     expanded
 }
 
@@ -2351,19 +2372,23 @@ fn scan_cells<'src>(
     let data = region.data();
     let bytes = data.as_bytes();
     let len = bytes.len();
+
     // A zero-length separator would never advance; treat it as a single byte to
     // stay safe. (The resolver never produces an empty separator.)
     let sep_len = separator.len().max(1);
 
     let mut cells: Vec<RawCell<'src>> = vec![];
+
     // The content start and specifier of the cell currently being accumulated.
     let mut content_start: Option<usize> = None;
+
     let mut cur_spec = CellSpec::default();
+
     // The span of a cell recovered from content that precedes the first
     // separator (see below); `Some` drives a missing-leading-separator warning.
     let mut recovered: Option<Span<'src>> = None;
-    let mut i = 0;
 
+    let mut i = 0;
     while i < len {
         if data
             .get(i..)
@@ -2419,6 +2444,7 @@ fn scan_cells<'src>(
                         content: region.slice(start..content_end),
                     });
                 }
+
                 None => {
                     // No cell has been opened yet, so this is the table's first
                     // separator. Non-blank content in front of it means the first
@@ -2435,6 +2461,7 @@ fn scan_cells<'src>(
                     }
                 }
             }
+
             cur_spec = next_spec;
             content_start = Some(i + sep_len);
             i += sep_len;
@@ -2492,12 +2519,15 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
     let mut rowspan = 1;
     let mut repeat = 1;
     let col_start = i;
+
     let mut j = i;
     while matches!(b.get(j).copied(), Some(c) if c.is_ascii_digit()) {
         j += 1;
     }
+
     let col_end = j;
     let mut has_dot = false;
+
     let mut row_start = j;
     if b.get(j).copied() == Some(b'.') {
         has_dot = true;
@@ -2507,6 +2537,7 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
             j += 1;
         }
     }
+
     let row_end = j;
     match b.get(j).copied() {
         // Span: the factor is interpreted as a colspan and rowspan. A missing
@@ -2527,6 +2558,7 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
             }
             i = j + 1;
         }
+
         // Duplication: the factor is interpreted as a duplication count, so the
         // cell's content and properties are cloned into `<n>` consecutive cells.
         // Only the column part of the factor is the count; any row part (`<n>.`)
@@ -2540,6 +2572,7 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
             }
             i = j + 1;
         }
+
         _ => {}
     }
 
@@ -2550,14 +2583,17 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
             h_align = Some(HorizontalAlignment::Left);
             i += 1;
         }
+
         Some(b'>') => {
             h_align = Some(HorizontalAlignment::Right);
             i += 1;
         }
+
         Some(b'^') => {
             h_align = Some(HorizontalAlignment::Center);
             i += 1;
         }
+
         _ => {}
     }
 
@@ -2569,14 +2605,17 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
                 v_align = Some(VerticalAlignment::Top);
                 i += 2;
             }
+
             Some(b'>') => {
                 v_align = Some(VerticalAlignment::Bottom);
                 i += 2;
             }
+
             Some(b'^') => {
                 v_align = Some(VerticalAlignment::Middle);
                 i += 2;
             }
+
             _ => {}
         }
     }
@@ -2650,6 +2689,7 @@ fn trim_cell_content(s: Span<'_>, style: ColumnStyle) -> Span<'_> {
             }
             s.slice(start..end)
         }
+
         ColumnStyle::AsciiDoc => {
             let end = data.trim_end().len();
             if data[..end].starts_with('\n') {
@@ -2663,6 +2703,7 @@ fn trim_cell_content(s: Span<'_>, style: ColumnStyle) -> Span<'_> {
                 s.slice(start..end)
             }
         }
+
         _ => trim_surrounding_whitespace(s),
     }
 }

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -36,7 +36,6 @@ use crate::{
 /// * Cell specifiers (spans, duplication, per-cell alignment and style); the
 ///   per-cell style operator that overrides a column's style operator is not
 ///   yet recognized.
-/// * Footer rows.
 ///
 /// Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, and `s`
 /// operators) are supported, along with proportional width and the horizontal
@@ -140,6 +139,14 @@ impl<'src> TableBlock<'src> {
             .as_ref()
             .is_some_and(|a| a.has_option("noheader"));
 
+        // The last row is promoted to a footer row when the `footer` option is
+        // set. Unlike the header row, a footer cell is processed with its
+        // column's style (it is simply the last body row, relabeled).
+        let opts_footer = metadata
+            .attrlist
+            .as_ref()
+            .is_some_and(|a| a.has_option("footer"));
+
         // The blank line must genuinely exist after the first row; the end of the
         // table (an empty remainder) does not count, so a single-row table is not
         // mistaken for an all-header table.
@@ -234,6 +241,11 @@ impl<'src> TableBlock<'src> {
             }
         }
 
+        // The footer row, when requested, is the last row of the table. It is
+        // moved out of the body so the caller sees it as a distinct footer. When
+        // the table has no rows to spare, no footer is produced.
+        let footer_row = if opts_footer { body_rows.pop() } else { None };
+
         let source = metadata
             .source
             .trim_remainder(closing_delimiter.discard_all())
@@ -252,7 +264,7 @@ impl<'src> TableBlock<'src> {
                     columns,
                     header_row,
                     body_rows,
-                    footer_row: None,
+                    footer_row,
                     source,
                     title_source: metadata.title_source,
                     title: metadata.title.clone(),

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -26,26 +26,29 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 /// columns.
 ///
 /// A table is introduced by a table delimiter (`|===`, or `!===` for a nested
-/// table) and closed by a matching delimiter. Cells are separated using
-/// prefix-separated value (PSV) syntax: the table's cell separator — a vertical
-/// bar (`|`) by default — at the start of a line or preceded by whitespace
-/// begins a new cell. Cells flow, in document order, into rows whose length is
-/// fixed by the number of columns. (The separator defaults to `!` inside a
-/// nested table and can be overridden with the `separator` attribute; see
-/// below.)
+/// table) and closed by a matching delimiter. By default cells are separated
+/// using prefix-separated value (PSV) syntax: the table's cell separator — a
+/// vertical bar (`|`) by default — at the start of a line or preceded by
+/// whitespace begins a new cell. Cells flow, in document order, into rows whose
+/// length is fixed by the number of columns. (The separator defaults to `!`
+/// inside a nested table and can be overridden with the `separator` attribute;
+/// see below.)
 ///
 /// The number of columns is determined either by the `cols` attribute or,
 /// implicitly, by the number of cells found in the first non-empty line after
 /// the opening delimiter.
 ///
-/// # Not yet supported
+/// # Data formats
 ///
-/// This is an initial implementation covering the basic PSV table. The
-/// following table features are recognized by the wider AsciiDoc specification
-/// but are not yet implemented:
-///
-/// * The CSV, TSV, and DSV data formats (and the `,===` / `:===` shorthand
-///   delimiters).
+/// In addition to the default PSV format, a table can be populated from
+/// delimiter-separated data with the [`format`](Self::data_format) attribute:
+/// `csv` (comma-separated values), `tsv` (tab-separated values), or `dsv`
+/// (delimited values, colon-separated by default). The `,===` and `:===`
+/// shorthand delimiters select the CSV and DSV formats respectively without an
+/// explicit `format` attribute. In a data format the separator is placed
+/// *between* values (not in front of each cell) and a cell carries no
+/// formatting spec; cell formatting is instead applied per column with the
+/// `cols` attribute. See [`DataFormat`] for the parsing rules.
 ///
 /// Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, and `s`
 /// operators) are supported, along with proportional width and the horizontal
@@ -81,6 +84,7 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
+    data_format: DataFormat,
     header_row: Option<TableRow<'src>>,
     body_rows: Vec<TableRow<'src>>,
     footer_row: Option<TableRow<'src>>,
@@ -99,20 +103,23 @@ pub struct TableBlock<'src> {
 impl<'src> TableBlock<'src> {
     /// Returns `true` if `line` is a table delimiter.
     ///
-    /// A table delimiter is a vertical bar (`|`) or an exclamation mark (`!`)
-    /// followed by three or more equals signs (`===`). The `!===` form opens a
-    /// table whose default cell separator is the exclamation mark, which lets a
-    /// nested table be distinguished from the `|`-separated table that encloses
-    /// it.
+    /// A table delimiter is one of the lead characters `|`, `!`, `,`, or `:`
+    /// followed by three or more equals signs (`===`). The lead character also
+    /// selects the table's data format and default cell separator:
     ///
-    /// **NOTE:** The `,===` (CSV) and `:===` (DSV) shorthand delimiters are not
-    /// yet recognized.
+    /// * `|===` is the ordinary (PSV) table delimiter.
+    /// * `!===` opens a table whose default cell separator is the exclamation
+    ///   mark, which lets a nested table be distinguished from the
+    ///   `|`-separated table that encloses it.
+    /// * `,===` is the shorthand for a CSV table.
+    /// * `:===` is the shorthand for a DSV table.
     pub(crate) fn is_table_delimiter(line: &Span<'src>) -> bool {
         let data = line.data();
-        // `len() >= 4` plus the leading `|`/`!` guarantees `rest` holds at least
-        // three bytes, so the closure only needs to confirm they are all `=`.
+        // `len() >= 4` plus the leading delimiter character guarantees `rest`
+        // holds at least three bytes, so the closure only needs to confirm they
+        // are all `=`.
         data.len() >= 4
-            && (data.starts_with('|') || data.starts_with('!'))
+            && matches!(data.as_bytes().first(), Some(b'|' | b'!' | b',' | b':'))
             && data
                 .get(1..)
                 .is_some_and(|rest| rest.bytes().all(|b| b == b'='))
@@ -146,57 +153,40 @@ impl<'src> TableBlock<'src> {
 
         let inside = delimiter.after.trim_remainder(closing_delimiter);
 
-        // The cell separator partitions each row into cells. It defaults to the
-        // vertical bar (`|`), except inside an AsciiDoc table cell — a nested,
-        // standalone document — where it defaults to the exclamation mark (`!`)
-        // so a nested table is distinguished from the `|`-separated table that
-        // encloses it. The `separator` attribute overrides the default with an
-        // explicit character; an empty `separator` falls back to the default.
-        let separator = resolve_separator(metadata, parser);
+        // The data format governs how the table body is split into cells. It
+        // defaults to PSV, but the `format` attribute selects CSV, TSV, or DSV,
+        // and the `,===` / `:===` shorthand delimiters select CSV / DSV. The
+        // lead character of the delimiter (`delimiter_text`) is passed so the
+        // shorthand can be honored.
+        let data_format = resolve_data_format(metadata, delimiter_text);
 
-        // Determine the number of columns, either from the `cols` attribute or
-        // implicitly from the number of cells in the first non-empty line.
-        let columns: Vec<TableColumn> = metadata
+        // The cell separator partitions each row into cells. In PSV it defaults
+        // to the vertical bar (`|`), except inside an AsciiDoc table cell — a
+        // nested, standalone document — where it defaults to the exclamation
+        // mark (`!`) so a nested table is distinguished from the `|`-separated
+        // table that encloses it. Each data format has its own default (CSV =
+        // comma, TSV = tab, DSV = colon). The `separator` attribute overrides
+        // the default; an empty `separator` falls back to the default, and the
+        // two-character sequence `\t` is interpreted as a tab.
+        let separator = resolve_separator(metadata, parser, data_format);
+
+        // The `cols` attribute, when present, fixes the number of columns and
+        // carries the per-column formatting. When it is absent the column count
+        // is implicit (resolved per format below).
+        let cols_attr: Vec<TableColumn> = metadata
             .attrlist
             .as_ref()
             .and_then(|a| a.named_attribute("cols"))
             .map(|attr| parse_cols(attr.value()))
             .unwrap_or_default();
 
-        // When the column count is implicit, it is the number of column slots in
-        // the first non-empty line: a cell that spans columns (`<n>+`) counts as
-        // `<n>` slots, not one, and a cell duplicated `<n>` times (`<n>*`) counts
-        // as `<n>` single-column slots (one per clone).
-        let first_line_cells: usize =
-            scan_cells(inside.discard_empty_lines().take_line().item, separator)
-                .iter()
-                .map(|c| c.spec.colspan.max(1) * c.spec.repeat.min(MAX_DUPLICATION_FACTOR))
-                .sum();
-
-        let ncols = if columns.is_empty() {
-            first_line_cells
-        } else {
-            columns.len()
-        };
-
-        let mut columns: Vec<TableColumn> = if columns.is_empty() {
-            (0..ncols).map(|_| TableColumn::default()).collect()
-        } else {
-            columns
-        };
-
         // The `autowidth` option sizes the table to its content; the columns
         // inherit the setting, so every column becomes autowidth regardless of
         // any proportional width set on its specifier.
-        if metadata
+        let autowidth = metadata
             .attrlist
             .as_ref()
-            .is_some_and(|a| a.has_option("autowidth"))
-        {
-            for column in columns.iter_mut() {
-                column.autowidth = true;
-            }
-        }
+            .is_some_and(|a| a.has_option("autowidth"));
 
         // The first row is an (implicit) header row when the line directly after
         // the opening delimiter is non-empty and is itself followed by an empty
@@ -278,119 +268,24 @@ impl<'src> TableBlock<'src> {
         let stripes =
             resolve_table_attribute::<Stripes>(metadata, parser, "stripes", "table-stripes");
 
-        // Scan every cell in the table, in document order, then partition into
-        // rows by walking the grid: a cell's span (colspan/rowspan) governs how
-        // many column slots it occupies, so a column-spanning cell fills its row
-        // with fewer cells and a row-spanning cell carries its columns down into
-        // the rows below.
-        //
-        // This mirrors Asciidoctor's grid walk. `active_rowspans[k]` records the
-        // number of column slots that cells from earlier rows occupy in the row
-        // `k` steps ahead of the one being filled; a row closes once its own
-        // cells' colspans plus the slots carried into it (`active_rowspans[0]`)
-        // reach `ncols`. A cell whose span pushes the row *past* `ncols` overruns
-        // the grid: the whole overrunning row is dropped (with a warning), again
-        // matching Asciidoctor. A row whose columns are entirely pre-filled by
-        // carried slots has no cells of its own to close it, so the next cell
-        // overruns and is dropped together with that pre-filled row.
-        // A duplicated cell (`<n>*`) is expanded into `<n>` independent cells —
-        // each carrying the original's content, alignment, and style — before the
-        // grid walk, so each clone occupies its own column slot exactly like an
-        // ordinary cell. A duplication factor of zero drops the cell entirely.
+        // Split the body into columns and rows according to the data format.
+        // PSV walks a grid that honors cell spans and duplication; the data
+        // formats (CSV/TSV/DSV) split on a separator with no per-cell spec and
+        // flow the values into fixed-width rows.
         let mut warnings: Vec<Warning<'src>> = vec![];
-        let raw_cells = expand_duplicates(scan_cells(inside, separator));
-
-        // A table can never have more rows than it has cells, so a row span is
-        // clamped to the cell count for the `active_rowspans` bookkeeping below: a
-        // larger span carries into rows that can't exist and so has no additional
-        // layout effect. The clamp also bounds the `active_rowspans` allocation,
-        // so a hostile specifier such as `.1000000000+` can't trigger a
-        // multi-gigabyte allocation. (The cell's reported [`rowspan`] keeps the
-        // literal parsed value, matching Asciidoctor.)
-        //
-        // [`rowspan`]: TableCell::rowspan
-        let max_rowspan = raw_cells.len().saturating_add(1);
-
-        let mut raw_rows: Vec<Vec<RawCell<'src>>> = vec![];
-        if ncols > 0 {
-            let mut active_rowspans: Vec<usize> = vec![0];
-            let mut column_visits = 0usize;
-            let mut current_row: Vec<RawCell<'src>> = vec![];
-
-            for raw in raw_cells {
-                let colspan = raw.spec.colspan.max(1);
-                let rowspan = raw.spec.rowspan.max(1).min(max_rowspan);
-
-                // A cell that spans more than one row reserves `colspan` slots in
-                // each of the rows it extends into (but not its own row).
-                if rowspan > 1 {
-                    if active_rowspans.len() < rowspan {
-                        active_rowspans.resize(rowspan, 0);
-                    }
-                    for slot in active_rowspans.iter_mut().take(rowspan).skip(1) {
-                        *slot += colspan;
-                    }
-                }
-
-                column_visits += colspan;
-                let cell_source = raw.content;
-                current_row.push(raw);
-
-                // The slots carried into the current row are `active_rowspans[0]`;
-                // the vector is never empty here, so the fallback is unreachable.
-                let carried = active_rowspans.first().copied().unwrap_or(0);
-                let effective = column_visits + carried;
-                if effective >= ncols {
-                    if effective == ncols {
-                        raw_rows.push(std::mem::take(&mut current_row));
-                    } else {
-                        // Overrun: this cell's span pushes the row past `ncols`.
-                        // Discard the whole row so the remaining cells stay
-                        // aligned to the grid.
-                        current_row.clear();
-                        warnings.push(Warning {
-                            source: cell_source,
-                            warning: WarningType::TableCellExceedsColumnCount,
-                        });
-                    }
-                    column_visits = 0;
-                    active_rowspans.remove(0);
-                    if active_rowspans.is_empty() {
-                        active_rowspans.push(0);
-                    }
-                }
+        let body = TableBody {
+            inside,
+            separator,
+            cols_attr,
+            autowidth,
+            has_header,
+        };
+        let (columns, rows) = match data_format {
+            DataFormat::Psv => build_psv_table(body, parser, &mut warnings),
+            DataFormat::Csv | DataFormat::Tsv | DataFormat::Dsv => {
+                build_data_table(body, data_format, parser, &mut warnings)
             }
-
-            // A trailing incomplete row (one that never reached `ncols`) is still
-            // emitted, matching the existing handling of short final rows.
-            if !current_row.is_empty() {
-                raw_rows.push(current_row);
-            }
-        }
-
-        // Each cell is processed according to the style of the column it falls
-        // in. A cell's column is its ordinal position within its row (matching
-        // Asciidoctor, which assigns the column by cell count, not grid slot). The
-        // header row (when present) is the first row and is always processed as
-        // plain header content, regardless of the column styles, so that a style
-        // operator doesn't affect the header row.
-        let mut rows: Vec<TableRow<'src>> = Vec::with_capacity(raw_rows.len());
-        for (row_idx, raw_row) in raw_rows.into_iter().enumerate() {
-            let is_header = has_header && row_idx == 0;
-            let mut cells = Vec::with_capacity(raw_row.len());
-            for (col_idx, raw) in raw_row.into_iter().enumerate() {
-                let column = columns.get(col_idx).cloned().unwrap_or_default();
-                cells.push(TableCell::parse(
-                    raw,
-                    &column,
-                    is_header,
-                    separator,
-                    parser,
-                    &mut warnings,
-                ));
-            }
-            rows.push(TableRow { cells });
-        }
+        };
 
         let mut rows = rows.into_iter();
         let header_row = if has_header { rows.next() } else { None };
@@ -417,6 +312,7 @@ impl<'src> TableBlock<'src> {
             item: Some(MatchedItem {
                 item: Self {
                     columns,
+                    data_format,
                     header_row,
                     body_rows,
                     footer_row,
@@ -454,6 +350,16 @@ impl<'src> TableBlock<'src> {
     /// Returns the columns of this table.
     pub fn columns(&self) -> &[TableColumn] {
         &self.columns
+    }
+
+    /// Returns the [`DataFormat`] used to populate this table.
+    ///
+    /// The format comes from the `format` attribute on the table (`psv`, `csv`,
+    /// `tsv`, or `dsv`) or from a shorthand delimiter (`,===` selects CSV,
+    /// `:===` selects DSV). When neither is present the format defaults to
+    /// [`DataFormat::Psv`].
+    pub fn data_format(&self) -> DataFormat {
+        self.data_format
     }
 
     /// Returns the fixed width of this table, as a percentage of the content
@@ -693,6 +599,46 @@ impl Default for TableColumn {
             style: ColumnStyle::Default,
         }
     }
+}
+
+/// The data format that governs how a [`TableBlock`]'s body is split into
+/// cells.
+///
+/// The format is selected by the `format` attribute (`psv`, `csv`, `tsv`, or
+/// `dsv`) or by a shorthand delimiter (`,===` for CSV, `:===` for DSV). The
+/// default is [`Psv`](Self::Psv).
+///
+/// In the PSV format the separator is placed in front of each cell and a cell
+/// may carry a formatting spec. In the delimiter-separated formats (CSV, TSV,
+/// and DSV) the separator is placed *between* values and a cell carries no
+/// spec; cell formatting is applied per column with the `cols` attribute
+/// instead. In every delimiter-separated format empty lines are skipped,
+/// whitespace surrounding each value is stripped, and a "ragged" table (whose
+/// rows do not all have the same number of cells) has its cells flowed into
+/// fixed-width rows, dropping any cells left over at the end.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum DataFormat {
+    /// Prefix-separated values: the default format. The separator (a vertical
+    /// bar, `|`, by default) is placed in front of each cell.
+    #[default]
+    Psv,
+
+    /// Comma-separated values (the `csv` format). The default separator is a
+    /// comma (`,`). Values may be enclosed in double quotes (`"`), within which
+    /// the separator and newlines are literal and a double quote is written by
+    /// doubling it (`""`); a newline that is not inside a quoted value begins a
+    /// new row. Loosely based on RFC 4180.
+    Csv,
+
+    /// Tab-separated values (the `tsv` format). Parsed by the same rules as
+    /// [`Csv`](Self::Csv), but the default separator is a tab.
+    Tsv,
+
+    /// Delimited values (the `dsv` format). The default separator is a colon
+    /// (`:`). Unlike CSV and TSV, an enclosing character is not recognized;
+    /// instead the separator can be included in a value by escaping it with a
+    /// single backslash (`\:`).
+    Dsv,
 }
 
 /// The style applied to the content of a [column](TableColumn) (and, by
@@ -942,21 +888,63 @@ fn resolve_table_attribute<B: TableAttributeValue>(
     }
 }
 
-/// Resolve the cell separator byte for a table.
+/// Resolve the [`DataFormat`] of a table.
 ///
-/// The separator defaults to the vertical bar (`|`), except inside an AsciiDoc
-/// table cell — a nested, standalone document — where it defaults to the
-/// exclamation mark (`!`), so a nested table is distinguished from the
-/// `|`-separated table that encloses it. An explicit `separator` attribute on
-/// the table overrides the default with its first byte; an empty `separator`
-/// value (e.g. `[separator=]`) falls back to the default. A non-ASCII first
-/// character is ignored (the byte-oriented cell scanner only recognizes a
-/// single-byte separator), so it too falls back to the default.
-fn resolve_separator(metadata: &BlockMetadata<'_>, parser: &Parser) -> u8 {
-    let default = if parser.nested_document_depth > 0 {
-        b'!'
-    } else {
-        b'|'
+/// An explicit, recognized `format` attribute (`psv`, `csv`, `tsv`, or `dsv`)
+/// always wins. Otherwise the lead character of the delimiter selects the
+/// format via its shorthand — `,===` is CSV and `:===` is DSV — and any other
+/// delimiter (`|===`, `!===`) is PSV.
+fn resolve_data_format(metadata: &BlockMetadata<'_>, delimiter_text: &str) -> DataFormat {
+    if let Some(attr) = metadata
+        .attrlist
+        .as_ref()
+        .and_then(|a| a.named_attribute("format"))
+    {
+        match attr.value().trim() {
+            "psv" => return DataFormat::Psv,
+            "csv" => return DataFormat::Csv,
+            "tsv" => return DataFormat::Tsv,
+            "dsv" => return DataFormat::Dsv,
+            // An unrecognized format value falls through to the shorthand (or
+            // the PSV default).
+            _ => {}
+        }
+    }
+
+    match delimiter_text.as_bytes().first() {
+        Some(b',') => DataFormat::Csv,
+        Some(b':') => DataFormat::Dsv,
+        _ => DataFormat::Psv,
+    }
+}
+
+/// Resolve the cell separator for a table.
+///
+/// Each [`DataFormat`] supplies a default separator: PSV uses the vertical bar
+/// (`|`), except inside an AsciiDoc table cell — a nested, standalone document
+/// — where it defaults to the exclamation mark (`!`) so a nested table is
+/// distinguished from the `|`-separated table that encloses it; CSV defaults to
+/// a comma (`,`), TSV to a tab, and DSV to a colon (`:`). An explicit
+/// `separator` attribute on the table overrides the default; an empty
+/// `separator` value (e.g. `[separator=]`) falls back to the default. The
+/// two-character sequence `\t` in the attribute value is interpreted as a tab,
+/// so a tab-separated table can be written `[format=csv,separator=\t]`.
+fn resolve_separator(
+    metadata: &BlockMetadata<'_>,
+    parser: &Parser,
+    data_format: DataFormat,
+) -> String {
+    let default = match data_format {
+        DataFormat::Psv => {
+            if parser.nested_document_depth > 0 {
+                "!"
+            } else {
+                "|"
+            }
+        }
+        DataFormat::Csv => ",",
+        DataFormat::Tsv => "\t",
+        DataFormat::Dsv => ":",
     };
 
     metadata
@@ -965,9 +953,634 @@ fn resolve_separator(metadata: &BlockMetadata<'_>, parser: &Parser) -> u8 {
         .and_then(|a| a.named_attribute("separator"))
         .map(|attr| attr.value())
         .filter(|value| !value.is_empty())
-        .and_then(|value| value.chars().next())
-        .filter(char::is_ascii)
-        .map_or(default, |c| c as u8)
+        // The author writes a literal tab as the escape sequence `\t`.
+        .map(|value| value.replace("\\t", "\t"))
+        .unwrap_or_else(|| default.to_string())
+}
+
+/// Finalize a table's columns once the column count is known.
+///
+/// When the `cols` attribute supplied columns (`cols_attr` is non-empty) they
+/// are used as-is; otherwise `ncols` default columns are created. When the
+/// table carries the `autowidth` option, every column is made autowidth
+/// regardless of the proportional width set on its specifier.
+fn finalize_columns(
+    cols_attr: Vec<TableColumn>,
+    ncols: usize,
+    autowidth: bool,
+) -> Vec<TableColumn> {
+    let mut columns = if cols_attr.is_empty() {
+        (0..ncols).map(|_| TableColumn::default()).collect()
+    } else {
+        cols_attr
+    };
+
+    if autowidth {
+        for column in columns.iter_mut() {
+            column.autowidth = true;
+        }
+    }
+
+    columns
+}
+
+/// The inputs shared by the PSV and data-format table-body builders.
+struct TableBody<'src> {
+    /// The region between the opening and closing delimiters.
+    inside: Span<'src>,
+    /// The resolved cell separator.
+    separator: String,
+    /// Columns parsed from the `cols` attribute (empty when the attribute is
+    /// absent, in which case the column count is implicit).
+    cols_attr: Vec<TableColumn>,
+    /// Whether the table carries the `autowidth` option.
+    autowidth: bool,
+    /// Whether the first row is a header row.
+    has_header: bool,
+}
+
+/// Build the columns and rows of a PSV (prefix-separated values) table.
+///
+/// The column count comes from the `cols` attribute (`cols_attr`) or, when that
+/// is absent, from the number of column slots in the first non-empty line.
+/// Cells are then scanned in document order and partitioned into rows by
+/// walking the grid: a cell's span (colspan/rowspan) governs how many column
+/// slots it occupies, so a column-spanning cell fills its row with fewer cells
+/// and a row-spanning cell carries its columns down into the rows below.
+///
+/// This mirrors Asciidoctor's grid walk. `active_rowspans[k]` records the
+/// number of column slots that cells from earlier rows occupy in the row `k`
+/// steps ahead of the one being filled; a row closes once its own cells'
+/// colspans plus the slots carried into it (`active_rowspans[0]`) reach
+/// `ncols`. A cell whose span pushes the row *past* `ncols` overruns the grid:
+/// the whole overrunning row is dropped (with a warning), again matching
+/// Asciidoctor. A row whose columns are entirely pre-filled by carried slots
+/// has no cells of its own to close it, so the next cell overruns and is
+/// dropped together with that pre-filled row. A duplicated cell (`<n>*`) is
+/// expanded into `<n>` independent cells — each carrying the original's
+/// content, alignment, and style — before the grid walk, so each clone occupies
+/// its own column slot exactly like an ordinary cell. A duplication factor of
+/// zero drops the cell entirely.
+fn build_psv_table<'src>(
+    body: TableBody<'src>,
+    parser: &mut Parser,
+    warnings: &mut Vec<Warning<'src>>,
+) -> (Vec<TableColumn>, Vec<TableRow<'src>>) {
+    let TableBody {
+        inside,
+        separator,
+        cols_attr,
+        autowidth,
+        has_header,
+    } = body;
+    let separator = separator.as_str();
+
+    // When the column count is implicit, it is the number of column slots in the
+    // first non-empty line: a cell that spans columns (`<n>+`) counts as `<n>`
+    // slots, not one, and a cell duplicated `<n>` times (`<n>*`) counts as `<n>`
+    // single-column slots (one per clone).
+    let first_line_cells: usize =
+        scan_cells(inside.discard_empty_lines().take_line().item, separator)
+            .iter()
+            .map(|c| c.spec.colspan.max(1) * c.spec.repeat.min(MAX_DUPLICATION_FACTOR))
+            .sum();
+
+    let ncols = if cols_attr.is_empty() {
+        first_line_cells
+    } else {
+        cols_attr.len()
+    };
+
+    let columns = finalize_columns(cols_attr, ncols, autowidth);
+
+    let raw_cells = expand_duplicates(scan_cells(inside, separator));
+
+    // A table can never have more rows than it has cells, so a row span is
+    // clamped to the cell count for the `active_rowspans` bookkeeping below: a
+    // larger span carries into rows that can't exist and so has no additional
+    // layout effect. The clamp also bounds the `active_rowspans` allocation, so a
+    // hostile specifier such as `.1000000000+` can't trigger a multi-gigabyte
+    // allocation. (The cell's reported [`rowspan`] keeps the literal parsed
+    // value, matching Asciidoctor.)
+    //
+    // [`rowspan`]: TableCell::rowspan
+    let max_rowspan = raw_cells.len().saturating_add(1);
+
+    let mut raw_rows: Vec<Vec<RawCell<'src>>> = vec![];
+    if ncols > 0 {
+        let mut active_rowspans: Vec<usize> = vec![0];
+        let mut column_visits = 0usize;
+        let mut current_row: Vec<RawCell<'src>> = vec![];
+
+        for raw in raw_cells {
+            let colspan = raw.spec.colspan.max(1);
+            let rowspan = raw.spec.rowspan.max(1).min(max_rowspan);
+
+            // A cell that spans more than one row reserves `colspan` slots in
+            // each of the rows it extends into (but not its own row).
+            if rowspan > 1 {
+                if active_rowspans.len() < rowspan {
+                    active_rowspans.resize(rowspan, 0);
+                }
+                for slot in active_rowspans.iter_mut().take(rowspan).skip(1) {
+                    *slot += colspan;
+                }
+            }
+
+            column_visits += colspan;
+            let cell_source = raw.content;
+            current_row.push(raw);
+
+            // The slots carried into the current row are `active_rowspans[0]`; the
+            // vector is never empty here, so the fallback is unreachable.
+            let carried = active_rowspans.first().copied().unwrap_or(0);
+            let effective = column_visits + carried;
+            if effective >= ncols {
+                if effective == ncols {
+                    raw_rows.push(std::mem::take(&mut current_row));
+                } else {
+                    // Overrun: this cell's span pushes the row past `ncols`.
+                    // Discard the whole row so the remaining cells stay aligned to
+                    // the grid.
+                    current_row.clear();
+                    warnings.push(Warning {
+                        source: cell_source,
+                        warning: WarningType::TableCellExceedsColumnCount,
+                    });
+                }
+                column_visits = 0;
+                active_rowspans.remove(0);
+                if active_rowspans.is_empty() {
+                    active_rowspans.push(0);
+                }
+            }
+        }
+
+        // A trailing incomplete row (one that never reached `ncols`) is still
+        // emitted, matching the existing handling of short final rows.
+        if !current_row.is_empty() {
+            raw_rows.push(current_row);
+        }
+    }
+
+    // Each cell is processed according to the style of the column it falls in. A
+    // cell's column is its ordinal position within its row (matching Asciidoctor,
+    // which assigns the column by cell count, not grid slot). The header row
+    // (when present) is the first row and is always processed as plain header
+    // content, regardless of the column styles, so that a style operator doesn't
+    // affect the header row.
+    let mut rows: Vec<TableRow<'src>> = Vec::with_capacity(raw_rows.len());
+    for (row_idx, raw_row) in raw_rows.into_iter().enumerate() {
+        let is_header = has_header && row_idx == 0;
+        let mut cells = Vec::with_capacity(raw_row.len());
+        for (col_idx, raw) in raw_row.into_iter().enumerate() {
+            let column = columns.get(col_idx).cloned().unwrap_or_default();
+            cells.push(TableCell::parse(
+                raw, &column, is_header, separator, parser, warnings,
+            ));
+        }
+        rows.push(TableRow { cells });
+    }
+
+    (columns, rows)
+}
+
+/// Build the columns and rows of a delimiter-separated table (CSV, TSV, or
+/// DSV).
+///
+/// The body is split into a flat list of [fields](DataField) by the format's
+/// parser, then flowed into fixed-width rows. The column count comes from the
+/// `cols` attribute (`cols_attr`) or, when that is absent, from the number of
+/// fields in the first row. Because a data cell carries no span, the fields are
+/// simply chunked `ncols` at a time; any fields left over after the last
+/// complete row are dropped ("extra cells at the end of the last row get
+/// dropped"). The first row is the header when `has_header` is set.
+fn build_data_table<'src>(
+    body: TableBody<'src>,
+    data_format: DataFormat,
+    parser: &mut Parser,
+    warnings: &mut Vec<Warning<'src>>,
+) -> (Vec<TableColumn>, Vec<TableRow<'src>>) {
+    let TableBody {
+        inside,
+        separator,
+        cols_attr,
+        autowidth,
+        has_header,
+    } = body;
+    let separator = separator.as_str();
+
+    // DSV is parsed by its own, simpler rules; CSV and TSV share their rules and
+    // differ only in the default separator (resolved by the caller). PSV never
+    // reaches this builder.
+    let (fields, first_row_len) = if data_format == DataFormat::Dsv {
+        parse_dsv_fields(inside, separator)
+    } else {
+        parse_csv_fields(inside, separator)
+    };
+
+    let ncols = if cols_attr.is_empty() {
+        first_row_len
+    } else {
+        cols_attr.len()
+    };
+
+    let columns = finalize_columns(cols_attr, ncols, autowidth);
+
+    // Integer division drops any partial trailing row; `checked_div` yields zero
+    // rows when there are no columns.
+    let nrows = fields.len().checked_div(ncols).unwrap_or(0);
+    let mut rows: Vec<TableRow<'src>> = Vec::with_capacity(nrows);
+    let mut fields = fields.into_iter();
+    for row_idx in 0..nrows {
+        let is_header = has_header && row_idx == 0;
+        let mut cells = Vec::with_capacity(ncols);
+        for col_idx in 0..ncols {
+            // `nrows * ncols <= fields.len()`, so the iterator always yields.
+            let Some(field) = fields.next() else { break };
+            let column = columns.get(col_idx).cloned().unwrap_or_default();
+            cells.push(TableCell::parse_data(
+                field, &column, is_header, parser, warnings,
+            ));
+        }
+        rows.push(TableRow { cells });
+    }
+
+    (columns, rows)
+}
+
+/// A single field of a delimiter-separated (CSV, TSV, or DSV) table, as located
+/// by [`parse_csv_fields`] or [`parse_dsv_fields`].
+///
+/// `content` is the field's value span with surrounding whitespace already
+/// stripped. `replacement` holds the value after quote or escape processing
+/// when it differs from `content` (a CSV value with a doubled-quote escape, or
+/// a DSV value with a backslash-escaped separator); it is `None` when the span
+/// is the verbatim value.
+struct DataField<'src> {
+    content: Span<'src>,
+    replacement: Option<String>,
+}
+
+/// Parse a CSV/TSV region into its [fields](DataField), returning them in
+/// document order together with the number of fields in the first row.
+///
+/// The rules, loosely based on RFC 4180: empty lines are skipped; whitespace
+/// surrounding each value is stripped; a value may be enclosed in double
+/// quotes, within which the separator and newlines are literal and a double
+/// quote is written by doubling it (`""`). A newline that is not inside a
+/// quoted value ends the row. The fields are returned flat; the caller flows
+/// them into rows.
+///
+/// This mirrors Asciidoctor's `Table::ParserContext`: a separator or newline is
+/// a cell boundary only when the text accumulated since the previous boundary
+/// has no [unclosed quote](has_unclosed_quotes); otherwise it is part of the
+/// value. As a result a value whose opening quote is never properly closed (or
+/// that has trailing characters after its closing quote) keeps its quotes and
+/// absorbs the following separators, rather than being treated as enclosed.
+fn parse_csv_fields<'src>(region: Span<'src>, separator: &str) -> (Vec<DataField<'src>>, usize) {
+    let data = region.data();
+    let n = data.len();
+    let sep_len = separator.len().max(1);
+    let at = |k: usize| data.as_bytes().get(k).copied();
+    let starts_with_sep = |pos: usize| data.get(pos..).is_some_and(|s| s.starts_with(separator));
+
+    let mut fields: Vec<DataField<'src>> = vec![];
+    let mut first_row_len = 0usize;
+    let mut first_row_done = false;
+    let mut fields_in_row = 0usize;
+
+    // The raw text of the cell currently being accumulated runs from `cell_start`
+    // to the next boundary.
+    let mut cell_start = 0usize;
+    let mut i = 0usize;
+
+    while i <= n {
+        let at_eof = i == n;
+        let at_sep = !at_eof && starts_with_sep(i);
+        let at_nl = !at_eof && at(i) == Some(b'\n');
+
+        if !(at_eof || at_sep || at_nl) {
+            i += 1;
+            continue;
+        }
+
+        let raw = data.get(cell_start..i).unwrap_or_default();
+
+        // A separator or newline that falls inside an unclosed quoted value is
+        // part of the value, not a boundary; absorb it and keep scanning.
+        if !at_eof && has_unclosed_quotes(raw) {
+            i += if at_sep { sep_len } else { 1 };
+            continue;
+        }
+
+        // A wholly blank physical line (or trailing blank text at the end of the
+        // region) between rows is skipped rather than emitted as an empty cell. A
+        // blank cell that follows a separator on a populated line is kept.
+        let blank_skip = (at_nl || at_eof) && fields_in_row == 0 && raw.trim().is_empty();
+        if !blank_skip {
+            fields.push(make_csv_field(region, cell_start, i));
+            fields_in_row += 1;
+            if !first_row_done {
+                first_row_len = fields_in_row;
+            }
+        }
+
+        if at_eof {
+            break;
+        }
+
+        if at_nl {
+            // The newline ends the row. The first populated row fixes the implicit
+            // column count.
+            if fields_in_row > 0 {
+                first_row_done = true;
+            }
+            fields_in_row = 0;
+            cell_start = i + 1;
+            i += 1;
+        } else {
+            cell_start = i + sep_len;
+            i += sep_len;
+        }
+    }
+
+    (fields, first_row_len)
+}
+
+/// Build a CSV/TSV [field](DataField) from the byte range `start..end`,
+/// applying Asciidoctor's `close_cell` value processing.
+///
+/// The value is stripped of surrounding whitespace; then, if it is enclosed in
+/// double quotes, the quotes are removed and the inner value is stripped again;
+/// finally any run of consecutive double quotes is collapsed to one (so an
+/// escaped `""` becomes a single `"`). A value that is not enclosed (no leading
+/// quote, an unclosed quote, or trailing characters after the closing quote)
+/// keeps its quotes and is only collapsed.
+fn make_csv_field<'src>(region: Span<'src>, start: usize, end: usize) -> DataField<'src> {
+    let trimmed = trim_surrounding_whitespace(region.slice(start..end));
+    let value = csv_cell_value(trimmed.data());
+    let replacement = (value != trimmed.data()).then_some(value);
+    DataField {
+        content: trimmed,
+        replacement,
+    }
+}
+
+/// Apply Asciidoctor's CSV value processing to an already-stripped cell value:
+/// unquote an enclosed value and collapse escaped double quotes (`""` -> `"`).
+fn csv_cell_value(text: &str) -> String {
+    if text.is_empty() || !text.contains('"') {
+        return text.to_string();
+    }
+
+    // An enclosed value (leading and trailing quote) has its quotes removed and
+    // is stripped again; a lone `"` becomes empty. Anything else keeps its text.
+    if text.starts_with('"') && text.ends_with('"') {
+        match text.get(1..text.len() - 1) {
+            Some(inner) => squeeze_quotes(inner.trim()),
+            None => String::new(),
+        }
+    } else {
+        squeeze_quotes(text)
+    }
+}
+
+/// Collapse every run of consecutive double quotes to a single double quote,
+/// matching Ruby's `String#squeeze('"')`.
+///
+/// Note: the `continue` intentionally leaves `prev_quote` set, so a run of
+/// *N ≥ 2* consecutive `"` collapses to a single `"` (e.g. `""""` -> `"`), not
+/// to pairs. This deliberately matches Asciidoctor rather than strict RFC 4180,
+/// under which only `""` is a double-quote escape — don't "fix" it to a
+/// two-character collapse without also changing Asciidoctor.
+fn squeeze_quotes(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut prev_quote = false;
+    for c in text.chars() {
+        if c == '"' {
+            if prev_quote {
+                continue;
+            }
+            prev_quote = true;
+        } else {
+            prev_quote = false;
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// Determine whether `buffer` (the cell text accumulated so far) holds an
+/// unclosed double quote, a direct port of Asciidoctor's
+/// `Table::ParserContext#buffer_has_unclosed_quotes?`.
+///
+/// Only a value that begins with a double quote can be "quoted"; for any other
+/// value embedded quotes are literal and this returns `false`. A leading quote
+/// is unclosed until a matching trailing quote appears (accounting for escaped
+/// `""` pairs).
+///
+/// Note: the escaped-pair collapse (`replace("\"\"", "")`) runs before the
+/// start/end check, so `"""` collapses to a single `"` and is reported
+/// *closed*. Strict RFC 4180 would read `"""` as an unclosed field (open quote
+/// plus escaped `""` + missing close); this matches Asciidoctor's
+/// `buffer_has_unclosed_quotes?` instead, so the divergence is intentional.
+fn has_unclosed_quotes(buffer: &str) -> bool {
+    let record = buffer.trim();
+
+    if record == "\"" {
+        return true;
+    }
+
+    if !record.starts_with('"') {
+        return false;
+    }
+
+    let trailing_quote = record.ends_with('"');
+    if (trailing_quote && record.ends_with("\"\"")) || record.starts_with("\"\"") {
+        let collapsed = record.replace("\"\"", "");
+        collapsed.starts_with('"') && !collapsed.ends_with('"')
+    } else {
+        !trailing_quote
+    }
+}
+
+/// Parse a DSV region into its [fields](DataField), returning them in document
+/// order together with the number of fields in the first row.
+///
+/// Each non-empty line is a row. Whitespace surrounding each value is stripped,
+/// and the separator can be included in a value by escaping it with a single
+/// backslash (`\:`). An enclosing character is not recognized.
+fn parse_dsv_fields<'src>(region: Span<'src>, separator: &str) -> (Vec<DataField<'src>>, usize) {
+    let data = region.data();
+    let n = data.len();
+    let sep_len = separator.len().max(1);
+    let escaped = format!("\\{separator}");
+    let at = |k: usize| data.as_bytes().get(k).copied();
+
+    let mut fields: Vec<DataField<'src>> = vec![];
+    let mut first_row_len = 0usize;
+    let mut row_count = 0usize;
+    let mut i = 0usize;
+
+    while i < n {
+        let mut line_end = i;
+        while line_end < n && at(line_end) != Some(b'\n') {
+            line_end += 1;
+        }
+
+        if data.get(i..line_end).unwrap_or("").trim().is_empty() {
+            i = if line_end < n { line_end + 1 } else { line_end };
+            continue;
+        }
+
+        let in_line = |pos: usize| {
+            data.get(pos..line_end)
+                .is_some_and(|s| s.starts_with(separator))
+        };
+
+        let mut fields_in_row = 0usize;
+        let mut field_start = i;
+        let mut p = i;
+        while p < line_end {
+            // A backslash that escapes the separator (`\:`) is not a boundary;
+            // skip past both so the separator stays in the value.
+            if at(p) == Some(b'\\')
+                && data
+                    .get(p + 1..line_end)
+                    .is_some_and(|s| s.starts_with(separator))
+            {
+                p += 1 + sep_len;
+                continue;
+            }
+
+            if in_line(p) {
+                fields.push(make_dsv_field(region, field_start, p, &escaped, separator));
+                fields_in_row += 1;
+                p += sep_len;
+                field_start = p;
+                continue;
+            }
+
+            p += 1;
+        }
+
+        // The final field of the line runs to the line end.
+        fields.push(make_dsv_field(
+            region,
+            field_start,
+            line_end,
+            &escaped,
+            separator,
+        ));
+        fields_in_row += 1;
+
+        if row_count == 0 {
+            first_row_len = fields_in_row;
+        }
+        row_count += 1;
+
+        i = if line_end < n { line_end + 1 } else { line_end };
+    }
+
+    (fields, first_row_len)
+}
+
+/// Build a DSV [field](DataField) from the byte range `start..end`, unescaping
+/// any backslash-escaped separators (`escaped`, e.g. `\:`) into the bare
+/// separator.
+fn make_dsv_field<'src>(
+    region: Span<'src>,
+    start: usize,
+    end: usize,
+    escaped: &str,
+    separator: &str,
+) -> DataField<'src> {
+    let trimmed = trim_surrounding_whitespace(region.slice(start..end));
+    let replacement = if trimmed.data().contains(escaped) {
+        Some(trimmed.data().replace(escaped, separator))
+    } else {
+        None
+    };
+
+    DataField {
+        content: trimmed,
+        replacement,
+    }
+}
+
+/// Process a cell's content according to its [style](ColumnStyle), shared by
+/// the PSV and data-format cell builders.
+///
+/// `trimmed` is the cell's content span with surrounding whitespace already
+/// removed. `replacement` is the pre-filtered value (an escaped separator
+/// unescaped, or a CSV/DSV value after quote/escape processing) when it differs
+/// from `trimmed`; it is ignored for the [`AsciiDoc`](ColumnStyle::AsciiDoc)
+/// style, which parses `trimmed` verbatim as a nested document. Every other
+/// style produces inline [`Simple`](TableCellContent::Simple) content with the
+/// verbatim substitution group for [`Literal`](ColumnStyle::Literal) and the
+/// normal group otherwise.
+fn process_content<'src>(
+    trimmed: Span<'src>,
+    replacement: Option<String>,
+    style: ColumnStyle,
+    parser: &mut Parser,
+    warnings: &mut Vec<Warning<'src>>,
+) -> TableCellContent<'src> {
+    if style == ColumnStyle::AsciiDoc {
+        // The AsciiDoc style effectively creates a nested, standalone AsciiDoc
+        // document in the cell. It inherits the parent document's attributes, but
+        // any attribute it defines is scoped to the cell and must not leak back
+        // into the parent. Snapshot the attribute set before parsing and restore
+        // it afterward to enforce that boundary (matching Asciidoctor, where a
+        // `:foo:` set inside a cell is not visible after the table).
+        let saved_attributes = parser.attribute_values.clone();
+
+        // An attribute that is set in the parent document cannot be modified
+        // inside the cell. Lock every inherited attribute that currently holds a
+        // value for the duration of the cell (other than the handful of
+        // exceptions the spec carves out), so a body assignment to one of them is
+        // ignored. An attribute that is unset in the parent is not locked: the
+        // cell may assign it (matching Asciidoctor, which here diverges from the
+        // spec's "set or explicitly unset" wording). The lock set is saved and
+        // restored so it applies only within the cell and nests correctly.
+        let saved_locks = parser.locked_attribute_names.clone();
+        for (name, value) in saved_attributes.iter() {
+            if !matches!(value.value, InterpretedValue::Unset)
+                && !ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES.contains(&name.as_str())
+            {
+                parser.locked_attribute_names.insert(name.clone());
+            }
+        }
+
+        // Mark that we are inside an AsciiDoc cell (a nested document) for the
+        // duration of the cell, so a table found within defaults its cell
+        // separator to `!` rather than `|` (matching Asciidoctor's
+        // `Document#nested?`). The depth is restored afterward so the marker is
+        // scoped to the cell and nests correctly.
+        parser.nested_document_depth += 1;
+        let mut maw = parse_blocks_until(trimmed, |_| false, parser);
+        parser.nested_document_depth -= 1;
+
+        parser.locked_attribute_names = saved_locks;
+        parser.attribute_values = saved_attributes;
+        warnings.append(&mut maw.warnings);
+        TableCellContent::AsciiDoc(maw.item.item)
+    } else {
+        let mut content = match replacement {
+            Some(replacement) => Content::from_filtered(trimmed, replacement),
+            None => Content::from(trimmed),
+        };
+
+        let substitutions = if style == ColumnStyle::Literal {
+            SubstitutionGroup::Verbatim
+        } else {
+            SubstitutionGroup::Normal
+        };
+        substitutions.apply(&mut content, parser, None);
+
+        TableCellContent::Simple(content)
+    }
 }
 
 /// A row of cells in a [`TableBlock`].
@@ -1019,7 +1632,7 @@ impl<'src> TableCell<'src> {
         raw: RawCell<'src>,
         column: &TableColumn,
         is_header: bool,
-        separator: u8,
+        separator: &str,
         parser: &mut Parser,
         warnings: &mut Vec<Warning<'src>>,
     ) -> Self {
@@ -1040,73 +1653,20 @@ impl<'src> TableCell<'src> {
 
         let trimmed = trim_surrounding_whitespace(raw.content);
 
-        let content = if style == ColumnStyle::AsciiDoc {
-            // The AsciiDoc style effectively creates a nested, standalone
-            // AsciiDoc document in the cell. It inherits the parent document's
-            // attributes, but any attribute it defines is scoped to the cell and
-            // must not leak back into the parent. Snapshot the attribute set
-            // before parsing and restore it afterward to enforce that boundary
-            // (matching Asciidoctor, where a `:foo:` set inside a cell is not
-            // visible after the table).
-            let saved_attributes = parser.attribute_values.clone();
-
-            // An attribute that is set in the parent document cannot be modified
-            // inside the cell. Lock every inherited attribute that currently
-            // holds a value for the duration of the cell (other than the handful
-            // of exceptions the spec carves out), so a body assignment to one of
-            // them is ignored. An attribute that is unset in the parent is not
-            // locked: the cell may assign it (matching Asciidoctor, which here
-            // diverges from the spec's "set or explicitly unset" wording). The
-            // lock set is saved and restored so it applies only within the cell
-            // and nests correctly.
-            let saved_locks = parser.locked_attribute_names.clone();
-            for (name, value) in saved_attributes.iter() {
-                if !matches!(value.value, InterpretedValue::Unset)
-                    && !ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES.contains(&name.as_str())
-                {
-                    parser.locked_attribute_names.insert(name.clone());
-                }
-            }
-
-            // Mark that we are inside an AsciiDoc cell (a nested document) for the
-            // duration of the cell, so a table found within defaults its cell
-            // separator to `!` rather than `|` (matching Asciidoctor's
-            // `Document#nested?`). The depth is restored afterward so the marker
-            // is scoped to the cell and nests correctly.
-            parser.nested_document_depth += 1;
-            let mut maw = parse_blocks_until(trimmed, |_| false, parser);
-            parser.nested_document_depth -= 1;
-
-            parser.locked_attribute_names = saved_locks;
-            parser.attribute_values = saved_attributes;
-            warnings.append(&mut maw.warnings);
-            TableCellContent::AsciiDoc(maw.item.item)
+        // An escaped cell separator (a backslash in front of the table's
+        // separator, e.g. `\|` or `\!`) is unescaped to the bare separator. Only
+        // the active separator is unescaped, so a `\|` in a `!`-separated table
+        // is left untouched. The replacement is computed only for the inline
+        // styles; an AsciiDoc cell parses its content verbatim (see
+        // [`process_content`]).
+        let escaped = format!("\\{separator}");
+        let replacement = if style != ColumnStyle::AsciiDoc && trimmed.data().contains(&escaped) {
+            Some(trimmed.data().replace(&escaped, separator))
         } else {
-            let data = trimmed.data();
-
-            // An escaped cell separator (a backslash in front of the table's
-            // separator character, e.g. `\|` or `\!`) is unescaped to the bare
-            // separator. Only the active separator is unescaped, so a `\|` in a
-            // `!`-separated table is left untouched.
-            let escaped = format!("\\{}", separator as char);
-            let mut content = if data.contains(&escaped) {
-                Content::from_filtered(
-                    trimmed,
-                    data.replace(&escaped, &(separator as char).to_string()),
-                )
-            } else {
-                Content::from(trimmed)
-            };
-
-            let substitutions = if style == ColumnStyle::Literal {
-                SubstitutionGroup::Verbatim
-            } else {
-                SubstitutionGroup::Normal
-            };
-            substitutions.apply(&mut content, parser, None);
-
-            TableCellContent::Simple(content)
+            None
         };
+
+        let content = process_content(trimmed, replacement, style, parser, warnings);
 
         Self {
             h_align,
@@ -1114,6 +1674,41 @@ impl<'src> TableCell<'src> {
             style,
             colspan: raw.spec.colspan.max(1),
             rowspan: raw.spec.rowspan.max(1),
+            content,
+        }
+    }
+
+    /// Build a cell from a [data field](DataField) of a delimiter-separated
+    /// table (CSV, TSV, or DSV).
+    ///
+    /// Unlike a PSV cell, a data cell carries no per-cell specifier: its
+    /// alignment and [style](ColumnStyle) come entirely from the `column`, and
+    /// it always spans a single row and column. The separator escaping is
+    /// handled by the format parser before this point, so the field already
+    /// holds the extracted value (its [`replacement`](DataField::replacement),
+    /// when present, is the value after quote/escape processing). A header cell
+    /// (`is_header`) is processed as plain header content.
+    fn parse_data(
+        field: DataField<'src>,
+        column: &TableColumn,
+        is_header: bool,
+        parser: &mut Parser,
+        warnings: &mut Vec<Warning<'src>>,
+    ) -> Self {
+        let style = if is_header {
+            ColumnStyle::Default
+        } else {
+            column.style
+        };
+
+        let content = process_content(field.content, field.replacement, style, parser, warnings);
+
+        Self {
+            h_align: column.h_align,
+            v_align: column.v_align,
+            style,
+            colspan: 1,
+            rowspan: 1,
             content,
         }
     }
@@ -1424,9 +2019,10 @@ fn expand_duplicates(cells: Vec<RawCell<'_>>) -> Vec<RawCell<'_>> {
 /// Scan a region for PSV cell boundaries, returning the [specifier](CellSpec)
 /// and raw (untrimmed) content span of each cell.
 ///
-/// A cell boundary is the table's `separator` byte (the vertical bar (`|`) by
-/// default, or the exclamation mark (`!`) for a nested table) that appears at
-/// the start of a line or is preceded by whitespace, optionally with a
+/// A cell boundary is the table's `separator` (the vertical bar (`|`) by
+/// default, the exclamation mark (`!`) for a nested table, or any string set
+/// with the `separator` attribute, e.g. the broken bar `¦`) that appears at the
+/// start of a line or is preceded by whitespace, optionally with a
 /// [cell specifier](CellSpec) (e.g. `^`, `2+`, `.>`) directly in front of the
 /// separator. The token immediately preceding a separator is taken to be a
 /// specifier when it parses as one (see [`parse_cell_spec`]); a token that
@@ -1437,19 +2033,25 @@ fn expand_duplicates(cells: Vec<RawCell<'_>>) -> Vec<RawCell<'_>> {
 /// valid specifier, so the separator already fails the boundary test and needs
 /// no special handling here; the backslash is stripped later in
 /// [`TableCell::parse`].
-fn scan_cells(region: Span<'_>, separator: u8) -> Vec<RawCell<'_>> {
+fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
     let data = region.data();
     let bytes = data.as_bytes();
     let len = bytes.len();
+    // A zero-length separator would never advance; treat it as a single byte to
+    // stay safe. (The resolver never produces an empty separator.)
+    let sep_len = separator.len().max(1);
 
-    let mut cells: Vec<RawCell<'_>> = vec![];
+    let mut cells: Vec<RawCell<'src>> = vec![];
     // The content start and specifier of the cell currently being accumulated.
     let mut content_start: Option<usize> = None;
     let mut cur_spec = CellSpec::default();
     let mut i = 0;
 
     while i < len {
-        if bytes.get(i).copied() == Some(separator) {
+        if data
+            .get(i..)
+            .is_some_and(|rest| rest.starts_with(separator))
+        {
             // Walk back to the start of the token directly preceding this
             // separator. The token (a possible cell specifier) runs back to the
             // previous whitespace, tab, or newline, or to the start of the
@@ -1484,7 +2086,9 @@ fn scan_cells(region: Span<'_>, separator: u8) -> Vec<RawCell<'_>> {
                     });
                 }
                 cur_spec = spec;
-                content_start = Some(i + 1);
+                content_start = Some(i + sep_len);
+                i += sep_len;
+                continue;
             }
         }
 

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::VecDeque, sync::Arc};
 
 use self_cell::self_cell;
 
@@ -1098,7 +1098,11 @@ fn build_psv_table<'src>(
 
     let mut raw_rows: Vec<Vec<RawCell<'src>>> = vec![];
     if ncols > 0 {
-        let mut active_rowspans: Vec<usize> = vec![0];
+        // A queue: each completed row consumes the slots carried into it from the
+        // front (`pop_front`), while a multi-row cell reserves slots in the rows it
+        // extends into via the back. `VecDeque` keeps both ends O(1); a `Vec` would
+        // pay an O(n) shift on every `remove(0)`.
+        let mut active_rowspans: VecDeque<usize> = VecDeque::from([0]);
         let mut column_visits = 0usize;
         let mut current_row: Vec<RawCell<'src>> = vec![];
 
@@ -1122,8 +1126,8 @@ fn build_psv_table<'src>(
             current_row.push(raw);
 
             // The slots carried into the current row are `active_rowspans[0]`; the
-            // vector is never empty here, so the fallback is unreachable.
-            let carried = active_rowspans.first().copied().unwrap_or(0);
+            // deque is never empty here, so the fallback is unreachable.
+            let carried = active_rowspans.front().copied().unwrap_or(0);
             let effective = column_visits + carried;
             if effective >= ncols {
                 if effective == ncols {
@@ -1139,9 +1143,9 @@ fn build_psv_table<'src>(
                     });
                 }
                 column_visits = 0;
-                active_rowspans.remove(0);
+                active_rowspans.pop_front();
                 if active_rowspans.is_empty() {
-                    active_rowspans.push(0);
+                    active_rowspans.push_back(0);
                 }
             }
         }
@@ -1627,10 +1631,17 @@ fn process_content<'src>(
             let owned = OwnedCell::new(expanded, |source| {
                 // Warnings from the owned parse borrow the owned source and so
                 // cannot escape it; the include path is rare and currently
-                // warning-free, so they are dropped here.
+                // warning-free, so they are dropped here. The `debug_assert`
+                // turns any future warning added to this path into a loud test
+                // failure rather than a silent loss.
                 let mut owned_warnings: Vec<Warning<'_>> = vec![];
                 let (title, inline, blocks) =
                     parse_asciidoc_cell_body(Span::new(source), parser, &mut owned_warnings);
+                debug_assert!(
+                    owned_warnings.is_empty(),
+                    "warnings from an include-expanded AsciiDoc cell are dropped; \
+                     propagate them before adding any to this path"
+                );
                 OwnedCellInner {
                     title,
                     inline,

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -54,6 +54,11 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 /// block of both (`<n>.<n>+`). The per-cell duplication (`*`) operator is
 /// supported: a cell with a duplication factor (`<n>*`) clones its content and
 /// properties into `<n>` consecutive cells.
+///
+/// Table sizing is supported: the [`width`](Self::width) attribute sets a fixed
+/// table width, the `autowidth` option ([`is_autowidth`](Self::is_autowidth))
+/// sizes the table and its columns to their content, and an individual column
+/// can be made [autowidth](TableColumn::is_autowidth) with the `~` width value.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -140,11 +145,24 @@ impl<'src> TableBlock<'src> {
             columns.len()
         };
 
-        let columns = if columns.is_empty() {
+        let mut columns: Vec<TableColumn> = if columns.is_empty() {
             (0..ncols).map(|_| TableColumn::default()).collect()
         } else {
             columns
         };
+
+        // The `autowidth` option sizes the table to its content; the columns
+        // inherit the setting, so every column becomes autowidth regardless of
+        // any proportional width set on its specifier.
+        if metadata
+            .attrlist
+            .as_ref()
+            .is_some_and(|a| a.has_option("autowidth"))
+        {
+            for column in columns.iter_mut() {
+                column.autowidth = true;
+            }
+        }
 
         // The first row is an (implicit) header row when the line directly after
         // the opening delimiter is non-empty and is itself followed by an empty
@@ -387,6 +405,39 @@ impl<'src> TableBlock<'src> {
         &self.columns
     }
 
+    /// Returns the fixed width of this table, as a percentage of the content
+    /// area, when the `width` attribute is set.
+    ///
+    /// The `width` attribute is an integer percentage from 1 to 100; the
+    /// trailing `%` sign is optional (`[width=75%]` and `[width=75]` are
+    /// equivalent). A value outside that range, or one that is not an integer,
+    /// is ignored and reported as `None`. When the attribute is absent the
+    /// table spans the width of the content area and this returns `None`.
+    pub fn width(&self) -> Option<usize> {
+        let raw = self
+            .attrlist
+            .as_ref()
+            .and_then(|a| a.named_attribute("width"))?
+            .value();
+
+        let raw = raw.strip_suffix('%').unwrap_or(raw);
+        match raw.parse::<usize>() {
+            Ok(width) if (1..=100).contains(&width) => Some(width),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if this table carries the `autowidth` option.
+    ///
+    /// An autowidth table is sized to fit its content rather than spanning the
+    /// width of the content area, and each of its [columns](TableColumn) is
+    /// likewise [autowidth](TableColumn::is_autowidth).
+    pub fn is_autowidth(&self) -> bool {
+        self.attrlist
+            .as_ref()
+            .is_some_and(|a| a.has_option("autowidth"))
+    }
+
     /// Returns the header row of this table, if one was declared.
     pub fn header_row(&self) -> Option<&TableRow<'src>> {
         self.header_row.as_ref()
@@ -467,16 +518,51 @@ impl<'src> HasSpan<'src> for TableBlock<'src> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableColumn {
     width: usize,
+    autowidth: bool,
     h_align: HorizontalAlignment,
     v_align: VerticalAlignment,
     style: ColumnStyle,
 }
 
 impl TableColumn {
-    /// Returns the proportional width of this column relative to the other
-    /// columns in the table.
+    /// Returns the width of this column relative to the other columns in the
+    /// table. The default width is `1`.
+    ///
+    /// This value carries two different meanings depending on the table, and a
+    /// caller that resolves columns to final sizes must check which applies:
+    ///
+    /// * In an ordinary table (no column is [autowidth](Self::is_autowidth)),
+    ///   the width is a *proportional* ratio. Each column's share of the table
+    ///   is its width divided by the sum of all the column widths, so
+    ///   `[cols="1,2,3"]` yields shares of 1/6, 2/6, and 3/6.
+    /// * When at least one column in the table is autowidth (its specifier uses
+    ///   the special width value `~`), the AsciiDoc specification instead reads
+    ///   these widths as literal *percentages* (100-based): in
+    ///   `[cols="25,~,~"]` the first column is 25% wide and the `~` columns are
+    ///   sized to their content.
+    ///
+    /// The two cases are distinguished by whether any column in the table is
+    /// autowidth, which the caller can test with
+    /// `table.columns().iter().any(TableColumn::is_autowidth)`.
+    ///
+    /// When this column itself is autowidth, this width is not used to size the
+    /// column (the column is sized to its content instead). A column made
+    /// autowidth by the `~` specifier reports the default width of `1`, but one
+    /// that inherits autowidth from the table's `autowidth` option retains
+    /// whatever width its specifier set (e.g. `2` for the first column of
+    /// `[%autowidth,cols="2,1"]`).
     pub fn width(&self) -> usize {
         self.width
+    }
+
+    /// Returns `true` if this column is sized to fit its content rather than to
+    /// a proportional width.
+    ///
+    /// A column is autowidth when its column specifier uses the special width
+    /// value `~`, or when the table as a whole carries the `autowidth` option
+    /// (in which case every column inherits the setting).
+    pub fn is_autowidth(&self) -> bool {
+        self.autowidth
     }
 
     /// Returns the horizontal alignment applied to this column's content.
@@ -511,6 +597,7 @@ impl Default for TableColumn {
     fn default() -> Self {
         Self {
             width: 1,
+            autowidth: false,
             h_align: HorizontalAlignment::Left,
             v_align: VerticalAlignment::Top,
             style: ColumnStyle::Default,
@@ -870,8 +957,9 @@ fn parse_cols(value: &str) -> Vec<TableColumn> {
 /// present, the operators follow the multiplier, so the `spec` passed here is
 /// the portion after the `*`.
 ///
-/// The width is the first contiguous run of digits after any alignment
-/// operators; a spec with no digits falls back to the default width. The style
+/// The width is either the special autowidth value `~` (sizing the column to
+/// its content) or the first contiguous run of digits after any alignment
+/// operators; a spec with neither falls back to the default width. The style
 /// operator is the trailing letter (`a`, `d`, `e`, `h`, `l`, `m`, or `s`); an
 /// unrecognized trailing letter leaves the style at its default.
 fn parse_col_spec(spec: &str) -> TableColumn {
@@ -915,13 +1003,24 @@ fn parse_col_spec(spec: &str) -> TableColumn {
         }
     }
 
-    // Width is the first run of digits after the alignment operators.
-    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-    let width = match digits.parse::<usize>() {
-        Ok(width) if width > 0 => width,
-        _ => TableColumn::default().width,
-    };
-    rest = &rest[digits.len()..];
+    // Width comes after the alignment operators. The special value `~` marks
+    // the column as autowidth (sized to its content); otherwise the width is
+    // the first run of digits. A spec with neither falls back to the default
+    // proportional width.
+    let mut autowidth = false;
+    let mut width = TableColumn::default().width;
+    if let Some(after_tilde) = rest.strip_prefix('~') {
+        autowidth = true;
+        rest = after_tilde;
+    } else {
+        let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if let Ok(parsed) = digits.parse::<usize>()
+            && parsed > 0
+        {
+            width = parsed;
+        }
+        rest = &rest[digits.len()..];
+    }
 
     // The style operator, if present, occupies the last position on the
     // specifier, so it is the entire remainder after the width. Matching the
@@ -941,6 +1040,7 @@ fn parse_col_spec(spec: &str) -> TableColumn {
 
     TableColumn {
         width,
+        autowidth,
         h_align,
         v_align,
         style,

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -43,16 +43,18 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 ///
 /// * The CSV, TSV, and DSV data formats (and the `,===` / `:===` shorthand
 ///   delimiters).
-/// * Cell specifier span (`+`) and duplication (`*`) operators: these are
-///   recognized in a cell specifier (so the cell separator is still located
-///   correctly) but their layout effect is not yet applied.
+/// * The cell specifier duplication (`*`) operator: it is recognized in a cell
+///   specifier (so the cell separator is still located correctly) but its
+///   layout effect is not yet applied.
 ///
 /// Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, and `s`
 /// operators) are supported, along with proportional width and the horizontal
 /// and vertical alignment operators. Per-cell horizontal and vertical alignment
 /// operators are supported and override the column's alignment, and a per-cell
 /// style operator (in the last position of the cell specifier) is supported and
-/// overrides the column's style.
+/// overrides the column's style. The per-cell span (`+`) operator is supported:
+/// a cell can span multiple columns (`<n>+`), multiple rows (`.<n>+`), or a
+/// block of both (`<n>.<n>+`).
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -124,7 +126,13 @@ impl<'src> TableBlock<'src> {
             .map(|attr| parse_cols(attr.value()))
             .unwrap_or_default();
 
-        let first_line_cells = scan_cells(inside.discard_empty_lines().take_line().item).len();
+        // When the column count is implicit, it is the number of column slots in
+        // the first non-empty line: a cell that spans columns (`<n>+`) counts as
+        // `<n>` slots, not one.
+        let first_line_cells: usize = scan_cells(inside.discard_empty_lines().take_line().item)
+            .iter()
+            .map(|c| c.spec.colspan.max(1))
+            .sum();
 
         let ncols = if columns.is_empty() {
             first_line_cells
@@ -206,54 +214,117 @@ impl<'src> TableBlock<'src> {
         };
 
         // Scan every cell in the table, in document order, then partition into
-        // rows of `ncols` cells each.
+        // rows by walking the grid: a cell's span (colspan/rowspan) governs how
+        // many column slots it occupies, so a column-spanning cell fills its row
+        // with fewer cells and a row-spanning cell carries its columns down into
+        // the rows below.
         //
-        // Each cell is processed according to the style of the column it falls
-        // in. The header row (when present) is the first `ncols` cells and is
-        // always processed as plain header content, regardless of the column
-        // styles, so that a style operator doesn't affect the header row.
+        // This mirrors Asciidoctor's grid walk. `active_rowspans[k]` records the
+        // number of column slots that cells from earlier rows occupy in the row
+        // `k` steps ahead of the one being filled; a row closes once its own
+        // cells' colspans plus the slots carried into it (`active_rowspans[0]`)
+        // reach `ncols`. A cell whose span pushes the row *past* `ncols` overruns
+        // the grid: the whole overrunning row is dropped (with a warning), again
+        // matching Asciidoctor. A row whose columns are entirely pre-filled by
+        // carried slots has no cells of its own to close it, so the next cell
+        // overruns and is dropped together with that pre-filled row.
         let mut warnings: Vec<Warning<'src>> = vec![];
         let raw_cells = scan_cells(inside);
-        let header_len = if has_header { ncols } else { 0 };
 
-        let mut cells = Vec::with_capacity(raw_cells.len());
-        for (idx, raw) in raw_cells.into_iter().enumerate() {
-            // `idx % ncols` is in bounds whenever `ncols > 0`; an empty table
-            // (`ncols == 0`) has no columns, so the cell falls back to the
-            // default column (default style and alignment).
-            let column = columns.get(idx % ncols.max(1)).cloned().unwrap_or_default();
-            let is_header = idx < header_len;
-            cells.push(TableCell::parse(
-                raw,
-                &column,
-                is_header,
-                parser,
-                &mut warnings,
-            ));
-        }
-        let mut cells = cells.into_iter();
+        // A table can never have more rows than it has cells, so a row span is
+        // clamped to the cell count for the `active_rowspans` bookkeeping below: a
+        // larger span carries into rows that can't exist and so has no additional
+        // layout effect. The clamp also bounds the `active_rowspans` allocation,
+        // so a hostile specifier such as `.1000000000+` can't trigger a
+        // multi-gigabyte allocation. (The cell's reported [`rowspan`] keeps the
+        // literal parsed value, matching Asciidoctor.)
+        //
+        // [`rowspan`]: TableCell::rowspan
+        let max_rowspan = raw_cells.len().saturating_add(1);
 
-        let header_row = if has_header && ncols > 0 {
-            let row: Vec<TableCell<'src>> = cells.by_ref().take(ncols).collect();
-            if row.is_empty() {
-                None
-            } else {
-                Some(TableRow { cells: row })
-            }
-        } else {
-            None
-        };
-
-        let mut body_rows: Vec<TableRow<'src>> = vec![];
+        let mut raw_rows: Vec<Vec<RawCell<'src>>> = vec![];
         if ncols > 0 {
-            loop {
-                let row: Vec<TableCell<'src>> = cells.by_ref().take(ncols).collect();
-                if row.is_empty() {
-                    break;
+            let mut active_rowspans: Vec<usize> = vec![0];
+            let mut column_visits = 0usize;
+            let mut current_row: Vec<RawCell<'src>> = vec![];
+
+            for raw in raw_cells {
+                let colspan = raw.spec.colspan.max(1);
+                let rowspan = raw.spec.rowspan.max(1).min(max_rowspan);
+
+                // A cell that spans more than one row reserves `colspan` slots in
+                // each of the rows it extends into (but not its own row).
+                if rowspan > 1 {
+                    if active_rowspans.len() < rowspan {
+                        active_rowspans.resize(rowspan, 0);
+                    }
+                    for slot in active_rowspans.iter_mut().take(rowspan).skip(1) {
+                        *slot += colspan;
+                    }
                 }
-                body_rows.push(TableRow { cells: row });
+
+                column_visits += colspan;
+                let cell_source = raw.content;
+                current_row.push(raw);
+
+                // The slots carried into the current row are `active_rowspans[0]`;
+                // the vector is never empty here, so the fallback is unreachable.
+                let carried = active_rowspans.first().copied().unwrap_or(0);
+                let effective = column_visits + carried;
+                if effective >= ncols {
+                    if effective == ncols {
+                        raw_rows.push(std::mem::take(&mut current_row));
+                    } else {
+                        // Overrun: this cell's span pushes the row past `ncols`.
+                        // Discard the whole row so the remaining cells stay
+                        // aligned to the grid.
+                        current_row.clear();
+                        warnings.push(Warning {
+                            source: cell_source,
+                            warning: WarningType::TableCellExceedsColumnCount,
+                        });
+                    }
+                    column_visits = 0;
+                    active_rowspans.remove(0);
+                    if active_rowspans.is_empty() {
+                        active_rowspans.push(0);
+                    }
+                }
+            }
+
+            // A trailing incomplete row (one that never reached `ncols`) is still
+            // emitted, matching the existing handling of short final rows.
+            if !current_row.is_empty() {
+                raw_rows.push(current_row);
             }
         }
+
+        // Each cell is processed according to the style of the column it falls
+        // in. A cell's column is its ordinal position within its row (matching
+        // Asciidoctor, which assigns the column by cell count, not grid slot). The
+        // header row (when present) is the first row and is always processed as
+        // plain header content, regardless of the column styles, so that a style
+        // operator doesn't affect the header row.
+        let mut rows: Vec<TableRow<'src>> = Vec::with_capacity(raw_rows.len());
+        for (row_idx, raw_row) in raw_rows.into_iter().enumerate() {
+            let is_header = has_header && row_idx == 0;
+            let mut cells = Vec::with_capacity(raw_row.len());
+            for (col_idx, raw) in raw_row.into_iter().enumerate() {
+                let column = columns.get(col_idx).cloned().unwrap_or_default();
+                cells.push(TableCell::parse(
+                    raw,
+                    &column,
+                    is_header,
+                    parser,
+                    &mut warnings,
+                ));
+            }
+            rows.push(TableRow { cells });
+        }
+
+        let mut rows = rows.into_iter();
+        let header_row = if has_header { rows.next() } else { None };
+        let mut body_rows: Vec<TableRow<'src>> = rows.collect();
 
         // The footer row, when requested, is the last row of the table. It is
         // moved out of the body so the caller sees it as a distinct footer. When
@@ -549,6 +620,8 @@ pub struct TableCell<'src> {
     h_align: HorizontalAlignment,
     v_align: VerticalAlignment,
     style: ColumnStyle,
+    colspan: usize,
+    rowspan: usize,
     content: TableCellContent<'src>,
 }
 
@@ -653,6 +726,8 @@ impl<'src> TableCell<'src> {
             h_align,
             v_align,
             style,
+            colspan: raw.spec.colspan.max(1),
+            rowspan: raw.spec.rowspan.max(1),
             content,
         }
     }
@@ -687,6 +762,26 @@ impl<'src> TableCell<'src> {
     /// operators on both column and cell specifiers.
     pub fn style(&self) -> ColumnStyle {
         self.style
+    }
+
+    /// Returns the number of columns this cell spans.
+    ///
+    /// The span comes from a column span factor (`<n>`) or block span factor
+    /// (`<n>.<n>`) in front of the span operator (`+`) on the cell's specifier.
+    /// A cell with no column span factor spans a single column, so the default
+    /// is `1`.
+    pub fn colspan(&self) -> usize {
+        self.colspan
+    }
+
+    /// Returns the number of rows this cell spans.
+    ///
+    /// The span comes from a row span factor (`.<n>`) or block span factor
+    /// (`<n>.<n>`) in front of the span operator (`+`) on the cell's specifier.
+    /// A cell with no row span factor spans a single row, so the default is
+    /// `1`.
+    pub fn rowspan(&self) -> usize {
+        self.rowspan
     }
 
     /// Returns the interpreted content of this cell.
@@ -848,17 +943,32 @@ fn parse_col_spec(spec: &str) -> TableColumn {
     }
 }
 
-/// The alignment and style overrides parsed from a
+/// The span, alignment, and style overrides parsed from a
 /// [cell specifier](RawCell::spec).
 ///
-/// Each field is `None` when the corresponding operator is absent from the
-/// specifier, in which case the cell inherits that alignment (or style) from
-/// its column.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+/// Each alignment and style field is `None` when the corresponding operator is
+/// absent from the specifier, in which case the cell inherits that alignment
+/// (or style) from its column. `colspan` and `rowspan` are the number of
+/// columns and rows the cell spans; they default to `1` (no span).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct CellSpec {
     h_align: Option<HorizontalAlignment>,
     v_align: Option<VerticalAlignment>,
     style: Option<ColumnStyle>,
+    colspan: usize,
+    rowspan: usize,
+}
+
+impl Default for CellSpec {
+    fn default() -> Self {
+        Self {
+            h_align: None,
+            v_align: None,
+            style: None,
+            colspan: 1,
+            rowspan: 1,
+        }
+    }
 }
 
 /// A single PSV cell as located by [`scan_cells`]: the alignment operators from
@@ -945,7 +1055,7 @@ fn scan_cells(region: Span<'_>) -> Vec<RawCell<'_>> {
     cells
 }
 
-/// Parse a cell specifier, returning its [alignment overrides](CellSpec), or
+/// Parse a cell specifier, returning its [span and overrides](CellSpec), or
 /// `None` if `token` is not a valid cell specifier.
 ///
 /// A cell specifier is positional and every part is optional, but the whole
@@ -957,8 +1067,10 @@ fn scan_cells(region: Span<'_>) -> Vec<RawCell<'_>> {
 ///
 /// * The factor and span/duplication operator are an optional count (e.g. `2`,
 ///   `2.3`, `.3`) that, when present, must be followed by `+` (span) or `*`
-///   (duplication). These operators are recognized so the cell separator is
-///   located correctly, but their layout effect is not yet applied.
+///   (duplication). For a span the factor is interpreted as the cell's colspan
+///   and rowspan (a missing column or row count defaults to 1). The duplication
+///   operator is recognized so the cell separator is located correctly, but its
+///   layout effect is not yet applied.
 /// * The horizontal alignment operator is `<`, `>`, or `^`.
 /// * The vertical alignment operator is a dot followed by `<`, `>`, or `^`.
 /// * The style operator is a single lowercase letter in the last position. A
@@ -971,21 +1083,55 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
     let b = token.as_bytes();
     let mut i = 0;
 
-    // Optional span/duplication: an optional count followed by `+` or `*`. The
-    // count is committed only when the operator that must follow it is present;
-    // otherwise leading digits remain and the token fails below.
+    // Optional span/duplication: an optional span factor followed by `+` (span)
+    // or `*` (duplication). The factor is a column count, an optional dot, and an
+    // optional row count (`<n>`, `.<n>`, or `<n>.<n>`). The factor is committed
+    // only when the operator that must follow it is present; otherwise the
+    // leading digits remain and the token fails the full-consumption check below.
+    let mut colspan = 1;
+    let mut rowspan = 1;
+    let col_start = i;
     let mut j = i;
     while matches!(b.get(j).copied(), Some(c) if c.is_ascii_digit()) {
         j += 1;
     }
+    let col_end = j;
+    let mut has_dot = false;
+    let mut row_start = j;
     if b.get(j).copied() == Some(b'.') {
+        has_dot = true;
         j += 1;
+        row_start = j;
         while matches!(b.get(j).copied(), Some(c) if c.is_ascii_digit()) {
             j += 1;
         }
     }
-    if matches!(b.get(j).copied(), Some(b'+' | b'*')) {
-        i = j + 1;
+    let row_end = j;
+    match b.get(j).copied() {
+        // Span: the factor is interpreted as a colspan and rowspan. A missing
+        // column or row count defaults to 1, so `2+` spans two columns, `.3+`
+        // spans three rows, and `2.3+` spans a 2x3 block.
+        Some(b'+') => {
+            // The factor consists only of ASCII digits and dots, so these ranges
+            // are always valid `str` slices.
+            let col_digits = token.get(col_start..col_end).unwrap_or_default();
+            if !col_digits.is_empty() {
+                colspan = col_digits.parse().unwrap_or(1);
+            }
+            if has_dot {
+                let row_digits = token.get(row_start..row_end).unwrap_or_default();
+                if !row_digits.is_empty() {
+                    rowspan = row_digits.parse().unwrap_or(1);
+                }
+            }
+            i = j + 1;
+        }
+        // Duplication: recognized so the cell separator is still located, but its
+        // layout effect (and so its factor) is not yet applied.
+        Some(b'*') => {
+            i = j + 1;
+        }
+        _ => {}
     }
 
     // Optional horizontal alignment operator.
@@ -1053,6 +1199,8 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
             h_align,
             v_align,
             style,
+            colspan,
+            rowspan,
         })
     } else {
         None

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -59,6 +59,11 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 /// table width, the `autowidth` option ([`is_autowidth`](Self::is_autowidth))
 /// sizes the table and its columns to their content, and an individual column
 /// can be made [autowidth](TableColumn::is_autowidth) with the `~` width value.
+///
+/// Table borders are supported: the [`frame`](Self::frame) attribute controls
+/// the border around the table and the [`grid`](Self::grid) attribute controls
+/// the borders between cells. Each falls back to a document-level default
+/// (`table-frame` / `table-grid`) and then to `all`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -69,6 +74,8 @@ pub struct TableBlock<'src> {
     title_source: Option<Span<'src>>,
     title: Option<String>,
     caption: Option<String>,
+    frame: Frame,
+    grid: Grid,
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
@@ -231,6 +238,15 @@ impl<'src> TableBlock<'src> {
             None
         };
 
+        // The `frame` and `grid` attributes control the table's borders. Each
+        // defaults to `all`; the default can be changed for the whole document
+        // with the `table-frame` / `table-grid` attribute, and an explicit
+        // attribute on the table overrides both. The value is resolved here
+        // (while `parser` is borrowed only immutably) and stored on the block so
+        // the accessors need no further document lookup.
+        let frame = resolve_border::<Frame>(metadata, parser, "frame", "table-frame");
+        let grid = resolve_border::<Grid>(metadata, parser, "grid", "table-grid");
+
         // Scan every cell in the table, in document order, then partition into
         // rows by walking the grid: a cell's span (colspan/rowspan) governs how
         // many column slots it occupies, so a column-spanning cell fills its row
@@ -376,6 +392,8 @@ impl<'src> TableBlock<'src> {
                     title_source: metadata.title_source,
                     title: metadata.title.clone(),
                     caption,
+                    frame,
+                    grid,
                     anchor: metadata.anchor,
                     anchor_reftext: metadata.anchor_reftext,
                     attrlist: metadata.attrlist.clone(),
@@ -436,6 +454,27 @@ impl<'src> TableBlock<'src> {
         self.attrlist
             .as_ref()
             .is_some_and(|a| a.has_option("autowidth"))
+    }
+
+    /// Returns the [`Frame`] that controls the border drawn around this table.
+    ///
+    /// The frame comes from the `frame` attribute on the table, which accepts
+    /// `all`, `ends`, `sides`, or `none`. When the attribute is absent the
+    /// value is taken from the `table-frame` document attribute, and when
+    /// that too is absent it defaults to [`Frame::All`].
+    pub fn frame(&self) -> Frame {
+        self.frame
+    }
+
+    /// Returns the [`Grid`] that controls the borders drawn between this
+    /// table's cells.
+    ///
+    /// The grid comes from the `grid` attribute on the table, which accepts
+    /// `all`, `rows`, `cols`, or `none`. When the attribute is absent the value
+    /// is taken from the `table-grid` document attribute, and when that too is
+    /// absent it defaults to [`Grid::All`].
+    pub fn grid(&self) -> Grid {
+        self.grid
     }
 
     /// Returns the header row of this table, if one was declared.
@@ -690,6 +729,118 @@ pub enum VerticalAlignment {
     /// Content is aligned to the bottom of the column's cells (the `.>`
     /// operator).
     Bottom,
+}
+
+/// The border drawn around a [`TableBlock`].
+///
+/// The frame is set with the `frame` attribute on the table (or, document-wide,
+/// the `table-frame` attribute). The default is [`All`](Self::All).
+///
+/// An unrecognized value falls back to [`All`](Self::All). (Asciidoctor instead
+/// passes an unrecognized value straight through to a CSS class, which the
+/// stylesheet ignores; this parser models only the four documented values.)
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum Frame {
+    /// A border is drawn on every side of the table (the `all` value). This is
+    /// the default frame.
+    #[default]
+    All,
+
+    /// A border is drawn on the top and bottom of the table (the `ends` value).
+    ///
+    /// The `topbot` value recognized by older versions of AsciiDoc is accepted
+    /// as a synonym.
+    Ends,
+
+    /// A border is drawn on the left and right sides of the table (the `sides`
+    /// value).
+    Sides,
+
+    /// No border is drawn around the table (the `none` value).
+    None,
+}
+
+/// The borders drawn between the cells of a [`TableBlock`].
+///
+/// The grid is set with the `grid` attribute on the table (or, document-wide,
+/// the `table-grid` attribute). The default is [`All`](Self::All).
+///
+/// An unrecognized value falls back to [`All`](Self::All). (Asciidoctor instead
+/// passes an unrecognized value straight through to a CSS class, which the
+/// stylesheet ignores; this parser models only the four documented values.)
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum Grid {
+    /// A border is drawn between all cells (the `all` value). This is the
+    /// default grid.
+    #[default]
+    All,
+
+    /// A border is drawn between the rows of the table (the `rows` value).
+    Rows,
+
+    /// A border is drawn between the columns of the table (the `cols` value).
+    Cols,
+
+    /// No border is drawn between the cells (the `none` value).
+    None,
+}
+
+/// A table border value ([`Frame`] or [`Grid`]) that can be parsed from an
+/// attribute value and has a default of `all`.
+trait BorderValue: Copy + Default {
+    /// Parse the value of a `frame` / `grid` attribute (or its document-level
+    /// `table-frame` / `table-grid` counterpart). An unrecognized value yields
+    /// the default.
+    fn from_attr_value(value: &str) -> Self;
+}
+
+impl BorderValue for Frame {
+    fn from_attr_value(value: &str) -> Self {
+        match value.trim() {
+            // `topbot` is the older synonym for `ends`.
+            "ends" | "topbot" => Frame::Ends,
+            "sides" => Frame::Sides,
+            "none" => Frame::None,
+            // `all` and any unrecognized value.
+            _ => Frame::All,
+        }
+    }
+}
+
+impl BorderValue for Grid {
+    fn from_attr_value(value: &str) -> Self {
+        match value.trim() {
+            "rows" => Grid::Rows,
+            "cols" => Grid::Cols,
+            "none" => Grid::None,
+            // `all` and any unrecognized value.
+            _ => Grid::All,
+        }
+    }
+}
+
+/// Resolve a table border attribute ([`Frame`] or [`Grid`]).
+///
+/// An explicit attribute on the table (`attr_name`) wins; otherwise the
+/// document-level default (`doc_attr_name`) is consulted; otherwise the value
+/// defaults to `all`.
+fn resolve_border<B: BorderValue>(
+    metadata: &BlockMetadata<'_>,
+    parser: &Parser,
+    attr_name: &str,
+    doc_attr_name: &str,
+) -> B {
+    if let Some(attr) = metadata
+        .attrlist
+        .as_ref()
+        .and_then(|a| a.named_attribute(attr_name))
+    {
+        B::from_attr_value(attr.value())
+    } else if let InterpretedValue::Value(value) = parser.attribute_value(doc_attr_name) {
+        B::from_attr_value(&value)
+    } else {
+        B::default()
+    }
 }
 
 /// A row of cells in a [`TableBlock`].

--- a/parser/src/blocks/tests/mod.rs
+++ b/parser/src/blocks/tests/mod.rs
@@ -12,6 +12,7 @@ mod media;
 mod raw_delimited;
 mod section;
 mod simple;
+mod table;
 
 mod content_model {
     use crate::blocks::ContentModel;

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -670,8 +670,8 @@ fn unrecognized_cell_style_operator_inherits_column_style() {
 fn cell_specifier_span_operator_without_factor_locates_separator() {
     // The span (`+`) and duplication (`*`) operators may appear without a count.
     // A bare `+` directly in front of a `|` is still a valid cell specifier, so
-    // `a +|b` is two cells. (The span operator's layout effect is not yet
-    // applied.)
+    // `a +|b` is two cells. With no count the span factor defaults to 1, so the
+    // bare `+` cell spans a single column (no layout effect).
     let table = parse_table("|===\n|a +|b\n|===");
 
     assert_eq!(table.columns().len(), 2);
@@ -703,4 +703,128 @@ fn dot_not_followed_by_vertical_operator_is_not_a_cell_separator() {
     assert_eq!(table.columns().len(), 1);
     let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
     assert_eq!(rows, vec![vec!["a .x|b".to_string()]]);
+}
+
+#[test]
+fn cell_span_exceeding_columns_drops_overrunning_row() {
+    // A span wider than the table overruns the grid. Matching Asciidoctor, the
+    // whole overrunning row is dropped and a warning is emitted: here the leading
+    // `x` cell is discarded along with the `3+|y` cell that overshoots the two
+    // columns, and the following row (`z`, `w`) stays aligned to the grid.
+    let mut parser = Parser::default();
+    let maw = Block::parse(
+        Span::new("[cols=\"2*\"]\n|===\n|x 3+|y\n|z |w\n|==="),
+        &mut parser,
+    );
+
+    assert!(maw.warnings.iter().any(|w| matches!(
+        w.warning,
+        crate::warnings::WarningType::TableCellExceedsColumnCount
+    )));
+
+    let table = match maw.item.unwrap().item {
+        Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    };
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(rows, vec![vec!["z".to_string(), "w".to_string()]]);
+}
+
+#[test]
+fn row_fully_covered_by_rowspans_drops_following_cell() {
+    // Two row-spanning cells (`.2+`) together cover every column of the next row,
+    // so that row has no cells of its own to close it. The following cell (`c1`)
+    // therefore overruns the pre-filled row and is dropped with it (matching
+    // Asciidoctor), leaving the remaining cells aligned: `c2` and `d1` form the
+    // second body row and the short final row holds `d2`.
+    let mut parser = Parser::default();
+    let maw = Block::parse(
+        Span::new("[cols=\"2*\"]\n|===\n.2+|a .2+|b\n|c1 |c2\n|d1 |d2\n|==="),
+        &mut parser,
+    );
+
+    assert_eq!(
+        maw.warnings
+            .iter()
+            .filter(|w| matches!(
+                w.warning,
+                crate::warnings::WarningType::TableCellExceedsColumnCount
+            ))
+            .count(),
+        1
+    );
+
+    let table = match maw.item.unwrap().item {
+        Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    };
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(
+        rows,
+        vec![
+            vec!["a".to_string(), "b".to_string()],
+            vec!["c2".to_string(), "d1".to_string()],
+            vec!["d2".to_string()],
+        ]
+    );
+}
+
+#[test]
+fn dropped_overrunning_cell_keeps_its_rowspan_carryover() {
+    // When a cell that carries a row span is itself part of an overrunning row,
+    // its already-reserved slots in the next rows are *not* rolled back when the
+    // row is dropped. Matching Asciidoctor, the `2.2+|b` cell (colspan 2, rowspan
+    // 2) overruns the two-column row and is dropped with `a`, but its rowspan
+    // still pre-fills the next row, so `c` overruns that pre-filled row and is
+    // dropped too. Only `d` and `e` survive.
+    let mut parser = Parser::default();
+    let maw = Block::parse(
+        Span::new("[cols=\"2*\"]\n|===\n|a 2.2+|b\n|c\n|d\n|e\n|==="),
+        &mut parser,
+    );
+
+    assert_eq!(
+        maw.warnings
+            .iter()
+            .filter(|w| matches!(
+                w.warning,
+                crate::warnings::WarningType::TableCellExceedsColumnCount
+            ))
+            .count(),
+        2
+    );
+
+    let table = match maw.item.unwrap().item {
+        Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    };
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(rows, vec![vec!["d".to_string(), "e".to_string()]]);
+}
+
+#[test]
+fn huge_row_span_factor_does_not_overallocate() {
+    // A row span factor far larger than the table can never carry into rows that
+    // don't exist, so it is clamped for the grid bookkeeping; without the clamp,
+    // `.1000000000+` would resize the `active_rowspans` vector to a billion
+    // entries (a multi-gigabyte allocation). The cell still reports its literal
+    // parsed `rowspan` (matching Asciidoctor), and the following cell, covered by
+    // the span, overruns and is dropped.
+    let mut parser = Parser::default();
+    let maw = Block::parse(Span::new("|===\n.1000000000+|a\n|b\n|==="), &mut parser);
+
+    assert!(maw.warnings.iter().any(|w| matches!(
+        w.warning,
+        crate::warnings::WarningType::TableCellExceedsColumnCount
+    )));
+
+    let table = match maw.item.unwrap().item {
+        Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    };
+    assert_eq!(table.body_rows().len(), 1);
+    let cell = &table.body_rows()[0].cells()[0];
+    assert_eq!(cell.colspan(), 1);
+    assert_eq!(cell.rowspan(), 1_000_000_000);
+    assert_eq!(row_text(&table.body_rows()[0]), vec!["a".to_string()]);
 }

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -282,11 +282,26 @@ fn escaped_cell_separator() {
 }
 
 #[test]
-fn cols_with_empty_specifier() {
-    // Empty entries in the `cols` list (e.g. from a doubled comma) are skipped.
-    let table = parse_table("[cols=\"1,,1\"]\n|===\n|a |b\n|===");
+fn separator_after_backslash_is_escaped() {
+    // The escape check inspects only the single byte before the separator, so a
+    // separator preceded by a backslash is escaped even when that backslash is
+    // itself preceded by another one. `|a\\|b` is therefore one cell whose
+    // content is `a\|b` (the escaping backslash is stripped), matching
+    // Asciidoctor, whose check is likewise the single-character
+    // `pre_match.end_with? '\'`.
+    let table = parse_table("|===\n|a\\\\|b\n|===");
 
-    assert_eq!(table.columns().len(), 2);
+    assert_eq!(table.body_rows().len(), 1);
+    assert_eq!(row_text(&table.body_rows()[0]), vec!["a\\|b".to_string()]);
+}
+
+#[test]
+fn cols_with_empty_specifier() {
+    // An empty entry in the `cols` list (e.g. from a doubled comma) contributes a
+    // default column, matching Asciidoctor: `cols="1,,1"` yields three columns.
+    let table = parse_table("[cols=\"1,,1\"]\n|===\n|a |b |c\n|===");
+
+    assert_eq!(table.columns().len(), 3);
 }
 
 #[test]
@@ -561,7 +576,7 @@ fn asciidoc_cell_resolves_references_in_nested_blocks() {
         .unwrap();
 
     let blocks = match table.body_rows()[0].cells()[0].content() {
-        TableCellContent::AsciiDoc(blocks) => blocks,
+        TableCellContent::AsciiDoc(cell) => cell.blocks(),
         TableCellContent::Simple(_) => panic!("expected AsciiDoc cell content"),
     };
 
@@ -591,7 +606,7 @@ fn asciidoc_cell_attributes_are_scoped_to_the_cell() {
         .unwrap();
 
     let blocks = match table.body_rows()[0].cells()[0].content() {
-        TableCellContent::AsciiDoc(blocks) => blocks,
+        TableCellContent::AsciiDoc(cell) => cell.blocks(),
         TableCellContent::Simple(_) => panic!("expected AsciiDoc cell content"),
     };
 
@@ -620,7 +635,8 @@ fn asciidoc_cell_attributes_are_scoped_to_the_cell() {
 /// Collect the rendered text of every block in an AsciiDoc cell.
 fn asciidoc_cell_text(table: &TableBlock<'_>, row: usize, col: usize) -> String {
     match table.body_rows()[row].cells()[col].content() {
-        TableCellContent::AsciiDoc(blocks) => blocks
+        TableCellContent::AsciiDoc(cell) => cell
+            .blocks()
             .iter()
             .filter_map(|block| block.rendered_content())
             .collect::<Vec<_>>()
@@ -738,29 +754,27 @@ fn cell_specifier_span_operator_without_factor_locates_separator() {
 }
 
 #[test]
-fn non_specifier_token_is_not_a_cell_separator() {
+fn non_specifier_token_is_a_plain_cell_separator() {
     // A token in front of a `|` that does not parse as a cell specifier (here the
-    // word `foo`, which is more than a single style letter) means the `|` is not
-    // a cell separator: `a foo|b` is a single cell whose content includes the
-    // literal `|`.
+    // word `foo`, which is more than a single style letter) is ordinary content:
+    // the `|` is still a plain cell separator, so `a foo|b` is two cells (matching
+    // Asciidoctor).
     let table = parse_table("|===\n|a foo|b\n|===");
 
-    assert_eq!(table.columns().len(), 1);
     let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
-    assert_eq!(rows, vec![vec!["a foo|b".to_string()]]);
+    assert_eq!(rows, vec![vec!["a foo".to_string(), "b".to_string()]]);
 }
 
 #[test]
-fn dot_not_followed_by_vertical_operator_is_not_a_cell_separator() {
+fn dot_not_followed_by_vertical_operator_is_a_plain_cell_separator() {
     // A vertical alignment operator is a dot followed by `<`, `>`, or `^`. A dot
     // followed by anything else (here `.x`) is not a valid cell specifier, so the
-    // `|` is not a cell separator: `a .x|b` is a single cell whose content
-    // includes the literal `.x|`.
+    // `.x` is content and the `|` is a plain cell separator: `a .x|b` is two cells
+    // (matching Asciidoctor).
     let table = parse_table("|===\n|a .x|b\n|===");
 
-    assert_eq!(table.columns().len(), 1);
     let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
-    assert_eq!(rows, vec![vec!["a .x|b".to_string()]]);
+    assert_eq!(rows, vec![vec!["a .x".to_string(), "b".to_string()]]);
 }
 
 #[test]
@@ -792,9 +806,11 @@ fn cell_span_exceeding_columns_drops_overrunning_row() {
 fn row_fully_covered_by_rowspans_drops_following_cell() {
     // Two row-spanning cells (`.2+`) together cover every column of the next row,
     // so that row has no cells of its own to close it. The following cell (`c1`)
-    // therefore overruns the pre-filled row and is dropped with it (matching
-    // Asciidoctor), leaving the remaining cells aligned: `c2` and `d1` form the
-    // second body row and the short final row holds `d2`.
+    // therefore overruns the pre-filled row and is dropped with it (a column-count
+    // overrun warning), leaving `c2` and `d1` aligned as the second body row. The
+    // trailing `d2` cell can't fill a row of its own, so the table ends on an
+    // incomplete row that is dropped with an end-of-table warning (matching
+    // Asciidoctor, which renders only two rows here).
     let mut parser = Parser::default();
     let maw = Block::parse(
         Span::new("[cols=\"2*\"]\n|===\n.2+|a .2+|b\n|c1 |c2\n|d1 |d2\n|==="),
@@ -811,6 +827,16 @@ fn row_fully_covered_by_rowspans_drops_following_cell() {
             .count(),
         1
     );
+    assert_eq!(
+        maw.warnings
+            .iter()
+            .filter(|w| matches!(
+                w.warning,
+                crate::warnings::WarningType::TableDroppingIncompleteRowAtEndOfTable
+            ))
+            .count(),
+        1
+    );
 
     let table = match maw.item.unwrap().item {
         Block::Table(table) => table,
@@ -822,7 +848,6 @@ fn row_fully_covered_by_rowspans_drops_following_cell() {
         vec![
             vec!["a".to_string(), "b".to_string()],
             vec!["c2".to_string(), "d1".to_string()],
-            vec!["d2".to_string()],
         ]
     );
 }
@@ -1011,9 +1036,24 @@ fn csv_unclosed_quote_is_literal() {
     let table = parse_table("[format=csv]\n|===\n\",a\n|===");
     assert_eq!(table.columns().len(), 1);
     assert_eq!(row_text(&table.body_rows()[0]), ["\",a"]);
+}
 
-    // A cell that is a single bare quote is an unclosed, empty quoted value.
-    let table = parse_table("[format=csv]\n|===\n\"\n|===");
+#[test]
+fn csv_lone_quote_is_unclosed_and_empty_with_warning() {
+    // A cell that is a single bare quote is an unclosed, empty quoted value: it is
+    // set to empty and an error is logged (matching Asciidoctor).
+    let mut parser = Parser::default();
+    let maw = Block::parse(Span::new("[format=csv]\n|===\n\"\n|==="), &mut parser);
+
+    assert!(maw.warnings.iter().any(|w| matches!(
+        w.warning,
+        crate::warnings::WarningType::TableCsvDataHasUnclosedQuote
+    )));
+
+    let table = match maw.item.unwrap().item {
+        Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    };
     assert_eq!(table.columns().len(), 1);
     assert_eq!(row_text(&table.body_rows()[0]), [""]);
 }

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -828,3 +828,80 @@ fn huge_row_span_factor_does_not_overallocate() {
     assert_eq!(cell.rowspan(), 1_000_000_000);
     assert_eq!(row_text(&table.body_rows()[0]), vec!["a".to_string()]);
 }
+
+#[test]
+fn duplication_clones_content_and_properties() {
+    // A duplication factor (`<n>*`) clones the cell into `<n>` independent cells,
+    // each an ordinary single-slot cell (colspan and rowspan of 1) that carries
+    // the original's content and style. Here `3*e|x` becomes three emphasized
+    // cells, each holding `x`.
+    let table = parse_table("[cols=\"3*\"]\n|===\n3*e|x\n|===");
+    let cells = table.body_rows()[0].cells();
+    assert_eq!(cells.len(), 3);
+    for cell in cells {
+        assert_eq!(cell.colspan(), 1);
+        assert_eq!(cell.rowspan(), 1);
+        assert_eq!(cell.style(), ColumnStyle::Emphasis);
+    }
+    assert_eq!(
+        row_text(&table.body_rows()[0]),
+        vec!["x".to_string(), "x".to_string(), "x".to_string()]
+    );
+}
+
+#[test]
+fn duplication_factor_ignores_row_part() {
+    // Only the column part of the factor is the duplication count; a row part
+    // (`<n>.<n>*`) is ignored, matching Asciidoctor. So `2.3*` duplicates the cell
+    // twice (not six times), and each clone keeps a rowspan of 1.
+    let table = parse_table("[cols=\"4*\"]\n|===\n2.3*|a |b |c\n|===");
+    let cells = table.body_rows()[0].cells();
+    assert_eq!(cells.len(), 4);
+    assert_eq!(cells[0].rowspan(), 1);
+    assert_eq!(
+        row_text(&table.body_rows()[0]),
+        vec![
+            "a".to_string(),
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string()
+        ]
+    );
+}
+
+#[test]
+fn duplication_factor_of_zero_drops_the_cell() {
+    // A duplication factor of zero (`0*`) clones the cell zero times, dropping it
+    // entirely; the following cells flow normally into the grid. Matching
+    // Asciidoctor, `0*|x |a |b |c` yields a single row of `a`, `b`, `c`.
+    let table = parse_table("[cols=\"3*\"]\n|===\n0*|x |a |b |c\n|===");
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(
+        rows,
+        vec![vec!["a".to_string(), "b".to_string(), "c".to_string()]]
+    );
+}
+
+#[test]
+fn bare_duplication_operator_clones_once() {
+    // A bare duplication operator (`*`) with no factor defaults to a count of 1,
+    // so `*|a` is a single cell and locates the separator just like a plain `|`.
+    let table = parse_table("|===\n|a *|b\n|===");
+    assert_eq!(table.columns().len(), 2);
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(rows, vec![vec!["a".to_string(), "b".to_string()]]);
+}
+
+#[test]
+fn huge_duplication_factor_does_not_overallocate() {
+    // A duplication factor is an amplifier — `1000000000*` would otherwise
+    // materialize a billion cells (a multi-gigabyte allocation). The factor is
+    // clamped to `MAX_DUPLICATION_FACTOR` (1,000), so the expansion stays
+    // bounded. This is the one place the implementation diverges from Asciidoctor,
+    // which would expand the literal factor. The table is built from the clamped
+    // cells without hanging or exhausting memory.
+    let table = parse_table("|===\n1000000000*|x\n|===");
+    let total: usize = table.body_rows().iter().map(|r| r.cells().len()).sum();
+    assert_eq!(total, 1_000);
+    assert_eq!(row_text(&table.body_rows()[0])[0], "x".to_string());
+}

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -140,6 +140,64 @@ fn column_multiplier() {
 }
 
 #[test]
+fn table_width_attribute() {
+    // The `width` attribute reports an integer percentage; the trailing `%` is
+    // optional.
+    assert_eq!(parse_table("[width=75%]\n|===\n|a\n|===").width(), Some(75));
+    assert_eq!(parse_table("[width=75]\n|===\n|a\n|===").width(), Some(75));
+
+    // No `width` attribute means no fixed width.
+    assert_eq!(parse_table("|===\n|a\n|===").width(), None);
+
+    // Values outside the 1-to-100 range, or non-integer values, are ignored.
+    assert_eq!(parse_table("[width=0]\n|===\n|a\n|===").width(), None);
+    assert_eq!(parse_table("[width=101]\n|===\n|a\n|===").width(), None);
+    assert_eq!(parse_table("[width=half]\n|===\n|a\n|===").width(), None);
+}
+
+#[test]
+fn autowidth_option_makes_columns_autowidth() {
+    // The shorthand `%autowidth` and the formal `options="autowidth"` both set
+    // the table to autowidth, and every column inherits the setting.
+    for source in [
+        "[%autowidth]\n|===\n|a |b\n|===",
+        "[options=\"autowidth\"]\n|===\n|a |b\n|===",
+    ] {
+        let table = parse_table(source);
+        assert!(table.is_autowidth());
+        assert!(table.columns().iter().all(|c| c.is_autowidth()));
+    }
+
+    // A column that inherits autowidth from the table's `autowidth` option
+    // still becomes autowidth, but retains the explicit width from its
+    // specifier (the width is simply not used to size an autowidth column).
+    let table = parse_table("[%autowidth,cols=\"2,1\"]\n|===\n|a |b\n|===");
+    assert!(table.columns().iter().all(|c| c.is_autowidth()));
+    let widths: Vec<usize> = table.columns().iter().map(|c| c.width()).collect();
+    assert_eq!(widths, vec![2, 1]);
+
+    // Without the option, the table and its columns keep proportional widths.
+    let table = parse_table("|===\n|a |b\n|===");
+    assert!(!table.is_autowidth());
+    assert!(table.columns().iter().all(|c| !c.is_autowidth()));
+}
+
+#[test]
+fn autowidth_column_via_tilde() {
+    // The `~` width value marks only that column as autowidth, leaving the
+    // others at their explicit width; the table itself is not autowidth.
+    let table = parse_table("[cols=\"25h,~,~\"]\n|===\n|a |b |c\n|===");
+
+    let columns: Vec<(usize, bool)> = table
+        .columns()
+        .iter()
+        .map(|c| (c.width(), c.is_autowidth()))
+        .collect();
+    assert_eq!(columns, vec![(25, false), (1, true), (1, true)]);
+    assert!(!table.is_autowidth());
+}
+
+#[test]
 fn cell_content_is_substituted() {
     // Cell content flows through the normal substitution pipeline.
     let table = parse_table("|===\n|*bold* and _italic_\n|===");

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -559,17 +559,111 @@ fn asciidoc_cell_attributes_are_scoped_to_the_cell() {
     assert!(parser.has_attribute("parent-attr"));
 }
 
+/// Collect the rendered text of every block in an AsciiDoc cell.
+fn asciidoc_cell_text(table: &TableBlock<'_>, row: usize, col: usize) -> String {
+    match table.body_rows()[row].cells()[col].content() {
+        TableCellContent::AsciiDoc(blocks) => blocks
+            .iter()
+            .filter_map(|block| block.rendered_content())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        TableCellContent::Simple(_) => panic!("expected AsciiDoc cell content"),
+    }
+}
+
+#[test]
+fn asciidoc_cell_cannot_modify_a_parent_attribute() {
+    // An attribute set in the parent document is locked inside an AsciiDoc cell:
+    // a reassignment is silently ignored, so the inherited value is what the cell
+    // sees. The lock is scoped to the cell, so the parent value is unchanged
+    // afterward.
+    let mut parser = Parser::default();
+    let doc = parser.parse(
+        ":locked: parent\n\n[cols=\"a\"]\n|===\n|\n:locked: child\n\nvalue is {locked}\n|===",
+    );
+    let table = doc
+        .nested_blocks()
+        .find_map(|block| match block {
+            Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .unwrap();
+
+    assert_eq!(asciidoc_cell_text(table, 0, 0), "value is parent");
+    assert_eq!(
+        parser.attribute_value("locked"),
+        crate::document::InterpretedValue::Value("parent".to_string())
+    );
+}
+
+#[test]
+fn asciidoc_cell_may_set_an_attribute_unset_in_the_parent() {
+    // Only attributes that are *set* in the parent are locked. An attribute that
+    // is explicitly unset in the parent is not locked, so the cell may assign it
+    // and the cell sees its own value (matching Asciidoctor, which here diverges
+    // from the spec's "set or explicitly unset" wording).
+    let mut parser = Parser::default();
+    let doc = parser.parse(
+        ":locked: value\n:locked!:\n\n[cols=\"a\"]\n|===\n|\n:locked: child\n\nvalue is {locked}\n|===",
+    );
+    let table = doc
+        .nested_blocks()
+        .find_map(|block| match block {
+            Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .unwrap();
+
+    assert_eq!(asciidoc_cell_text(table, 0, 0), "value is child");
+}
+
+#[test]
+fn asciidoc_cell_may_modify_an_exempt_attribute() {
+    // A handful of attributes are exempt from the cell lock; `compat-mode` is one
+    // of them, so a cell may modify it even though the parent set it, while a
+    // non-exempt attribute (`locked`) stays at the inherited value.
+    let mut parser = Parser::default();
+    let doc = parser.parse(
+        ":compat-mode: parent\n:locked: parent\n\n[cols=\"a\"]\n|===\n|\n:compat-mode: child\n:locked: child\n\nc={compat-mode} l={locked}\n|===",
+    );
+    let table = doc
+        .nested_blocks()
+        .find_map(|block| match block {
+            Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .unwrap();
+
+    assert_eq!(asciidoc_cell_text(table, 0, 0), "c=child l=parent");
+}
+
 #[test]
 fn cell_specifier_style_operator_locates_separator() {
     // A single lowercase letter directly in front of a `|` is a (style) cell
     // specifier, so the `|` is a cell separator: `a s|b` is two cells, not one.
-    // The style operator is recognized only so the separator is located; its
-    // styling effect is not yet applied, so the cell renders as plain content.
+    // A recognized style operator (here `s`) is applied to the cell.
     let table = parse_table("|===\n|a s|b\n|===");
 
     assert_eq!(table.columns().len(), 2);
     let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
     assert_eq!(rows, vec![vec!["a".to_string(), "b".to_string()]]);
+
+    let cells = table.body_rows()[0].cells();
+    assert_eq!(cells[0].style(), ColumnStyle::Default);
+    assert_eq!(cells[1].style(), ColumnStyle::Strong);
+}
+
+#[test]
+fn unrecognized_cell_style_operator_inherits_column_style() {
+    // A single lowercase letter that isn't a recognized style operator (here `z`)
+    // still locates the cell separator, but it leaves the cell's style unset, so
+    // the cell inherits its column's style rather than reverting to the default.
+    // This matches Asciidoctor, which ignores an unrecognized cell style operator.
+    let table = parse_table("[cols=\"m,m\"]\n|===\n|head1 |head2\n\nz|zee s|ess\n|===");
+
+    let cells = table.body_rows()[0].cells();
+    assert_eq!(cells[0].style(), ColumnStyle::Monospace);
+    assert_eq!(cells[1].style(), ColumnStyle::Strong);
 }
 
 #[test]

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -3,7 +3,10 @@
 
 use crate::{
     HasSpan, Parser, Span,
-    blocks::{Block, ContentModel, HorizontalAlignment, IsBlock, TableBlock, VerticalAlignment},
+    blocks::{
+        Block, ColumnStyle, ContentModel, HorizontalAlignment, IsBlock, TableBlock,
+        TableCellContent, VerticalAlignment,
+    },
     content::SubstitutionGroup,
     parser::ModificationContext,
 };
@@ -22,10 +25,16 @@ fn parse_table(source: &str) -> TableBlock<'_> {
 }
 
 /// Collect the rendered content of every cell in a row.
+///
+/// Every cell in these basic-table tests uses the default (inline) style, so a
+/// cell is expected to hold [`TableCellContent::Simple`].
 fn row_text(row: &crate::blocks::TableRow<'_>) -> Vec<String> {
     row.cells()
         .iter()
-        .map(|cell| cell.content().rendered().to_string())
+        .map(|cell| match cell.content() {
+            TableCellContent::Simple(content) => content.rendered().to_string(),
+            TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
+        })
         .collect()
 }
 
@@ -437,8 +446,8 @@ fn malformed_vertical_operator_falls_back_to_defaults() {
     // must be followed by `<`, `>`, or `^`. When the dot is followed by anything
     // else (here the letter `x`), the operator is malformed; rather than panic,
     // the parser leaves the dot unconsumed so the column falls back to the
-    // default vertical alignment (top) and default width, and the stray text is
-    // ignored along with the as-yet-unmodeled style operator.
+    // default vertical alignment (top) and default width. The leftover `.x` is
+    // not a recognized single-letter style operator, so the style also defaults.
     let table = parse_table("[cols=\".x,1\"]\n|===\n|a |b\n|===");
 
     let columns = table.columns();
@@ -446,4 +455,106 @@ fn malformed_vertical_operator_falls_back_to_defaults() {
     assert_eq!(columns[0].width(), 1);
     assert_eq!(columns[0].h_align(), HorizontalAlignment::Left);
     assert_eq!(columns[0].v_align(), VerticalAlignment::Top);
+    assert_eq!(columns[0].style(), ColumnStyle::Default);
+}
+
+#[test]
+fn literal_column_processes_content_verbatim() {
+    // The `l` (literal) style processes a cell's content with the verbatim
+    // substitution group: inline markup like `*z*` is left intact and only the
+    // special characters are escaped, in contrast to the default style's normal
+    // substitutions.
+    let table = parse_table("[cols=\"l\"]\n|===\n|lit *z* and <x>\n|===");
+
+    assert_eq!(table.columns()[0].style(), ColumnStyle::Literal);
+
+    match table.body_rows()[0].cells()[0].content() {
+        TableCellContent::Simple(content) => {
+            assert_eq!(content.rendered(), "lit *z* and &lt;x&gt;");
+        }
+        TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
+    }
+}
+
+#[test]
+fn malformed_style_operator_falls_back_to_default() {
+    // The style operator is the entire remainder after the width, so trailing
+    // junk (here `em`, perhaps a typo for the `e` style) is not a recognized
+    // single-letter operator and the column falls back to the default style
+    // rather than silently honoring the first letter.
+    let table = parse_table("[cols=\"1em\"]\n|===\n|a\n|===");
+
+    assert_eq!(table.columns()[0].style(), ColumnStyle::Default);
+}
+
+#[test]
+fn asciidoc_cell_resolves_references_in_nested_blocks() {
+    // Cross-references inside an AsciiDoc cell are resolved during the document's
+    // reference-resolution pass, which descends into the cell's nested blocks.
+    let doc = Parser::default()
+        .parse("[#target]\nTarget paragraph.\n\n[cols=\"a\"]\n|===\n|See xref:target[].\n|===");
+
+    let table = doc
+        .nested_blocks()
+        .find_map(|block| match block {
+            Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .unwrap();
+
+    let blocks = match table.body_rows()[0].cells()[0].content() {
+        TableCellContent::AsciiDoc(blocks) => blocks,
+        TableCellContent::Simple(_) => panic!("expected AsciiDoc cell content"),
+    };
+
+    let rendered = blocks[0].rendered_content().unwrap();
+    assert!(
+        rendered.contains("href=\"#target\""),
+        "xref was not resolved: {rendered}"
+    );
+}
+
+#[test]
+fn asciidoc_cell_attributes_are_scoped_to_the_cell() {
+    // An AsciiDoc cell inherits the parent document's attributes, but an
+    // attribute it defines is scoped to the cell and does not leak back into the
+    // parent document (matching Asciidoctor).
+    let mut parser = Parser::default();
+    let doc = parser.parse(
+        ":parent-attr: inherited\n\n[cols=\"a\"]\n|===\n|\n:cell-attr: leaked\ncell sees: {parent-attr} {cell-attr}\n|===",
+    );
+
+    let table = doc
+        .nested_blocks()
+        .find_map(|block| match block {
+            Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .unwrap();
+
+    let blocks = match table.body_rows()[0].cells()[0].content() {
+        TableCellContent::AsciiDoc(blocks) => blocks,
+        TableCellContent::Simple(_) => panic!("expected AsciiDoc cell content"),
+    };
+
+    // Inside the cell, both the inherited parent attribute and the cell's own
+    // attribute resolve.
+    let rendered: String = blocks
+        .iter()
+        .filter_map(|block| block.rendered_content())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        rendered.contains("inherited"),
+        "cell did not inherit the parent attribute: {rendered}"
+    );
+    assert!(
+        rendered.contains("leaked"),
+        "cell did not see its own attribute: {rendered}"
+    );
+
+    // The attribute defined inside the cell did not leak into the parent, while
+    // the parent's own attribute is unaffected.
+    assert!(!parser.has_attribute("cell-attr"));
+    assert!(parser.has_attribute("parent-attr"));
 }

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -399,3 +399,34 @@ fn caption_attribute_is_ignored_without_a_title() {
     assert!(table.title().is_none());
     assert!(table.caption().is_none());
 }
+
+#[test]
+fn empty_caption_attribute_suppresses_the_label() {
+    // An explicitly empty `caption` (e.g. `[caption=]`) removes the label on the
+    // table: the title is kept but no caption (and no number) is assigned, so the
+    // title renders with no prefix.
+    let table = parse_table("[caption=]\n.A table with a title but no label\n|===\n|a\n|===");
+
+    assert_eq!(table.title(), Some("A table with a title but no label"));
+    assert!(table.caption().is_none());
+}
+
+#[test]
+fn empty_caption_attribute_does_not_consume_a_table_number() {
+    // A table whose label is removed with an empty `caption` is skipped by the
+    // document-wide counter, so a following `table-caption` table is numbered as
+    // if the unlabeled table were not there.
+    let doc = Parser::default().parse(
+        ".First\n|===\n|a\n|===\n\n[caption=]\n.Unlabeled\n|===\n|b\n|===\n\n.Third\n|===\n|c\n|===",
+    );
+
+    let captions: Vec<Option<&str>> = doc
+        .nested_blocks()
+        .filter_map(|block| match block {
+            Block::Table(table) => Some(table.caption()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(captions, vec![Some("Table 1. "), None, Some("Table 2. ")]);
+}

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     HasSpan, Parser, Span,
-    blocks::{Block, ContentModel, IsBlock, TableBlock},
+    blocks::{Block, ContentModel, HorizontalAlignment, IsBlock, TableBlock, VerticalAlignment},
     content::SubstitutionGroup,
     parser::ModificationContext,
 };
@@ -429,4 +429,21 @@ fn empty_caption_attribute_does_not_consume_a_table_number() {
         .collect();
 
     assert_eq!(captions, vec![Some("Table 1. "), None, Some("Table 2. ")]);
+}
+
+#[test]
+fn malformed_vertical_operator_falls_back_to_defaults() {
+    // A dot in a column specifier introduces a vertical alignment operator, which
+    // must be followed by `<`, `>`, or `^`. When the dot is followed by anything
+    // else (here the letter `x`), the operator is malformed; rather than panic,
+    // the parser leaves the dot unconsumed so the column falls back to the
+    // default vertical alignment (top) and default width, and the stray text is
+    // ignored along with the as-yet-unmodeled style operator.
+    let table = parse_table("[cols=\".x,1\"]\n|===\n|a |b\n|===");
+
+    let columns = table.columns();
+    assert_eq!(columns.len(), 2);
+    assert_eq!(columns[0].width(), 1);
+    assert_eq!(columns[0].h_align(), HorizontalAlignment::Left);
+    assert_eq!(columns[0].v_align(), VerticalAlignment::Top);
 }

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -340,3 +340,62 @@ fn empty_table_caption_suppresses_the_label() {
         vec![(Some("First"), None), (Some("Second"), None)]
     );
 }
+
+#[test]
+fn caption_attribute_sets_the_label_verbatim() {
+    // An explicit `caption` attribute provides the label exactly as written,
+    // including its trailing space, with no automatically inserted number.
+    let table =
+        parse_table("[caption=\"Table A. \"]\n.A table with a custom label\n|===\n|a\n|===");
+
+    assert_eq!(table.title(), Some("A table with a custom label"));
+    assert_eq!(table.caption(), Some("Table A. "));
+}
+
+#[test]
+fn caption_attribute_does_not_consume_a_table_number() {
+    // A table labeled with an explicit `caption` is skipped by the document-wide
+    // counter, so a following `table-caption` table is numbered as if the
+    // explicitly captioned table were not there.
+    let doc = Parser::default().parse(
+        ".First\n|===\n|a\n|===\n\n[caption=\"Table A. \"]\n.Custom\n|===\n|b\n|===\n\n.Third\n|===\n|c\n|===",
+    );
+
+    let captions: Vec<Option<&str>> = doc
+        .nested_blocks()
+        .filter_map(|block| match block {
+            Block::Table(table) => Some(table.caption()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        captions,
+        vec![Some("Table 1. "), Some("Table A. "), Some("Table 2. ")]
+    );
+}
+
+#[test]
+fn caption_attribute_applies_even_when_table_caption_is_unset() {
+    // The `caption` attribute is honored independently of `table-caption`, so it
+    // still labels a titled table even when `table-caption` has been unset.
+    let doc = Parser::default()
+        .parse(":!table-caption:\n\n[caption=\"Forced. \"]\n.Numbers\n|===\n|a\n|===");
+
+    let caption = doc.nested_blocks().find_map(|block| match block {
+        Block::Table(table) => table.caption().map(|c| c.to_string()),
+        _ => None,
+    });
+
+    assert_eq!(caption.as_deref(), Some("Forced. "));
+}
+
+#[test]
+fn caption_attribute_is_ignored_without_a_title() {
+    // The caption labels a title; with no title there is nothing to caption, so
+    // an untitled table carries no caption even when `caption` is set.
+    let table = parse_table("[caption=\"Table A. \"]\n|===\n|a\n|===");
+
+    assert!(table.title().is_none());
+    assert!(table.caption().is_none());
+}

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -1,0 +1,244 @@
+//! Tests for the basic PSV table block, covering the examples in
+//! `docs/modules/tables/pages/build-a-basic-table.adoc`.
+
+use crate::{
+    HasSpan, Parser, Span,
+    blocks::{Block, ContentModel, IsBlock, TableBlock},
+    content::SubstitutionGroup,
+};
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+fn parse_table(source: &str) -> TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = Block::parse(Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Collect the rendered content of every cell in a row.
+fn row_text(row: &crate::blocks::TableRow<'_>) -> Vec<String> {
+    row.cells()
+        .iter()
+        .map(|cell| cell.content().rendered().to_string())
+        .collect()
+}
+
+#[test]
+fn two_columns_three_rows() {
+    // From <<ex-rows>>: two columns via `cols`, three body rows, no header.
+    let table = parse_table(
+        "[cols=\"1,1\"]\n|===\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|===",
+    );
+
+    assert_eq!(table.content_model(), ContentModel::Table);
+    assert_eq!(table.raw_context().as_ref(), "table");
+    assert_eq!(table.columns().len(), 2);
+    assert!(table.header_row().is_none());
+
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(
+        rows,
+        vec![
+            vec![
+                "Cell in column 1, row 1".to_string(),
+                "Cell in column 2, row 1".to_string()
+            ],
+            vec![
+                "Cell in column 1, row 2".to_string(),
+                "Cell in column 2, row 2".to_string()
+            ],
+            vec![
+                "Cell in column 1, row 3".to_string(),
+                "Cell in column 2, row 3".to_string()
+            ],
+        ]
+    );
+}
+
+#[test]
+fn multiple_cells_on_one_line() {
+    // From <<ex-rows>>: a row may place several cells on a single line, each
+    // separated by a space followed by a vertical bar.
+    let table = parse_table(
+        "[cols=\"1,1\"]\n|===\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n\n|Cell in column 1, row 2 |Cell in column 2, row 2\n|Cell in column 1, row 3 |Cell in column 2, row 3\n|===",
+    );
+
+    assert_eq!(table.body_rows().len(), 3);
+    assert_eq!(
+        row_text(&table.body_rows()[2]),
+        vec![
+            "Cell in column 1, row 3".to_string(),
+            "Cell in column 2, row 3".to_string()
+        ]
+    );
+}
+
+#[test]
+fn implicit_header_row() {
+    // From <<ex-header>>: the first line after the delimiter is non-empty and is
+    // followed by a blank line, so it becomes the header row.
+    let table = parse_table(
+        "[cols=\"1,1\"]\n|===\n|Cell in column 1, header row |Cell in column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|===",
+    );
+
+    let header = table.header_row().unwrap();
+    assert_eq!(
+        row_text(header),
+        vec![
+            "Cell in column 1, header row".to_string(),
+            "Cell in column 2, header row".to_string()
+        ]
+    );
+
+    assert_eq!(table.body_rows().len(), 2);
+}
+
+#[test]
+fn implicit_columns_from_first_row() {
+    // From add-columns.adoc <<ex-implicit>>: with no `cols` attribute and a blank
+    // line before the first row, the column count comes from the first row's cell
+    // count and there is no header.
+    let table = parse_table(
+        "|===\n\n|Cell in column 1, row 1 |Cell in column 2, row 1 |Cell in column 3, row 1\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n|===",
+    );
+
+    assert_eq!(table.columns().len(), 3);
+    assert!(table.header_row().is_none());
+    assert_eq!(table.body_rows().len(), 2);
+    assert_eq!(
+        row_text(&table.body_rows()[0]),
+        vec![
+            "Cell in column 1, row 1".to_string(),
+            "Cell in column 2, row 1".to_string(),
+            "Cell in column 3, row 1".to_string()
+        ]
+    );
+}
+
+#[test]
+fn column_multiplier() {
+    // From add-columns.adoc: `cols="5,3*"` yields one column then three more.
+    let table = parse_table("[cols=\"5,3*\"]\n|===\n|a |b |c |d\n|===");
+
+    let widths: Vec<usize> = table.columns().iter().map(|c| c.width()).collect();
+    assert_eq!(widths, vec![5, 1, 1, 1]);
+}
+
+#[test]
+fn cell_content_is_substituted() {
+    // Cell content flows through the normal substitution pipeline.
+    let table = parse_table("|===\n|*bold* and _italic_\n|===");
+
+    assert_eq!(
+        row_text(&table.body_rows()[0]),
+        vec!["<strong>bold</strong> and <em>italic</em>".to_string()]
+    );
+}
+
+#[test]
+fn leading_and_trailing_whitespace_stripped() {
+    // From <<ex-more-cells>>: leading and trailing spaces around cell content are
+    // stripped.
+    let table = parse_table("[cols=\"1,1\"]\n|===\n|a |    b spaced\n|===");
+
+    assert_eq!(
+        row_text(&table.body_rows()[0]),
+        vec!["a".to_string(), "b spaced".to_string()]
+    );
+}
+
+#[test]
+fn block_is_recognized_via_debug() {
+    let mut parser = Parser::default();
+    let mi = Block::parse(Span::new("|===\n|a |b\n|==="), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    let debug_output = format!("{:?}", mi.item);
+    assert!(debug_output.starts_with("Block::Table"));
+}
+
+#[test]
+fn unterminated_table_warns() {
+    let mut parser = Parser::default();
+    let maw = Block::parse(Span::new("|===\n|a |b"), &mut parser);
+
+    assert!(maw.warnings.iter().any(|w| matches!(
+        w.warning,
+        crate::warnings::WarningType::UnterminatedDelimitedBlock
+    )));
+}
+
+#[test]
+fn block_level_accessors() {
+    // Exercise every `IsBlock`/`HasSpan` accessor through the `Block` enum
+    // (rather than the unwrapped `TableBlock`) so the delegating match arms in
+    // `block.rs` are covered.
+    let mut parser = Parser::default();
+    let block = Block::parse(Span::new("|===\n|a |b\n|==="), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap()
+        .item;
+
+    assert_eq!(block.content_model(), ContentModel::Table);
+    assert_eq!(block.raw_context().as_ref(), "table");
+    assert_eq!(block.resolved_context().as_ref(), "table");
+    assert!(block.rendered_content().is_none());
+    assert_eq!(block.nested_blocks().count(), 0);
+    assert!(block.declared_style().is_none());
+    assert!(block.id().is_none());
+    assert!(block.roles().is_empty());
+    assert!(block.options().is_empty());
+    assert!(block.title_source().is_none());
+    assert!(block.title().is_none());
+    assert!(block.anchor().is_none());
+    assert!(block.anchor_reftext().is_none());
+    assert!(block.attrlist().is_none());
+    assert_eq!(block.substitution_group(), SubstitutionGroup::Normal);
+    assert_eq!(block.span().data(), "|===\n|a |b\n|===");
+}
+
+#[test]
+fn escaped_cell_separator() {
+    // A backslash-escaped separator (`\|`) is not a cell boundary; the backslash
+    // is stripped from the rendered cell content.
+    let table = parse_table("|===\n|a \\| b\n|===");
+
+    assert_eq!(table.body_rows().len(), 1);
+    assert_eq!(row_text(&table.body_rows()[0]), vec!["a | b".to_string()]);
+}
+
+#[test]
+fn cols_with_empty_specifier() {
+    // Empty entries in the `cols` list (e.g. from a doubled comma) are skipped.
+    let table = parse_table("[cols=\"1,,1\"]\n|===\n|a |b\n|===");
+
+    assert_eq!(table.columns().len(), 2);
+}
+
+#[test]
+fn no_cols_and_first_line_without_a_cell() {
+    // With no `cols` attribute and a first line that contains no cell separator,
+    // the column count is zero and the body loop is skipped entirely.
+    let table = parse_table("|===\nnot a cell\n|===");
+
+    assert!(table.columns().is_empty());
+    assert!(table.header_row().is_none());
+    assert!(table.body_rows().is_empty());
+}
+
+#[test]
+fn header_option_without_cells() {
+    // The `header` option forces header handling even when the table has no
+    // cells, exercising the empty-header-row branch.
+    let table = parse_table("[%header,cols=\"1,1\"]\n|===\nnot a cell\n|===");
+
+    assert_eq!(table.columns().len(), 2);
+    assert!(table.header_row().is_none());
+    assert!(table.body_rows().is_empty());
+}

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -558,3 +558,55 @@ fn asciidoc_cell_attributes_are_scoped_to_the_cell() {
     assert!(!parser.has_attribute("cell-attr"));
     assert!(parser.has_attribute("parent-attr"));
 }
+
+#[test]
+fn cell_specifier_style_operator_locates_separator() {
+    // A single lowercase letter directly in front of a `|` is a (style) cell
+    // specifier, so the `|` is a cell separator: `a s|b` is two cells, not one.
+    // The style operator is recognized only so the separator is located; its
+    // styling effect is not yet applied, so the cell renders as plain content.
+    let table = parse_table("|===\n|a s|b\n|===");
+
+    assert_eq!(table.columns().len(), 2);
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(rows, vec![vec!["a".to_string(), "b".to_string()]]);
+}
+
+#[test]
+fn cell_specifier_span_operator_without_factor_locates_separator() {
+    // The span (`+`) and duplication (`*`) operators may appear without a count.
+    // A bare `+` directly in front of a `|` is still a valid cell specifier, so
+    // `a +|b` is two cells. (The span operator's layout effect is not yet
+    // applied.)
+    let table = parse_table("|===\n|a +|b\n|===");
+
+    assert_eq!(table.columns().len(), 2);
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(rows, vec![vec!["a".to_string(), "b".to_string()]]);
+}
+
+#[test]
+fn non_specifier_token_is_not_a_cell_separator() {
+    // A token in front of a `|` that does not parse as a cell specifier (here the
+    // word `foo`, which is more than a single style letter) means the `|` is not
+    // a cell separator: `a foo|b` is a single cell whose content includes the
+    // literal `|`.
+    let table = parse_table("|===\n|a foo|b\n|===");
+
+    assert_eq!(table.columns().len(), 1);
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(rows, vec![vec!["a foo|b".to_string()]]);
+}
+
+#[test]
+fn dot_not_followed_by_vertical_operator_is_not_a_cell_separator() {
+    // A vertical alignment operator is a dot followed by `<`, `>`, or `^`. A dot
+    // followed by anything else (here `.x`) is not a valid cell specifier, so the
+    // `|` is not a cell separator: `a .x|b` is a single cell whose content
+    // includes the literal `.x|`.
+    let table = parse_table("|===\n|a .x|b\n|===");
+
+    assert_eq!(table.columns().len(), 1);
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(rows, vec![vec!["a .x|b".to_string()]]);
+}

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -5,6 +5,7 @@ use crate::{
     HasSpan, Parser, Span,
     blocks::{Block, ContentModel, IsBlock, TableBlock},
     content::SubstitutionGroup,
+    parser::ModificationContext,
 };
 
 /// Parse `source` as a single block and return the [`TableBlock`] it produced.
@@ -241,4 +242,101 @@ fn header_option_without_cells() {
     assert_eq!(table.columns().len(), 2);
     assert!(table.header_row().is_none());
     assert!(table.body_rows().is_empty());
+}
+
+#[test]
+fn titled_table_is_captioned() {
+    // A block title on a table produces both a title and an automatic caption
+    // ("Table 1. ") drawn from the default `table-caption` value.
+    let table = parse_table(".A table with a title\n|===\n|a |b\n|===");
+
+    assert_eq!(table.title(), Some("A table with a title"));
+    assert_eq!(table.caption(), Some("Table 1. "));
+}
+
+#[test]
+fn untitled_table_has_no_caption() {
+    // Without a title, a table is not captioned and does not consume a number.
+    let table = parse_table("|===\n|a |b\n|===");
+
+    assert!(table.title().is_none());
+    assert!(table.caption().is_none());
+}
+
+#[test]
+fn captioned_tables_are_numbered_in_document_order() {
+    // Only titled tables consume a number, and they are numbered in document
+    // order across the whole document.
+    let doc = Parser::default()
+        .parse(".First\n|===\n|a\n|===\n\n|===\n|b\n|===\n\n.Second\n|===\n|c\n|===");
+
+    let captions: Vec<Option<&str>> = doc
+        .nested_blocks()
+        .filter_map(|block| match block {
+            Block::Table(table) => Some(table.caption()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(captions, vec![Some("Table 1. "), None, Some("Table 2. ")]);
+}
+
+#[test]
+fn table_caption_can_be_relabeled() {
+    // The label portion of the caption is taken from the `table-caption`
+    // document attribute.
+    let doc = Parser::default().parse(":table-caption: Spreadsheet\n\n.Numbers\n|===\n|a\n|===");
+
+    let caption = doc.nested_blocks().find_map(|block| match block {
+        Block::Table(table) => table.caption().map(|c| c.to_string()),
+        _ => None,
+    });
+
+    assert_eq!(caption.as_deref(), Some("Spreadsheet 1. "));
+}
+
+#[test]
+fn unsetting_table_caption_suppresses_the_label() {
+    // When `table-caption` is unset, a titled table keeps its title but receives
+    // no caption (and no number).
+    let doc = Parser::default().parse(":!table-caption:\n\n.Numbers\n|===\n|a\n|===");
+
+    let table = doc
+        .nested_blocks()
+        .find_map(|block| match block {
+            Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .unwrap();
+
+    assert_eq!(table.title(), Some("Numbers"));
+    assert!(table.caption().is_none());
+}
+
+#[test]
+fn empty_table_caption_suppresses_the_label() {
+    // An explicitly empty `table-caption` value (a distinct AsciiDoc operation
+    // from a hard unset, e.g. `:!table-caption:`) is also treated as "no label":
+    // each titled table keeps its title but receives no caption and does not
+    // consume a table number. This exercises the empty-label guard separately
+    // from the `Unset` path.
+    let mut parser = Parser::default().with_intrinsic_attribute(
+        "table-caption",
+        "",
+        ModificationContext::Anywhere,
+    );
+    let doc = parser.parse(".First\n|===\n|a\n|===\n\n.Second\n|===\n|b\n|===");
+
+    let observed: Vec<(Option<&str>, Option<&str>)> = doc
+        .nested_blocks()
+        .filter_map(|block| match block {
+            Block::Table(table) => Some((table.title(), table.caption())),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        observed,
+        vec![(Some("First"), None), (Some("Second"), None)]
+    );
 }

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -4,7 +4,7 @@
 use crate::{
     HasSpan, Parser, Span,
     blocks::{
-        Block, ColumnStyle, ContentModel, HorizontalAlignment, IsBlock, TableBlock,
+        Block, ColumnStyle, ContentModel, DataFormat, HorizontalAlignment, IsBlock, TableBlock,
         TableCellContent, VerticalAlignment,
     },
     content::SubstitutionGroup,
@@ -962,4 +962,94 @@ fn huge_duplication_factor_does_not_overallocate() {
     let total: usize = table.body_rows().iter().map(|r| r.cells().len()).sum();
     assert_eq!(total, 1_000);
     assert_eq!(row_text(&table.body_rows()[0])[0], "x".to_string());
+}
+
+// The `format` attribute selects the data format, and an unrecognized value
+// falls back to PSV. (Exercises `resolve_data_format`, including its
+// unrecognized-value arm.)
+#[test]
+fn data_format_attribute_recognizes_each_value() {
+    assert_eq!(
+        parse_table("|===\n|a |b\n|===").data_format(),
+        DataFormat::Psv
+    );
+    assert_eq!(
+        parse_table("[format=psv]\n|===\n|a |b\n|===").data_format(),
+        DataFormat::Psv
+    );
+    assert_eq!(
+        parse_table("[format=csv]\n|===\na,b\n|===").data_format(),
+        DataFormat::Csv
+    );
+    assert_eq!(
+        parse_table("[format=tsv]\n|===\na\tb\n|===").data_format(),
+        DataFormat::Tsv
+    );
+    assert_eq!(
+        parse_table("[format=dsv]\n|===\na:b\n|===").data_format(),
+        DataFormat::Dsv
+    );
+
+    // An unrecognized format value falls back to PSV.
+    assert_eq!(
+        parse_table("[format=bogus]\n|===\n|a |b\n|===").data_format(),
+        DataFormat::Psv
+    );
+}
+
+// A CSV value whose opening double quote is never closed keeps the quote and is
+// treated as literal text, matching Asciidoctor
+// (`buffer_has_unclosed_quotes?`).
+#[test]
+fn csv_unclosed_quote_is_literal() {
+    let table = parse_table("[format=csv]\n|===\nx,\"unterminated\n|===");
+    assert_eq!(table.columns().len(), 2);
+    assert_eq!(row_text(&table.body_rows()[0]), ["x", "\"unterminated"]);
+
+    // A bare leading quote leaves the value unclosed, so the following separator
+    // is absorbed into the (single) cell rather than ending it.
+    let table = parse_table("[format=csv]\n|===\n\",a\n|===");
+    assert_eq!(table.columns().len(), 1);
+    assert_eq!(row_text(&table.body_rows()[0]), ["\",a"]);
+
+    // A cell that is a single bare quote is an unclosed, empty quoted value.
+    let table = parse_table("[format=csv]\n|===\n\"\n|===");
+    assert_eq!(table.columns().len(), 1);
+    assert_eq!(row_text(&table.body_rows()[0]), [""]);
+}
+
+// A CSV value with characters after its closing quote is not a properly
+// enclosed value, so it (and any separators it spans) are taken literally as
+// one cell.
+#[test]
+fn csv_text_after_closing_quote_is_literal() {
+    let table = parse_table("[format=csv]\n|===\n\"abc\"x,d\n|===");
+    assert_eq!(table.columns().len(), 1);
+    assert_eq!(row_text(&table.body_rows()[0]), ["\"abc\"x,d"]);
+}
+
+// An escaped double quote (`""`) collapses to a single `"`, whether the value
+// is enclosed in quotes or not.
+#[test]
+fn csv_escaped_quotes_collapse() {
+    let table = parse_table("[format=csv]\n|===\n\"a\"\"b\",a\"\"b\n|===");
+    assert_eq!(table.columns().len(), 2);
+    assert_eq!(row_text(&table.body_rows()[0]), ["a\"b", "a\"b"]);
+
+    // An odd run of trailing quotes still leaves the value unclosed, so the
+    // separator is absorbed and the quotes are only collapsed.
+    let table = parse_table("[format=csv]\n|===\n\"a\"\",b\n|===");
+    assert_eq!(table.columns().len(), 1);
+    assert_eq!(row_text(&table.body_rows()[0]), ["\"a\",b"]);
+}
+
+// A trailing separator produces an empty cell at the end of the row
+// (Asciidoctor preserves it), so the row's column count includes that empty
+// cell.
+#[test]
+fn csv_trailing_separator_keeps_empty_cell() {
+    let table = parse_table("[format=csv]\n|===\na,b,\nc,d,e\n|===");
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(row_text(&table.body_rows()[0]), ["a", "b", ""]);
+    assert_eq!(row_text(&table.body_rows()[1]), ["c", "d", "e"]);
 }

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -45,6 +45,7 @@ struct InternalDependent<'src> {
     warnings: Vec<Warning<'src>>,
     source_map: SourceMap,
     catalog: Catalog,
+    show_doctitle: bool,
 }
 
 self_cell! {
@@ -114,6 +115,11 @@ impl<'src> Document<'src> {
                 blocks = section_blocks;
             }
 
+            // Whether the document title renders as an `<h1>`. An embedded
+            // document shows its title only when `showtitle` is set (the
+            // default is hidden), so resolve it from the final attribute state.
+            let show_doctitle = parser.resolve_show_title(false);
+
             InternalDependent {
                 header,
                 blocks,
@@ -121,6 +127,7 @@ impl<'src> Document<'src> {
                 warnings,
                 source_map,
                 catalog: parser.take_catalog(),
+                show_doctitle,
             }
         });
 
@@ -133,6 +140,19 @@ impl<'src> Document<'src> {
     /// Return the document header.
     pub fn header(&self) -> &Header<'_> {
         &self.internal.borrow_dependent().header
+    }
+
+    /// Return the document title (the level-0 `= Title`), if there was one.
+    pub fn doctitle(&self) -> Option<&str> {
+        self.header().title()
+    }
+
+    /// Return whether the document title should be displayed (as an `<h1>`).
+    ///
+    /// This reflects the effective `showtitle`/`notitle` attribute state: an
+    /// embedded document shows its title only when `showtitle` is set.
+    pub fn show_doctitle(&self) -> bool {
+        self.internal.borrow_dependent().show_doctitle
     }
 
     /// Return an iterator over any warnings found during parsing.

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -144,6 +144,27 @@ pub(super) fn built_in_attrs() -> HashMap<String, AttributeValue> {
         },
     );
 
+    // The document type defaults to `article` and may be set in the header or
+    // via the API. The derived `backend-html5-doctype-{doctype}` attribute is
+    // defined (empty) only for the active doctype; it is kept in sync by
+    // `Parser::refresh_doctype_derived_attr` whenever `doctype` changes.
+    attrs.insert(
+        "doctype".to_owned(),
+        AttributeValue {
+            allowable_value: AllowableValue::Any,
+            modification_context: ModificationContext::ApiOrHeader,
+            value: InterpretedValue::Value("article".to_owned()),
+        },
+    );
+    attrs.insert(
+        "backend-html5-doctype-article".to_owned(),
+        AttributeValue {
+            allowable_value: AllowableValue::Any,
+            modification_context: ModificationContext::Anywhere,
+            value: InterpretedValue::Value(String::new()),
+        },
+    );
+
     attrs
 }
 

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -125,6 +125,15 @@ pub(super) fn built_in_attrs() -> HashMap<String, AttributeValue> {
         },
     );
 
+    attrs.insert(
+        "table-caption".to_owned(),
+        AttributeValue {
+            allowable_value: AllowableValue::Any,
+            modification_context: ModificationContext::Anywhere,
+            value: InterpretedValue::Set,
+        },
+    );
+
     // TO DO: Replace ./images with value of imagesdir if that is non-default.
     attrs.insert(
         "iconsdir".to_owned(),
@@ -142,6 +151,7 @@ pub(super) fn built_in_default_values() -> HashMap<String, String> {
     let mut defaults: HashMap<String, String> = HashMap::new();
 
     defaults.insert("example-caption".to_owned(), "Example".to_owned());
+    defaults.insert("table-caption".to_owned(), "Table".to_owned());
     defaults.insert("iconsdir".to_owned(), "./images/icons".to_owned());
     defaults.insert("sectnums".to_owned(), "all".to_owned());
     defaults.insert("toc".to_owned(), "auto".to_owned());

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -84,6 +84,17 @@ pub struct Parser {
     /// saved and restored around each cell, so the lock applies only within
     /// the cell (and nests correctly).
     pub(crate) locked_attribute_names: HashSet<String>,
+
+    /// Number of AsciiDoc table cells currently being parsed in the call stack.
+    ///
+    /// An AsciiDoc table cell creates a nested, standalone AsciiDoc document.
+    /// While that document is being parsed this counter is greater than zero,
+    /// which (matching Asciidoctor's `Document#nested?`) changes the default
+    /// cell separator of any table found inside from the vertical bar (`|`) to
+    /// the exclamation mark (`!`), so a nested table needs no explicit
+    /// `separator` attribute. The counter is incremented and decremented around
+    /// each AsciiDoc cell, so it nests correctly.
+    pub(crate) nested_document_depth: usize,
 }
 
 impl Default for Parser {
@@ -105,6 +116,7 @@ impl Default for Parser {
             topmost_section_type: SectionType::Normal,
             last_table_number: 0,
             locked_attribute_names: HashSet::new(),
+            nested_document_depth: 0,
         }
     }
 }

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1,4 +1,8 @@
-use std::{cell::RefCell, collections::HashMap, rc::Rc};
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    rc::Rc,
+};
 
 use crate::{
     Document, HasSpan,
@@ -66,6 +70,20 @@ pub struct Parser {
     /// Number most recently assigned to a captioned table. Incremented each
     /// time a titled table receives an automatic caption (e.g. "Table 1.").
     pub(crate) last_table_number: usize,
+
+    /// Canonical names of attributes that are locked against modification from
+    /// the document body for the current scope.
+    ///
+    /// An AsciiDoc table cell creates a nested document that inherits the
+    /// parent document's attributes. An attribute that is *set* in the
+    /// parent _cannot_ be modified inside the cell (matching Asciidoctor,
+    /// which here diverges from the spec's "set or explicitly unset" wording),
+    /// so while a cell is being parsed every inherited attribute name
+    /// (other than a handful of exceptions) is recorded here and a body
+    /// attribute assignment to such a name is silently ignored. The set is
+    /// saved and restored around each cell, so the lock applies only within
+    /// the cell (and nests correctly).
+    pub(crate) locked_attribute_names: HashSet<String>,
 }
 
 impl Default for Parser {
@@ -86,6 +104,7 @@ impl Default for Parser {
             sectnumlevels: 3,
             topmost_section_type: SectionType::Normal,
             last_table_number: 0,
+            locked_attribute_names: HashSet::new(),
         }
     }
 }
@@ -485,6 +504,13 @@ impl Parser {
         warnings: &mut Vec<Warning<'src>>,
     ) {
         let attr_name = remap_attr_name(attr.name().data());
+
+        // An attribute inherited from the parent document of an AsciiDoc table
+        // cell is locked for the duration of that cell: a body assignment to it
+        // is silently ignored (no warning), matching Asciidoctor.
+        if self.locked_attribute_names.contains(&attr_name) {
+            return;
+        }
 
         // Verify that we have permission to overwrite any existing attribute value.
         if let Some(existing_attr) = self.attribute_values.get(&attr_name)

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -255,6 +255,63 @@ impl Parser {
             .unwrap_or(false)
     }
 
+    /// Resolves whether a document title should be displayed, from the
+    /// `showtitle`/`notitle` attribute pair (which are complements).
+    ///
+    /// `showtitle` takes precedence: if present, the title shows precisely when
+    /// it is set. Otherwise `notitle`, if present, hides the title when set.
+    /// When neither attribute is present, `default_shown` decides — a
+    /// standalone document (such as a nested AsciiDoc table cell) shows its
+    /// title, while an embedded document does not.
+    pub(crate) fn resolve_show_title(&self, default_shown: bool) -> bool {
+        if self.has_attribute("showtitle") {
+            self.is_attribute_set("showtitle")
+        } else if self.has_attribute("notitle") {
+            !self.is_attribute_set("notitle")
+        } else {
+            default_shown
+        }
+    }
+
+    /// Forces the `doctype` attribute to `value`, refreshing the derived
+    /// `backend-html5-doctype-*` attribute.
+    ///
+    /// Used when a nested AsciiDoc table cell resets its doctype to the default
+    /// (a cell does not inherit the parent's doctype). The value stays
+    /// modifiable from the document body so the cell may still set its own
+    /// doctype.
+    pub(crate) fn force_doctype(&mut self, value: &str) {
+        self.attribute_values.insert(
+            "doctype".to_string(),
+            AttributeValue {
+                allowable_value: AllowableValue::Any,
+                modification_context: ModificationContext::ApiOrDocumentBody,
+                value: InterpretedValue::Value(value.to_string()),
+            },
+        );
+        self.refresh_doctype_derived_attr();
+    }
+
+    /// Recomputes the `backend-html5-doctype-{doctype}` intrinsic attribute so
+    /// exactly one exists — for the active doctype — resolving to an empty
+    /// (defined) value. References to any other doctype stay undefined and so
+    /// render literally.
+    pub(crate) fn refresh_doctype_derived_attr(&mut self) {
+        self.attribute_values
+            .retain(|name, _| !name.starts_with("backend-html5-doctype-"));
+
+        if let InterpretedValue::Value(doctype) = self.attribute_value("doctype") {
+            self.attribute_values.insert(
+                format!("backend-html5-doctype-{doctype}"),
+                AttributeValue {
+                    allowable_value: AllowableValue::Any,
+                    modification_context: ModificationContext::Anywhere,
+                    value: InterpretedValue::Value(String::new()),
+                },
+            );
+        }
+    }
+
     /// Sets the value of an [intrinsic attribute].
     ///
     /// Intrinsic attributes are set automatically by the processor. These
@@ -483,7 +540,11 @@ impl Parser {
             value,
         };
 
+        let is_doctype = attr_name == "doctype";
         self.attribute_values.insert(attr_name, attribute_value);
+        if is_doctype {
+            self.refresh_doctype_derived_attr();
+        }
     }
 
     /// Called from [`Header::parse()`] for a value that is derived from parsing
@@ -542,7 +603,11 @@ impl Parser {
             value: attr.value().clone(),
         };
 
+        let is_doctype = attr_name == "doctype";
         self.attribute_values.insert(attr_name, attribute_value);
+        if is_doctype {
+            self.refresh_doctype_derived_attr();
+        }
     }
 
     /// Assign the next section number for a given level.
@@ -796,5 +861,91 @@ mod tests {
             simple_block.content().rendered(),
             "Hello [AMP] goodbye [LT] world [GT] test"
         );
+    }
+
+    mod resolve_show_title {
+        use crate::parser::{ModificationContext, Parser};
+
+        fn with(name: &str, set: bool) -> Parser {
+            Parser::default().with_intrinsic_attribute_bool(
+                name,
+                set,
+                ModificationContext::Anywhere,
+            )
+        }
+
+        #[test]
+        fn neither_present_uses_default() {
+            assert!(Parser::default().resolve_show_title(true));
+            assert!(!Parser::default().resolve_show_title(false));
+        }
+
+        #[test]
+        fn showtitle_takes_precedence_and_decides() {
+            // Present and set -> shown; present and unset -> hidden, regardless
+            // of the default.
+            assert!(with("showtitle", true).resolve_show_title(false));
+            assert!(!with("showtitle", false).resolve_show_title(true));
+        }
+
+        #[test]
+        fn notitle_is_the_complement_when_showtitle_absent() {
+            // notitle set -> hidden; notitle unset -> shown.
+            assert!(!with("notitle", true).resolve_show_title(true));
+            assert!(with("notitle", false).resolve_show_title(false));
+        }
+    }
+
+    mod refresh_doctype_derived_attr {
+        use crate::{document::InterpretedValue, parser::Parser};
+
+        #[test]
+        fn tracks_the_active_doctype() {
+            let mut parser = Parser::default();
+
+            // The default doctype is `article`, so only its derived attribute is
+            // defined (to an empty value).
+            assert_eq!(
+                parser.attribute_value("backend-html5-doctype-article"),
+                InterpretedValue::Value(String::new())
+            );
+            assert_eq!(
+                parser.attribute_value("backend-html5-doctype-book"),
+                InterpretedValue::Unset
+            );
+
+            // Forcing a new doctype moves the derived attribute with it.
+            parser.force_doctype("book");
+            assert_eq!(
+                parser.attribute_value("backend-html5-doctype-book"),
+                InterpretedValue::Value(String::new())
+            );
+            assert_eq!(
+                parser.attribute_value("backend-html5-doctype-article"),
+                InterpretedValue::Unset
+            );
+        }
+
+        #[test]
+        fn defines_no_derived_attr_when_doctype_is_not_a_value() {
+            let mut parser = Parser::default();
+
+            // The default article derived attribute starts out defined.
+            assert_eq!(
+                parser.attribute_value("backend-html5-doctype-article"),
+                InterpretedValue::Value(String::new())
+            );
+
+            // With `doctype` unset (no `Value`), a refresh clears any existing
+            // derived attribute and defines none.
+            parser.attribute_values.remove("doctype");
+            parser.refresh_doctype_derived_attr();
+
+            assert_eq!(parser.attribute_value("doctype"), InterpretedValue::Unset);
+            assert_eq!(
+                parser.attribute_value("backend-html5-doctype-article"),
+                InterpretedValue::Unset
+            );
+        }
     }
 }

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -62,6 +62,10 @@ pub struct Parser {
     /// Section type of outermost section. (Used to determine whether to number
     /// child sections as a normal section or appendix.)
     pub(crate) topmost_section_type: SectionType,
+
+    /// Number most recently assigned to a captioned table. Incremented each
+    /// time a titled table receives an automatic caption (e.g. "Table 1.").
+    pub(crate) last_table_number: usize,
 }
 
 impl Default for Parser {
@@ -81,6 +85,7 @@ impl Default for Parser {
             },
             sectnumlevels: 3,
             topmost_section_type: SectionType::Normal,
+            last_table_number: 0,
         }
     }
 }
@@ -153,6 +158,9 @@ impl Parser {
 
         // Reset section numbering for each new document.
         self.last_section_number = SectionNumber::default();
+
+        // Reset table numbering for each new document.
+        self.last_table_number = 0;
 
         Document::parse(&preprocessed_source, source_map, self)
     }
@@ -515,6 +523,16 @@ impl Parser {
                 self.last_section_number.clone()
             }
         }
+    }
+
+    /// Assigns the next sequential number to a captioned table and returns it.
+    ///
+    /// Tables are numbered in document order, but only those that actually
+    /// receive a caption (i.e. titled tables for which the `table-caption`
+    /// attribute is set) consume a number.
+    pub(crate) fn assign_table_number(&mut self) -> usize {
+        self.last_table_number += 1;
+        self.last_table_number
     }
 }
 

--- a/parser/src/tests/asciidoc_lang/attributes/options.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/options.rs
@@ -246,53 +246,31 @@ For instance, consider a table with the three built-in option values, `header`, 
         .unwrap_if_no_warnings()
         .unwrap();
 
-        // IMPORTANT: This test will have to be revised once we parse tables.
+        assert!(matches!(mi.item, crate::blocks::Block::Table(_)));
 
         assert_eq!(
-            mi.item,
-            Block::Simple(SimpleBlock {
-                content: Content {
-                    original: Span {
-                        data: "|===\n|Cell A1 |Cell B1",
-                        line: 2,
-                        col: 1,
-                        offset: 36,
+            mi.item.attrlist().unwrap(),
+            Attrlist {
+                attributes: &[
+                    ElementAttribute {
+                        name: None,
+                        shorthand_items: &["%header", "%footer", "%autowidth",],
+                        value: "%header%footer%autowidth"
                     },
-                    rendered: "|===\n|Cell A1 |Cell B1",
-                },
-                source: Span {
-                    data: "[%header%footer%autowidth,cols=2*~]\n|===\n|Cell A1 |Cell B1",
-                    line: 1,
-                    col: 1,
-                    offset: 0,
-                },
-                style: SimpleBlockStyle::Paragraph,
-                title_source: None,
-                title: None,
+                    ElementAttribute {
+                        name: Some("cols"),
+                        shorthand_items: &[],
+                        value: "2*~"
+                    },
+                ],
                 anchor: None,
-                anchor_reftext: None,
-                attrlist: Some(Attrlist {
-                    attributes: &[
-                        ElementAttribute {
-                            name: None,
-                            shorthand_items: &["%header", "%footer", "%autowidth",],
-                            value: "%header%footer%autowidth"
-                        },
-                        ElementAttribute {
-                            name: Some("cols"),
-                            shorthand_items: &[],
-                            value: "2*~"
-                        },
-                    ],
-                    anchor: None,
-                    source: Span {
-                        data: "%header%footer%autowidth,cols=2*~",
-                        line: 1,
-                        col: 2,
-                        offset: 1,
-                    },
-                },),
-            },)
+                source: Span {
+                    data: "%header%footer%autowidth,cols=2*~",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+            },
         );
 
         let options = mi.item.options();
@@ -529,53 +507,31 @@ Instead of using the shorthand notation, <<ex-table-formal>> shows how the value
         .unwrap_if_no_warnings()
         .unwrap();
 
-        // IMPORTANT: This test will have to be revised once we support tables.
+        assert!(matches!(mi.item, crate::blocks::Block::Table(_)));
 
         assert_eq!(
-            mi.item,
-            Block::Simple(SimpleBlock {
-                content: Content {
-                    original: Span {
-                        data: "|===\n|Cell A1 |Cell B1",
-                        line: 2,
-                        col: 1,
-                        offset: 42,
+            mi.item.attrlist().unwrap(),
+            Attrlist {
+                attributes: &[
+                    ElementAttribute {
+                        name: Some("cols"),
+                        shorthand_items: &[],
+                        value: "2*~"
                     },
-                    rendered: "|===\n|Cell A1 |Cell B1",
-                },
-                source: Span {
-                    data: "[cols=2*~,opts=\"header,footer,autowidth\"]\n|===\n|Cell A1 |Cell B1",
-                    line: 1,
-                    col: 1,
-                    offset: 0,
-                },
-                style: SimpleBlockStyle::Paragraph,
-                title_source: None,
-                title: None,
+                    ElementAttribute {
+                        name: Some("opts"),
+                        shorthand_items: &[],
+                        value: "header,footer,autowidth"
+                    },
+                ],
                 anchor: None,
-                anchor_reftext: None,
-                attrlist: Some(Attrlist {
-                    attributes: &[
-                        ElementAttribute {
-                            name: Some("cols"),
-                            shorthand_items: &[],
-                            value: "2*~"
-                        },
-                        ElementAttribute {
-                            name: Some("opts"),
-                            shorthand_items: &[],
-                            value: "header,footer,autowidth"
-                        },
-                    ],
-                    anchor: None,
-                    source: Span {
-                        data: "cols=2*~,opts=\"header,footer,autowidth\"",
-                        line: 1,
-                        col: 2,
-                        offset: 1,
-                    },
-                },),
-            },)
+                source: Span {
+                    data: "cols=2*~,opts=\"header,footer,autowidth\"",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+            },
         );
 
         let options = mi.item.options();

--- a/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
@@ -489,45 +489,27 @@ Specifically, this syntax sets the `header`, `footer`, and `autowidth` options.
         .unwrap()
         .item;
 
+        assert!(matches!(block, crate::blocks::Block::Table(_)));
+
         assert_eq!(
-            block,
-            Block::Simple(SimpleBlock {
-                content: Content {
-                    original: Span {
-                        data: "|===\n|Header A |Header B\n|Footer A |Footer B\n|===",
-                        line: 2,
-                        col: 1,
-                        offset: 27,
-                    },
-                    rendered: "|===\n|Header A |Header B\n|Footer A |Footer B\n|===",
-                },
-                source: Span {
-                    data: "[%header%footer%autowidth]\n|===\n|Header A |Header B\n|Footer A |Footer B\n|===",
-                    line: 1,
-                    col: 1,
-                    offset: 0,
-                },
-                style: SimpleBlockStyle::Paragraph,
-                title_source: None,
-                title: None,
+            block.attrlist().unwrap(),
+            Attrlist {
+                attributes: &[ElementAttribute {
+                    name: None,
+                    shorthand_items: &["%header", "%footer", "%autowidth",],
+                    value: "%header%footer%autowidth"
+                },],
                 anchor: None,
-                anchor_reftext: None,
-                attrlist: Some(Attrlist {
-                    attributes: &[ElementAttribute {
-                        name: None,
-                        shorthand_items: &["%header", "%footer", "%autowidth",],
-                        value: "%header%footer%autowidth"
-                    },],
-                    anchor: None,
-                    source: Span {
-                        data: "%header%footer%autowidth",
-                        line: 1,
-                        col: 2,
-                        offset: 1,
-                    },
-                },),
-            },)
+                source: Span {
+                    data: "%header%footer%autowidth",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+            },
         );
+
+        assert_eq!(block.options(), vec!["header", "footer", "autowidth"]);
 
         verifies!(
             r#"
@@ -860,10 +842,10 @@ If enclosing quotes are used, they are dropped from the parsed value and the pre
             r#"
  [#unset]
  === Unset a named attribute
- 
+
  To undefine a named attribute, set the value to `None` (case sensitive).
  // end::name[]
- 
+
 "#
         );
 

--- a/parser/src/tests/asciidoc_lang/mod.rs
+++ b/parser/src/tests/asciidoc_lang/mod.rs
@@ -33,5 +33,6 @@ mod pass;
 mod root;
 mod sections;
 mod subs;
+mod tables;
 mod text;
 mod verbatim;

--- a/parser/src/tests/asciidoc_lang/subs/attributes.rs
+++ b/parser/src/tests/asciidoc_lang/subs/attributes.rs
@@ -306,20 +306,34 @@ mod default_attributes_substitution {
         assert_eq!(block1.content().rendered(), "Stuff nonsense");
     }
 
-    #[ignore]
     #[test]
     fn tables() {
-        to_do_verifies!(
+        verifies!(
             r#"
 |Tables |Varies
 
 "#
         );
 
-        todo!("Write test once table parsing is implemented");
+        // The attributes substitution applies to default table cells but not to
+        // literal (`l`) cells, hence "Varies".
+        let doc = Parser::default().parse(":val: subd\n\n|===\n|{val}\nl|{val}\n|===");
 
-        // Blocked on https://github.com/asciidoc-rs/asciidoc-parser/issues/296:
-        // Implement table parsing
+        let Some(Block::Table(table)) = doc.nested_blocks().next() else {
+            panic!("expected a table block");
+        };
+
+        let cells: Vec<_> = table.body_rows().iter().flat_map(|r| r.cells()).collect();
+
+        let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(default_cell.rendered(), "subd");
+
+        let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(literal_cell.rendered(), "{val}");
     }
 
     #[test]

--- a/parser/src/tests/asciidoc_lang/subs/macros.rs
+++ b/parser/src/tests/asciidoc_lang/subs/macros.rs
@@ -305,20 +305,38 @@ mod default_macros_substitution {
         );
     }
 
-    #[ignore]
     #[test]
     fn tables() {
-        to_do_verifies!(
+        verifies!(
             r#"
 |Tables |Varies
 
 "#
         );
 
-        todo!("Write test once table parsing is implemented");
+        // The macros substitution applies to default table cells but not to
+        // literal (`l`) cells, hence "Varies".
+        let doc = Parser::default()
+            .parse("|===\n|https://example.org[Example]\nl|https://example.org[Example]\n|===");
 
-        // Blocked on https://github.com/asciidoc-rs/asciidoc-parser/issues/296:
-        // Implement table parsing
+        let Some(Block::Table(table)) = doc.nested_blocks().next() else {
+            panic!("expected a table block");
+        };
+
+        let cells: Vec<_> = table.body_rows().iter().flat_map(|r| r.cells()).collect();
+
+        let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(
+            default_cell.rendered(),
+            r#"<a href="https://example.org">Example</a>"#
+        );
+
+        let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(literal_cell.rendered(), "https://example.org[Example]");
     }
 
     #[test]

--- a/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
+++ b/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
@@ -318,20 +318,34 @@ mod default_post_replacements_substitution {
         assert_eq!(block1.content().rendered(), "abc<br>\ndef");
     }
 
-    #[ignore]
     #[test]
     fn tables() {
-        to_do_verifies!(
+        verifies!(
             r#"
 |Tables |Varies
 
 "#
         );
 
-        todo!("Write test once table parsing is implemented");
+        // The post replacements substitution (the line-break `+`) applies to
+        // default table cells but not to literal (`l`) cells, hence "Varies".
+        let doc = Parser::default().parse("|===\n|abc +\ndef\nl|abc +\nghi\n|===");
 
-        // Blocked on https://github.com/asciidoc-rs/asciidoc-parser/issues/296:
-        // Implement table parsing
+        let Some(Block::Table(table)) = doc.nested_blocks().next() else {
+            panic!("expected a table block");
+        };
+
+        let cells: Vec<_> = table.body_rows().iter().flat_map(|r| r.cells()).collect();
+
+        let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(default_cell.rendered(), "abc<br>\ndef");
+
+        let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(literal_cell.rendered(), "abc +\nghi");
     }
 
     #[ignore]

--- a/parser/src/tests/asciidoc_lang/subs/quotes.rs
+++ b/parser/src/tests/asciidoc_lang/subs/quotes.rs
@@ -512,20 +512,34 @@ mod default_quotes_substitution {
         assert_eq!(block1.content().rendered(), "Stuff over <em>nonsense</em>");
     }
 
-    #[ignore]
     #[test]
     fn tables() {
-        to_do_verifies!(
+        verifies!(
             r#"
-|Tables |{y}
+|Tables |Varies
 
 "#
         );
 
-        todo!("Write test once table parsing is implemented");
+        // The quotes substitution applies to default table cells but not to
+        // literal (`l`) cells, hence "Varies".
+        let doc = Parser::default().parse("|===\n|*bold*\nl|*lit*\n|===");
 
-        // Blocked on https://github.com/asciidoc-rs/asciidoc-parser/issues/296:
-        // Implement table parsing
+        let Some(Block::Table(table)) = doc.nested_blocks().next() else {
+            panic!("expected a table block");
+        };
+
+        let cells: Vec<_> = table.body_rows().iter().flat_map(|r| r.cells()).collect();
+
+        let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(default_cell.rendered(), "<strong>bold</strong>");
+
+        let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(literal_cell.rendered(), "*lit*");
     }
 
     #[test]

--- a/parser/src/tests/asciidoc_lang/subs/replacements.rs
+++ b/parser/src/tests/asciidoc_lang/subs/replacements.rs
@@ -555,20 +555,34 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
         assert_eq!(block1.content().rendered(), "Stuff &#169; nonsense");
     }
 
-    #[ignore]
     #[test]
     fn tables() {
-        to_do_verifies!(
+        verifies!(
             r#"
 |Tables |Varies
 
 "#
         );
 
-        todo!("Write test once table parsing is implemented");
+        // The replacements substitution applies to default table cells but not to
+        // literal (`l`) cells, hence "Varies".
+        let doc = Parser::default().parse("|===\n|(C)\nl|(C)\n|===");
 
-        // Blocked on https://github.com/asciidoc-rs/asciidoc-parser/issues/296:
-        // Implement table parsing
+        let Some(Block::Table(table)) = doc.nested_blocks().next() else {
+            panic!("expected a table block");
+        };
+
+        let cells: Vec<_> = table.body_rows().iter().flat_map(|r| r.cells()).collect();
+
+        let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(default_cell.rendered(), "&#169;");
+
+        let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(literal_cell.rendered(), "(C)");
     }
 
     #[test]

--- a/parser/src/tests/asciidoc_lang/subs/special_characters.rs
+++ b/parser/src/tests/asciidoc_lang/subs/special_characters.rs
@@ -371,20 +371,35 @@ mod default_special_characters_substitution {
         assert_eq!(block1.content().rendered(), "Stuff &gt; nonsense");
     }
 
-    #[ignore]
     #[test]
     fn tables() {
-        to_do_verifies!(
+        verifies!(
             r#"
 |Tables |{y}
 
 "#
         );
 
-        todo!("Write test once table parsing is implemented");
+        // Special character substitution always applies to table cell content,
+        // including literal (`l`) cells, where most other substitution steps are
+        // skipped.
+        let doc = Parser::default().parse("|===\n|a > b\nl|c > d\n|===");
 
-        // Blocked on https://github.com/asciidoc-rs/asciidoc-parser/issues/296:
-        // Implement table parsing
+        let Some(Block::Table(table)) = doc.nested_blocks().next() else {
+            panic!("expected a table block");
+        };
+
+        let cells: Vec<_> = table.body_rows().iter().flat_map(|r| r.cells()).collect();
+
+        let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(default_cell.rendered(), "a &gt; b");
+
+        let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(literal_cell.rendered(), "c &gt; d");
     }
 
     #[test]

--- a/parser/src/tests/asciidoc_lang/tables/add_cells_and_rows.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_cells_and_rows.rs
@@ -166,10 +166,9 @@ Taking into account any xref:span-cells.adoc[spans], which are applied via a <<s
 
     // Cell specifiers introduce per-cell spans, duplication, alignment, and
     // style operators, each specified in detail on a dedicated page (span-cells,
-    // duplicate-cells, align-by-cell, format-cell-content). The span, alignment,
-    // and style operators (and the override behavior) are implemented and
-    // verified here; the duplication operator is recognized so the separator is
-    // located, but its layout effect is not yet applied.
+    // duplicate-cells, align-by-cell, format-cell-content). The span,
+    // duplication, alignment, and style operators (and the override behavior)
+    // are all implemented and verified here.
     verifies!(
         r#"
 [#specifiers]

--- a/parser/src/tests/asciidoc_lang/tables/add_cells_and_rows.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_cells_and_rows.rs
@@ -166,10 +166,10 @@ Taking into account any xref:span-cells.adoc[spans], which are applied via a <<s
 
     // Cell specifiers introduce per-cell spans, duplication, alignment, and
     // style operators, each specified in detail on a dedicated page (span-cells,
-    // duplicate-cells, align-by-cell, format-cell-content). The alignment and
-    // style operators (and the override behavior) are implemented and verified
-    // here; the span and duplication operators are recognized so the separator
-    // is located, but their layout effect is not yet applied.
+    // duplicate-cells, align-by-cell, format-cell-content). The span, alignment,
+    // and style operators (and the override behavior) are implemented and
+    // verified here; the duplication operator is recognized so the separator is
+    // located, but its layout effect is not yet applied.
     verifies!(
         r#"
 [#specifiers]

--- a/parser/src/tests/asciidoc_lang/tables/add_cells_and_rows.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_cells_and_rows.rs
@@ -164,13 +164,13 @@ Taking into account any xref:span-cells.adoc[spans], which are applied via a <<s
         }
     );
 
-    // Cell specifiers (per-cell spans, duplication, alignment, and style
-    // operators) are introduced here but specified in detail on dedicated
-    // pages (span-cells, duplicate-cells, align-by-cell, format-cell-content).
-    // They are not yet implemented, so this normative section is flagged as a
-    // TODO: come back and verify it (especially the `ex-specifier` example)
-    // once per-cell specifiers are supported and those pages are covered.
-    to_do_verifies!(
+    // Cell specifiers introduce per-cell spans, duplication, alignment, and
+    // style operators, each specified in detail on a dedicated page (span-cells,
+    // duplicate-cells, align-by-cell, format-cell-content). The alignment and
+    // style operators (and the override behavior) are implemented and verified
+    // here; the span and duplication operators are recognized so the separator
+    // is located, but their layout effect is not yet applied.
+    verifies!(
         r#"
 [#specifiers]
 === Cell specifiers and operators
@@ -201,6 +201,45 @@ Also, the operator in a cell specifier will override the operator in a xref:add-
 
 "#
     );
+
+    // Expansion of `ex-specifier`. The first cell's specifier (`>s`) makes its
+    // content right-aligned and bold; the second cell has no specifier, so the
+    // default properties (left-aligned, default style) apply. This also shows
+    // that a cell specifier applies only to the cell it's placed on, not to the
+    // whole row.
+    let table = specifier_table(
+        "[cols=\"2*\"]\n|===\n>s|This cell's specifier indicates that this cell's content is right-aligned and bold.\n|The cell specifier on this cell hasn't been set explicitly, so the  default properties are applied.\n|===",
+    );
+    let row = &table.body_rows()[0];
+    assert_eq!(row.cells()[0].h_align(), HorizontalAlignment::Right);
+    assert_eq!(row.cells()[0].style(), ColumnStyle::Strong);
+    assert_eq!(row.cells()[1].h_align(), HorizontalAlignment::Left);
+    assert_eq!(row.cells()[1].style(), ColumnStyle::Default);
+
+    // A cell specifier operator overrides the column specifier operator for the
+    // same property: the column is centered and monospace (`^m`), but the cell's
+    // own `>` and `s` operators win, while a property the cell leaves unset (here
+    // vertical alignment) still falls back to the column.
+    let table = specifier_table("[cols=\"^.^m\"]\n|===\n>s|overridden\n|===");
+    let cell = &table.body_rows()[0].cells()[0];
+    assert_eq!(cell.h_align(), HorizontalAlignment::Right);
+    assert_eq!(cell.style(), ColumnStyle::Strong);
+    assert_eq!(cell.v_align(), VerticalAlignment::Middle);
+}
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn specifier_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
 }
 
 #[test]

--- a/parser/src/tests/asciidoc_lang/tables/add_cells_and_rows.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_cells_and_rows.rs
@@ -1,0 +1,950 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/add-cells-and-rows.adoc");
+
+non_normative!(
+    r#"
+= Add Cells and Rows to a Table
+//let's add a tip or xref to something about the "default" cell separator and data format and the alternatives that's not too invasive to the flow
+
+"#
+);
+
+#[test]
+fn table_cells() {
+    non_normative!(
+        r#"
+== Table cells
+
+"#
+    );
+
+    verifies!(
+        r#"
+[[cell-separator]]Each new cell in a table is declared with a cell separator.
+The default [.term]*cell separator* is a vertical bar (`|`).
+All of the content entered after a cell separator is included in that cell until the processor encounters a space followed by another vertical bar (`|`) or a new line that begins with a `|`.
+
+.Creating table cells with the default cell separator
+[source#ex-separator]
+----
+[cols="3,2,3"]
+|===
+|This content is placed in the first cell of column 1
+|This line starts with a vertical bar so this content is placed in a new cell in column 2 |When the processor encounters a whitespace followed by a vertical bar it ends the previous cell and starts a new cell
+|===
+----
+
+When the processor encounters another `|`, it creates a new cell in the next consecutive column.
+Once the processor reaches the xref:add-columns.adoc[last column assigned to the table], the next cell it encounters is placed in a new row.
+Taking into account any xref:span-cells.adoc[spans], which are applied via a <<specifiers,cell specifier>>, each row consists of the same number of cells.
+
+"#
+    );
+
+    // A space (or tab) followed by a `|`, or a `|` at the start of a line, ends
+    // the previous cell and begins a new one. The three cells declared here flow
+    // into a single row because the table has three columns.
+    let doc = Parser::default().parse(
+        "[cols=\"3,2,3\"]\n|===\n|This content is placed in the first cell of column 1\n|This line starts with a vertical bar so this content is placed in a new cell in column 2 |When the processor encounters a whitespace followed by a vertical bar it ends the previous cell and starts a new cell\n|===",
+    );
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[
+                    TableColumn {
+                        width: 3,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
+                    },
+                    TableColumn {
+                        width: 2,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
+                    },
+                    TableColumn {
+                        width: 3,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
+                    },
+                ],
+                header_row: None,
+                body_rows: &[TableRow {
+                    cells: &[
+                        TableCell {
+                            content: TableCellContent::Simple(Content {
+                                original: Span {
+                                    data: "This content is placed in the first cell of column 1",
+                                    line: 3,
+                                    col: 2,
+                                    offset: 21,
+                                },
+                                rendered: "This content is placed in the first cell of column 1",
+                            }),
+                        },
+                        TableCell {
+                            content: TableCellContent::Simple(Content {
+                                original: Span {
+                                    data: "This line starts with a vertical bar so this content is placed in a new cell in column 2",
+                                    line: 4,
+                                    col: 2,
+                                    offset: 75,
+                                },
+                                rendered: "This line starts with a vertical bar so this content is placed in a new cell in column 2",
+                            }),
+                        },
+                        TableCell {
+                            content: TableCellContent::Simple(Content {
+                                original: Span {
+                                    data: "When the processor encounters a whitespace followed by a vertical bar it ends the previous cell and starts a new cell",
+                                    line: 4,
+                                    col: 92,
+                                    offset: 165,
+                                },
+                                rendered: "When the processor encounters a whitespace followed by a vertical bar it ends the previous cell and starts a new cell",
+                            }),
+                        },
+                    ],
+                }],
+                footer_row: None,
+                source: Span {
+                    data: "[cols=\"3,2,3\"]\n|===\n|This content is placed in the first cell of column 1\n|This line starts with a vertical bar so this content is placed in a new cell in column 2 |When the processor encounters a whitespace followed by a vertical bar it ends the previous cell and starts a new cell\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                caption: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: Some("cols"),
+                        shorthand_items: &[],
+                        value: "3,2,3",
+                    }],
+                    anchor: None,
+                    source: Span {
+                        data: "cols=\"3,2,3\"",
+                        line: 1,
+                        col: 2,
+                        offset: 1,
+                    },
+                }),
+            })],
+            source: Span {
+                data: "[cols=\"3,2,3\"]\n|===\n|This content is placed in the first cell of column 1\n|This line starts with a vertical bar so this content is placed in a new cell in column 2 |When the processor encounters a whitespace followed by a vertical bar it ends the previous cell and starts a new cell\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+
+    // Cell specifiers (per-cell spans, duplication, alignment, and style
+    // operators) are introduced here but specified in detail on dedicated
+    // pages (span-cells, duplicate-cells, align-by-cell, format-cell-content).
+    // They are not yet implemented, so this normative section is flagged as a
+    // TODO: come back and verify it (especially the `ex-specifier` example)
+    // once per-cell specifiers are supported and those pages are covered.
+    to_do_verifies!(
+        r#"
+[#specifiers]
+=== Cell specifiers and operators
+
+A [.term]*cell specifier* is a positional attribute placed directly in front of a cell separator that represents the position and style properties assigned to a cell's content.
+In the example below, a horizontal alignment operator and style operator have been assigned to the first cell's specifier.
+
+.Using cell specifiers
+[source#ex-specifier]
+----
+[cols="2*"]
+|===
+>s|This cell's specifier indicates that this cell's content is right-aligned and bold.
+|The cell specifier on this cell hasn't been set explicitly, so the  default properties are applied.
+|===
+----
+
+AsciiDoc provides operators to control the following cell properties:
+
+* xref:span-cells.adoc[span]
+* xref:duplicate-cells.adoc[duplication]
+* xref:align-by-cell.adoc#horizontal-operators[horizontal alignment]
+* xref:align-by-cell.adoc#vertical-operators[vertical alignment]
+* xref:format-cell-content.adoc[content style]
+
+A cell specifier only applies to the cell it's placed on, not to all of the cells in the same row.
+Also, the operator in a cell specifier will override the operator in a xref:add-columns.adoc#col-specifier[column specifier] if they belong to the same property.
+
+"#
+    );
+}
+
+#[test]
+fn create_a_table_cell() {
+    non_normative!(
+        r#"
+== Create a table cell
+
+In this section, we'll set up a table and add two rows of cells to it.
+First, let's create two cells in <<ex-cells>> and see how they get arranged into a row.
+
+"#
+    );
+
+    verifies!(
+        r#"
+.Add two cells to a table
+[source#ex-cells]
+----
+[cols="1,1"] <.>
+|===
+|This cell is in column 1, row 1 <.>
+|This cell is in column 2, row 1 <.>
+|===
+----
+<.> The table has two columns because two column specifiers are assigned to the `cols` attribute.
+<.> The processor places this cell in the first column and row of the table because the vertical bar (`|`) at the beginning of this cell is the first cell separator the processor encounters after the opening table delimiter (`|===`).
+<.> This is the second `|` the processor encounters, so this cell is placed in the second column of the first row.
+
+Though the two cells in <<ex-cells>> were entered on separate lines, the processor places them in the same row.
+
+.Result of <<ex-cells>>
+[cols="1,1"]
+|===
+|This cell is in column 1, row 1
+|This cell is in column 2, row 1
+|===
+
+Since the number of columns in <<ex-cells>> is set to two by the `cols` attribute, and there are two cells entered in the table, the first row is complete.
+Now, let's add two more cells to the table.
+
+"#
+    );
+
+    // Two cells entered on separate lines flow into a single row because the
+    // table has two columns.
+    let doc = Parser::default().parse(
+        "[cols=\"1,1\"]\n|===\n|This cell is in column 1, row 1\n|This cell is in column 2, row 1\n|===",
+    );
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
+                    },
+                ],
+                header_row: None,
+                body_rows: &[TableRow {
+                    cells: &[
+                        TableCell {
+                            content: TableCellContent::Simple(Content {
+                                original: Span {
+                                    data: "This cell is in column 1, row 1",
+                                    line: 3,
+                                    col: 2,
+                                    offset: 19,
+                                },
+                                rendered: "This cell is in column 1, row 1",
+                            }),
+                        },
+                        TableCell {
+                            content: TableCellContent::Simple(Content {
+                                original: Span {
+                                    data: "This cell is in column 2, row 1",
+                                    line: 4,
+                                    col: 2,
+                                    offset: 52,
+                                },
+                                rendered: "This cell is in column 2, row 1",
+                            }),
+                        },
+                    ],
+                }],
+                footer_row: None,
+                source: Span {
+                    data: "[cols=\"1,1\"]\n|===\n|This cell is in column 1, row 1\n|This cell is in column 2, row 1\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                caption: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: Some("cols"),
+                        shorthand_items: &[],
+                        value: "1,1",
+                    }],
+                    anchor: None,
+                    source: Span {
+                        data: "cols=\"1,1\"",
+                        line: 1,
+                        col: 2,
+                        offset: 1,
+                    },
+                }),
+            })],
+            source: Span {
+                data: "[cols=\"1,1\"]\n|===\n|This cell is in column 1, row 1\n|This cell is in column 2, row 1\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+
+    verifies!(
+        r#"
+.Add two more cells to a table
+[source#ex-more-cells]
+----
+[cols="1,1"]
+|===
+|This cell is in column 1, row 1
+|This cell is in column 2, row 1
+<.>
+|This cell is in column 1, row 2 <.>
+|    This cell is in column 2, row 2 <.>
+|===
+----
+<.> Separate rows by one or more empty lines.
+<.> The processor places this cell on the second row because the table has two columns and this is the third cell separator (`|`) it encounters.
+<.> Any leading or trailing spaces around the cell content is stripped by the processor.
+
+The table from <<ex-more-cells>> now has four cells arranged into two consecutive rows.
+
+.Result of <<ex-more-cells>>
+[cols="1,1"]
+|===
+|This cell is in column 1, row 1
+|This cell is in column 2, row 1
+
+|This cell is in column 1, row 2
+|    This cell is in column 2, row 2
+|===
+
+The cells in a row can be entered on the same line or consecutive lines because the row a cell in placed on is determined by the number of columns in a table and the order in which the processor encounters the cell's separator (`|`).
+
+"#
+    );
+
+    // Four cells flow into two rows of two. Rows are separated by one or more
+    // empty lines, and leading/trailing whitespace around cell content is
+    // stripped (the second cell of the second row is indented four spaces).
+    let doc = Parser::default().parse(
+        "[cols=\"1,1\"]\n|===\n|This cell is in column 1, row 1\n|This cell is in column 2, row 1\n\n|This cell is in column 1, row 2\n|    This cell is in column 2, row 2\n|===",
+    );
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
+                    },
+                ],
+                header_row: None,
+                body_rows: &[
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: TableCellContent::Simple(Content {
+                                    original: Span {
+                                        data: "This cell is in column 1, row 1",
+                                        line: 3,
+                                        col: 2,
+                                        offset: 19,
+                                    },
+                                    rendered: "This cell is in column 1, row 1",
+                                }),
+                            },
+                            TableCell {
+                                content: TableCellContent::Simple(Content {
+                                    original: Span {
+                                        data: "This cell is in column 2, row 1",
+                                        line: 4,
+                                        col: 2,
+                                        offset: 52,
+                                    },
+                                    rendered: "This cell is in column 2, row 1",
+                                }),
+                            },
+                        ],
+                    },
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: TableCellContent::Simple(Content {
+                                    original: Span {
+                                        data: "This cell is in column 1, row 2",
+                                        line: 6,
+                                        col: 2,
+                                        offset: 86,
+                                    },
+                                    rendered: "This cell is in column 1, row 2",
+                                }),
+                            },
+                            TableCell {
+                                content: TableCellContent::Simple(Content {
+                                    original: Span {
+                                        data: "This cell is in column 2, row 2",
+                                        line: 7,
+                                        col: 6,
+                                        offset: 123,
+                                    },
+                                    rendered: "This cell is in column 2, row 2",
+                                }),
+                            },
+                        ],
+                    },
+                ],
+                footer_row: None,
+                source: Span {
+                    data: "[cols=\"1,1\"]\n|===\n|This cell is in column 1, row 1\n|This cell is in column 2, row 1\n\n|This cell is in column 1, row 2\n|    This cell is in column 2, row 2\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                caption: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: Some("cols"),
+                        shorthand_items: &[],
+                        value: "1,1",
+                    }],
+                    anchor: None,
+                    source: Span {
+                        data: "cols=\"1,1\"",
+                        line: 1,
+                        col: 2,
+                        offset: 1,
+                    },
+                }),
+            })],
+            source: Span {
+                data: "[cols=\"1,1\"]\n|===\n|This cell is in column 1, row 1\n|This cell is in column 2, row 1\n\n|This cell is in column 1, row 2\n|    This cell is in column 2, row 2\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+}
+
+#[test]
+fn enter_a_rows_cells_on_a_single_line() {
+    non_normative!(
+        r#"
+[#same]
+== Enter a row's cells on a single line
+
+"#
+    );
+
+    verifies!(
+        r#"
+You can enter a row's cells on a single line.
+//This method is how the number or columns in a table are implicitly assigned and implicitly assign the `header` option to the table's first row.
+When entering cells on a single line, *at least one space must be entered between the last character of the previous cell's content and the cell separator (`|`) of the next cell*.
+
+.Cells entered on the same line
+[source#ex-single-line]
+----
+|===
+|Column 1 |Column 2 |Column 3 <.> <.>
+
+|Cell in column 1, row 2 |Cell in column 2, row 2 |Cell in column 3, row 2 <.>
+
+|Cell in column 1, row 3 <.>
+|Cell in column 2, row 3 |Cell in column 3, row 3
+|===
+----
+<.> Since `cols` is not set, the first row in this table must have the cells entered on a single line in order to implicitly assign three columns to the table.
+<.> The first row is entered on the line directly after the opening table delimiter (`|===`) and followed by an empty line.
+This automatically assigns the `header` option to it.
+<.> When multiple cells are entered on a single line, enter at least one space between the last character of the previous cell's content and the cell separator (`|`) of the next cell.
+<.> A row's cells can be entered on a combination of lines as long as the lines are consecutive.
+
+The table created in <<ex-single-line>> contains three columns and three rows.
+
+.Result of <<ex-single-line>>
+|===
+|Column 1 |Column 2 |Column 3
+
+|Cell in column 1, row 2 |Cell in column 2, row 2 |Cell in column 3, row 2
+
+|Cell in column 1, row 3
+|Cell in column 2, row 3 |Cell in column 3, row 3
+|===
+
+Any leading and trailing spaces around the cell content are stripped and don't affect the table's layout when rendered.
+
+"#
+    );
+
+    // `cols` is not set, so the three cells on the first line implicitly assign
+    // three columns. That first line, followed by an empty line, is treated as
+    // the header row. The remaining cells flow into two body rows, whether
+    // entered on a single line or across consecutive lines.
+    let doc = Parser::default().parse(
+        "|===\n|Column 1 |Column 2 |Column 3\n\n|Cell in column 1, row 2 |Cell in column 2, row 2 |Cell in column 3, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3 |Cell in column 3, row 3\n|===",
+    );
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
+                    },
+                ],
+                header_row: Some(TableRow {
+                    cells: &[
+                        TableCell {
+                            content: TableCellContent::Simple(Content {
+                                original: Span {
+                                    data: "Column 1",
+                                    line: 2,
+                                    col: 2,
+                                    offset: 6,
+                                },
+                                rendered: "Column 1",
+                            }),
+                        },
+                        TableCell {
+                            content: TableCellContent::Simple(Content {
+                                original: Span {
+                                    data: "Column 2",
+                                    line: 2,
+                                    col: 12,
+                                    offset: 16,
+                                },
+                                rendered: "Column 2",
+                            }),
+                        },
+                        TableCell {
+                            content: TableCellContent::Simple(Content {
+                                original: Span {
+                                    data: "Column 3",
+                                    line: 2,
+                                    col: 22,
+                                    offset: 26,
+                                },
+                                rendered: "Column 3",
+                            }),
+                        },
+                    ],
+                }),
+                body_rows: &[
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: TableCellContent::Simple(Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 2",
+                                        line: 4,
+                                        col: 2,
+                                        offset: 37,
+                                    },
+                                    rendered: "Cell in column 1, row 2",
+                                }),
+                            },
+                            TableCell {
+                                content: TableCellContent::Simple(Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 2",
+                                        line: 4,
+                                        col: 27,
+                                        offset: 62,
+                                    },
+                                    rendered: "Cell in column 2, row 2",
+                                }),
+                            },
+                            TableCell {
+                                content: TableCellContent::Simple(Content {
+                                    original: Span {
+                                        data: "Cell in column 3, row 2",
+                                        line: 4,
+                                        col: 52,
+                                        offset: 87,
+                                    },
+                                    rendered: "Cell in column 3, row 2",
+                                }),
+                            },
+                        ],
+                    },
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: TableCellContent::Simple(Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 3",
+                                        line: 6,
+                                        col: 2,
+                                        offset: 113,
+                                    },
+                                    rendered: "Cell in column 1, row 3",
+                                }),
+                            },
+                            TableCell {
+                                content: TableCellContent::Simple(Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 3",
+                                        line: 7,
+                                        col: 2,
+                                        offset: 138,
+                                    },
+                                    rendered: "Cell in column 2, row 3",
+                                }),
+                            },
+                            TableCell {
+                                content: TableCellContent::Simple(Content {
+                                    original: Span {
+                                        data: "Cell in column 3, row 3",
+                                        line: 7,
+                                        col: 27,
+                                        offset: 163,
+                                    },
+                                    rendered: "Cell in column 3, row 3",
+                                }),
+                            },
+                        ],
+                    },
+                ],
+                footer_row: None,
+                source: Span {
+                    data: "|===\n|Column 1 |Column 2 |Column 3\n\n|Cell in column 1, row 2 |Cell in column 2, row 2 |Cell in column 3, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3 |Cell in column 3, row 3\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                caption: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: None,
+            })],
+            source: Span {
+                data: "|===\n|Column 1 |Column 2 |Column 3\n\n|Cell in column 1, row 2 |Cell in column 2, row 2 |Cell in column 3, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3 |Cell in column 3, row 3\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+}
+
+#[test]
+fn enter_a_rows_cells_on_consecutive_lines() {
+    non_normative!(
+        r#"
+[#consecutive]
+== Enter a row's cells on consecutive lines
+
+The cells in a row can be entered on consecutive, individual lines.
+When using this method, remember to either xref:add-columns.adoc[set the cols attribute] or xref:add-columns.adoc#implicit-cols[enter the first row's cells on a single line].
+
+"#
+    );
+
+    verifies!(
+        r#"
+.Cells on consecutive, individual lines
+[source#ex-consecutive-lines]
+----
+include::example$row.adoc[tag=indv]
+----
+
+The `cols` attribute in <<ex-consecutive-lines>> is assigned a xref:add-columns.adoc#column-multiplier[multiplier] of `+3*+`, indicating that this table has three columns.
+
+.Result of <<ex-consecutive-lines>>
+include::example$row.adoc[tag=indv]
+
+Entering cells on consecutive lines can improve the readability (and debugging) of your raw AsciiDoc content when you're applying <<specifiers,specifiers to the cells>>, using xref:format-cell-content.adoc#a-operator[AsciiDoc block elements in the cells], or entering a lot of content into the cells.
+"#
+    );
+
+    // The example pulls in `example$row.adoc[tag=indv]`, whose expanded content
+    // is asserted here directly. The `cols="3*"` multiplier sets three columns,
+    // and the cells (entered on consecutive, individual lines) flow into two
+    // body rows. The first row is not a header because the line after the
+    // opening delimiter is immediately followed by another cell, not a blank.
+    let doc = Parser::default().parse(
+        "[cols=\"3*\"]\n|===\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n|Cell in column 3, row 1\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n|===",
+    );
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
+                    },
+                ],
+                header_row: None,
+                body_rows: &[
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: TableCellContent::Simple(Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 1",
+                                        line: 3,
+                                        col: 2,
+                                        offset: 18,
+                                    },
+                                    rendered: "Cell in column 1, row 1",
+                                }),
+                            },
+                            TableCell {
+                                content: TableCellContent::Simple(Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 1",
+                                        line: 4,
+                                        col: 2,
+                                        offset: 43,
+                                    },
+                                    rendered: "Cell in column 2, row 1",
+                                }),
+                            },
+                            TableCell {
+                                content: TableCellContent::Simple(Content {
+                                    original: Span {
+                                        data: "Cell in column 3, row 1",
+                                        line: 5,
+                                        col: 2,
+                                        offset: 68,
+                                    },
+                                    rendered: "Cell in column 3, row 1",
+                                }),
+                            },
+                        ],
+                    },
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: TableCellContent::Simple(Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 2",
+                                        line: 7,
+                                        col: 2,
+                                        offset: 94,
+                                    },
+                                    rendered: "Cell in column 1, row 2",
+                                }),
+                            },
+                            TableCell {
+                                content: TableCellContent::Simple(Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 2",
+                                        line: 8,
+                                        col: 2,
+                                        offset: 119,
+                                    },
+                                    rendered: "Cell in column 2, row 2",
+                                }),
+                            },
+                            TableCell {
+                                content: TableCellContent::Simple(Content {
+                                    original: Span {
+                                        data: "Cell in column 3, row 2",
+                                        line: 9,
+                                        col: 2,
+                                        offset: 144,
+                                    },
+                                    rendered: "Cell in column 3, row 2",
+                                }),
+                            },
+                        ],
+                    },
+                ],
+                footer_row: None,
+                source: Span {
+                    data: "[cols=\"3*\"]\n|===\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n|Cell in column 3, row 1\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                caption: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: Some("cols"),
+                        shorthand_items: &[],
+                        value: "3*",
+                    }],
+                    anchor: None,
+                    source: Span {
+                        data: "cols=\"3*\"",
+                        line: 1,
+                        col: 2,
+                        offset: 1,
+                    },
+                }),
+            })],
+            source: Span {
+                data: "[cols=\"3*\"]\n|===\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n|Cell in column 3, row 1\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/add_columns.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_columns.rs
@@ -120,27 +120,31 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                         width: 3,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 3,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 3,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 3,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 3,
@@ -148,10 +152,10 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                                     offset: 23,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 3,
@@ -159,10 +163,10 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                                     offset: 33,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 3,
@@ -170,10 +174,10 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                                     offset: 43,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 4",
                                     line: 3,
@@ -181,14 +185,14 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                                     offset: 53,
                                 },
                                 rendered: "Column 4",
-                            },
+                            }),
                         },
                     ],
                 }),
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 1",
                                     line: 5,
@@ -196,10 +200,10 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                                     offset: 64,
                                 },
                                 rendered: "Cell in column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 2",
                                     line: 6,
@@ -207,10 +211,10 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                                     offset: 82,
                                 },
                                 rendered: "Cell in column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 3",
                                     line: 7,
@@ -218,10 +222,10 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                                     offset: 100,
                                 },
                                 rendered: "Cell in column 3",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 4",
                                     line: 8,
@@ -229,7 +233,7 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                                     offset: 118,
                                 },
                                 rendered: "Cell in column 4",
-                            },
+                            }),
                         },
                     ],
                 }],
@@ -331,23 +335,26 @@ The integer `3`, combined with the `+*+` operator, indicates that the table will
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: None,
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 3,
@@ -355,10 +362,10 @@ The integer `3`, combined with the `+*+` operator, indicates that the table will
                                     offset: 18,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 3,
@@ -366,10 +373,10 @@ The integer `3`, combined with the `+*+` operator, indicates that the table will
                                     offset: 28,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 3,
@@ -377,7 +384,7 @@ The integer `3`, combined with the `+*+` operator, indicates that the table will
                                     offset: 38,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                     ],
                 }],
@@ -485,27 +492,31 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                         width: 5,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 3,
@@ -513,10 +524,10 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                                     offset: 20,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 3,
@@ -524,10 +535,10 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                                     offset: 30,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 3,
@@ -535,10 +546,10 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                                     offset: 40,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 4",
                                     line: 3,
@@ -546,14 +557,14 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                                     offset: 50,
                                 },
                                 rendered: "Column 4",
-                            },
+                            }),
                         },
                     ],
                 }),
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 1",
                                     line: 5,
@@ -561,10 +572,10 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                                     offset: 61,
                                 },
                                 rendered: "Cell in column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 2",
                                     line: 6,
@@ -572,10 +583,10 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                                     offset: 79,
                                 },
                                 rendered: "Cell in column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 3",
                                     line: 7,
@@ -583,10 +594,10 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                                     offset: 97,
                                 },
                                 rendered: "Cell in column 3",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 4",
                                     line: 8,
@@ -594,7 +605,7 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                                     offset: 115,
                                 },
                                 rendered: "Cell in column 4",
-                            },
+                            }),
                         },
                     ],
                 }],
@@ -728,16 +739,19 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: None,
@@ -745,7 +759,7 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
                     TableRow {
                         cells: &[
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 1, row 1",
                                         line: 3,
@@ -753,10 +767,10 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
                                         offset: 7,
                                     },
                                     rendered: "Cell in column 1, row 1",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 2, row 1",
                                         line: 3,
@@ -764,10 +778,10 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
                                         offset: 32,
                                     },
                                     rendered: "Cell in column 2, row 1",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 3, row 1",
                                         line: 3,
@@ -775,14 +789,14 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
                                         offset: 57,
                                     },
                                     rendered: "Cell in column 3, row 1",
-                                },
+                                }),
                             },
                         ],
                     },
                     TableRow {
                         cells: &[
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 1, row 2",
                                         line: 5,
@@ -790,10 +804,10 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
                                         offset: 83,
                                     },
                                     rendered: "Cell in column 1, row 2",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 2, row 2",
                                         line: 5,
@@ -801,10 +815,10 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
                                         offset: 108,
                                     },
                                     rendered: "Cell in column 2, row 2",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 3, row 2",
                                         line: 5,
@@ -812,7 +826,7 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
                                         offset: 133,
                                     },
                                     rendered: "Cell in column 3, row 2",
-                                },
+                                }),
                             },
                         ],
                     },

--- a/parser/src/tests/asciidoc_lang/tables/add_columns.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_columns.rs
@@ -1,0 +1,789 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/add-columns.adoc");
+
+non_normative!(
+    r#"
+= Add Columns to a Table
+
+The number of columns in a table is specified by the `cols` attribute or <<implicit-cols,by the number of cells found in the first non-empty line>> after the opening table delimiter (`|===`).
+
+"#
+);
+
+#[test]
+fn specify_the_number_of_columns_with_the_cols_attribute() {
+    non_normative!(
+        r#"
+[#cols-attribute]
+== Specify the number of columns with the cols attribute
+
+"#
+    );
+
+    verifies!(
+        r#"
+The `cols` attribute is set in the attribute list on a table block.
+It accepts a comma-separated list of column specifiers.
+[[col-specifier]]Each [.term]*column specifier* represents a column and the width, alignment, and style properties assigned to that column.
+A column specifier is commonly represented by a number, but in some cases, can be represented by a symbol or letter.
+In <<ex-cols>>, `cols` is assigned a list of four numeric column specifiers.
+
+.Assign column specifiers to the cols attribute
+[source#ex-cols]
+----
+[cols="1,1,1,1"]
+----
+
+In <<ex-cols>>, the value assigned to `cols`  contains four column specifiers.
+The number of entries in the value's list determines the number of columns in the table.
+That means the table in the above example will contain four columns.
+When the specifier is a number, such as `1` or `50`, the integer represents the xref:adjust-column-widths.adoc[width of the column in proportion to the other columns in the table].
+In <<ex-cols>>, each column will be the same width because the integer in each specifier is the same.
+Let's look at the column specifiers in <<ex-cols-alt>> and compare it to <<ex-cols>>.
+
+.Assign column specifiers to the cols attribute
+[source#ex-cols-alt]
+----
+[cols="3,3,3,3"]
+----
+
+Both <<ex-cols>> and <<ex-cols-alt>> will produce tables with four columns of equal width.
+Let's use the `cols` value in <<ex-cols-alt>> to create a table.
+
+.Create a table with four columns of equal width
+[source#ex-cols-table]
+----
+[cols="3,3,3,3"] <.>
+|=== <.>
+|Column 1 |Column 2 |Column 3 |Column 4 <.>
+<.>
+|Cell in column 1 <.>
+|Cell in column 2
+|Cell in column 3
+|Cell in column 4
+|=== <.>
+----
+<.> In an attribute list, set the `cols` attribute, followed by an equals sign (`=`), and then a list of comma-separated column specifiers enclosed in double quotation marks (`"`).
+<.> On the line directly after the attribute list, enter the opening table delimiter.
+A table delimiter is one vertical bar followed by three equals signs (`|===`).
+<.> A table cell is specified by a vertical bar (`|`).
+Since four consecutive cells are entered on the first line directly after the delimiter, this row is implicitly set as the table's header row.
+<.> Insert an empty line after the header row.
+<.> The cells for the next row can be entered on a single line or on individual lines.
+<.> On a new line after the last cell of the last row, enter another table delimiter (`|===`) to close the table block.
+
+<<ex-cols-table>> creates the table displayed below.
+
+.Result of <<ex-cols-table>>
+[cols="3,3,3,3"]
+|===
+|Column 1 |Column 2 |Column 3 |Column 4
+
+|Cell in column 1
+|Cell in column 2
+|Cell in column 3
+|Cell in column 4
+|===
+
+As specified, the table includes four columns of equal width, a header row, and a regular row.
+Since all of the columns in <<ex-cols-table>> are assigned the same width via their column specifiers (i.e., `3`), the number of columns could be specified with a <<column-multiplier,column multiplier>>.
+Or, you could adjust the width of an individual column by xref:adjust-column-widths.adoc[increasing the numerical value of its specifier].
+
+"#
+    );
+
+    let doc = Parser::default().parse(
+        "[cols=\"3,3,3,3\"]\n|===\n|Column 1 |Column 2 |Column 3 |Column 4\n\n|Cell in column 1\n|Cell in column 2\n|Cell in column 3\n|Cell in column 4\n|===",
+    );
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[
+                    TableColumn { width: 3 },
+                    TableColumn { width: 3 },
+                    TableColumn { width: 3 },
+                    TableColumn { width: 3 },
+                ],
+                header_row: Some(TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 1",
+                                    line: 3,
+                                    col: 2,
+                                    offset: 23,
+                                },
+                                rendered: "Column 1",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 2",
+                                    line: 3,
+                                    col: 12,
+                                    offset: 33,
+                                },
+                                rendered: "Column 2",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 3",
+                                    line: 3,
+                                    col: 22,
+                                    offset: 43,
+                                },
+                                rendered: "Column 3",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 4",
+                                    line: 3,
+                                    col: 32,
+                                    offset: 53,
+                                },
+                                rendered: "Column 4",
+                            },
+                        },
+                    ],
+                }),
+                body_rows: &[TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Cell in column 1",
+                                    line: 5,
+                                    col: 2,
+                                    offset: 64,
+                                },
+                                rendered: "Cell in column 1",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Cell in column 2",
+                                    line: 6,
+                                    col: 2,
+                                    offset: 82,
+                                },
+                                rendered: "Cell in column 2",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Cell in column 3",
+                                    line: 7,
+                                    col: 2,
+                                    offset: 100,
+                                },
+                                rendered: "Cell in column 3",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Cell in column 4",
+                                    line: 8,
+                                    col: 2,
+                                    offset: 118,
+                                },
+                                rendered: "Cell in column 4",
+                            },
+                        },
+                    ],
+                }],
+                footer_row: None,
+                source: Span {
+                    data: "[cols=\"3,3,3,3\"]\n|===\n|Column 1 |Column 2 |Column 3 |Column 4\n\n|Cell in column 1\n|Cell in column 2\n|Cell in column 3\n|Cell in column 4\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                caption: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: Some("cols"),
+                        shorthand_items: &[],
+                        value: "3,3,3,3",
+                    }],
+                    anchor: None,
+                    source: Span {
+                        data: "cols=\"3,3,3,3\"",
+                        line: 1,
+                        col: 2,
+                        offset: 1,
+                    },
+                }),
+            })],
+            source: Span {
+                data: "[cols=\"3,3,3,3\"]\n|===\n|Column 1 |Column 2 |Column 3 |Column 4\n\n|Cell in column 1\n|Cell in column 2\n|Cell in column 3\n|Cell in column 4\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+}
+
+#[test]
+fn using_a_column_multiplier() {
+    non_normative!(
+        r#"
+[#column-multiplier]
+=== Using a column multiplier
+
+"#
+    );
+
+    verifies!(
+        r#"
+A [.term]*column multiplier* allows you to apply the same width, horizontal alignment, vertical alignment, and content style to multiple, consecutive columns in a table.
+A multiplier consists of an integer (`<n>`) and an asterisk (`+*+`).
+The integer represents the number of consecutive columns to be added to the table.
+The asterisk (`+*+`) is called the [.term]*multiplier operator* and is placed directly after the integer (`+<n>*+`).
+The operator tells the converter to interpret the integer as part of a column multiplier instead of a column specifier.
+
+For example, let's rewrite the value of `[cols="5,5,5"]` as a column multiplier.
+
+.Represent [cols="5,5,5"] using a column multiplier
+[source]
+----
+[cols="3*"] <.>
+----
+<.> Assign an integer to `cols` that represents the number of columns in the table.
+Enter the multiplier operator (`+*+`) directly after the integer.
+
+The integer `3`, combined with the `+*+` operator, indicates that the table will contain three columns of equal width.
+
+"#
+    );
+
+    let doc = Parser::default().parse("[cols=\"3*\"]\n|===\n|Column 1 |Column 2 |Column 3\n|===");
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[
+                    TableColumn { width: 1 },
+                    TableColumn { width: 1 },
+                    TableColumn { width: 1 },
+                ],
+                header_row: None,
+                body_rows: &[TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 1",
+                                    line: 3,
+                                    col: 2,
+                                    offset: 18,
+                                },
+                                rendered: "Column 1",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 2",
+                                    line: 3,
+                                    col: 12,
+                                    offset: 28,
+                                },
+                                rendered: "Column 2",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 3",
+                                    line: 3,
+                                    col: 22,
+                                    offset: 38,
+                                },
+                                rendered: "Column 3",
+                            },
+                        },
+                    ],
+                }],
+                footer_row: None,
+                source: Span {
+                    data: "[cols=\"3*\"]\n|===\n|Column 1 |Column 2 |Column 3\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                caption: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: Some("cols"),
+                        shorthand_items: &[],
+                        value: "3*",
+                    }],
+                    anchor: None,
+                    source: Span {
+                        data: "cols=\"3*\"",
+                        line: 1,
+                        col: 2,
+                        offset: 1,
+                    },
+                }),
+            })],
+            source: Span {
+                data: "[cols=\"3*\"]\n|===\n|Column 1 |Column 2 |Column 3\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+}
+
+#[test]
+fn combine_a_column_specifier_and_a_column_multiplier() {
+    verifies!(
+        r#"
+You can use a multiplier in a comma-separated list with column specifiers, too.
+In <<ex-spec-and-multiplier>>, the first column is represented by a column specifier, and the next three columns are represented by a multiplier.
+
+.Assign a column specifier and a column multiplier to cols
+[source#ex-spec-and-multiplier]
+----
+[cols="5,3*"]
+|===
+|Column 1 |Column 2 |Column 3 |Column 4
+
+|Cell in column 1
+|Cell in column 2
+|Cell in column 3
+|Cell in column 4
+|===
+----
+
+As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adjust-column-widths.adoc[wide first column] followed by three columns of equal width.
+
+.Result of <<ex-spec-and-multiplier>>
+[cols="5,3*"]
+|===
+|Column 1 |Column 2 |Column 3 |Column 4
+
+|Cell in column 1
+|Cell in column 2
+|Cell in column 3
+|Cell in column 4
+|===
+
+"#
+    );
+
+    let doc = Parser::default().parse(
+        "[cols=\"5,3*\"]\n|===\n|Column 1 |Column 2 |Column 3 |Column 4\n\n|Cell in column 1\n|Cell in column 2\n|Cell in column 3\n|Cell in column 4\n|===",
+    );
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[
+                    TableColumn { width: 5 },
+                    TableColumn { width: 1 },
+                    TableColumn { width: 1 },
+                    TableColumn { width: 1 },
+                ],
+                header_row: Some(TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 1",
+                                    line: 3,
+                                    col: 2,
+                                    offset: 20,
+                                },
+                                rendered: "Column 1",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 2",
+                                    line: 3,
+                                    col: 12,
+                                    offset: 30,
+                                },
+                                rendered: "Column 2",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 3",
+                                    line: 3,
+                                    col: 22,
+                                    offset: 40,
+                                },
+                                rendered: "Column 3",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 4",
+                                    line: 3,
+                                    col: 32,
+                                    offset: 50,
+                                },
+                                rendered: "Column 4",
+                            },
+                        },
+                    ],
+                }),
+                body_rows: &[TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Cell in column 1",
+                                    line: 5,
+                                    col: 2,
+                                    offset: 61,
+                                },
+                                rendered: "Cell in column 1",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Cell in column 2",
+                                    line: 6,
+                                    col: 2,
+                                    offset: 79,
+                                },
+                                rendered: "Cell in column 2",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Cell in column 3",
+                                    line: 7,
+                                    col: 2,
+                                    offset: 97,
+                                },
+                                rendered: "Cell in column 3",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Cell in column 4",
+                                    line: 8,
+                                    col: 2,
+                                    offset: 115,
+                                },
+                                rendered: "Cell in column 4",
+                            },
+                        },
+                    ],
+                }],
+                footer_row: None,
+                source: Span {
+                    data: "[cols=\"5,3*\"]\n|===\n|Column 1 |Column 2 |Column 3 |Column 4\n\n|Cell in column 1\n|Cell in column 2\n|Cell in column 3\n|Cell in column 4\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                caption: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: Some("cols"),
+                        shorthand_items: &[],
+                        value: "5,3*",
+                    }],
+                    anchor: None,
+                    source: Span {
+                        data: "cols=\"5,3*\"",
+                        line: 1,
+                        col: 2,
+                        offset: 1,
+                    },
+                }),
+            })],
+            source: Span {
+                data: "[cols=\"5,3*\"]\n|===\n|Column 1 |Column 2 |Column 3 |Column 4\n\n|Cell in column 1\n|Cell in column 2\n|Cell in column 3\n|Cell in column 4\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+}
+
+non_normative!(
+    r#"
+[#cols-format]
+=== Alignment and style column operators
+
+AsciiDoc provides operators that control the positioning and style of column content when the `cols` attribute is set.
+A column specifier or multiplier can contain these optional operators for one or more of the following properties:
+
+* xref:align-by-column.adoc#horizontal-operators[horizontal alignment]
+* xref:align-by-column.adoc#vertical-operators[vertical alignment]
+* xref:format-column-content.adoc[content style]
+
+Many of these operators can be applied to individual cells as well.
+
+"#
+);
+
+#[test]
+fn specify_the_number_of_columns_using_the_first_row() {
+    non_normative!(
+        r#"
+[#implicit-cols]
+== Specify the number of columns using the first row
+
+"#
+    );
+
+    verifies!(
+        r#"
+When all of the columns in a table use the default width, alignment, and style values, you don't need to set the `cols` attribute.
+Instead, you can implicitly declare the number of columns by entering all of the first row's cells on the same line.
+The processor will derive the number columns from the number of cells in this row.
+<<ex-implicit>> uses its first row to indicate that it has three columns.
+
+.Create a table with three columns using its first row
+[source#ex-implicit]
+----
+|===
+<.>
+|Cell in column 1, row 1 |Cell in column 2, row 1 |Cell in column 3, row 1 <.>
+
+|Cell in column 1, row 2 <.>
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+|===
+----
+<.> After the opening delimiter, insert an empty line before the first row, unless you want the first row to be treated as header row.
+<.> Enter all of the first row's cells on a single line.
+Each cell represents one column.
+<.> The cells in subsequent rows don't need to be entered on a single line.
+
+The table in <<ex-implicit>> has three columns since its first row contains three cells.
+
+.Result of <<ex-implicit>>
+|===
+
+|Cell in column 1, row 1 |Cell in column 2, row 1 |Cell in column 3, row 1
+
+|Cell in column 1, row 2 |Cell in column 2, row 2 |Cell in column 3, row 2
+|===
+"#
+    );
+
+    let doc = Parser::default().parse(
+        "|===\n\n|Cell in column 1, row 1 |Cell in column 2, row 1 |Cell in column 3, row 1\n\n|Cell in column 1, row 2 |Cell in column 2, row 2 |Cell in column 3, row 2\n|===",
+    );
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[
+                    TableColumn { width: 1 },
+                    TableColumn { width: 1 },
+                    TableColumn { width: 1 },
+                ],
+                header_row: None,
+                body_rows: &[
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 1",
+                                        line: 3,
+                                        col: 2,
+                                        offset: 7,
+                                    },
+                                    rendered: "Cell in column 1, row 1",
+                                },
+                            },
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 1",
+                                        line: 3,
+                                        col: 27,
+                                        offset: 32,
+                                    },
+                                    rendered: "Cell in column 2, row 1",
+                                },
+                            },
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 3, row 1",
+                                        line: 3,
+                                        col: 52,
+                                        offset: 57,
+                                    },
+                                    rendered: "Cell in column 3, row 1",
+                                },
+                            },
+                        ],
+                    },
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 2",
+                                        line: 5,
+                                        col: 2,
+                                        offset: 83,
+                                    },
+                                    rendered: "Cell in column 1, row 2",
+                                },
+                            },
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 2",
+                                        line: 5,
+                                        col: 27,
+                                        offset: 108,
+                                    },
+                                    rendered: "Cell in column 2, row 2",
+                                },
+                            },
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 3, row 2",
+                                        line: 5,
+                                        col: 52,
+                                        offset: 133,
+                                    },
+                                    rendered: "Cell in column 3, row 2",
+                                },
+                            },
+                        ],
+                    },
+                ],
+                footer_row: None,
+                source: Span {
+                    data: "|===\n\n|Cell in column 1, row 1 |Cell in column 2, row 1 |Cell in column 3, row 1\n\n|Cell in column 1, row 2 |Cell in column 2, row 2 |Cell in column 3, row 2\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                caption: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: None,
+            })],
+            source: Span {
+                data: "|===\n\n|Cell in column 1, row 1 |Cell in column 2, row 1 |Cell in column 3, row 1\n\n|Cell in column 1, row 2 |Cell in column 2, row 2 |Cell in column 3, row 2\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/add_columns.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_columns.rs
@@ -116,10 +116,26 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 3 },
-                    TableColumn { width: 3 },
-                    TableColumn { width: 3 },
-                    TableColumn { width: 3 },
+                    TableColumn {
+                        width: 3,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 3,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 3,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 3,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
@@ -311,9 +327,21 @@ The integer `3`, combined with the `+*+` operator, indicates that the table will
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 1 },
-                    TableColumn { width: 1 },
-                    TableColumn { width: 1 },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: None,
                 body_rows: &[TableRow {
@@ -453,10 +481,26 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 5 },
-                    TableColumn { width: 1 },
-                    TableColumn { width: 1 },
-                    TableColumn { width: 1 },
+                    TableColumn {
+                        width: 5,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
@@ -680,9 +724,21 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 1 },
-                    TableColumn { width: 1 },
-                    TableColumn { width: 1 },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: None,
                 body_rows: &[

--- a/parser/src/tests/asciidoc_lang/tables/add_footer_row.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_footer_row.rs
@@ -1,0 +1,264 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/add-footer-row.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Return the rendered text of a [`Simple`](crate::blocks::TableCellContent)
+/// cell, panicking if the cell holds AsciiDoc block content instead.
+fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
+    match cell.content() {
+        crate::blocks::TableCellContent::Simple(content) => content.rendered().to_string(),
+        crate::blocks::TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
+    }
+}
+
+/// Return the rendered text of each cell in the table's footer row, panicking
+/// if the table has no footer row.
+fn footer_texts(table: &crate::blocks::TableBlock<'_>) -> Vec<String> {
+    table
+        .footer_row()
+        .expect("expected a footer row")
+        .cells()
+        .iter()
+        .map(simple_text)
+        .collect()
+}
+
+non_normative!(
+    r#"
+= Create a Footer Row
+
+"#
+);
+
+#[test]
+fn intro() {
+    verifies!(
+        r#"
+The last row of a table is promoted to a footer row if the `footer` value is assigned to the table's `options` attribute.
+
+"#
+    );
+
+    // Assigning `footer` to the `options` attribute promotes the last row,
+    // moving it out of the body and into the footer. (The second line of
+    // content is non-empty, so no implicit header is detected and both rows
+    // start out in the body.)
+    let table = parse_table("[options=\"footer\"]\n|===\n|Cell 1 |Cell 2\n|Foot 1 |Foot 2\n|===");
+    assert_eq!(footer_texts(&table), vec!["Foot 1", "Foot 2"]);
+    assert_eq!(table.body_rows().len(), 1);
+
+    // Without the `footer` option, the last row stays in the body.
+    let no_footer = parse_table("|===\n|Cell 1 |Cell 2\n|Foot 1 |Foot 2\n|===");
+    assert!(no_footer.footer_row().is_none());
+}
+
+#[test]
+fn assign_footer_to_last_row() {
+    non_normative!(
+        r#"
+== Assign footer to the last row
+
+"#
+    );
+
+    verifies!(
+        r#"
+The footer row semantics and styles are applied to the last row in a table by assigning `footer` to the `options` attribute.
+The `options` attribute is set in the table's attribute list using the shorthand (`%value`) or formal syntax (`options="value"`).
+
+"#
+    );
+
+    // Shorthand `%footer` promotes the last row to the footer.
+    let shorthand = parse_table("[%footer]\n|===\n|Cell 1 |Cell 2\n|Foot 1 |Foot 2\n|===");
+    assert_eq!(footer_texts(&shorthand), vec!["Foot 1", "Foot 2"]);
+
+    // Formal `options="footer"` promotes the last row too.
+    let formal = parse_table("[options=\"footer\"]\n|===\n|Cell 1 |Cell 2\n|Foot 1 |Foot 2\n|===");
+    assert_eq!(footer_texts(&formal), vec!["Foot 1", "Foot 2"]);
+
+    // Unlike the header row (which ignores column style operators), a footer
+    // cell is processed with its column's style: here the `a` operator parses
+    // the footer cell's content as a nested AsciiDoc list block.
+    let styled =
+        parse_table("[%footer,cols=\"a,1\"]\n|===\n|Cell 1 |Cell 2\n|* item\n|Foot 2\n|===");
+    assert!(matches!(
+        styled.footer_row().unwrap().cells()[0].content(),
+        crate::blocks::TableCellContent::AsciiDoc(_)
+    ));
+
+    verifies!(
+        r#"
+The `options` attribute is represented by the percent sign (`%`) when it's set using the shorthand syntax.
+"#
+    );
+
+    // The `%` shorthand sets the `options` attribute, so `%footer` assigns the
+    // `footer` option and promotes the last row.
+    let table = parse_table("[%footer]\n|===\n|Cell 1 |Cell 2\n|Foot 1 |Foot 2\n|===");
+    assert!(table.footer_row().is_some());
+
+    verifies!(
+        r#"
+In <<ex-short>>, `footer` is assigned using the shorthand syntax for `options`.
+
+.Table with footer assigned using the shorthand syntax
+[source#ex-short]
+----
+[%header%footer,cols="2,2,1"] <.>
+|===
+|Column 1, header row
+|Column 2, header row
+|Column 3, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+
+|Column 1, footer row
+|Column 2, footer row
+|Column 3, footer row
+|===
+----
+"#
+    );
+
+    // The `ex-short` example assigns `footer` (alongside `header`) using the
+    // `%` shorthand syntax, so the last row is promoted to the footer.
+    let ex_short = parse_table(
+        "[%header%footer,cols=\"2,2,1\"]\n|===\n|Column 1, header row\n|Column 2, header row\n|Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n\n|Column 1, footer row\n|Column 2, footer row\n|Column 3, footer row\n|===",
+    );
+    assert!(ex_short.footer_row().is_some());
+
+    verifies!(
+        r#"
+<.> Values assigned using the shorthand syntax must be entered before the `cols` attribute (or any other named attributes) in a table's attribute list, otherwise the processor will ignore them.
+
+"#
+    );
+
+    // Shorthand `%header%footer` entered before `cols` is honored: the first row
+    // is the header and the last row is the footer (this is the `ex-short`
+    // example from the page).
+    let before = parse_table(
+        "[%header%footer,cols=\"2,2,1\"]\n|===\n|Column 1, header row\n|Column 2, header row\n|Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n\n|Column 1, footer row\n|Column 2, footer row\n|Column 3, footer row\n|===",
+    );
+    assert!(before.header_row().is_some());
+    assert_eq!(
+        footer_texts(&before),
+        vec![
+            "Column 1, footer row",
+            "Column 2, footer row",
+            "Column 3, footer row"
+        ]
+    );
+    assert_eq!(before.body_rows().len(), 1);
+
+    // The same shorthand entered after the `cols` (named) attribute is ignored,
+    // so the last row is not promoted to a footer row.
+    let after = parse_table(
+        "[cols=\"2,2,1\",%footer]\n|===\n|Cell 1 |Cell 2 |Cell 3\n\n|Foot 1 |Foot 2 |Foot 3\n|===",
+    );
+    assert!(after.footer_row().is_none());
+
+    verifies!(
+        r#"
+The table from <<ex-short>> is displayed below.
+
+.Result of <<ex-short>>
+[%header%footer,cols="2,2,1"]
+|===
+|Column 1, header row
+|Column 2, header row
+|Column 3, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+
+|Column 1, footer row
+|Column 2, footer row
+|Column 3, footer row
+|===
+
+"#
+    );
+
+    // The rendered result of <<ex-short>>: the last row renders as the footer.
+    let ex_short_result = parse_table(
+        "[%header%footer,cols=\"2,2,1\"]\n|===\n|Column 1, header row\n|Column 2, header row\n|Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n\n|Column 1, footer row\n|Column 2, footer row\n|Column 3, footer row\n|===",
+    );
+    assert_eq!(
+        footer_texts(&ex_short_result),
+        vec![
+            "Column 1, footer row",
+            "Column 2, footer row",
+            "Column 3, footer row"
+        ]
+    );
+
+    verifies!(
+        r#"
+In <<ex-formal>>, the `options` attribute is set and assigned the `footer` value using the formal syntax.
+The `options` attribute accepts a comma-separated list of values.
+
+.Table with footer assigned to the options attribute
+[source#ex-formal]
+----
+include::example$row.adoc[tag=opt-f]
+----
+
+"#
+    );
+
+    // The `ex-formal` example sets the `options` attribute to `footer` using the
+    // formal syntax, promoting the last row to the footer.
+    let ex_formal =
+        parse_table("[options=\"footer\"]\n|===\n|Cell 1 |Cell 2\n|Foot 1 |Foot 2\n|===");
+    assert!(ex_formal.footer_row().is_some());
+
+    // The formal `options` value is a comma-separated list; `footer` is honored
+    // when it appears among other values.
+    let table = parse_table(
+        "[options=\"footer,unbreakable\"]\n|===\n|Cell 1 |Cell 2\n|Foot 1 |Foot 2\n|===",
+    );
+    assert!(table.footer_row().is_some());
+
+    verifies!(
+        r#"
+The last row of the table in <<ex-formal>> is rendered using the corresponding footer styles.
+
+.Result of <<ex-formal>>
+include::example$row.adoc[tag=opt-f]
+"#
+    );
+
+    // The `opt-f` example from row.adoc: an implicit header (first line
+    // non-empty, second line blank) plus the formal `footer` option, so the
+    // first row is the header, the middle row is the body, and the last row is
+    // the footer.
+    let formal = parse_table(
+        "[options=\"footer\"]\n|===\n|Column 1, header row |Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Column 1, footer row\n|Column 2, footer row\n|===",
+    );
+    assert!(formal.header_row().is_some());
+    assert_eq!(formal.body_rows().len(), 1);
+    assert_eq!(
+        footer_texts(&formal),
+        vec!["Column 1, footer row", "Column 2, footer row"]
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
@@ -1,0 +1,374 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/add-header-row.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Return the rendered text of a [`Simple`](crate::blocks::TableCellContent)
+/// cell, panicking if the cell holds AsciiDoc block content instead.
+fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
+    match cell.content() {
+        crate::blocks::TableCellContent::Simple(content) => content.rendered().to_string(),
+        crate::blocks::TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
+    }
+}
+
+/// Return the rendered text of each cell in the table's header row, panicking
+/// if the table has no header row.
+fn header_texts(table: &crate::blocks::TableBlock<'_>) -> Vec<String> {
+    table
+        .header_row()
+        .expect("expected a header row")
+        .cells()
+        .iter()
+        .map(simple_text)
+        .collect()
+}
+
+non_normative!(
+    r#"
+= Create a Header Row
+
+"#
+);
+
+#[test]
+fn intro() {
+    verifies!(
+        r#"
+The first row of a table is promoted to a header row if the `header` value is assigned to the table's `options` attribute.
+You can assign `header` to a table's first row explicitly or implicitly.
+
+"#
+    );
+
+    // Assigning `header` to the `options` attribute promotes the first row,
+    // regardless of the table's layout.
+    let explicit =
+        parse_table("[options=\"header\"]\n|===\n|Column 1 |Column 2\n|Cell 1 |Cell 2\n|===");
+    assert!(explicit.header_row().is_some());
+
+    // The first row can also be promoted implicitly, based on the table's
+    // layout (a non-empty first line followed by an empty line).
+    let implicit = parse_table("|===\n|Column 1 |Column 2\n\n|Cell 1 |Cell 2\n|===");
+    assert!(implicit.header_row().is_some());
+}
+
+#[test]
+fn header_ignores_operators() {
+    verifies!(
+        r#"
+TIP: The header row ignores any style operators assigned via column and cell specifiers.
+"#
+    );
+
+    // A column style operator (here the AsciiDoc `a` operator) governs the body
+    // cells in its column but is ignored for the header row: the header cell is
+    // processed as plain, default content even though its column is styled.
+    let table = parse_table(
+        "[cols=\"a,1\",options=\"header\"]\n|===\n|Column 1 |Column 2\n\n|* item\n|Cell 2\n|===",
+    );
+    assert!(matches!(
+        table.header_row().unwrap().cells()[0].content(),
+        crate::blocks::TableCellContent::Simple(_)
+    ));
+
+    // The body cell in the same column *is* processed with the column's style,
+    // so its content is parsed as a nested AsciiDoc list block.
+    assert!(matches!(
+        table.body_rows()[0].cells()[0].content(),
+        crate::blocks::TableCellContent::AsciiDoc(_)
+    ));
+
+    to_do_verifies!(
+        r#"
+It also ignores alignment operators assigned to the table's column specifiers; however, any alignment operators assigned to a cell specifier in the header row are applied.
+
+"#
+    );
+
+    // The interaction between the header row and alignment operators on a cell
+    // specifier depends on cell specifiers, which are not yet implemented.
+    if false {
+        todo!("cell specifiers and cell-level alignment for the header row");
+    }
+}
+
+#[test]
+fn explicitly_assign_header() {
+    non_normative!(
+        r#"
+== Explicitly assign header to the first row
+
+"#
+    );
+
+    verifies!(
+        r#"
+The header row semantics and styles are explicitly assigned to the first row in a table by assigning `header` to the `options` attribute.
+The `options` attribute is set in the table's attribute list using the shorthand (`%value`) or formal syntax (`options="value"`).
+
+"#
+    );
+
+    // Shorthand `%header` (entered before `cols`) promotes the first row; this
+    // is the `ex-short` example from the page.
+    let shorthand = parse_table(
+        "[%header,cols=\"2,2,1\"]\n|===\n|Column 1, header row\n|Column 2, header row\n|Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n|===",
+    );
+    assert_eq!(
+        header_texts(&shorthand),
+        vec![
+            "Column 1, header row",
+            "Column 2, header row",
+            "Column 3, header row"
+        ]
+    );
+    assert_eq!(shorthand.body_rows().len(), 1);
+
+    // Formal `options="header"` promotes the first row too; this is the `opt-h`
+    // example (row.adoc) referenced by the page.
+    let formal = parse_table(
+        "[cols=\"2*\",options=\"header\"]\n|===\n|Column 1, header row\n|Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|===",
+    );
+    assert_eq!(
+        header_texts(&formal),
+        vec!["Column 1, header row", "Column 2, header row"]
+    );
+    assert_eq!(formal.body_rows().len(), 2);
+
+    verifies!(
+        r#"
+The `options` attribute is represented by the percent sign (`%`) when it's set using the shorthand syntax.
+"#
+    );
+
+    // The `%` shorthand sets the `options` attribute, so `%header` assigns the
+    // `header` option. (No blank line follows the first row here, so the header
+    // can only come from the option, not from implicit detection.)
+    let table = parse_table("[%header]\n|===\n|Column 1 |Column 2\n|Cell 1 |Cell 2\n|===");
+    assert!(table.header_row().is_some());
+
+    non_normative!(
+        r#"
+In <<ex-short>>, `header` is assigned to using the shorthand syntax for `options`.
+
+.Table with `header` assigned using the shorthand syntax
+[source#ex-short]
+----
+[%header,cols="2,2,1"] <.>
+|===
+|Column 1, header row
+|Column 2, header row
+|Column 3, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+|===
+----
+"#
+    );
+
+    verifies!(
+        r#"
+<.> Values assigned using the shorthand syntax must be entered before the `cols` attribute (or any other named attributes) in a table's attribute list, otherwise the processor will ignore them.
+
+"#
+    );
+
+    // Shorthand `%header` entered before `cols` is honored.
+    let before = parse_table(
+        "[%header,cols=\"2,2,1\"]\n|===\n|Column 1 |Column 2 |Column 3\n|Cell 1 |Cell 2 |Cell 3\n|===",
+    );
+    assert!(before.header_row().is_some());
+
+    // The same shorthand entered after the `cols` (named) attribute is ignored,
+    // so the first row is not promoted. (No blank line follows it, so implicit
+    // detection does not apply either.)
+    let after = parse_table(
+        "[cols=\"2,2,1\",%header]\n|===\n|Column 1 |Column 2 |Column 3\n|Cell 1 |Cell 2 |Cell 3\n|===",
+    );
+    assert!(after.header_row().is_none());
+
+    non_normative!(
+        r#"
+The table from <<ex-short>> is displayed below.
+
+.Result of <<ex-short>>
+[%header,cols="2,2,1"]
+|===
+|Column 1, header row
+|Column 2, header row
+|Column 3, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+|===
+
+In <<ex-formal>>, the `options` attribute is set and assigned the `header` value using the formal syntax.
+"#
+    );
+
+    verifies!(
+        r#"
+The `options` attribute accepts a comma-separated list of values.
+
+"#
+    );
+
+    // The formal `options` value is a comma-separated list; `header` is honored
+    // when it appears among other values.
+    let table = parse_table(
+        "[options=\"header,unbreakable\"]\n|===\n|Column 1 |Column 2\n|Cell 1 |Cell 2\n|===",
+    );
+    assert!(table.header_row().is_some());
+
+    non_normative!(
+        r#"
+.Table with header assigned to the options attribute
+[source#ex-formal]
+----
+include::example$row.adoc[tag=opt-h]
+----
+
+The first row of the table in <<ex-formal>> is rendered using the corresponding header styles and semantics.
+
+.Result of <<ex-formal>>
+include::example$row.adoc[tag=opt-h]
+
+"#
+    );
+}
+
+#[test]
+fn implicitly_assign_header() {
+    non_normative!(
+        r#"
+== Implicitly assign header to the first row
+
+"#
+    );
+
+    verifies!(
+        r#"
+You can implicitly define a header row based on how you layout the table.
+The following conventions determine when the first row automatically becomes the header row:
+
+. The first line of content inside the table delimiters is not empty.
+. The second line of content inside the table delimiters is empty.
+
+"#
+    );
+
+    // Both conventions hold: the first line of content is non-empty and the
+    // second line is empty, so the first row becomes the header (the `impl-h`
+    // example from row.adoc).
+    let table = parse_table(
+        "|===\n|Column 1, header row |Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|===",
+    );
+    assert_eq!(
+        header_texts(&table),
+        vec!["Column 1, header row", "Column 2, header row"]
+    );
+    assert_eq!(table.body_rows().len(), 2);
+
+    // When the second line of content is *not* empty, the convention fails and
+    // the first row is not promoted to a header row.
+    let no_header = parse_table("|===\n|Cell 1 |Cell 2\n|Cell 3 |Cell 4\n|===");
+    assert!(no_header.header_row().is_none());
+
+    non_normative!(
+        r#"
+.First row is implicitly assigned header
+[source#ex-implicit]
+----
+include::example$row.adoc[tag=impl-h]
+----
+
+As seen in the result below, if all of these rules hold true, then the first row of the table is treated as a header row.
+
+.Result of <<ex-implicit>>
+include::example$row.adoc[tag=impl-h]
+
+"#
+    );
+}
+
+#[test]
+fn deactivate_implicit_header() {
+    non_normative!(
+        r#"
+=== Deactivate the implicit assignment of header
+
+"#
+    );
+
+    verifies!(
+        r#"
+To suppress the implicit behavior of promoting the first row to a header row, assign the value `noheader` to the `options` attribute using the formal (`options=noheader`) or shorthand (`%noheader`) syntax.
+In <<ex-noheader>>, `noheader` is assigned using the shorthand syntax.
+
+"#
+    );
+
+    // Shorthand `%noheader` suppresses the implicit header (the `ex-noheader`
+    // example from the page): the first row stays in the body.
+    let table = parse_table(
+        "[%noheader]\n|===\n|Cell in column 1, row 1 |Cell in column 2, row 1\n\n|Cell in column 1, row 2 |Cell in column 2, row 2\n|===",
+    );
+    assert!(table.header_row().is_none());
+    assert_eq!(table.body_rows().len(), 2);
+
+    // Formal `options="noheader"` suppresses the implicit header as well.
+    let table =
+        parse_table("[options=\"noheader\"]\n|===\n|Cell 1 |Cell 2\n\n|Cell 3 |Cell 4\n|===");
+    assert!(table.header_row().is_none());
+
+    // `noheader` only suppresses the *implicit* assignment; an explicit `header`
+    // still wins when both options are present.
+    let table = parse_table("[%header%noheader]\n|===\n|Cell 1 |Cell 2\n\n|Cell 3 |Cell 4\n|===");
+    assert!(table.header_row().is_some());
+
+    non_normative!(
+        r#"
+.Deactivate implicit header row with noheader
+[source#ex-noheader]
+----
+[%noheader]
+|===
+|Cell in column 1, row 1 |Cell in column 2, row 1
+
+|Cell in column 1, row 2 |Cell in column 2, row 2
+|===
+----
+
+The table from <<ex-noheader>> is displayed below.
+
+.Result of <<ex-noheader>>
+[%noheader]
+|===
+|Cell in column 1, row 1 |Cell in column 2, row 1
+
+|Cell in column 1, row 2 |Cell in column 2, row 2
+|===
+
+//CAUTION: We're considering using a similar convention for enabling the footer in the future.
+//Thus, if you rely on this convention to enable the header row, it's advised that you not put all the cells in the last row on the same line unless you intend on making it the footer row.
+"#
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
@@ -162,7 +162,7 @@ The `options` attribute is represented by the percent sign (`%`) when it's set u
     let table = parse_table("[%header]\n|===\n|Column 1 |Column 2\n|Cell 1 |Cell 2\n|===");
     assert!(table.header_row().is_some());
 
-    non_normative!(
+    verifies!(
         r#"
 In <<ex-short>>, `header` is assigned to using the shorthand syntax for `options`.
 
@@ -182,6 +182,14 @@ In <<ex-short>>, `header` is assigned to using the shorthand syntax for `options
 ----
 "#
     );
+
+    // The `ex-short` example assigns `header` using the `%` shorthand syntax, so
+    // the first row is promoted to the header. (The callout `<.>` on the
+    // attribute line is doc-authoring markup, not part of the table source.)
+    let ex_short = parse_table(
+        "[%header,cols=\"2,2,1\"]\n|===\n|Column 1, header row\n|Column 2, header row\n|Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n|===",
+    );
+    assert!(ex_short.header_row().is_some());
 
     verifies!(
         r#"
@@ -204,7 +212,7 @@ In <<ex-short>>, `header` is assigned to using the shorthand syntax for `options
     );
     assert!(after.header_row().is_none());
 
-    non_normative!(
+    verifies!(
         r#"
 The table from <<ex-short>> is displayed below.
 
@@ -220,16 +228,42 @@ The table from <<ex-short>> is displayed below.
 |Cell in column 3, row 2
 |===
 
-In <<ex-formal>>, the `options` attribute is set and assigned the `header` value using the formal syntax.
 "#
+    );
+
+    // The rendered result of <<ex-short>>: the first row renders as the header.
+    let ex_short_result = parse_table(
+        "[%header,cols=\"2,2,1\"]\n|===\n|Column 1, header row\n|Column 2, header row\n|Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n|===",
+    );
+    assert_eq!(
+        header_texts(&ex_short_result),
+        vec![
+            "Column 1, header row",
+            "Column 2, header row",
+            "Column 3, header row"
+        ]
     );
 
     verifies!(
         r#"
+In <<ex-formal>>, the `options` attribute is set and assigned the `header` value using the formal syntax.
 The `options` attribute accepts a comma-separated list of values.
+
+.Table with header assigned to the options attribute
+[source#ex-formal]
+----
+include::example$row.adoc[tag=opt-h]
+----
 
 "#
     );
+
+    // The `ex-formal` example (`opt-h` from row.adoc) sets the `options`
+    // attribute to `header` using the formal syntax, promoting the first row.
+    let ex_formal = parse_table(
+        "[cols=\"2*\",options=\"header\"]\n|===\n|Column 1, header row\n|Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|===",
+    );
+    assert!(ex_formal.header_row().is_some());
 
     // The formal `options` value is a comma-separated list; `header` is honored
     // when it appears among other values.
@@ -238,20 +272,23 @@ The `options` attribute accepts a comma-separated list of values.
     );
     assert!(table.header_row().is_some());
 
-    non_normative!(
+    verifies!(
         r#"
-.Table with header assigned to the options attribute
-[source#ex-formal]
-----
-include::example$row.adoc[tag=opt-h]
-----
-
 The first row of the table in <<ex-formal>> is rendered using the corresponding header styles and semantics.
 
 .Result of <<ex-formal>>
 include::example$row.adoc[tag=opt-h]
 
 "#
+    );
+
+    // The rendered result of <<ex-formal>>: the first row renders as the header.
+    let ex_formal_result = parse_table(
+        "[cols=\"2*\",options=\"header\"]\n|===\n|Column 1, header row\n|Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|===",
+    );
+    assert_eq!(
+        header_texts(&ex_formal_result),
+        vec!["Column 1, header row", "Column 2, header row"]
     );
 }
 
@@ -292,7 +329,7 @@ The following conventions determine when the first row automatically becomes the
     let no_header = parse_table("|===\n|Cell 1 |Cell 2\n|Cell 3 |Cell 4\n|===");
     assert!(no_header.header_row().is_none());
 
-    non_normative!(
+    verifies!(
         r#"
 .First row is implicitly assigned header
 [source#ex-implicit]
@@ -300,12 +337,33 @@ The following conventions determine when the first row automatically becomes the
 include::example$row.adoc[tag=impl-h]
 ----
 
+"#
+    );
+
+    // The `ex-implicit` example (`impl-h` from row.adoc) relies on layout alone:
+    // a non-empty first line followed by a blank line promotes the first row.
+    let ex_implicit = parse_table(
+        "|===\n|Column 1, header row |Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|===",
+    );
+    assert!(ex_implicit.header_row().is_some());
+
+    verifies!(
+        r#"
 As seen in the result below, if all of these rules hold true, then the first row of the table is treated as a header row.
 
 .Result of <<ex-implicit>>
 include::example$row.adoc[tag=impl-h]
 
 "#
+    );
+
+    // The rendered result of <<ex-implicit>>: the first row renders as the header.
+    let ex_implicit_result = parse_table(
+        "|===\n|Column 1, header row |Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|===",
+    );
+    assert_eq!(
+        header_texts(&ex_implicit_result),
+        vec!["Column 1, header row", "Column 2, header row"]
     );
 }
 
@@ -344,7 +402,7 @@ In <<ex-noheader>>, `noheader` is assigned using the shorthand syntax.
     let table = parse_table("[%header%noheader]\n|===\n|Cell 1 |Cell 2\n\n|Cell 3 |Cell 4\n|===");
     assert!(table.header_row().is_some());
 
-    non_normative!(
+    verifies!(
         r#"
 .Deactivate implicit header row with noheader
 [source#ex-noheader]
@@ -357,6 +415,19 @@ In <<ex-noheader>>, `noheader` is assigned using the shorthand syntax.
 |===
 ----
 
+"#
+    );
+
+    // The `ex-noheader` example suppresses the implicit header via the `%noheader`
+    // shorthand, so the first row stays in the body rather than being promoted.
+    let ex_noheader = parse_table(
+        "[%noheader]\n|===\n|Cell in column 1, row 1 |Cell in column 2, row 1\n\n|Cell in column 1, row 2 |Cell in column 2, row 2\n|===",
+    );
+    assert!(ex_noheader.header_row().is_none());
+    assert_eq!(ex_noheader.body_rows().len(), 2);
+
+    verifies!(
+        r#"
 The table from <<ex-noheader>> is displayed below.
 
 .Result of <<ex-noheader>>
@@ -367,6 +438,19 @@ The table from <<ex-noheader>> is displayed below.
 |Cell in column 1, row 2 |Cell in column 2, row 2
 |===
 
+"#
+    );
+
+    // The rendered result of <<ex-noheader>>: no header row is present and both
+    // rows remain in the body.
+    let ex_noheader_result = parse_table(
+        "[%noheader]\n|===\n|Cell in column 1, row 1 |Cell in column 2, row 1\n\n|Cell in column 1, row 2 |Cell in column 2, row 2\n|===",
+    );
+    assert!(ex_noheader_result.header_row().is_none());
+    assert_eq!(ex_noheader_result.body_rows().len(), 2);
+
+    non_normative!(
+        r#"
 //CAUTION: We're considering using a similar convention for enabling the footer in the future.
 //Thus, if you rely on this convention to enable the header row, it's advised that you not put all the cells in the last row on the same line unless you intend on making it the footer row.
 "#

--- a/parser/src/tests/asciidoc_lang/tables/add_title.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_title.rs
@@ -1,0 +1,189 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/add-title.adoc");
+
+non_normative!(
+    r#"
+= Add a Title to a Table
+:navtitle: Add a Title
+// TODO/FIX: When soft unset is used from the Antora playbook, and then the attribute is reset in the document, it doesn't use the default value, so "Table" has to be explicitly assigned. Otherwise the label is simply the incremented number (i.e., "1.").
+:table-caption: Table
+
+A table can have an optional title (i.e., table caption).
+To add a title to a table, use the block title syntax.
+
+"#
+);
+
+#[test]
+fn add_a_title_to_a_table() {
+    verifies!(
+        r#"
+.Add an optional title to a table
+[source#ex-title]
+----
+.A table with a title <.>
+[%autowidth]
+|===
+|Column 1, header row |Column 2, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|===
+----
+<.> On the line directly above the table's opening delimiter (or above its optional attribute line, as shown here), enter a dot (`.`) directly followed by the text of the title.
+
+"#
+    );
+
+    let source = ".A table with a title\n[%autowidth]\n|===\n|Column 1, header row |Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|===";
+
+    let doc = Parser::default().parse(source);
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[TableColumn { width: 1 }, TableColumn { width: 1 }],
+                header_row: Some(TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 1, header row",
+                                    line: 4,
+                                    col: 2,
+                                    offset: 41,
+                                },
+                                rendered: "Column 1, header row",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 2, header row",
+                                    line: 4,
+                                    col: 24,
+                                    offset: 63,
+                                },
+                                rendered: "Column 2, header row",
+                            },
+                        },
+                    ],
+                }),
+                body_rows: &[TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Cell in column 1, row 2",
+                                    line: 6,
+                                    col: 2,
+                                    offset: 86,
+                                },
+                                rendered: "Cell in column 1, row 2",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Cell in column 2, row 2",
+                                    line: 7,
+                                    col: 2,
+                                    offset: 111,
+                                },
+                                rendered: "Cell in column 2, row 2",
+                            },
+                        },
+                    ],
+                }],
+                footer_row: None,
+                source: Span {
+                    data: ".A table with a title\n[%autowidth]\n|===\n|Column 1, header row |Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: Some(Span {
+                    data: "A table with a title",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                }),
+                title: Some("A table with a title"),
+                caption: Some("Table 1. "),
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: None,
+                        shorthand_items: &["%autowidth"],
+                        value: "%autowidth",
+                    }],
+                    anchor: None,
+                    source: Span {
+                        data: "%autowidth",
+                        line: 2,
+                        col: 2,
+                        offset: 23,
+                    },
+                }),
+            })],
+            source: Span {
+                data: source,
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+
+    verifies!(
+        r#"
+The table from <<ex-title>> is displayed below.
+
+.A table with a title
+[%autowidth]
+|===
+|Column 1, header row |Column 2, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|===
+
+You'll notice in the above result, that the processor automatically added _Table 1._ in front of the table's title.
+"#
+    );
+
+    // The displayed table renders with the processor's automatic caption
+    // ("Table 1. ") prepended to the block title, both inside the table's
+    // `<caption class="title">`.
+    assert_xpath(
+        &doc,
+        "//caption[text()=\"Table 1. A table with a title\"]",
+        1,
+    );
+
+    non_normative!(
+        r#"
+This title label can be xref:customize-title-label.adoc[customized] or xref:turn-off-title-label.adoc[deactivated].
+"#
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/add_title.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_title.rs
@@ -63,17 +63,19 @@ fn add_a_title_to_a_table() {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     }
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1, header row",
                                     line: 4,
@@ -81,10 +83,10 @@ fn add_a_title_to_a_table() {
                                     offset: 41,
                                 },
                                 rendered: "Column 1, header row",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2, header row",
                                     line: 4,
@@ -92,14 +94,14 @@ fn add_a_title_to_a_table() {
                                     offset: 63,
                                 },
                                 rendered: "Column 2, header row",
-                            },
+                            }),
                         },
                     ],
                 }),
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 1, row 2",
                                     line: 6,
@@ -107,10 +109,10 @@ fn add_a_title_to_a_table() {
                                     offset: 86,
                                 },
                                 rendered: "Cell in column 1, row 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 2, row 2",
                                     line: 7,
@@ -118,7 +120,7 @@ fn add_a_title_to_a_table() {
                                     offset: 111,
                                 },
                                 rendered: "Cell in column 2, row 2",
-                            },
+                            }),
                         },
                     ],
                 }],

--- a/parser/src/tests/asciidoc_lang/tables/add_title.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_title.rs
@@ -58,7 +58,18 @@ fn add_a_title_to_a_table() {
                 },
             },
             blocks: &[Block::Table(TableBlock {
-                columns: &[TableColumn { width: 1 }, TableColumn { width: 1 }],
+                columns: &[
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    }
+                ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {

--- a/parser/src/tests/asciidoc_lang/tables/add_title.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_title.rs
@@ -194,9 +194,22 @@ You'll notice in the above result, that the processor automatically added _Table
         1,
     );
 
-    non_normative!(
+    verifies!(
         r#"
 This title label can be xref:customize-title-label.adoc[customized] or xref:turn-off-title-label.adoc[deactivated].
 "#
+    );
+
+    // The two cross-references render as links to the sibling pages that cover
+    // customizing and deactivating the title label.
+    let see_also = Parser::default().parse(
+        "This title label can be xref:customize-title-label.adoc[customized] or xref:turn-off-title-label.adoc[deactivated].",
+    );
+    let crate::blocks::Block::Simple(para) = &see_also.nested_blocks().next().unwrap() else {
+        panic!("expected a paragraph");
+    };
+    assert_eq!(
+        para.content().rendered(),
+        "This title label can be <a href=\"#customize-title-label.adoc\">customized</a> or <a href=\"#turn-off-title-label.adoc\">deactivated</a>."
     );
 }

--- a/parser/src/tests/asciidoc_lang/tables/adjust_column_widths.rs
+++ b/parser/src/tests/asciidoc_lang/tables/adjust_column_widths.rs
@@ -56,23 +56,26 @@ When using the HTML5 backend with the default Asciidoctor stylesheet, tables str
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: None,
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 2,
@@ -80,10 +83,10 @@ When using the HTML5 backend with the default Asciidoctor stylesheet, tables str
                                     offset: 6,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 2,
@@ -91,10 +94,10 @@ When using the HTML5 backend with the default Asciidoctor stylesheet, tables str
                                     offset: 16,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 2,
@@ -102,7 +105,7 @@ When using the HTML5 backend with the default Asciidoctor stylesheet, tables str
                                     offset: 26,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                     ],
                 },],
@@ -199,22 +202,25 @@ As seen below, the columns stretch across the width of the page according to the
                         width: 2,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 3,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 3,
@@ -222,10 +228,10 @@ As seen below, the columns stretch across the width of the page according to the
                                     offset: 21,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 3,
@@ -233,10 +239,10 @@ As seen below, the columns stretch across the width of the page according to the
                                     offset: 31,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 3,
@@ -244,14 +250,14 @@ As seen below, the columns stretch across the width of the page according to the
                                     offset: 41,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                     ],
                 },),
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 2",
                                     line: 5,
@@ -259,10 +265,10 @@ As seen below, the columns stretch across the width of the page according to the
                                     offset: 52,
                                 },
                                 rendered: "This column has a proportional width of 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 1",
                                     line: 6,
@@ -270,10 +276,10 @@ As seen below, the columns stretch across the width of the page according to the
                                     offset: 95,
                                 },
                                 rendered: "This column has a proportional width of 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 3",
                                     line: 7,
@@ -281,7 +287,7 @@ As seen below, the columns stretch across the width of the page according to the
                                     offset: 138,
                                 },
                                 rendered: "This column has a proportional width of 3",
-                            },
+                            }),
                         },
                     ],
                 },],
@@ -420,22 +426,25 @@ The columns, displayed in the table below, have adjusted across the width of the
                         width: 6,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 3,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 3,
@@ -443,10 +452,10 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 21,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 3,
@@ -454,10 +463,10 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 31,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 3,
@@ -465,14 +474,14 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 41,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                     ],
                 },),
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 6",
                                     line: 5,
@@ -480,10 +489,10 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 52,
                                 },
                                 rendered: "This column has a proportional width of 6",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 1",
                                     line: 6,
@@ -491,10 +500,10 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 95,
                                 },
                                 rendered: "This column has a proportional width of 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 3",
                                     line: 7,
@@ -502,7 +511,7 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 138,
                                 },
                                 rendered: "This column has a proportional width of 3",
-                            },
+                            }),
                         },
                     ],
                 },],
@@ -570,22 +579,25 @@ The columns, displayed in the table below, have adjusted across the width of the
                         width: 6,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 2,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 3,
@@ -593,10 +605,10 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 21,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 3,
@@ -604,10 +616,10 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 31,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 3,
@@ -615,14 +627,14 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 41,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                     ],
                 },),
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 6",
                                     line: 5,
@@ -630,10 +642,10 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 52,
                                 },
                                 rendered: "This column has a proportional width of 6",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 1",
                                     line: 6,
@@ -641,10 +653,10 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 95,
                                 },
                                 rendered: "This column has a proportional width of 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 2",
                                     line: 7,
@@ -652,7 +664,7 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 138,
                                 },
                                 rendered: "This column has a proportional width of 2",
-                            },
+                            }),
                         },
                     ],
                 },],
@@ -765,22 +777,25 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                         width: 15,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 30,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 55,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 3,
@@ -788,10 +803,10 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 27,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 3,
@@ -799,10 +814,10 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 37,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 3,
@@ -810,14 +825,14 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 47,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                     ],
                 },),
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a width of 15%",
                                     line: 5,
@@ -825,10 +840,10 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 58,
                                 },
                                 rendered: "This column has a width of 15%",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a width of 30%",
                                     line: 6,
@@ -836,10 +851,10 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 90,
                                 },
                                 rendered: "This column has a width of 30%",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a width of 55%",
                                     line: 7,
@@ -847,7 +862,7 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 122,
                                 },
                                 rendered: "This column has a width of 55%",
-                            },
+                            }),
                         },
                     ],
                 },],
@@ -915,22 +930,25 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                         width: 15,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 30,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 55,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 3,
@@ -938,10 +956,10 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 24,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 3,
@@ -949,10 +967,10 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 34,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 3,
@@ -960,14 +978,14 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 44,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                     ],
                 },),
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a width of 15%",
                                     line: 5,
@@ -975,10 +993,10 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 55,
                                 },
                                 rendered: "This column has a width of 15%",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a width of 30%",
                                     line: 6,
@@ -986,10 +1004,10 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 87,
                                 },
                                 rendered: "This column has a width of 30%",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a width of 55%",
                                     line: 7,
@@ -997,7 +1015,7 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 119,
                                 },
                                 rendered: "This column has a width of 55%",
-                            },
+                            }),
                         },
                     ],
                 },],

--- a/parser/src/tests/asciidoc_lang/tables/adjust_column_widths.rs
+++ b/parser/src/tests/asciidoc_lang/tables/adjust_column_widths.rs
@@ -52,9 +52,21 @@ When using the HTML5 backend with the default Asciidoctor stylesheet, tables str
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 1 },
-                    TableColumn { width: 1 },
-                    TableColumn { width: 1 },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: None,
                 body_rows: &[TableRow {
@@ -183,9 +195,21 @@ As seen below, the columns stretch across the width of the page according to the
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 2 },
-                    TableColumn { width: 1 },
-                    TableColumn { width: 3 },
+                    TableColumn {
+                        width: 2,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 3,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
@@ -392,9 +416,21 @@ The columns, displayed in the table below, have adjusted across the width of the
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 6 },
-                    TableColumn { width: 1 },
-                    TableColumn { width: 3 },
+                    TableColumn {
+                        width: 6,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 3,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
@@ -530,9 +566,21 @@ The columns, displayed in the table below, have adjusted across the width of the
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 6 },
-                    TableColumn { width: 1 },
-                    TableColumn { width: 2 },
+                    TableColumn {
+                        width: 6,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 2,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
@@ -713,9 +761,21 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 15 },
-                    TableColumn { width: 30 },
-                    TableColumn { width: 55 },
+                    TableColumn {
+                        width: 15,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 30,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 55,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
@@ -851,9 +911,21 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 15 },
-                    TableColumn { width: 30 },
-                    TableColumn { width: 55 },
+                    TableColumn {
+                        width: 15,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 30,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 55,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: Some(TableRow {
                     cells: &[

--- a/parser/src/tests/asciidoc_lang/tables/adjust_column_widths.rs
+++ b/parser/src/tests/asciidoc_lang/tables/adjust_column_widths.rs
@@ -1,0 +1,970 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/adjust-column-widths.adoc");
+
+non_normative!(
+    r#"
+= Adjust Column Widths
+// Check "proportional" usage
+
+"#
+);
+
+#[test]
+fn column_width() {
+    non_normative!(
+        r#"
+== Column width
+
+"#
+    );
+
+    verifies!(
+        r#"
+The width of a column is assigned by its xref:add-columns.adoc#col-specifier[column specifier].
+The value of a column's width is either an integer or a percentage.
+The default column width is `1`.
+The integer or percentage represents the width of the column in proportion to the other columns within the total width of the table.
+The total width of a table is backend dependent.
+When using the HTML5 backend with the default Asciidoctor stylesheet, tables stretch the width of the page body unless the xref:width.adoc[table width attribute] is explicitly set.
+
+"#
+    );
+
+    let doc = Parser::default().parse("|===\n|Column 1 |Column 2 |Column 3\n|===");
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[
+                    TableColumn { width: 1 },
+                    TableColumn { width: 1 },
+                    TableColumn { width: 1 },
+                ],
+                header_row: None,
+                body_rows: &[TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 1",
+                                    line: 2,
+                                    col: 2,
+                                    offset: 6,
+                                },
+                                rendered: "Column 1",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 2",
+                                    line: 2,
+                                    col: 12,
+                                    offset: 16,
+                                },
+                                rendered: "Column 2",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 3",
+                                    line: 2,
+                                    col: 22,
+                                    offset: 26,
+                                },
+                                rendered: "Column 3",
+                            },
+                        },
+                    ],
+                },],
+                footer_row: None,
+                source: Span {
+                    data: "|===\n|Column 1 |Column 2 |Column 3\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                caption: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: None,
+            },),],
+            source: Span {
+                data: "|===\n|Column 1 |Column 2 |Column 3\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+}
+
+#[test]
+fn assign_column_widths_using_integers() {
+    non_normative!(
+        r#"
+== Assign column widths using integers
+
+"#
+    );
+
+    verifies!(
+        r#"
+To assign widths to the columns in a table, set the `cols` attribute and assign it a list of comma-separated column specifiers using integers.
+
+.Assign column widths using integers
+[source#ex-int]
+----
+[cols="2,1,3"]
+|===
+|Column 1 |Column 2 |Column 3
+
+|This column has a proportional width of 2
+|This column has a proportional width of 1
+|This column has a proportional width of 3
+|===
+----
+
+As seen below, the columns stretch across the width of the page according to their proportional widths.
+
+.Result of <<ex-int>>
+[cols="2,1,3"]
+|===
+|Column 1 |Column 2 |Column 3
+
+|This column has a proportional width of 2
+|This column has a proportional width of 1
+|This column has a proportional width of 3
+|===
+
+"#
+    );
+
+    let doc = Parser::default().parse("[cols=\"2,1,3\"]\n|===\n|Column 1 |Column 2 |Column 3\n\n|This column has a proportional width of 2\n|This column has a proportional width of 1\n|This column has a proportional width of 3\n|===");
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[
+                    TableColumn { width: 2 },
+                    TableColumn { width: 1 },
+                    TableColumn { width: 3 },
+                ],
+                header_row: Some(TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 1",
+                                    line: 3,
+                                    col: 2,
+                                    offset: 21,
+                                },
+                                rendered: "Column 1",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 2",
+                                    line: 3,
+                                    col: 12,
+                                    offset: 31,
+                                },
+                                rendered: "Column 2",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 3",
+                                    line: 3,
+                                    col: 22,
+                                    offset: 41,
+                                },
+                                rendered: "Column 3",
+                            },
+                        },
+                    ],
+                },),
+                body_rows: &[TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "This column has a proportional width of 2",
+                                    line: 5,
+                                    col: 2,
+                                    offset: 52,
+                                },
+                                rendered: "This column has a proportional width of 2",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "This column has a proportional width of 1",
+                                    line: 6,
+                                    col: 2,
+                                    offset: 95,
+                                },
+                                rendered: "This column has a proportional width of 1",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "This column has a proportional width of 3",
+                                    line: 7,
+                                    col: 2,
+                                    offset: 138,
+                                },
+                                rendered: "This column has a proportional width of 3",
+                            },
+                        },
+                    ],
+                },],
+                footer_row: None,
+                source: Span {
+                    data: "[cols=\"2,1,3\"]\n|===\n|Column 1 |Column 2 |Column 3\n\n|This column has a proportional width of 2\n|This column has a proportional width of 1\n|This column has a proportional width of 3\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                caption: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: Some("cols",),
+                        value: "2,1,3",
+                        shorthand_items: &[],
+                    },],
+                    anchor: None,
+                    source: Span {
+                        data: "cols=\"2,1,3\"",
+                        line: 1,
+                        col: 2,
+                        offset: 1,
+                    },
+                },),
+            },),],
+            source: Span {
+                data: "[cols=\"2,1,3\"]\n|===\n|Column 1 |Column 2 |Column 3\n\n|This column has a proportional width of 2\n|This column has a proportional width of 1\n|This column has a proportional width of 3\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+}
+
+#[test]
+fn increase_or_decrease_the_width_of_a_column() {
+    non_normative!(
+        r#"
+=== Increase or decrease the width of a column
+
+"#
+    );
+
+    verifies!(
+        r#"
+To increase the width of a column, use a bigger integer in the column's specifier.
+Let's make column 1 from <<ex-int>> the largest column in the table by increasing its width from `2` to `6` in <<ex-increase>>.
+
+.Increase the width of a column
+[source#ex-increase]
+----
+[cols="6,1,3"]
+|===
+|Column 1 |Column 2 |Column 3
+
+|This column has a proportional width of 6
+|This column has a proportional width of 1
+|This column has a proportional width of 3
+|===
+----
+
+Below, the result of <<ex-increase>> shows that column 1 is now much wider than column 3.
+
+.Result of <<ex-increase>>
+[cols="6,1,3"]
+|===
+|Column 1 |Column 2 |Column 3
+
+|This column has a proportional width of 6
+|This column has a proportional width of 1
+|This column has a proportional width of 3
+|===
+
+To decrease the width of a column, use a smaller integer in its specifier.
+In <<ex-decrease>>, let's make the width of column 3 smaller, but not quite as small as column 2, by decreasing its width from `3` to `2`.
+
+.Decrease the width of a column
+[source#ex-decrease]
+----
+[cols="6,1,2"]
+|===
+|Column 1 |Column 2 |Column 3
+
+|This column has a proportional width of 6
+|This column has a proportional width of 1
+|This column has a proportional width of 2
+|===
+----
+
+The columns, displayed in the table below, have adjusted across the width of the page according to their proportional widths.
+
+.Result of <<ex-decrease>>
+[cols="6,1,2"]
+|===
+|Column 1 |Column 2 |Column 3
+
+|This column has a proportional width of 6
+|This column has a proportional width of 1
+|This column has a proportional width of 2
+|===
+
+"#
+    );
+
+    let doc = Parser::default().parse("[cols=\"6,1,3\"]\n|===\n|Column 1 |Column 2 |Column 3\n\n|This column has a proportional width of 6\n|This column has a proportional width of 1\n|This column has a proportional width of 3\n|===");
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[
+                    TableColumn { width: 6 },
+                    TableColumn { width: 1 },
+                    TableColumn { width: 3 },
+                ],
+                header_row: Some(TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 1",
+                                    line: 3,
+                                    col: 2,
+                                    offset: 21,
+                                },
+                                rendered: "Column 1",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 2",
+                                    line: 3,
+                                    col: 12,
+                                    offset: 31,
+                                },
+                                rendered: "Column 2",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 3",
+                                    line: 3,
+                                    col: 22,
+                                    offset: 41,
+                                },
+                                rendered: "Column 3",
+                            },
+                        },
+                    ],
+                },),
+                body_rows: &[TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "This column has a proportional width of 6",
+                                    line: 5,
+                                    col: 2,
+                                    offset: 52,
+                                },
+                                rendered: "This column has a proportional width of 6",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "This column has a proportional width of 1",
+                                    line: 6,
+                                    col: 2,
+                                    offset: 95,
+                                },
+                                rendered: "This column has a proportional width of 1",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "This column has a proportional width of 3",
+                                    line: 7,
+                                    col: 2,
+                                    offset: 138,
+                                },
+                                rendered: "This column has a proportional width of 3",
+                            },
+                        },
+                    ],
+                },],
+                footer_row: None,
+                source: Span {
+                    data: "[cols=\"6,1,3\"]\n|===\n|Column 1 |Column 2 |Column 3\n\n|This column has a proportional width of 6\n|This column has a proportional width of 1\n|This column has a proportional width of 3\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                caption: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: Some("cols",),
+                        value: "6,1,3",
+                        shorthand_items: &[],
+                    },],
+                    anchor: None,
+                    source: Span {
+                        data: "cols=\"6,1,3\"",
+                        line: 1,
+                        col: 2,
+                        offset: 1,
+                    },
+                },),
+            },),],
+            source: Span {
+                data: "[cols=\"6,1,3\"]\n|===\n|Column 1 |Column 2 |Column 3\n\n|This column has a proportional width of 6\n|This column has a proportional width of 1\n|This column has a proportional width of 3\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+
+    let doc = Parser::default().parse("[cols=\"6,1,2\"]\n|===\n|Column 1 |Column 2 |Column 3\n\n|This column has a proportional width of 6\n|This column has a proportional width of 1\n|This column has a proportional width of 2\n|===");
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[
+                    TableColumn { width: 6 },
+                    TableColumn { width: 1 },
+                    TableColumn { width: 2 },
+                ],
+                header_row: Some(TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 1",
+                                    line: 3,
+                                    col: 2,
+                                    offset: 21,
+                                },
+                                rendered: "Column 1",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 2",
+                                    line: 3,
+                                    col: 12,
+                                    offset: 31,
+                                },
+                                rendered: "Column 2",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 3",
+                                    line: 3,
+                                    col: 22,
+                                    offset: 41,
+                                },
+                                rendered: "Column 3",
+                            },
+                        },
+                    ],
+                },),
+                body_rows: &[TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "This column has a proportional width of 6",
+                                    line: 5,
+                                    col: 2,
+                                    offset: 52,
+                                },
+                                rendered: "This column has a proportional width of 6",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "This column has a proportional width of 1",
+                                    line: 6,
+                                    col: 2,
+                                    offset: 95,
+                                },
+                                rendered: "This column has a proportional width of 1",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "This column has a proportional width of 2",
+                                    line: 7,
+                                    col: 2,
+                                    offset: 138,
+                                },
+                                rendered: "This column has a proportional width of 2",
+                            },
+                        },
+                    ],
+                },],
+                footer_row: None,
+                source: Span {
+                    data: "[cols=\"6,1,2\"]\n|===\n|Column 1 |Column 2 |Column 3\n\n|This column has a proportional width of 6\n|This column has a proportional width of 1\n|This column has a proportional width of 2\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                caption: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: Some("cols",),
+                        value: "6,1,2",
+                        shorthand_items: &[],
+                    },],
+                    anchor: None,
+                    source: Span {
+                        data: "cols=\"6,1,2\"",
+                        line: 1,
+                        col: 2,
+                        offset: 1,
+                    },
+                },),
+            },),],
+            source: Span {
+                data: "[cols=\"6,1,2\"]\n|===\n|Column 1 |Column 2 |Column 3\n\n|This column has a proportional width of 6\n|This column has a proportional width of 1\n|This column has a proportional width of 2\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+}
+
+#[test]
+fn change_column_widths_using_percentage_values() {
+    non_normative!(
+        r#"
+== Change column widths using percentage values
+
+"#
+    );
+
+    verifies!(
+        r#"
+Column widths can be assigned using a percentage between `1%` and `100%`.
+Like with integer values, set `cols` and assign it a list of comma-separated column specifiers using percentages.
+
+.Assign column widths using percentages
+[source#ex-percent]
+----
+[cols="15%,30%,55%"]
+|===
+|Column 1 |Column 2 |Column 3
+
+|This column has a width of 15%
+|This column has a width of 30%
+|This column has a width of 55%
+|===
+----
+
+As seen in the table below, the columns stretch across the width of the page according to the percentage assigned via their column specifiers.
+
+.Result of <<ex-percent>>
+[cols="15%,30%,55%"]
+|===
+|Column 1 |Column 2 |Column 3
+
+|This column has a width of 15%
+|This column has a width of 30%
+|This column has a width of 55%
+|===
+
+When assigning percentages to `cols`, you don't have to include the percent sign (`%`).
+For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
+"#
+    );
+
+    let doc = Parser::default().parse("[cols=\"15%,30%,55%\"]\n|===\n|Column 1 |Column 2 |Column 3\n\n|This column has a width of 15%\n|This column has a width of 30%\n|This column has a width of 55%\n|===");
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[
+                    TableColumn { width: 15 },
+                    TableColumn { width: 30 },
+                    TableColumn { width: 55 },
+                ],
+                header_row: Some(TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 1",
+                                    line: 3,
+                                    col: 2,
+                                    offset: 27,
+                                },
+                                rendered: "Column 1",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 2",
+                                    line: 3,
+                                    col: 12,
+                                    offset: 37,
+                                },
+                                rendered: "Column 2",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 3",
+                                    line: 3,
+                                    col: 22,
+                                    offset: 47,
+                                },
+                                rendered: "Column 3",
+                            },
+                        },
+                    ],
+                },),
+                body_rows: &[TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "This column has a width of 15%",
+                                    line: 5,
+                                    col: 2,
+                                    offset: 58,
+                                },
+                                rendered: "This column has a width of 15%",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "This column has a width of 30%",
+                                    line: 6,
+                                    col: 2,
+                                    offset: 90,
+                                },
+                                rendered: "This column has a width of 30%",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "This column has a width of 55%",
+                                    line: 7,
+                                    col: 2,
+                                    offset: 122,
+                                },
+                                rendered: "This column has a width of 55%",
+                            },
+                        },
+                    ],
+                },],
+                footer_row: None,
+                source: Span {
+                    data: "[cols=\"15%,30%,55%\"]\n|===\n|Column 1 |Column 2 |Column 3\n\n|This column has a width of 15%\n|This column has a width of 30%\n|This column has a width of 55%\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                caption: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: Some("cols",),
+                        value: "15%,30%,55%",
+                        shorthand_items: &[],
+                    },],
+                    anchor: None,
+                    source: Span {
+                        data: "cols=\"15%,30%,55%\"",
+                        line: 1,
+                        col: 2,
+                        offset: 1,
+                    },
+                },),
+            },),],
+            source: Span {
+                data: "[cols=\"15%,30%,55%\"]\n|===\n|Column 1 |Column 2 |Column 3\n\n|This column has a width of 15%\n|This column has a width of 30%\n|This column has a width of 55%\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+
+    let doc = Parser::default().parse("[cols=\"15,30,55\"]\n|===\n|Column 1 |Column 2 |Column 3\n\n|This column has a width of 15%\n|This column has a width of 30%\n|This column has a width of 55%\n|===");
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[
+                    TableColumn { width: 15 },
+                    TableColumn { width: 30 },
+                    TableColumn { width: 55 },
+                ],
+                header_row: Some(TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 1",
+                                    line: 3,
+                                    col: 2,
+                                    offset: 24,
+                                },
+                                rendered: "Column 1",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 2",
+                                    line: 3,
+                                    col: 12,
+                                    offset: 34,
+                                },
+                                rendered: "Column 2",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 3",
+                                    line: 3,
+                                    col: 22,
+                                    offset: 44,
+                                },
+                                rendered: "Column 3",
+                            },
+                        },
+                    ],
+                },),
+                body_rows: &[TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "This column has a width of 15%",
+                                    line: 5,
+                                    col: 2,
+                                    offset: 55,
+                                },
+                                rendered: "This column has a width of 15%",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "This column has a width of 30%",
+                                    line: 6,
+                                    col: 2,
+                                    offset: 87,
+                                },
+                                rendered: "This column has a width of 30%",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "This column has a width of 55%",
+                                    line: 7,
+                                    col: 2,
+                                    offset: 119,
+                                },
+                                rendered: "This column has a width of 55%",
+                            },
+                        },
+                    ],
+                },],
+                footer_row: None,
+                source: Span {
+                    data: "[cols=\"15,30,55\"]\n|===\n|Column 1 |Column 2 |Column 3\n\n|This column has a width of 15%\n|This column has a width of 30%\n|This column has a width of 55%\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                caption: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: Some("cols",),
+                        value: "15,30,55",
+                        shorthand_items: &[],
+                    },],
+                    anchor: None,
+                    source: Span {
+                        data: "cols=\"15,30,55\"",
+                        line: 1,
+                        col: 2,
+                        offset: 1,
+                    },
+                },),
+            },),],
+            source: Span {
+                data: "[cols=\"15,30,55\"]\n|===\n|Column 1 |Column 2 |Column 3\n\n|This column has a width of 15%\n|This column has a width of 30%\n|This column has a width of 55%\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/align_by_cell.rs
+++ b/parser/src/tests/asciidoc_lang/tables/align_by_cell.rs
@@ -1,0 +1,423 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/align-by-cell.adoc");
+
+non_normative!(
+    r#"
+= Align Content by Cell
+
+The alignment operators are applied to a xref:add-cells-and-rows.adoc#specifiers[cell's specifier] and allow you to horizontally and vertically align a cell's content.
+
+"#
+);
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Collect the `(horizontal, vertical)` alignment of each cell in each body
+/// row of `table`.
+fn body_alignments(
+    table: &crate::blocks::TableBlock<'_>,
+) -> Vec<Vec<(HorizontalAlignment, VerticalAlignment)>> {
+    table
+        .body_rows()
+        .iter()
+        .map(|row| {
+            row.cells()
+                .iter()
+                .map(|cell| (cell.h_align(), cell.v_align()))
+                .collect()
+        })
+        .collect()
+}
+
+#[test]
+fn horizontal_alignment_operators() {
+    non_normative!(
+        r#"
+[#horizontal-operators]
+== Horizontal alignment operators
+
+"#
+    );
+
+    verifies!(
+        r#"
+Content can be horizontally aligned to the left or right side of the cell as well as the center of the cell.
+
+Flush left operator (<):: The less-than sign (`<`) aligns the content to the left side of the cell.
+This is the default horizontal alignment.
+Flush right operator (>):: The greater-than sign (`>`) aligns the content to the right side of the cell.
+Center operator (^):: The caret (`+^+`) centers the content horizontally in the cell.
+
+A horizontal alignment operator is entered after a span or duplication operator (if present) and in front a <<vertical-operators,vertical alignment operator>> (if present).
+
+====
+<factor><span or duplication operator><**horizontal alignment operator**><vertical alignment operator><style operator>|<cell's content>
+====
+
+"#
+    );
+
+    // The three horizontal alignment operators on cell specifiers: `<` (left,
+    // the default), `>` (right), and `^` (center). Entered directly in front of
+    // the cell separator (`|`).
+    let table = parse_table("|===\n<|a >|b ^|c\n|===");
+    assert_eq!(
+        body_alignments(&table),
+        vec![vec![
+            (HorizontalAlignment::Left, VerticalAlignment::Top),
+            (HorizontalAlignment::Right, VerticalAlignment::Top),
+            (HorizontalAlignment::Center, VerticalAlignment::Top),
+        ]]
+    );
+}
+
+#[test]
+fn center_content_horizontally_in_a_cell() {
+    non_normative!(
+        r#"
+=== Center content horizontally in a cell
+
+"#
+    );
+
+    verifies!(
+        r#"
+To horizontally center the content in a cell, place the `+^+` operator in front of the xref:add-cells-and-rows.adoc#cell-separator[cell's separator] (`|`).
+Don't insert any spaces between the `|` and the operator.
+
+.Center the content of a cell horizontally
+[source#ex-hcenter]
+----
+include::example$align-cell.adoc[tag=hcenter]
+----
+
+The table from <<ex-hcenter>> is rendered below.
+
+.Result of <<ex-hcenter>>
+include::example$align-cell.adoc[tag=hcenter]
+
+"#
+    );
+
+    // Expansion of `example$align-cell.adoc[tag=hcenter]`. The first cell is
+    // centered (`^|`); the second falls back to the default (left).
+    let table = parse_table(
+        "|===\n|Column Name |Column Name\n\n^|This content is horizontally centered because the cell specifier includes the `+^+` operator.\n|There isn't a horizontal alignment operator on this cell specifier, so the cell falls back to the default horizontal alignment.\nContent is aligned to the left side of the cell by default.\n|===",
+    );
+    assert_eq!(
+        body_alignments(&table),
+        vec![vec![
+            (HorizontalAlignment::Center, VerticalAlignment::Top),
+            (HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]]
+    );
+
+    verifies!(
+        r#"
+If the cell specifier includes a span (`<n>+`) or duplication (`+<n>*+`), place the `+^+` directly after the span or duplication operator.
+
+.Center content horizontally in spanned columns and duplicated cells
+[source#ex-factor]
+----
+include::example$align-cell.adoc[tag=factor]
+----
+
+The table from <<ex-factor>> is rendered below.
+
+.Result of <<ex-factor>>
+include::example$align-cell.adoc[tag=factor]
+
+"#
+    );
+
+    // Expansion of `example$align-cell.adoc[tag=factor]`. The `+^+` operator is
+    // placed directly after the span (`2+`) and duplication (`2*`) operators;
+    // both cells are centered. (The span/duplication operators are recognized
+    // but their layout effect is not yet applied.)
+    let table = parse_table(
+        "|===\n|Column Name |Column Name\n\n2+^|This cell spans two columns, and its content is horizontally centered because the cell specifier includes the `+^+` operator.\n2*^|This content is duplicated in two adjacent columns.\nIts content is horizontally centered because the cell specifier\nincludes the `+^+` operator.\n|===",
+    );
+    assert_eq!(
+        body_alignments(&table),
+        vec![vec![
+            (HorizontalAlignment::Center, VerticalAlignment::Top),
+            (HorizontalAlignment::Center, VerticalAlignment::Top),
+        ]]
+    );
+}
+
+#[test]
+fn align_the_content_of_a_cell_to_the_right() {
+    non_normative!(
+        r#"
+== Align the content of a cell to the right
+
+"#
+    );
+
+    verifies!(
+        r#"
+To align the content in a cell to its right side, place the `>` operator in front of the xref:add-cells-and-rows.adoc#cell-separator[cell's separator] (`|`), but after a span (`<n>+`) or duplication (`+<n>*+`) operator (if present).
+Don't insert any spaces between the `|` and the operators.
+
+.Right align the content of a cell
+[source#ex-right]
+----
+include::example$align-cell.adoc[tag=right]
+----
+
+The table from <<ex-right>> is rendered below.
+
+.Result of <<ex-right>>
+include::example$align-cell.adoc[tag=right]
+
+"#
+    );
+
+    // Expansion of `example$align-cell.adoc[tag=right]`. The `>` operator
+    // right-aligns the first cell and the spanned cell (`2+>`); the cell with no
+    // operator falls back to the default (left).
+    let table = parse_table(
+        "|===\n|Column Name |Column Name\n\n>|This content is aligned to the right side of the cell because the cell specifier includes the `>` operator.\n|There isn't a horizontal alignment operator on this cell specifier, so the cell falls back to the default horizontal alignment.\nContent is aligned to the left side of the cell by default.\n\n2+>|This cell spans two columns.\n\nIts content is aligned to the right because the cell specifier includes the `>` operator.\nThe `>` operator must be placed directly after the span operator (`+`).\n|===",
+    );
+    assert_eq!(
+        body_alignments(&table),
+        vec![
+            vec![
+                (HorizontalAlignment::Right, VerticalAlignment::Top),
+                (HorizontalAlignment::Left, VerticalAlignment::Top),
+            ],
+            vec![(HorizontalAlignment::Right, VerticalAlignment::Top)],
+        ]
+    );
+}
+
+#[test]
+fn vertical_alignment_operators() {
+    non_normative!(
+        r#"
+[#vertical-operators]
+== Vertical alignment operators
+
+"#
+    );
+
+    verifies!(
+        r#"
+Content can be vertically aligned to the top or bottom of a cell as well as the center of a cell.
+Vertical alignment operators always begin with a dot (`.`).
+
+Flush top operator (.<):: The dot and less-than sign (`.<`) aligns the content to the top of the cell.
+This is the default vertical alignment.
+Flush bottom operator (.>):: The dot and greater-than sign (`.>`) aligns the content to the bottom of the cell.
+Center operator (.^):: The dot and caret (`+.^+`) centers the content vertically.
+
+A vertical alignment operator is entered after a <<horizontal-operators,horizontal alignment operator>> (if present) and in front of a style operator (if present).
+
+====
+<factor><span or duplication operator><horizontal alignment operator><**vertical alignment operator**><style operator>|<cell's content>
+====
+
+"#
+    );
+
+    // The three vertical alignment operators on cell specifiers: `.<` (top, the
+    // default), `.>` (bottom), and `.^` (center).
+    let table = parse_table("|===\n.<|a .>|b .^|c\n|===");
+    assert_eq!(
+        body_alignments(&table),
+        vec![vec![
+            (HorizontalAlignment::Left, VerticalAlignment::Top),
+            (HorizontalAlignment::Left, VerticalAlignment::Bottom),
+            (HorizontalAlignment::Left, VerticalAlignment::Middle),
+        ]]
+    );
+}
+
+#[test]
+fn align_content_to_the_bottom_of_a_cell() {
+    non_normative!(
+        r#"
+=== Align content to the bottom of a cell
+
+"#
+    );
+
+    verifies!(
+        r#"
+To align the content to the bottom of a cell, place the `+.>+` operator in front of the xref:add-cells-and-rows.adoc#cell-separator[cell's separator] (`|`).
+Don't insert any spaces between the `|` and the operator.
+
+.Align content to the bottom of a cell
+[source#ex-bottom]
+----
+include::example$align-cell.adoc[tag=bottom]
+----
+
+The table from <<ex-bottom>> is rendered below.
+
+.Result of <<ex-bottom>>
+include::example$align-cell.adoc[tag=bottom]
+
+"#
+    );
+
+    // Expansion of `example$align-cell.adoc[tag=bottom]`. The first cell is
+    // bottom-aligned (`.>|`); the second has no vertical alignment operator and
+    // falls back to the column's alignment (the `cols="2,1"` columns are
+    // top-aligned by default).
+    let table = parse_table(
+        "[cols=\"2,1\"]\n|===\n|Column Name |Column Name\n\n.>|This content is aligned to the bottom of the cell because the cell specifier includes the `.>` operator.\n|There isn't a vertical alignment operator on this cell specifier, so the cell falls back to the alignment assigned via the column specifier or the default vertical alignment.\nContent is aligned to the top of the cell by default.\n|===",
+    );
+    assert_eq!(
+        body_alignments(&table),
+        vec![vec![
+            (HorizontalAlignment::Left, VerticalAlignment::Bottom),
+            (HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]]
+    );
+
+    verifies!(
+        r#"
+If the cell specifier includes a span (`<n>+`) or duplication (`+<n>*+`), place the `.>` after the span or duplication operator.
+
+.Align content to the bottom of a cell that spans rows
+[source#ex-span-vertical]
+----
+include::example$align-cell.adoc[tag=vspan]
+----
+
+The table from <<ex-span-vertical>> is rendered below.
+
+.Result of <<ex-span-vertical>>
+include::example$align-cell.adoc[tag=vspan]
+
+"#
+    );
+
+    // Expansion of `example$align-cell.adoc[tag=vspan]`. The `.>` is placed
+    // after the row-span operator (`.2+`); that cell is bottom-aligned, while
+    // the cells with no vertical alignment operator stay top-aligned. (The
+    // row-span operator is recognized but its layout effect is not yet applied.)
+    let table = parse_table(
+        "|===\n|Column Name |Column Name\n\n|There isn't a vertical alignment operator on this cell specifier, so the content is aligned to the top of the cell by default.\n\n.2+.>|This cell spans two rows, and its content is aligned to the bottom because the cell specifier includes the `.>` operator.\n\n|This content is aligned to the top of the cell by default.\n|===",
+    );
+    assert_eq!(
+        body_alignments(&table),
+        vec![
+            vec![
+                (HorizontalAlignment::Left, VerticalAlignment::Top),
+                (HorizontalAlignment::Left, VerticalAlignment::Bottom),
+            ],
+            vec![(HorizontalAlignment::Left, VerticalAlignment::Top)],
+        ]
+    );
+}
+
+#[test]
+fn center_content_vertically_in_a_cell() {
+    non_normative!(
+        r#"
+=== Center content vertically in a cell
+
+"#
+    );
+
+    verifies!(
+        r#"
+To vertically center the content in a cell, place the `+.^+` operator in front of the xref:add-cells-and-rows.adoc#cell-separator[cell's separator] (`|`).
+Don't insert any spaces between the `|` and the operator.
+
+.Center the content of a cell vertically
+[source#ex-vcenter]
+----
+include::example$align-cell.adoc[tag=vcenter]
+----
+
+The table from <<ex-vcenter>> is rendered below.
+
+.Result of <<ex-vcenter>>
+include::example$align-cell.adoc[tag=vcenter]
+
+"#
+    );
+
+    // Expansion of `example$align-cell.adoc[tag=vcenter]`. The first cell is
+    // vertically centered (`.^|`); the second falls back to the default (top).
+    let table = parse_table(
+        "|===\n|Column Name |Column Name\n\n.^|This content is vertically centered because the cell specifier includes the `+.^+` operator.\n|There isn't a vertical alignment operator on this cell specifier, so the cell falls back to the default vertical alignment.\nContent is aligned to the top of the cell by default.\n|===",
+    );
+    assert_eq!(
+        body_alignments(&table),
+        vec![vec![
+            (HorizontalAlignment::Left, VerticalAlignment::Middle),
+            (HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]]
+    );
+}
+
+#[test]
+fn apply_horizontal_and_vertical_alignment_operators_to_the_same_cell() {
+    non_normative!(
+        r#"
+== Apply horizontal and vertical alignment operators to the same cell
+
+"#
+    );
+
+    verifies!(
+        r#"
+A cell can have a vertical and horizontal alignment operator included in its cell specifier.
+The <<horizontal-operators,horizontal operator>> always precedes the <<vertical-operators,vertical operator>>.
+
+.Align cells horizontally and vertically
+[source#ex-combine]
+----
+include::example$align-cell.adoc[tag=combine]
+----
+
+The table from <<ex-combine>> is rendered below.
+
+.Result <<ex-combine>>
+include::example$align-cell.adoc[tag=combine]
+"#
+    );
+
+    // Expansion of `example$align-cell.adoc[tag=combine]`. Each specifier
+    // applies both a horizontal and a vertical operator (the horizontal always
+    // first): `^.>` (center, bottom), `>.^` (right, middle), `2.3+^.^` (center,
+    // middle, after a span), and `3*.>` (bottom, after a duplication; the
+    // horizontal alignment falls back to the column default). The cell with no
+    // operators falls back to the default alignments (left, top).
+    let table = parse_table(
+        "|===\n|Column 1 |Column 2 |Column 3\n\n^.>|The specifier for this cell is `^.>`.\nThe content is centered horizontally and aligned to the bottom of the cell.\n|There aren't any alignment operators on this cell's specifier, so the cell falls back to the default alignments.\nThe default horizontal alignment is the left side of the cell.\nThe default vertical alignment is the top of the cell.\n>.^|The specifier for this cell is `>.^`.\nThe content is aligned to the right side of the cell and centered vertically.\n\n2.3+^.^|The specifier for this cell is `pass:[2.3+^.^]`.\nIt spans two columns and three rows.\n\nIts content is centered horizontally and vertically.\n3*.>|The specifier for this cell is `3*.>`.\nThe cell is duplicated in three consecutive rows in the same column.\nIt's content is aligned to the bottom of the cell.\n|===",
+    );
+    assert_eq!(
+        body_alignments(&table),
+        vec![
+            vec![
+                (HorizontalAlignment::Center, VerticalAlignment::Bottom),
+                (HorizontalAlignment::Left, VerticalAlignment::Top),
+                (HorizontalAlignment::Right, VerticalAlignment::Middle),
+            ],
+            vec![
+                (HorizontalAlignment::Center, VerticalAlignment::Middle),
+                (HorizontalAlignment::Left, VerticalAlignment::Bottom),
+            ],
+        ]
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/align_by_cell.rs
+++ b/parser/src/tests/asciidoc_lang/tables/align_by_cell.rs
@@ -147,8 +147,8 @@ include::example$align-cell.adoc[tag=factor]
     // Expansion of `example$align-cell.adoc[tag=factor]`. The `+^+` operator is
     // placed directly after the span (`2+`) and duplication (`2*`) operators;
     // both cells are centered. The `2+` span fills the two-column row on its own,
-    // so it lands in its own row; the duplication operator's layout effect is not
-    // yet applied, so the `2*^` cell becomes a single cell in the next row.
+    // so it lands in its own row; the `2*^` duplication clones its centered
+    // content into the two cells of the next row.
     let table = parse_table(
         "|===\n|Column Name |Column Name\n\n2+^|This cell spans two columns, and its content is horizontally centered because the cell specifier includes the `+^+` operator.\n2*^|This content is duplicated in two adjacent columns.\nIts content is horizontally centered because the cell specifier\nincludes the `+^+` operator.\n|===",
     );
@@ -156,7 +156,10 @@ include::example$align-cell.adoc[tag=factor]
         body_alignments(&table),
         vec![
             vec![(HorizontalAlignment::Center, VerticalAlignment::Top)],
-            vec![(HorizontalAlignment::Center, VerticalAlignment::Top)],
+            vec![
+                (HorizontalAlignment::Center, VerticalAlignment::Top),
+                (HorizontalAlignment::Center, VerticalAlignment::Top),
+            ],
         ]
     );
 }
@@ -404,7 +407,10 @@ include::example$align-cell.adoc[tag=combine]
     // first): `^.>` (center, bottom), `>.^` (right, middle), `2.3+^.^` (center,
     // middle, after a span), and `3*.>` (bottom, after a duplication; the
     // horizontal alignment falls back to the column default). The cell with no
-    // operators falls back to the default alignments (left, top).
+    // operators falls back to the default alignments (left, top). The `3*.>`
+    // duplication clones its bottom-aligned content into three cells: the first
+    // fills the row alongside the `2.3+` block span, and the next two each land
+    // in a row of their own (alongside the columns the block span carries down).
     let table = parse_table(
         "|===\n|Column 1 |Column 2 |Column 3\n\n^.>|The specifier for this cell is `^.>`.\nThe content is centered horizontally and aligned to the bottom of the cell.\n|There aren't any alignment operators on this cell's specifier, so the cell falls back to the default alignments.\nThe default horizontal alignment is the left side of the cell.\nThe default vertical alignment is the top of the cell.\n>.^|The specifier for this cell is `>.^`.\nThe content is aligned to the right side of the cell and centered vertically.\n\n2.3+^.^|The specifier for this cell is `pass:[2.3+^.^]`.\nIt spans two columns and three rows.\n\nIts content is centered horizontally and vertically.\n3*.>|The specifier for this cell is `3*.>`.\nThe cell is duplicated in three consecutive rows in the same column.\nIt's content is aligned to the bottom of the cell.\n|===",
     );
@@ -420,6 +426,8 @@ include::example$align-cell.adoc[tag=combine]
                 (HorizontalAlignment::Center, VerticalAlignment::Middle),
                 (HorizontalAlignment::Left, VerticalAlignment::Bottom),
             ],
+            vec![(HorizontalAlignment::Left, VerticalAlignment::Bottom)],
+            vec![(HorizontalAlignment::Left, VerticalAlignment::Bottom)],
         ]
     );
 }

--- a/parser/src/tests/asciidoc_lang/tables/align_by_cell.rs
+++ b/parser/src/tests/asciidoc_lang/tables/align_by_cell.rs
@@ -146,17 +146,18 @@ include::example$align-cell.adoc[tag=factor]
 
     // Expansion of `example$align-cell.adoc[tag=factor]`. The `+^+` operator is
     // placed directly after the span (`2+`) and duplication (`2*`) operators;
-    // both cells are centered. (The span/duplication operators are recognized
-    // but their layout effect is not yet applied.)
+    // both cells are centered. The `2+` span fills the two-column row on its own,
+    // so it lands in its own row; the duplication operator's layout effect is not
+    // yet applied, so the `2*^` cell becomes a single cell in the next row.
     let table = parse_table(
         "|===\n|Column Name |Column Name\n\n2+^|This cell spans two columns, and its content is horizontally centered because the cell specifier includes the `+^+` operator.\n2*^|This content is duplicated in two adjacent columns.\nIts content is horizontally centered because the cell specifier\nincludes the `+^+` operator.\n|===",
     );
     assert_eq!(
         body_alignments(&table),
-        vec![vec![
-            (HorizontalAlignment::Center, VerticalAlignment::Top),
-            (HorizontalAlignment::Center, VerticalAlignment::Top),
-        ]]
+        vec![
+            vec![(HorizontalAlignment::Center, VerticalAlignment::Top)],
+            vec![(HorizontalAlignment::Center, VerticalAlignment::Top)],
+        ]
     );
 }
 
@@ -311,8 +312,9 @@ include::example$align-cell.adoc[tag=vspan]
 
     // Expansion of `example$align-cell.adoc[tag=vspan]`. The `.>` is placed
     // after the row-span operator (`.2+`); that cell is bottom-aligned, while
-    // the cells with no vertical alignment operator stay top-aligned. (The
-    // row-span operator is recognized but its layout effect is not yet applied.)
+    // the cells with no vertical alignment operator stay top-aligned. The `.2+`
+    // cell spans two rows, so it carries its column down into the next row, which
+    // then needs only the one remaining cell.
     let table = parse_table(
         "|===\n|Column Name |Column Name\n\n|There isn't a vertical alignment operator on this cell specifier, so the content is aligned to the top of the cell by default.\n\n.2+.>|This cell spans two rows, and its content is aligned to the bottom because the cell specifier includes the `.>` operator.\n\n|This content is aligned to the top of the cell by default.\n|===",
     );

--- a/parser/src/tests/asciidoc_lang/tables/align_by_column.rs
+++ b/parser/src/tests/asciidoc_lang/tables/align_by_column.rs
@@ -635,12 +635,21 @@ centered vertically.
         ]
     );
 
-    // Cell specifiers (and thus their per-cell alignment operators) are not yet
-    // parsed, so the override of a column's alignment by a cell's alignment can't
-    // be verified yet.
-    to_do_verifies!(
+    verifies!(
         r#"
 IMPORTANT: If there is an xref:align-by-cell.adoc[alignment operator on a cell's specifier], it will override the column's alignment operator.
 "#
     );
+
+    // The column is centered horizontally and aligned to the bottom (`^.>`), but
+    // the cell's own specifier (`>.^`) overrides both: the cell is right-aligned
+    // and centered vertically.
+    let table = parse_table("[cols=\"^.>\"]\n|===\n>.^|overridden\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![(1, HorizontalAlignment::Center, VerticalAlignment::Bottom)]
+    );
+    let cell = &table.body_rows()[0].cells()[0];
+    assert_eq!(cell.h_align(), HorizontalAlignment::Right);
+    assert_eq!(cell.v_align(), VerticalAlignment::Middle);
 }

--- a/parser/src/tests/asciidoc_lang/tables/align_by_column.rs
+++ b/parser/src/tests/asciidoc_lang/tables/align_by_column.rs
@@ -1,0 +1,646 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/align-by-column.adoc");
+
+non_normative!(
+    r#"
+= Align Content by Column
+// Using Wikipedia's names for the operators. For reference, see https://en.wikipedia.org/wiki/Less-than_sign
+
+The alignment operators allow you to horizontally and vertically align a column's content.
+They're applied to a column specifier and xref:add-columns.adoc#cols-attribute[assigned to the cols attribute].
+
+"#
+);
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Collect each column's `(width, horizontal alignment, vertical alignment)`.
+fn column_alignments(
+    table: &crate::blocks::TableBlock<'_>,
+) -> Vec<(usize, HorizontalAlignment, VerticalAlignment)> {
+    table
+        .columns()
+        .iter()
+        .map(|c| (c.width(), c.h_align(), c.v_align()))
+        .collect()
+}
+
+#[test]
+fn horizontal_alignment_operators() {
+    non_normative!(
+        r#"
+[#horizontal-operators]
+== Horizontal alignment operators
+
+"#
+    );
+
+    verifies!(
+        r#"
+Content can be horizontally aligned to the left or right side of the column as well as the center of the column.
+
+Flush left operator (<):: The less-than sign (`<`) left aligns the content.
+This is the default horizontal alignment.
+Flush right operator (>):: The greater-than sign (`>`) right aligns the content.
+Center operator (^):: The caret (`+^+`) centers the content.
+
+A horizontal alignment operator is entered in front a <<vertical-operators,vertical alignment operator>> (if present) and in front of a xref:adjust-column-widths.adoc[column's width] (if present).
+If the number of columns is assigned using a multiplier (`+<n>*+`), the horizontal alignment operator is placed directly after the multiplier operator (`+*+`).
+
+* `[cols="2,pass:q[#^#]1"]` A horizontal alignment operator is placed in front of the column width.
+* `[cols="pass:q[#>#].^1,2"]` A horizontal alignment operator is placed in front of a vertical alignment operator.
+* `[cols="pass:q[#>#],pass:q[#^#]"]` When a column width isn't specified, a horizontal alignment operator can represent both the column and the column content's alignment.
+* `[cols="3*pass:q[#>#]"]` The horizontal alignment operator is placed directly after a multiplier.
+
+"#
+    );
+
+    // The `<` operator is the default, so its presence does not change the
+    // alignment from the left.
+    let table = parse_table("[cols=\"<2,1\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (2, HorizontalAlignment::Left, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+
+    // A horizontal alignment operator is placed in front of the column width.
+    let table = parse_table("[cols=\"2,^1\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (2, HorizontalAlignment::Left, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Center, VerticalAlignment::Top),
+        ]
+    );
+
+    // A horizontal alignment operator is placed in front of a vertical alignment
+    // operator.
+    let table = parse_table("[cols=\">.^1,2\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Right, VerticalAlignment::Middle),
+            (2, HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+
+    // When a column width isn't specified, a horizontal alignment operator can
+    // represent both the column and the column content's alignment.
+    let table = parse_table("[cols=\">,^\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Right, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Center, VerticalAlignment::Top),
+        ]
+    );
+
+    // The horizontal alignment operator is placed directly after a multiplier.
+    let table = parse_table("[cols=\"3*>\"]\n|===\n|a |b |c\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Right, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Right, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Right, VerticalAlignment::Top),
+        ]
+    );
+}
+
+#[test]
+fn center_content_horizontally_in_a_column() {
+    non_normative!(
+        r#"
+=== Center content horizontally in a column
+
+"#
+    );
+
+    verifies!(
+        r#"
+To horizontally center the content in a column, place the `+^+` operator at the beginning of the xref:add-columns.adoc#col-specifier[column's specifier].
+
+.Center column content horizontally
+[source#ex-horizontal]
+----
+[cols="^4,1"]
+|===
+|This content is horizontally centered.
+|There isn't a horizontal alignment operator on this column's specifier, so the column falls back to the default horizontal alignment.
+Content is left-aligned by default.
+|===
+----
+
+The table from <<ex-horizontal>> is rendered below.
+
+.Result of <<ex-horizontal>>
+[cols="^4,1"]
+|===
+|This content is horizontally centered.
+|There isn't a horizontal alignment operator on this column's specifier, so the column falls back to the default horizontal alignment.
+Content is left-aligned by default.
+|===
+
+"#
+    );
+
+    let table = parse_table(
+        "[cols=\"^4,1\"]\n|===\n|This content is horizontally centered.\n|There isn't a horizontal alignment operator on this column's specifier, so the column falls back to the default horizontal alignment.\nContent is left-aligned by default.\n|===",
+    );
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (4, HorizontalAlignment::Center, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+
+    verifies!(
+        r#"
+When the columns are specified using the xref:add-columns.adoc#column-multiplier[multiplier], place the `+^+` operator after the multiplier operator (`+*+`).
+
+.Horizontal alignment and multiplier operator order
+[source#ex-horizontal-multiplier]
+----
+[cols="2*^",options=header]
+|===
+|Column name
+|Column name
+
+|This content is horizontally centered.
+|This content is also horizontally centered.
+|===
+----
+
+The table from <<ex-horizontal-multiplier>> is rendered below.
+
+.Result of <<ex-horizontal-multiplier>>
+[cols="2*^",options=header]
+|===
+|Column name
+|Column name
+
+|This content is horizontally centered.
+|This content is also horizontally centered.
+|===
+
+"#
+    );
+
+    let table = parse_table(
+        "[cols=\"2*^\",options=header]\n|===\n|Column name\n|Column name\n\n|This content is horizontally centered.\n|This content is also horizontally centered.\n|===",
+    );
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Center, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Center, VerticalAlignment::Top),
+        ]
+    );
+    assert!(table.header_row().is_some());
+}
+
+#[test]
+fn right_align_content_in_a_column() {
+    non_normative!(
+        r#"
+=== Right align content in a column
+
+"#
+    );
+
+    verifies!(
+        r#"
+To align the content in a column to its right side, place the `+>+` operator in front of the column's specifier.
+
+.Right align column content
+[source#ex-right]
+----
+[cols=">4,1"]
+|===
+|This content is aligned to the right side of the column.
+|There isn't a horizontal alignment operator on this column's specifier, so the column falls back to the default horizontal alignment.
+Content is left-aligned by default.
+|===
+----
+
+The table <<ex-right>> is rendered below.
+
+.Result of <<ex-right>>
+[cols=">4,1"]
+|===
+|This content is aligned to the right side of the column.
+|There isn't a horizontal alignment operator on this column's specifier, so the column falls back to the default horizontal alignment.
+Content is left-aligned by default.
+|===
+
+"#
+    );
+
+    let table = parse_table(
+        "[cols=\">4,1\"]\n|===\n|This content is aligned to the right side of the column.\n|There isn't a horizontal alignment operator on this column's specifier, so the column falls back to the default horizontal alignment.\nContent is left-aligned by default.\n|===",
+    );
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (4, HorizontalAlignment::Right, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+
+    verifies!(
+        r#"
+When the columns are specified using the xref:add-columns.adoc#column-multiplier[multiplier], place the `+>+` operator after the multiplier operator (`+*+`).
+
+.Right alignment and multiplier operator order
+[source#ex-right-multiplier]
+----
+[cols="2*>",options=header]
+|===
+|Column name
+|Column name
+
+|This content is aligned to the right side of the column.
+|This content is also aligned to the right side of the column.
+|===
+----
+
+The table from <<ex-right-multiplier>> is rendered below.
+
+.Result of <<ex-right-multiplier>>
+[cols="2*>",options=header]
+|===
+|Column name
+|Column name
+
+|This content is aligned to the right side of the column.
+|This content is also aligned to the right side of the column.
+|===
+
+"#
+    );
+
+    let table = parse_table(
+        "[cols=\"2*>\",options=header]\n|===\n|Column name\n|Column name\n\n|This content is aligned to the right side of the column.\n|This content is also aligned to the right side of the column.\n|===",
+    );
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Right, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Right, VerticalAlignment::Top),
+        ]
+    );
+    assert!(table.header_row().is_some());
+}
+
+#[test]
+fn vertical_alignment_operators() {
+    non_normative!(
+        r#"
+[#vertical-operators]
+== Vertical alignment operators
+
+"#
+    );
+
+    verifies!(
+        r#"
+Content can be vertically aligned to the top or bottom of a column's cells as well as the center of a column.
+Vertical alignment operators always begin with a dot (`.`).
+
+Flush top operator (.<):: The dot and less-than sign (`.<`) aligns the content to the top of the column's cells.
+This is the default vertical alignment.
+Flush bottom operator (.>):: The dot and greater-than sign (`.>`) aligns the content to the bottom of the column's cells.
+Center operator (.^):: The dot and caret (`+.^+`) centers the content vertically.
+
+A vertical alignment operator is entered directly after a <<horizontal-operators,horizontal alignment operator>> (if present) and before a xref:adjust-column-widths.adoc[column's width] (if present).
+If the number of columns is assigned using a multiplier (`+<n>*+`), the vertical alignment operator is placed directly after the horizontal alignment operator (if present).
+Otherwise, it's placed directly after the multiplier operator (`+*+`).
+
+* `[cols="2,pass:q[#.^#]1"]` A vertical alignment operator is placed in front of the column width.
+* `[cols=">pass:q[#.^#]1,2"]` The vertical alignment operator is placed after the horizontal alignment operator but before the column width.
+* `[cols="pass:q[#.^#],pass:q[#.>#]"]` When a column width doesn't need to be specified, a vertical alignment operator can represent both the column and the column content's alignment.
+* `[cols="3*pass:q[#.>#]"]` The vertical alignment operator is placed directly after a multiplier unless there is a horizontal alignment operator.
+Then it's placed after the horizontal alignment operator, (e.g., `[cols="3*^pass:q[#.>#]"]`)
+
+"#
+    );
+
+    // The `.<` operator is the default, so its presence does not change the
+    // alignment from the top.
+    let table = parse_table("[cols=\"2,.<1\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (2, HorizontalAlignment::Left, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+
+    // A vertical alignment operator is placed in front of the column width.
+    let table = parse_table("[cols=\"2,.^1\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (2, HorizontalAlignment::Left, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Middle),
+        ]
+    );
+
+    // The vertical alignment operator is placed after the horizontal alignment
+    // operator but before the column width.
+    let table = parse_table("[cols=\">.^1,2\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Right, VerticalAlignment::Middle),
+            (2, HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+
+    // When a column width doesn't need to be specified, a vertical alignment
+    // operator can represent both the column and the column content's alignment.
+    let table = parse_table("[cols=\".^,.>\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Left, VerticalAlignment::Middle),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Bottom),
+        ]
+    );
+
+    // The vertical alignment operator is placed directly after a multiplier when
+    // there is no horizontal alignment operator.
+    let table = parse_table("[cols=\"3*.>\"]\n|===\n|a |b |c\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Left, VerticalAlignment::Bottom),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Bottom),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Bottom),
+        ]
+    );
+
+    // When a horizontal alignment operator is present, the vertical alignment
+    // operator is placed after it.
+    let table = parse_table("[cols=\"3*^.>\"]\n|===\n|a |b |c\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Center, VerticalAlignment::Bottom),
+            (1, HorizontalAlignment::Center, VerticalAlignment::Bottom),
+            (1, HorizontalAlignment::Center, VerticalAlignment::Bottom),
+        ]
+    );
+}
+
+#[test]
+fn align_content_to_the_bottom_of_a_columns_cells() {
+    non_normative!(
+        r#"
+=== Align content to the bottom of a column's cells
+
+"#
+    );
+
+    verifies!(
+        r#"
+To align the content in a column to the bottom of each cell, place the `+.>+` operator directly in front of the xref:adjust-column-widths.adoc[column's width].
+
+.Bottom align column content
+[source#ex-bottom]
+----
+[cols=".>2,1"]
+|===
+|This content is vertically aligned to the bottom of the cell.
+|There isn't a vertical alignment operator on this column's specifier, so the column falls back to the default vertical alignment.
+Content is top-aligned by default.
+|===
+----
+
+The table from <<ex-bottom>> is rendered below.
+
+.Result of <<ex-bottom>>
+[cols=".>2,1"]
+|===
+|This content is vertically aligned to the bottom of the cell.
+|There isn't a vertical alignment operator on this column's specifier, so the column falls back to the default vertical alignment.
+Content is top-aligned by default.
+|===
+
+"#
+    );
+
+    let table = parse_table(
+        "[cols=\".>2,1\"]\n|===\n|This content is vertically aligned to the bottom of the cell.\n|There isn't a vertical alignment operator on this column's specifier, so the column falls back to the default vertical alignment.\nContent is top-aligned by default.\n|===",
+    );
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (2, HorizontalAlignment::Left, VerticalAlignment::Bottom),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+}
+
+#[test]
+fn center_content_vertically_in_a_column() {
+    non_normative!(
+        r#"
+=== Center content vertically in a column
+
+"#
+    );
+
+    verifies!(
+        r#"
+To vertically center the content in a column, place the `+.^+` operator directly in front of the xref:adjust-column-widths.adoc[column's width].
+
+.Center column content vertically
+[source#ex-vertical]
+----
+[cols=".^2,1"]
+|===
+|This content is centered vertically in the cell.
+|There isn't a vertical alignment operator on this column's specifier, so the column falls back to the default vertical alignment.
+Content is top-aligned by default.
+|===
+----
+
+The table from <<ex-vertical>> is rendered below.
+
+.Result of <<ex-vertical>>
+[cols=".^2,1"]
+|===
+|This content is centered vertically in the cell.
+|There isn't a vertical alignment operator on this column's specifier, so the column falls back to the default vertical alignment.
+Content is top-aligned by default.
+|===
+
+"#
+    );
+
+    let table = parse_table(
+        "[cols=\".^2,1\"]\n|===\n|This content is centered vertically in the cell.\n|There isn't a vertical alignment operator on this column's specifier, so the column falls back to the default vertical alignment.\nContent is top-aligned by default.\n|===",
+    );
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (2, HorizontalAlignment::Left, VerticalAlignment::Middle),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+
+    verifies!(
+        r#"
+To vertically align the content to the middle of the cells in all of the columns, enter the  `.^` operator after the xref:add-columns.adoc#column-multiplier[multiplier].
+
+.Vertical alignment and multiplier operator order
+[source#ex-vertical-multiplier]
+----
+[cols="2*.^",options=header]
+|===
+|Column name
+|Column name
+
+|This content is vertically centered.
+|This content is also vertically centered.
+|===
+----
+
+The table from <<ex-vertical-multiplier>> is rendered below.
+
+.Result of <<ex-vertical-multiplier>>
+[cols="2*.^",options=header]
+|===
+|Column name
+|Column name
+
+|This content is centered vertically in the cell.
+|This content is also centered vertically in the cell.
+|===
+
+"#
+    );
+
+    let table = parse_table(
+        "[cols=\"2*.^\",options=header]\n|===\n|Column name\n|Column name\n\n|This content is vertically centered.\n|This content is also vertically centered.\n|===",
+    );
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Left, VerticalAlignment::Middle),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Middle),
+        ]
+    );
+    assert!(table.header_row().is_some());
+
+    verifies!(
+        r#"
+When a horizontal alignment operator is also applied to the multiplier, then the vertical alignment operator is placed directly after the horizontal operator (e.g., `[cols="2*>.^"]`).
+
+"#
+    );
+
+    let table = parse_table("[cols=\"2*>.^\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Right, VerticalAlignment::Middle),
+            (1, HorizontalAlignment::Right, VerticalAlignment::Middle),
+        ]
+    );
+}
+
+#[test]
+fn apply_horizontal_and_vertical_alignment_operators_to_the_same_column() {
+    non_normative!(
+        r#"
+== Apply horizontal and vertical alignment operators to the same column
+
+"#
+    );
+
+    verifies!(
+        r#"
+A column can have a vertical and horizontal alignment operator placed on its xref:add-columns.adoc#col-specifier[specifier].
+The <<horizontal-operators,horizontal operator>> always precedes the <<vertical-operators,vertical operator>>.
+Both operators precede the column width.
+When a xref:add-columns.adoc#column-multiplier[multiplier] is used, the operators are placed after the multiplier.
+
+.Horizontally and vertically align column content
+[source#ex-center]
+----
+[cols="^.>2,1,>.^1"]
+|===
+|Column name |Column name |Column name
+
+|This content is centered horizontally and aligned to the bottom
+of the cell.
+|There aren't any alignment operators on this column's specifier,
+so the column falls back to the default alignments.
+The default horizontal alignment is left-aligned.
+The default vertical alignment is top-aligned.
+|This content is aligned to the right side of the cell and
+centered vertically.
+|===
+----
+
+The table from <<ex-center>> is rendered below.
+
+.Result of <<ex-center>>
+[cols="^.>2,1,>.^1"]
+|===
+|Column name |Column name |Column name
+
+|This content is centered horizontally and aligned to the bottom
+of the cell.
+|There aren't any alignment operators on this column's specifier,
+so the column falls back to the default alignments.
+The default horizontal alignment is left-aligned.
+The default vertical alignment is top-aligned.
+|This content is aligned to the right side of the cell and
+centered vertically.
+|===
+
+"#
+    );
+
+    let table = parse_table(
+        "[cols=\"^.>2,1,>.^1\"]\n|===\n|Column name |Column name |Column name\n\n|This content is centered horizontally and aligned to the bottom\nof the cell.\n|There aren't any alignment operators on this column's specifier,\nso the column falls back to the default alignments.\nThe default horizontal alignment is left-aligned.\nThe default vertical alignment is top-aligned.\n|This content is aligned to the right side of the cell and\ncentered vertically.\n|===",
+    );
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (2, HorizontalAlignment::Center, VerticalAlignment::Bottom),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Right, VerticalAlignment::Middle),
+        ]
+    );
+
+    // Cell specifiers (and thus their per-cell alignment operators) are not yet
+    // parsed, so the override of a column's alignment by a cell's alignment can't
+    // be verified yet.
+    to_do_verifies!(
+        r#"
+IMPORTANT: If there is an xref:align-by-cell.adoc[alignment operator on a cell's specifier], it will override the column's alignment operator.
+"#
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/assign_a_role.rs
+++ b/parser/src/tests/asciidoc_lang/tables/assign_a_role.rs
@@ -1,0 +1,78 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/assign-a-role.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+// The `tag=base` table referenced by the example on the page: a minimal,
+// two-cell table. Roles are independent of the table's shape, so this stands in
+// for the included example.
+const BASE: &str = "|===\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n|===";
+
+non_normative!(
+    r#"
+= Assign a Role to a Table
+
+"#
+);
+
+#[test]
+fn role_attribute() {
+    verifies!(
+        r#"
+Like with all blocks, you can add a role to a table using the `role` attribute.
+"#
+    );
+
+    // The formal `role` named attribute assigns the role to the table.
+    let src = format!("[role=name-of-role]\n{BASE}");
+    let table = parse_table(&src);
+    assert_eq!(table.roles(), vec!["name-of-role"]);
+
+    // A role may also carry multiple, space-separated values.
+    let src = format!("[role=\"role-one role-two\"]\n{BASE}");
+    let table = parse_table(&src);
+    assert_eq!(table.roles(), vec!["role-one", "role-two"]);
+
+    // The mapping of a role to an HTML CSS class is a rendering concern; this
+    // crate does not convert to HTML.
+    non_normative!(
+        r#"
+The role attribute becomes a CSS class when converted to HTML.
+"#
+    );
+}
+
+#[test]
+fn role_shorthand() {
+    verifies!(
+        r#"
+The preferred shorthand for assigning the role attribute is to put the role name in the first position of the block attribute list prefixed with a `.` character, as shown here:
+
+[source]
+----
+[.name-of-role]
+include::example$table.adoc[tag=base]
+----
+"#
+    );
+
+    // The dot-prefixed shorthand in the first position assigns the role just
+    // like the formal `role` attribute does.
+    let src = format!("[.name-of-role]\n{BASE}");
+    let table = parse_table(&src);
+    assert_eq!(table.roles(), vec!["name-of-role"]);
+}

--- a/parser/src/tests/asciidoc_lang/tables/borders.rs
+++ b/parser/src/tests/asciidoc_lang/tables/borders.rs
@@ -1,0 +1,393 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/borders.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Return the first [`TableBlock`] in `doc`.
+///
+/// Used by the tests that exercise the `table-frame` / `table-grid` document
+/// attributes: those attributes must be set in the document header, so the
+/// whole document is parsed rather than a single block.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn first_table<'a>(doc: &'a crate::Document<'a>) -> &'a crate::blocks::TableBlock<'a> {
+    doc.nested_blocks()
+        .find_map(|block| match block {
+            crate::blocks::Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .expect("expected a table block")
+}
+
+// Expansion of `include::example$row.adoc[tag=base-h]`: the standard
+// three-column table with a header row and two body rows used throughout the
+// table documentation.
+const BASE_H: &str = "|===\n|Column 1, header row |Column 2, header row |Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|Cell in column 3, row 3\n|===";
+
+non_normative!(
+    r#"
+= Table Borders
+:!table-frame:
+:!table-grid:
+
+"#
+);
+
+#[test]
+fn intro() {
+    verifies!(
+        r#"
+The borders on a table are controlled using the `frame` and `grid` block attributes.
+You can combine these two attributes to achieve a variety of border styles for your tables.
+
+"#
+    );
+
+    // With no `frame` or `grid` attribute, a table draws a border on every side
+    // and between every cell.
+    let table = parse_table(BASE_H);
+    assert_eq!(table.frame(), Frame::All);
+    assert_eq!(table.grid(), Grid::All);
+}
+
+#[test]
+fn frame() {
+    non_normative!(
+        r#"
+== Frame
+
+"#
+    );
+
+    verifies!(
+        r#"
+The border around a table is controlled using the `frame` attribute on the table.
+The frame attribute defaults to the value `all` (implied value), which draws a border on each side of the table.
+This default can be changed by setting the `table-frame` document attribute.
+You can override the default value by setting the frame attribute on the table to the value `all`, `ends`, `sides` or `none`.
+
+"#
+    );
+
+    // The frame defaults to `all`, and the implied (empty) value resolves the
+    // same way.
+    assert_eq!(parse_table(BASE_H).frame(), Frame::All);
+    let src = format!("[frame=all]\n{BASE_H}");
+    assert_eq!(parse_table(&src).frame(), Frame::All);
+
+    // The `table-frame` document attribute changes the default for tables that
+    // don't set their own `frame`.
+    let src = format!(":table-frame: sides\n\n{BASE_H}");
+    let doc = Parser::default().parse(&src);
+    assert_eq!(first_table(&doc).frame(), Frame::Sides);
+
+    // An explicit `frame` on the table overrides the document attribute.
+    let src = format!(":table-frame: sides\n\n[frame=ends]\n{BASE_H}");
+    let doc = Parser::default().parse(&src);
+    assert_eq!(first_table(&doc).frame(), Frame::Ends);
+
+    // An unrecognized value falls back to the default.
+    let src = format!("[frame=bogus]\n{BASE_H}");
+    assert_eq!(parse_table(&src).frame(), Frame::All);
+
+    verifies!(
+        r#"
+The `ends` value draws a border on the top and bottom of the table.
+
+"#
+    );
+
+    // `ends` draws a border on the top and bottom; `topbot` is accepted as the
+    // older synonym for the same value.
+    let src = format!("[frame=ends]\n{BASE_H}");
+    assert_eq!(parse_table(&src).frame(), Frame::Ends);
+    let src = format!("[frame=topbot]\n{BASE_H}");
+    assert_eq!(parse_table(&src).frame(), Frame::Ends);
+
+    verifies!(
+        r#"
+.Table with frame=ends
+[source#ex-ends]
+----
+[frame=ends]
+include::example$row.adoc[tag=base-h]
+----
+
+.Result of <<ex-ends>>
+[frame=ends]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    // <<ex-ends>>: the standard three-column table framed on its ends. The frame
+    // is the only thing that changes; the header and body rows are unaffected.
+    let src = format!("[frame=ends]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert_eq!(table.frame(), Frame::Ends);
+    assert_eq!(table.grid(), Grid::All);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.body_rows().len(), 2);
+
+    verifies!(
+        r#"
+The `sides` value draws a border on the right and left side of the table.
+
+"#
+    );
+
+    // `sides` draws a border on the left and right.
+    let src = format!("[frame=sides]\n{BASE_H}");
+    assert_eq!(parse_table(&src).frame(), Frame::Sides);
+
+    verifies!(
+        r#"
+.Table with frame=sides
+[source#ex-sides]
+----
+[frame=sides]
+include::example$row.adoc[tag=base-h]
+----
+
+.Result of <<ex-sides>>
+[frame=sides]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    // <<ex-sides>>: the standard three-column table framed on its sides.
+    let src = format!("[frame=sides]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert_eq!(table.frame(), Frame::Sides);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.body_rows().len(), 2);
+
+    verifies!(
+        r#"
+The `none` value removes the borders around the table.
+
+"#
+    );
+
+    // `none` removes the frame entirely.
+    let src = format!("[frame=none]\n{BASE_H}");
+    assert_eq!(parse_table(&src).frame(), Frame::None);
+
+    verifies!(
+        r#"
+.Table with frame=none
+[source#ex-noframe]
+----
+[frame=none]
+include::example$row.adoc[tag=base-h]
+----
+
+.Result of <<ex-noframe>>
+[frame=none]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    // <<ex-noframe>>: the standard three-column table with no frame.
+    let src = format!("[frame=none]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert_eq!(table.frame(), Frame::None);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.body_rows().len(), 2);
+}
+
+#[test]
+fn grid() {
+    non_normative!(
+        r#"
+== Grid
+
+"#
+    );
+
+    verifies!(
+        r#"
+The borders between the cells in a table are controlled using the `grid` attribute on the table.
+The grid attribute defaults to the value `all` (implied value), which draws a border between all cells.
+This default can be changed by setting the `table-grid` document attribute.
+You can override the default value by setting the grid attribute on the table to the value `all`, `rows`, `cols` or `none`.
+
+"#
+    );
+
+    // The grid defaults to `all`, and the implied (empty) value resolves the
+    // same way.
+    assert_eq!(parse_table(BASE_H).grid(), Grid::All);
+    let src = format!("[grid=all]\n{BASE_H}");
+    assert_eq!(parse_table(&src).grid(), Grid::All);
+
+    // The `table-grid` document attribute changes the default for tables that
+    // don't set their own `grid`.
+    let src = format!(":table-grid: cols\n\n{BASE_H}");
+    let doc = Parser::default().parse(&src);
+    assert_eq!(first_table(&doc).grid(), Grid::Cols);
+
+    // An explicit `grid` on the table overrides the document attribute.
+    let src = format!(":table-grid: cols\n\n[grid=rows]\n{BASE_H}");
+    let doc = Parser::default().parse(&src);
+    assert_eq!(first_table(&doc).grid(), Grid::Rows);
+
+    // An unrecognized value falls back to the default.
+    let src = format!("[grid=bogus]\n{BASE_H}");
+    assert_eq!(parse_table(&src).grid(), Grid::All);
+
+    verifies!(
+        r#"
+The `rows` value draws a border between the rows of the table.
+
+"#
+    );
+
+    // `rows` draws a border between the rows.
+    let src = format!("[grid=rows]\n{BASE_H}");
+    assert_eq!(parse_table(&src).grid(), Grid::Rows);
+
+    verifies!(
+        r#"
+.Table with grid=rows
+[source#ex-rows]
+----
+[grid=rows]
+include::example$row.adoc[tag=base-h]
+----
+
+.Result of <<ex-rows>>
+[grid=rows]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    // <<ex-rows>>: the standard three-column table with a border only between
+    // its rows. The grid is the only thing that changes.
+    let src = format!("[grid=rows]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert_eq!(table.grid(), Grid::Rows);
+    assert_eq!(table.frame(), Frame::All);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.body_rows().len(), 2);
+
+    verifies!(
+        r#"
+The `cols` value draws borders between the columns.
+
+"#
+    );
+
+    // `cols` draws a border between the columns.
+    let src = format!("[grid=cols]\n{BASE_H}");
+    assert_eq!(parse_table(&src).grid(), Grid::Cols);
+
+    verifies!(
+        r#"
+.Table with grid=cols
+[source#ex-cols]
+----
+[grid=cols]
+include::example$row.adoc[tag=base-h]
+----
+
+.Result of <<ex-cols>>
+[grid=cols]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    // <<ex-cols>>: the standard three-column table with a border only between
+    // its columns.
+    let src = format!("[grid=cols]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert_eq!(table.grid(), Grid::Cols);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.body_rows().len(), 2);
+
+    verifies!(
+        r#"
+The `none` value removes all borders between the cells.
+
+"#
+    );
+
+    // `none` removes the grid entirely.
+    let src = format!("[grid=none]\n{BASE_H}");
+    assert_eq!(parse_table(&src).grid(), Grid::None);
+
+    verifies!(
+        r#"
+.Table with grid=none
+[source#ex-nogrid]
+----
+[grid=none]
+include::example$row.adoc[tag=base-h]
+----
+
+.Result of <<ex-nogrid>>
+[grid=none]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    // <<ex-nogrid>>: the standard three-column table with no grid.
+    let src = format!("[grid=none]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert_eq!(table.grid(), Grid::None);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.body_rows().len(), 2);
+}
+
+// The interaction between row/column spans and border placement is a rendering
+// limitation of styling HTML with CSS. It describes downstream converter
+// behavior rather than anything this parser models, so the whole section is
+// non-normative here.
+non_normative!(
+    r#"
+== Interaction with row and column spans
+
+Using row and column spans may interfere with the placement of borders on a table.
+This is a limitation of styling HTML using CSS.
+
+When a cell extends into other rows or columns, that cell is not represented in the HTML for the rows or columns it extends into.
+This is a problem if the cell reaches the boundary of the table.
+The CSS selector only matches the cell where it starts and thus does not detect when it is touching the table boundary.
+It therefore cannot add or remove the border as it would for a 1x1 cell (i.e., a cell confined to a single row and column).
+
+The interference with border placement caused by row and column spans does not always happen.
+Borders on a table with a rowspan or colspan that reaches the table boundary will always work correctly when the frame and grid are congruent.
+In this context, congruent means the frame and grid are contributing borders to the same edges.
+
+Here are those scenarios in which the frame and grid are congruent:
+
+* frame=all, grid=all
+* frame=all, grid=none
+* frame=all, grid=rows
+* frame=all, grid=cols
+* frame=ends, grid=rows
+* frame=sides, grid=cols
+* frame=none, grid=none
+
+If you use row and column spans in a table, you are strongly encouraged to use one of these frame and grid combinations.
+"#
+);

--- a/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
+++ b/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
@@ -216,6 +216,7 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                 },
                 title_source: None,
                 title: None,
+                caption: None,
                 anchor: None,
                 anchor_reftext: None,
                 attrlist: Some(Attrlist {
@@ -438,6 +439,7 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                 },
                 title_source: None,
                 title: None,
+                caption: None,
                 anchor: None,
                 anchor_reftext: None,
                 attrlist: Some(Attrlist {

--- a/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
+++ b/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
@@ -130,11 +130,13 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     }
                 ],
                 header_row: None,
@@ -142,7 +144,7 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                     TableRow {
                         cells: &[
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 1, row 1",
                                         line: 3,
@@ -150,10 +152,10 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                                         offset: 19,
                                     },
                                     rendered: "Cell in column 1, row 1",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 2, row 1",
                                         line: 4,
@@ -161,14 +163,14 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                                         offset: 44,
                                     },
                                     rendered: "Cell in column 2, row 1",
-                                },
+                                }),
                             },
                         ],
                     },
                     TableRow {
                         cells: &[
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 1, row 2",
                                         line: 6,
@@ -176,10 +178,10 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                                         offset: 70,
                                     },
                                     rendered: "Cell in column 1, row 2",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 2, row 2",
                                         line: 6,
@@ -187,14 +189,14 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                                         offset: 95,
                                     },
                                     rendered: "Cell in column 2, row 2",
-                                },
+                                }),
                             },
                         ],
                     },
                     TableRow {
                         cells: &[
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 1, row 3",
                                         line: 7,
@@ -202,10 +204,10 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                                         offset: 120,
                                     },
                                     rendered: "Cell in column 1, row 3",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 2, row 3",
                                         line: 7,
@@ -213,7 +215,7 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                                         offset: 145,
                                     },
                                     rendered: "Cell in column 2, row 3",
-                                },
+                                }),
                             },
                         ],
                     },
@@ -339,17 +341,19 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     }
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 1, header row",
                                     line: 3,
@@ -357,10 +361,10 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                                     offset: 19,
                                 },
                                 rendered: "Cell in column 1, header row",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 2, header row",
                                     line: 3,
@@ -368,7 +372,7 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                                     offset: 49,
                                 },
                                 rendered: "Cell in column 2, header row",
-                            },
+                            }),
                         },
                     ],
                 }),
@@ -376,7 +380,7 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                     TableRow {
                         cells: &[
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 1, row 2",
                                         line: 5,
@@ -384,10 +388,10 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                                         offset: 80,
                                     },
                                     rendered: "Cell in column 1, row 2",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 2, row 2",
                                         line: 6,
@@ -395,14 +399,14 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                                         offset: 105,
                                     },
                                     rendered: "Cell in column 2, row 2",
-                                },
+                                }),
                             },
                         ],
                     },
                     TableRow {
                         cells: &[
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 1, row 3",
                                         line: 8,
@@ -410,10 +414,10 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                                         offset: 131,
                                     },
                                     rendered: "Cell in column 1, row 3",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 2, row 3",
                                         line: 9,
@@ -421,14 +425,14 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                                         offset: 156,
                                     },
                                     rendered: "Cell in column 2, row 3",
-                                },
+                                }),
                             },
                         ],
                     },
                     TableRow {
                         cells: &[
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 1, row 4",
                                         line: 11,
@@ -436,10 +440,10 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                                         offset: 182,
                                     },
                                     rendered: "Cell in column 1, row 4",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 2, row 4",
                                         line: 12,
@@ -447,7 +451,7 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                                         offset: 207,
                                     },
                                     rendered: "Cell in column 2, row 4",
-                                },
+                                }),
                             },
                         ],
                     },

--- a/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
+++ b/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
@@ -125,7 +125,18 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                 },
             },
             blocks: &[Block::Table(TableBlock {
-                columns: &[TableColumn { width: 1 }, TableColumn { width: 1 }],
+                columns: &[
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    }
+                ],
                 header_row: None,
                 body_rows: &[
                     TableRow {
@@ -323,7 +334,18 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                 },
             },
             blocks: &[Block::Table(TableBlock {
-                columns: &[TableColumn { width: 1 }, TableColumn { width: 1 }],
+                columns: &[
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    }
+                ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {

--- a/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
+++ b/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
@@ -1,0 +1,469 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/build-a-basic-table.adoc");
+
+non_normative!(
+    r#"
+= Build a Basic Table
+:page-aliases: index.adoc
+
+A table is a delimited block that can have optional customizations, such as an ID and a title, as well as table-specific attributes, options, and roles.
+However, at its most basic, a table only needs columns and rows.
+
+On this page, you'll learn:
+
+* [x] How to set up an AsciiDoc table block and its attribute list.
+* [x] How to add columns to a table using the `cols` attribute.
+* [x] How to add cells to a table and arrange them into rows.
+* [x] How to designate a row as the table's header row.
+
+"#
+);
+
+#[test]
+fn create_a_table_with_two_columns_and_three_rows() {
+    non_normative!(
+        r#"
+== Create a table with two columns and three rows
+"#
+    );
+
+    verifies!(
+        r#"
+
+In <<ex-cols>>, we'll assign the `cols` attribute a list of column specifiers.
+A column specifier represents a column.
+
+.Set up a table with two columns
+[source#ex-cols]
+----
+[cols="1,1"] <.> <.>
+|=== <.>
+----
+<.> On a new line, create an attribute list.
+Set the `cols` attribute, followed by an equals sign (`=`).
+<.> Assign a list of comma-separated column specifiers enclosed in double quotation marks (`"`) to `cols`.
+Each column specifier represents a column.
+<.> On the line directly after the attribute list, enter the opening table delimiter.
+A table delimiter is one vertical bar followed by three equals signs (`|===`).
+This delimiter starts the table block.
+
+The table in <<ex-cols>> will contain two columns because there are two comma-separated entries in the list assigned to `cols`.
+Each entry in the list is called a column specifier.
+A [.term]*column specifier* represents a column and the width, alignment, and style properties assigned to that column.
+When each column specifier is the same number, in this case the integer `1`, all of the columns`' widths will be identical.
+Each column in <<ex-cols>> will be the same width regardless of how much content they contain.
+
+Next, let's add three rows to the table.
+Each row has the same number of cells.
+Since the table in <<ex-rows>> has two columns, each row will contain two cells.
+A cell starts with a vertical bar (`|`).
+
+.Add three rows to the table
+[source#ex-rows]
+----
+[cols="1,1"]
+|===
+|Cell in column 1, row 1 <.>
+|Cell in column 2, row 1 <.>
+<.>
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+
+|Cell in column 1, row 3
+|Cell in column 2, row 3 <.>
+|=== <.>
+----
+<.> To create a new cell, press kbd:[Shift+|].
+After the vertical bar (`|`), enter the content you want displayed in that cell.
+<.> On a new line, start another cell with a `|`.
+Each consecutive cell is placed in a separate, consecutive column in a row.
+<.> Rows are separated by one or more empty lines.
+<.> When you finish adding cells to your table, press kbd:[Enter] to go to a new line.
+<.> Enter the closing delimiter (`|===`) to end the table block.
+
+TIP: The suggestion to start each cell on its own line and to separate rows by empty lines is merely a stylistic choice.
+You can enter xref:add-cells-and-rows.adoc[more than one cell or all of the cells in a row on the same line] since the processor creates a new cell each time it encounters a vertical bar (`|`).
+
+The table from <<ex-rows>> is displayed below.
+It contains two columns and three rows of text positioned and styled using the default alignment, style, border, and width attribute values.
+
+[cols="1,1"]
+|===
+|Cell in column 1, row 1
+|Cell in column 2, row 1
+
+|Cell in column 1, row 2 |Cell in column 2, row 2
+|Cell in column 1, row 3 |Cell in column 2, row 3
+|===
+
+In addition to the xref:add-columns.adoc[cols attribute], you can identify the number of columns using a xref:add-columns.adoc#column-multiplier[column multiplier] or xref:add-columns.adoc#implicit-cols[the table's first row].
+However, the `cols` attribute is required to customize the xref:adjust-column-widths.adoc[width], xref:align-by-column.adoc[alignment], or xref:format-column-content.adoc[style] of a column.
+
+"#
+    );
+
+    let doc = Parser::default().parse(
+        "[cols=\"1,1\"]\n|===\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n\n|Cell in column 1, row 2 |Cell in column 2, row 2\n|Cell in column 1, row 3 |Cell in column 2, row 3\n|===",
+    );
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[TableColumn { width: 1 }, TableColumn { width: 1 }],
+                header_row: None,
+                body_rows: &[
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 1",
+                                        line: 3,
+                                        col: 2,
+                                        offset: 19,
+                                    },
+                                    rendered: "Cell in column 1, row 1",
+                                },
+                            },
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 1",
+                                        line: 4,
+                                        col: 2,
+                                        offset: 44,
+                                    },
+                                    rendered: "Cell in column 2, row 1",
+                                },
+                            },
+                        ],
+                    },
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 2",
+                                        line: 6,
+                                        col: 2,
+                                        offset: 70,
+                                    },
+                                    rendered: "Cell in column 1, row 2",
+                                },
+                            },
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 2",
+                                        line: 6,
+                                        col: 27,
+                                        offset: 95,
+                                    },
+                                    rendered: "Cell in column 2, row 2",
+                                },
+                            },
+                        ],
+                    },
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 3",
+                                        line: 7,
+                                        col: 2,
+                                        offset: 120,
+                                    },
+                                    rendered: "Cell in column 1, row 3",
+                                },
+                            },
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 3",
+                                        line: 7,
+                                        col: 27,
+                                        offset: 145,
+                                    },
+                                    rendered: "Cell in column 2, row 3",
+                                },
+                            },
+                        ],
+                    },
+                ],
+                footer_row: None,
+                source: Span {
+                    data: "[cols=\"1,1\"]\n|===\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n\n|Cell in column 1, row 2 |Cell in column 2, row 2\n|Cell in column 1, row 3 |Cell in column 2, row 3\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: Some("cols"),
+                        shorthand_items: &[],
+                        value: "1,1",
+                    }],
+                    anchor: None,
+                    source: Span {
+                        data: "cols=\"1,1\"",
+                        line: 1,
+                        col: 2,
+                        offset: 1,
+                    },
+                }),
+            })],
+            source: Span {
+                data: "[cols=\"1,1\"]\n|===\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n\n|Cell in column 1, row 2 |Cell in column 2, row 2\n|Cell in column 1, row 3 |Cell in column 2, row 3\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+}
+
+#[test]
+fn add_a_header_row_to_the_table() {
+    non_normative!(
+        r#"
+=== Add a header row to the table
+"#
+    );
+
+    verifies!(
+        r#"
+
+Let's add a header row to the table in <<ex-header>>.
+You can implicitly identify the first row of a table as a header row by entering all of the first row's cells on the line directly after the opening table delimiter.
+
+.Add a header row to the table
+[source#ex-header]
+----
+[cols="1,1"]
+|===
+|Cell in column 1, header row |Cell in column 2, header row <.>
+<.>
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+
+|Cell in column 1, row 3
+|Cell in column 2, row 3
+
+|Cell in column 1, row 4
+|Cell in column 2, row 4
+|===
+----
+<.> On the line directly after the opening delimiter (`|===`), enter all of the first row's cells on a single line.
+<.> Leave the line directly after the header row empty.
+
+The table from <<ex-header>> is displayed below.
+
+[cols="1,1"]
+|===
+|Cell in column 1, header row |Cell in column 2, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+
+|Cell in column 1, row 3
+|Cell in column 2, row 3
+
+|Cell in column 1, row 4
+|Cell in column 2, row 4
+|===
+
+A header row can also be identified by assigning xref:add-header-row.adoc[header to the options attribute].
+"#
+    );
+
+    let doc = Parser::default().parse(
+        "[cols=\"1,1\"]\n|===\n|Cell in column 1, header row |Cell in column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n\n|Cell in column 1, row 4\n|Cell in column 2, row 4\n|===",
+    );
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[TableColumn { width: 1 }, TableColumn { width: 1 }],
+                header_row: Some(TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Cell in column 1, header row",
+                                    line: 3,
+                                    col: 2,
+                                    offset: 19,
+                                },
+                                rendered: "Cell in column 1, header row",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Cell in column 2, header row",
+                                    line: 3,
+                                    col: 32,
+                                    offset: 49,
+                                },
+                                rendered: "Cell in column 2, header row",
+                            },
+                        },
+                    ],
+                }),
+                body_rows: &[
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 2",
+                                        line: 5,
+                                        col: 2,
+                                        offset: 80,
+                                    },
+                                    rendered: "Cell in column 1, row 2",
+                                },
+                            },
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 2",
+                                        line: 6,
+                                        col: 2,
+                                        offset: 105,
+                                    },
+                                    rendered: "Cell in column 2, row 2",
+                                },
+                            },
+                        ],
+                    },
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 3",
+                                        line: 8,
+                                        col: 2,
+                                        offset: 131,
+                                    },
+                                    rendered: "Cell in column 1, row 3",
+                                },
+                            },
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 3",
+                                        line: 9,
+                                        col: 2,
+                                        offset: 156,
+                                    },
+                                    rendered: "Cell in column 2, row 3",
+                                },
+                            },
+                        ],
+                    },
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 4",
+                                        line: 11,
+                                        col: 2,
+                                        offset: 182,
+                                    },
+                                    rendered: "Cell in column 1, row 4",
+                                },
+                            },
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 4",
+                                        line: 12,
+                                        col: 2,
+                                        offset: 207,
+                                    },
+                                    rendered: "Cell in column 2, row 4",
+                                },
+                            },
+                        ],
+                    },
+                ],
+                footer_row: None,
+                source: Span {
+                    data: "[cols=\"1,1\"]\n|===\n|Cell in column 1, header row |Cell in column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n\n|Cell in column 1, row 4\n|Cell in column 2, row 4\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: Some("cols"),
+                        shorthand_items: &[],
+                        value: "1,1",
+                    }],
+                    anchor: None,
+                    source: Span {
+                        data: "cols=\"1,1\"",
+                        line: 1,
+                        col: 2,
+                        offset: 1,
+                    },
+                }),
+            })],
+            source: Span {
+                data: "[cols=\"1,1\"]\n|===\n|Cell in column 1, header row |Cell in column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n\n|Cell in column 1, row 4\n|Cell in column 2, row 4\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/customize_title_label.rs
+++ b/parser/src/tests/asciidoc_lang/tables/customize_title_label.rs
@@ -1,0 +1,279 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/customize-title-label.adoc");
+
+non_normative!(
+    r#"
+= Customize the Title Label
+:table-caption: Data Set
+
+When you xref:add-title.adoc[add a title to a table], the processor automatically prefixes it with the label _Table <n>._, where _<n>_ is the 1-based index of all of the titled tables in the document.
+This label can be modified at the document level or per table.
+It can also be xref:turn-off-title-label.adoc[deactivated].
+
+"#
+);
+
+#[test]
+fn modify_the_label_using_table_caption() {
+    non_normative!(
+        r#"
+== Modify the label using table-caption
+
+"#
+    );
+
+    verifies!(
+        r#"
+You can change the label for all titled tables using the document attribute `table-caption`.
+(Don't let the attribute's name mislead you.
+It's the attribute that controls the table title labels at the document level.)
+
+In the document header, set the `table-caption` attribute and assign it your custom label text.
+
+[source]
+----
+= Document Title
+:table-caption: Data Set <.> <.>
+----
+<.> Set the document attribute `table-caption` and assign it the text you want to precede each table title.
+<.> Don't enter a number after the label text.
+The processor will automatically insert and increment the number.
+
+In <<ex-label>>, the first and third tables have a title, but the second table doesn't have a title.
+
+.Add two titled tables and one untitled table to a document
+[source#ex-label]
+----
+= Document Title
+:table-caption: Data Set
+
+.A table with a title
+[cols="2,1"]
+|===
+|Lots and lots of data |A little data
+
+|834,734 |3
+|3,999,271.5601 |5
+|===
+
+|===
+|Group |Climate |Example
+
+|A
+|Tropical
+|Suva, Fiji
+
+|B
+|Arid
+|Lima, Peru
+|===
+
+.Another table with a title
+|===
+|Value |Result |Notes
+
+|Null |A mystery |See Appendix R
+|===
+----
+
+Since `table-caption` is assigned the value `Data Set`, any table title should be preceded with the label _Data Set <n>._
+The three tables from <<ex-label>> are displayed below.
+
+.A table with a title
+[cols="2,1"]
+|===
+|Lots and lots of data |A little data
+
+|834,734 |3
+|3,999,271.5601 |5
+|===
+
+|===
+|Group |Climate |Example
+
+|A
+|Tropical
+|Suva, Fiji
+
+|B
+|Arid
+|Lima, Peru
+|===
+
+.Another table with a title
+|===
+|Value |Result |Notes
+
+|Null |A mystery |See Appendix R
+|===
+
+Notice that the table that doesn't have a title didn't get a label nor was it counted when the processor incremented the label number.
+Therefore, the third table is assigned the label _Data Set 2._
+
+"#
+    );
+
+    // The three tables share a document whose `table-caption` is "Data Set". The
+    // two titled tables are labeled "Data Set 1." and "Data Set 2."; the untitled
+    // middle table is neither labeled nor counted, so the third table is numbered
+    // 2 rather than 3.
+    let doc = Parser::default().parse(
+        "= Document Title\n:table-caption: Data Set\n\n.A table with a title\n[cols=\"2,1\"]\n|===\n|Lots and lots of data |A little data\n\n|834,734 |3\n|3,999,271.5601 |5\n|===\n\n|===\n|Group |Climate |Example\n\n|A\n|Tropical\n|Suva, Fiji\n\n|B\n|Arid\n|Lima, Peru\n|===\n\n.Another table with a title\n|===\n|Value |Result |Notes\n\n|Null |A mystery |See Appendix R\n|===",
+    );
+
+    // The displayed tables render the label and title together inside each
+    // titled table's `<caption class="title">`. The untitled middle table emits
+    // no caption, so only two captions exist in the document.
+    assert_xpath(
+        &doc,
+        "//caption[text()=\"Data Set 1. A table with a title\"]",
+        1,
+    );
+    assert_xpath(
+        &doc,
+        "//caption[text()=\"Data Set 2. Another table with a title\"]",
+        1,
+    );
+    assert_xpath(&doc, "//caption", 2);
+}
+
+#[test]
+fn modify_the_label_of_an_individual_table_using_caption() {
+    non_normative!(
+        r#"
+== Modify the label of an individual table using caption
+
+"#
+    );
+
+    verifies!(
+        r#"
+You can customize the label on an individual table by setting the `caption` attribute.
+(Don't let the name of the attribute mislead you.
+The caption attribute only sets the caption's label, not the whole caption line).
+When using `caption`, assign it the exact value you want displayed (including trailing spaces).
+Labels assigned using `caption` don't get an automatically incremented number and only apply to the table they are set on.
+
+CAUTION: If you want a space between the label and the title, you must add a trailing space to the value of the caption attribute.
+
+.Modify the label using caption
+[source#ex-caption]
+----
+[caption="Table A. "] <.> <.>
+.A table with a custom label
+[cols="3*"]
+|===
+|Null
+|A mystery
+|See Appendix R
+|===
+----
+<.> Create an attribute list directly above the table's title and set the named attribute `caption`, followed by an equals sign (`=`), and then a value.
+<.> Enclose the value in double quotation marks (`"`).
+Otherwise the processor will remove any trailing whitespaces, and the title text will start directly after the last character of the label.
+
+The table from <<ex-caption>> is displayed below.
+
+[caption="Table A. "]
+.A table with a custom label
+[cols="3*"]
+|===
+|Null
+|A mystery
+|See Appendix R
+|===
+
+"#
+    );
+
+    // The explicit `caption` attribute (on its own attribute-list line above the
+    // title, with the `cols` specifier on a second line below it) sets the label
+    // verbatim — including its trailing space — with no automatically inserted
+    // number. The label and title render together inside the table's
+    // `<caption class="title">`.
+    let doc = Parser::default().parse(
+        "[caption=\"Table A. \"]\n.A table with a custom label\n[cols=\"3*\"]\n|===\n|Null\n|A mystery\n|See Appendix R\n|===",
+    );
+
+    assert_xpath(
+        &doc,
+        "//caption[text()=\"Table A. A table with a custom label\"]",
+        1,
+    );
+
+    verifies!(
+        r#"
+If you create any subsequent tables in your document and don't set `caption` on them, the title labels will revert to the value assigned to `table-caption`.
+
+"#
+    );
+
+    // A table that sets `caption` is skipped by the table counter, so a later
+    // titled table without `caption` reverts to the `table-caption` label and
+    // resumes the automatic numbering from "Table 1.".
+    let doc = Parser::default()
+        .parse("[caption=\"Custom. \"]\n.Custom\n|===\n|a\n|===\n\n.Next\n|===\n|b\n|===");
+
+    assert_xpath(&doc, "//caption[text()=\"Custom. Custom\"]", 1);
+    assert_xpath(&doc, "//caption[text()=\"Table 1. Next\"]", 1);
+
+    non_normative!(
+        r#"
+If you want the caption of the table to only consist of the caption label, use the following syntax:
+
+"#
+    );
+
+    // Reproducing this example requires two features the parser does not yet
+    // support: setting a block's title through a `title` attribute, and the
+    // `{counter:table-number}` counter reference. The example is tracked here
+    // but not yet exercised.
+    //
+    // TODO: Promote to `verifies!` once counter support lands.
+    // https://github.com/asciidoc-rs/asciidoc-parser/issues/514
+    to_do_verifies!(
+        r#"
+[source]
+----
+[caption=,title="{table-caption} {counter:table-number}"]
+include::example$table.adoc[tag=b-col-h]
+----
+
+"#
+    );
+
+    if false {
+        todo!("block title attribute and counter:table-number support");
+    }
+}
+
+#[test]
+fn modify_the_label_of_an_individual_table_to_only_the_caption_label() {
+    non_normative!(
+        r#"
+Alternately, you can write is as follows:
+
+"#
+    );
+
+    // Reproducing this example requires `{counter:table-number}` counter
+    // support, which is not yet implemented.
+    //
+    // TODO: Promote to `verifies!` once counter support lands.
+    // https://github.com/asciidoc-rs/asciidoc-parser/issues/514
+    to_do_verifies!(
+        r#"
+[source]
+----
+.{empty}
+[caption="{table-caption} {counter:table-number}"]
+include::example$table.adoc[tag=b-col-h]
+----
+"#
+    );
+
+    if false {
+        todo!("counter:table-number support");
+    }
+}

--- a/parser/src/tests/asciidoc_lang/tables/data_format.rs
+++ b/parser/src/tests/asciidoc_lang/tables/data_format.rs
@@ -1,0 +1,983 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/data-format.adoc");
+
+use crate::blocks::{DataFormat, TableCellContent};
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Return the rendered text of a [`Simple`](TableCellContent::Simple) cell,
+/// panicking if the cell holds AsciiDoc block content.
+fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
+    match cell.content() {
+        TableCellContent::Simple(content) => content.rendered().to_string(),
+        TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
+    }
+}
+
+/// Return the rendered text of every cell in the table, in document order
+/// (header row first, then body rows, then any footer row).
+fn all_texts(table: &crate::blocks::TableBlock<'_>) -> Vec<String> {
+    table
+        .header_row()
+        .into_iter()
+        .chain(table.body_rows())
+        .chain(table.footer_row())
+        .flat_map(|row| row.cells().iter().map(simple_text))
+        .collect()
+}
+
+non_normative!(
+    r#"
+= Table Data Formats
+:navtitle: CSV, TSV and DSV Data
+:url-dsv: https://en.wikipedia.org/wiki/Delimiter-separated_values
+:url-rfc-4180: https://tools.ietf.org/html/rfc4180
+
+== Default table syntax
+
+A table is delimited by a vertical bar and three equal signs (`|===`).
+It contains cells that are arranged into rows according to the number of columns the table is assigned.
+The number of columns a table contains can be specified implicitly using the number of cells in the table's first row or by setting the `cols` attribute.
+Each cell is specified by a vertical bar (`|`).
+
+If you're new to AsciiDoc tables, xref:build-a-basic-table.adoc[] provides step by step directions for creating your first table.
+
+== Style and layout options
+
+Table content can be:
+
+* styled and aligned by column or cell,
+* aligned by row,
+* duplicated across multiple rows, and
+* marked up by any AsciiDoc syntax.
+
+Table cells can span rows and columns.
+
+You can adjust a table's:
+
+* width,
+* orientation, and
+* border style.
+
+You can also specify each column's width and designate header and footer rows.
+
+== Supported data formats
+
+"#
+);
+
+#[test]
+fn supported_data_formats() {
+    verifies!(
+        r#"
+The default table data format is prefix-separated values (PSV); that means the processor creates a new cell each time it encounters a vertical bar (`|`).
+AsciiDoc also supports comma-separated values (CSV), tab-separated values (TSV), and delimited data values (DSV).
+
+"#
+    );
+
+    // PSV is the default data format.
+    assert_eq!(
+        parse_table("|===\n|a |b\n|===").data_format(),
+        DataFormat::Psv
+    );
+
+    // CSV, TSV, and DSV are also supported, selected with the `format` attribute.
+    assert_eq!(
+        parse_table("[format=csv]\n|===\na,b\n|===").data_format(),
+        DataFormat::Csv
+    );
+    assert_eq!(
+        parse_table("[format=tsv]\n|===\na\tb\n|===").data_format(),
+        DataFormat::Tsv
+    );
+    assert_eq!(
+        parse_table("[format=dsv]\n|===\na:b\n|===").data_format(),
+        DataFormat::Dsv
+    );
+}
+
+#[test]
+fn escape_the_cell_separator() {
+    verifies!(
+        r#"
+== Escape the cell separator
+
+The parser scans for the cell separator to partition cells _before_ it processes the cell text.
+So even if you try to hide the cell separator using an inline passthrough, the parser will see it.
+If the cell contain contains the cell separator, you must escape that character.
+There are three ways to escape it:
+
+* Prefix the character with a leading backslash (i.e., `\|`), which will be removed from the output.
+* Use the `\{vbar}` attribute reference in place of `|` in content.
+* Change the cell separator used by the table.
+
+Unless you do one of these things, the cell separator will be interpreted as a cell boundary.
+
+Consider the following example, which escapes the cell separator using a leading backslash:
+
+[source]
+----
+[cols=2*]
+|===
+|The default separator in PSV tables is the \| character.
+|The \| character is often referred to as a "`pipe`".
+|===
+----
+
+This table will render as follows:
+
+.Result: Converted PSV table that contains pipe characters
+[cols=2*]
+|===
+|The default separator in PSV tables is the \| character.
+|The \| character is often referred to as a "`pipe`".
+|===
+
+"#
+    );
+
+    // The backslash-escaped separator (`\|`) is unescaped to a bare `|`, and the
+    // leading backslash is removed from the rendered cell.
+    let table = parse_table(
+        "[cols=2*]\n|===\n|The default separator in PSV tables is the \\| character.\n|The \\| character is often referred to as a \"`pipe`\".\n|===",
+    );
+    assert_eq!(table.body_rows().len(), 1);
+    let cells: Vec<String> = table.body_rows()[0]
+        .cells()
+        .iter()
+        .map(simple_text)
+        .collect();
+    assert_eq!(
+        cells[0],
+        "The default separator in PSV tables is the | character."
+    );
+    assert!(cells[1].contains("The | character"), "got: {:?}", cells[1]);
+}
+
+#[test]
+fn escape_with_backslash() {
+    verifies!(
+        r#"
+Notice that the pipe character appears without the leading backslash (i.e., unescaped) in the rendered result.
+
+"#
+    );
+
+    // The escaped separator (`\|`) is unescaped to a bare `|` in the rendered
+    // cell, and the leading backslash is removed.
+    let table = parse_table(
+        "[cols=2*]\n|===\n|The default separator in PSV tables is the \\| character.\n|The \\| character is often referred to as a \"`pipe`\".\n|===",
+    );
+    let cell = simple_text(&table.body_rows()[0].cells()[0]);
+    assert!(cell.contains("the | character"), "got: {cell:?}");
+    assert!(
+        !cell.contains("\\|"),
+        "backslash should be removed: {cell:?}"
+    );
+}
+
+#[test]
+fn substitute_with_vbar() {
+    verifies!(
+        r#"
+An alternative is to use the `\{vbar}` attribute reference as a substitute.
+This approach produces the same result as the previous example.
+
+"#
+    );
+
+    // The `{vbar}` attribute reference produces the same result as the escaped
+    // separator: a bare `|` in the rendered cell.
+    let table = parse_table(
+        "[cols=2*]\n|===\n|The default separator in PSV tables is the {vbar} character.\n|The {vbar} character is often referred to as a \"`pipe`\".\n|===",
+    );
+    let cell = simple_text(&table.body_rows()[0].cells()[0]);
+    assert!(cell.contains("the | character"), "got: {cell:?}");
+}
+
+#[test]
+fn substitute_the_vbar_reference() {
+    verifies!(
+        r#"
+[source]
+----
+[cols=2*]
+|===
+|The default separator in PSV tables is the {vbar} character.
+|The {vbar} character is often referred to as a "`pipe`".
+|===
+----
+
+Escaping each cell separator character that appears in the content of a cell can be tedious.
+There are also times when you can't or don't want to modify the cell content (perhaps because it is being included from another file).
+To address these cases, AsciiDoc allows you to override the cell separator.
+
+"#
+    );
+
+    // The `{vbar}` attribute reference renders as a bare `|`, producing the same
+    // result as the backslash escape.
+    let table = parse_table(
+        "[cols=2*]\n|===\n|The default separator in PSV tables is the {vbar} character.\n|The {vbar} character is often referred to as a \"`pipe`\".\n|===",
+    );
+    let cells: Vec<String> = table.body_rows()[0]
+        .cells()
+        .iter()
+        .map(simple_text)
+        .collect();
+    assert_eq!(
+        cells[0],
+        "The default separator in PSV tables is the | character."
+    );
+    assert!(cells[1].contains("The | character"), "got: {:?}", cells[1]);
+}
+
+#[test]
+fn override_the_cell_separator() {
+    verifies!(
+        r#"
+The cell separator is controlled using the `separator` attribute on the table block.
+You'll want to select any single character that is not found in the content.
+A good candidate is the broken bar, or `¦`.
+
+"#
+    );
+
+    // With the separator overridden to the broken bar (`¦`), the vertical bar in
+    // the cell content is ordinary text rather than a cell boundary.
+    let table = parse_table(
+        "[cols=2*,separator=¦]\n|===\n¦The default separator in PSV tables is the | character.\n¦The | character is often referred to as a \"`pipe`\".\n|===",
+    );
+    assert_eq!(table.body_rows().len(), 1);
+    assert_eq!(table.body_rows()[0].cells().len(), 2);
+    let cell = simple_text(&table.body_rows()[0].cells()[0]);
+    assert_eq!(
+        cell,
+        "The default separator in PSV tables is the | character."
+    );
+}
+
+#[test]
+fn custom_separator_example() {
+    verifies!(
+        r#"
+Here's the previous example rewritten using a custom separator.
+
+[source]
+----
+[cols=2*,separator=¦]
+|===
+¦The default separator in PSV tables is the | character.
+¦The | character is often referred to as a "`pipe`".
+|===
+----
+
+Notice that it's no longer necessary to escape the pipe character in the content of the table cells.
+You can safely use the original cell separator in the cell content and not worry about it being interpreted as the boundary of a cell.
+
+[#delimiter-separated-values]
+== Delimiter-separated values
+
+"#
+    );
+
+    // With the separator overridden to the broken bar (`¦`), the vertical bars in
+    // the cell content are ordinary text and need no escaping.
+    let table = parse_table(
+        "[cols=2*,separator=¦]\n|===\n¦The default separator in PSV tables is the | character.\n¦The | character is often referred to as a \"`pipe`\".\n|===",
+    );
+    assert_eq!(table.body_rows().len(), 1);
+    let cells: Vec<String> = table.body_rows()[0]
+        .cells()
+        .iter()
+        .map(simple_text)
+        .collect();
+    assert_eq!(
+        cells[0],
+        "The default separator in PSV tables is the | character."
+    );
+    assert!(cells[1].contains("The | character"), "got: {:?}", cells[1]);
+}
+
+#[test]
+fn delimiter_between_values() {
+    verifies!(
+        r#"
+Tables can also be populated from data formatted as delimiter-separated values (i.e., data tables).
+In contrast with the PSV format, in which the delimiter is placed in front of each cell value, the delimiter in a delimiter-separated format (CSV, TSV, DSV) is placed between the cell values (called a _separator_) and does not accept a cell formatting spec.
+Each line of data is assumed to represent a single row, though you'll learn that's not a strict rule.
+How the table data gets interpreted is controlled by the `format` and `separator` attributes on the table.
+
+"#
+    );
+
+    // The separator sits between the values, so three comma-separated values
+    // produce three cells (a three-column row).
+    let table = parse_table("[format=csv]\n|===\na,b,c\n|===");
+    assert_eq!(table.data_format(), DataFormat::Csv);
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(all_texts(&table), ["a", "b", "c"]);
+
+    // A data cell does not accept a cell formatting spec: what would be a colspan
+    // operator in PSV (`2+`) is taken literally as the cell's value.
+    let table = parse_table("[format=csv]\n|===\n2+,b,c\n|===");
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(table.body_rows()[0].cells()[0].colspan(), 1);
+    assert_eq!(simple_text(&table.body_rows()[0].cells()[0]), "2+");
+}
+
+non_normative!(
+    r#"
+.What the delimiter?
+****
+Aren't comma-separated values a subset of {url-dsv}[delimiter-separated values^]?
+It really depends on who you consult.
+
+The term "`delimiter-separated values`" in this text refers to the family of data formats that use a delimiter, including comma-separated values (CSV), tab-separated values (TSV) and delimited data (DSV), all of which are supported in AsciiDoc tables.
+CSV is the data format used most often.
+
+"`Comma-separated values`" is really a misleading term since CSV can use delimiters other than `,` as the field separator (which, in this context, separates cells).
+What we're really talking about is how the data is interpreted.
+
+CSV and TSV both use a delimiter and an optional enclosing character, loosely based on {url-rfc-4180}[RFC 4180^].
+DSV (i.e., delimited data) only uses a delimiter, which can be escaped using a backslash; an enclosing character is not recognized.
+These parsing rules are described in detail in <<data-table-formats>>.
+****
+
+"#
+);
+
+#[test]
+fn csv_format() {
+    verifies!(
+        r#"
+Let's consider an example of using comma-separated values (CSV) to populate an AsciiDoc table with data.
+To instruct the processor to read the data as CSV, set the value of the `format` attribute on the table to `csv`.
+When the `format` attribute is set to `csv`, the default data separator is a comma (`,`), as seen in the table below.
+
+"#
+    );
+
+    // With `format=csv`, the default separator is a comma.
+    let table = parse_table(
+        "[%header,format=csv]\n|===\nArtist,Track,Genre\nBaauer,Harlem Shake,Hip Hop\nThe Lumineers,Ho Hey,Folk Rock\n|===",
+    );
+    assert_eq!(table.data_format(), DataFormat::Csv);
+    assert_eq!(table.columns().len(), 3);
+
+    let header: Vec<String> = table
+        .header_row()
+        .unwrap()
+        .cells()
+        .iter()
+        .map(simple_text)
+        .collect();
+    assert_eq!(header, ["Artist", "Track", "Genre"]);
+    assert_eq!(table.body_rows().len(), 2);
+}
+
+#[test]
+fn csv_example() {
+    verifies!(
+        r#"
+[source]
+----
+include::example$data.adoc[tag=csv]
+----
+
+.Result: Rendered CSV table
+[width=90%]
+include::example$data.adoc[tag=csv]
+
+This feature is particularly useful when you want to populate a table in your manuscript from data stored in a separate file.
+You can do so using the xref:directives:include.adoc[include directive] between the table delimiters, as shown here:
+
+[source]
+----
+[%header,format=csv]
+|===
+\include::tracks.csv[]
+|===
+----
+
+"#
+    );
+
+    // `include::example$data.adoc[tag=csv]` expands to this CSV table.
+    let table = parse_table(
+        "[%header,format=csv]\n|===\nArtist,Track,Genre\nBaauer,Harlem Shake,Hip Hop\nThe Lumineers,Ho Hey,Folk Rock\n|===",
+    );
+    assert_eq!(table.data_format(), DataFormat::Csv);
+    let header: Vec<String> = table
+        .header_row()
+        .unwrap()
+        .cells()
+        .iter()
+        .map(simple_text)
+        .collect();
+    assert_eq!(header, ["Artist", "Track", "Genre"]);
+    assert_eq!(
+        all_texts(&table),
+        [
+            "Artist",
+            "Track",
+            "Genre",
+            "Baauer",
+            "Harlem Shake",
+            "Hip Hop",
+            "The Lumineers",
+            "Ho Hey",
+            "Folk Rock"
+        ]
+    );
+}
+
+#[test]
+fn tsv_format() {
+    verifies!(
+        r#"
+If your data is separated by tabs instead of commas, set the `format` to `tsv` (tab-separated values) instead.
+
+"#
+    );
+
+    // With `format=tsv`, the default separator is a tab.
+    let table = parse_table("[format=tsv]\n|===\nArtist\tTrack\tGenre\n|===");
+    assert_eq!(table.data_format(), DataFormat::Tsv);
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(all_texts(&table), ["Artist", "Track", "Genre"]);
+}
+
+#[test]
+fn dsv_format() {
+    verifies!(
+        r#"
+Now let's consider an example of using delimited data (DSV) to populate an AsciiDoc table with data.
+To instruct the processor to read the data as DSV, set the value of the `format` attribute on the table to `dsv`.
+When the `format` attribute is set to `dsv`, the default data separator is a colon (`:`), as seen in the table below.
+
+"#
+    );
+
+    // With `format=dsv`, the default separator is a colon.
+    let table = parse_table(
+        "[%header,format=dsv]\n|===\nArtist:Track:Genre\nRobyn:Indestructible:Dance\nThe Piano Guys:Code Name Vivaldi:Classical\n|===",
+    );
+    assert_eq!(table.data_format(), DataFormat::Dsv);
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(table.body_rows().len(), 2);
+}
+
+#[test]
+fn dsv_example() {
+    verifies!(
+        r#"
+[source]
+----
+include::example$data.adoc[tag=dsv]
+----
+
+.Result: Rendered DSV table
+[width=90%]
+include::example$data.adoc[tag=dsv]
+
+"#
+    );
+
+    // `include::example$data.adoc[tag=dsv]` expands to this DSV table.
+    let table = parse_table(
+        "[%header,format=dsv]\n|===\nArtist:Track:Genre\nRobyn:Indestructible:Dance\nThe Piano Guys:Code Name Vivaldi:Classical\n|===",
+    );
+    assert_eq!(table.data_format(), DataFormat::Dsv);
+    assert_eq!(
+        all_texts(&table),
+        [
+            "Artist",
+            "Track",
+            "Genre",
+            "Robyn",
+            "Indestructible",
+            "Dance",
+            "The Piano Guys",
+            "Code Name Vivaldi",
+            "Classical"
+        ]
+    );
+}
+
+non_normative!(
+    r#"
+== Data table formats
+
+The CSV and TSV data formats are parsed differently from the DSV data format.
+The following two sections outline those differences.
+
+=== CSV and TSV
+
+"#
+);
+
+#[test]
+fn csv_and_tsv_parsing_rules() {
+    verifies!(
+        r#"
+Table data in either CSV or TSV format is parsed according to the following rules, loosely based on {url-rfc-4180}[RFC 4180^]:
+
+* The default delimiter for CSV is a comma (`,`) while the default delimiter for TSV is a tab character.
+* Empty lines are skipped (unless enclosed in a quoted value).
+* Whitespace surrounding each value is stripped.
+* Values can be enclosed in double quotes (`"`).
+ ** A quoted value may contain zero or more separator or newline characters.
+ ** A newline begins a new row unless the newline is enclosed in double quotes.
+ ** A quoted value may include the double quote character if escaped using another double quote (`""`).
+ ** Newlines in quoted values are retained.
+* If rows do not have the same number of cells ("`ragged`" tables), cells are shuffled to fully fill the rows.
+ ** This is different behavior than Excel, which pads short rows with empty cells.
+ ** Extra cells at the end of the last row get dropped.
+ ** As a rule of thumb, data for a single row should be on the same line.
+
+"#
+    );
+
+    // The default delimiter is a comma for CSV and a tab for TSV.
+    assert_eq!(
+        parse_table("[format=csv]\n|===\na,b,c\n|===")
+            .columns()
+            .len(),
+        3
+    );
+    assert_eq!(
+        parse_table("[format=tsv]\n|===\na\tb\tc\n|===")
+            .columns()
+            .len(),
+        3
+    );
+
+    // Empty lines are skipped and the whitespace surrounding each value is
+    // stripped.
+    let table = parse_table("[format=csv]\n|===\na, b ,c\nd,e,f\n\ng,h,i\n|===");
+    assert!(table.header_row().is_none());
+    assert_eq!(
+        all_texts(&table),
+        ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
+    );
+
+    // A quoted value may contain the separator, which is then literal.
+    let table = parse_table("[format=csv]\n|===\na,\"b,c\",d\n|===");
+    assert_eq!(all_texts(&table), ["a", "b,c", "d"]);
+
+    // A quoted value may contain newlines, which are retained, and a newline
+    // inside the quotes does not begin a new row.
+    let table = parse_table("[format=csv,cols=2*]\n|===\n\"line1\nline2\",x\ny,z\n|===");
+    assert_eq!(table.body_rows().len(), 2);
+    assert_eq!(
+        simple_text(&table.body_rows()[0].cells()[0]),
+        "line1\nline2"
+    );
+    assert_eq!(simple_text(&table.body_rows()[0].cells()[1]), "x");
+    assert_eq!(simple_text(&table.body_rows()[1].cells()[0]), "y");
+
+    // A doubled double quote inside a quoted value is an escaped literal quote.
+    let table = parse_table("[format=csv]\n|===\n\"he said \"\"hi\"\"\",p,q\n|===");
+    assert_eq!(
+        simple_text(&table.body_rows()[0].cells()[0]),
+        "he said \"hi\""
+    );
+
+    // A ragged table flows its cells into complete rows (it is not padded like
+    // Excel); cells left over after the last complete row are dropped.
+    let table = parse_table("[format=csv,cols=3*]\n|===\na,b,c,d,e\n|===");
+    assert_eq!(all_texts(&table), ["a", "b", "c"]);
+
+    let table = parse_table("[format=csv]\n|===\na,b,c\nd,e\nf,g,h,i\n|===");
+    assert!(table.header_row().is_none());
+    assert_eq!(
+        all_texts(&table),
+        ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
+    );
+}
+
+non_normative!(
+    r#"
+=== DSV
+
+"#
+);
+
+#[test]
+fn dsv_parsing_rules() {
+    verifies!(
+        r#"
+Table data in DSV format is parsed according to the following rules:
+
+* The default delimiter for DSV is a colon (`:`).
+* Empty lines are skipped.
+* Whitespace surrounding each value is stripped.
+* The delimiter character can be included in the value if escaped using a single backslash (`\:`).
+* If rows do not have the same number of cells ("`ragged`" tables), cells are shuffled to fully fill the rows.
+
+"#
+    );
+
+    // The default delimiter for DSV is a colon, empty lines are skipped, and the
+    // whitespace surrounding each value is stripped.
+    let table = parse_table("[format=dsv]\n|===\na : b :c\nd:e:f\n|===");
+    assert!(table.header_row().is_none());
+    assert_eq!(all_texts(&table), ["a", "b", "c", "d", "e", "f"]);
+
+    let table = parse_table("[format=dsv]\n|===\na:b\n\nc:d\n|===");
+    assert!(table.header_row().is_some());
+    assert_eq!(all_texts(&table), ["a", "b", "c", "d"]);
+
+    // The delimiter can be included in a value by escaping it with a single
+    // backslash; an enclosing character is not recognized.
+    let table = parse_table("[format=dsv]\n|===\nd\\:e:f:g\n|===");
+    assert_eq!(all_texts(&table), ["d:e", "f", "g"]);
+
+    // A ragged DSV table also flows its cells into complete rows.
+    let table = parse_table("[format=dsv,cols=2*]\n|===\na:b:c\n|===");
+    assert_eq!(all_texts(&table), ["a", "b"]);
+}
+
+non_normative!(
+    r#"
+== Custom delimiters
+
+"#
+);
+
+#[test]
+fn custom_delimiters() {
+    verifies!(
+        r#"
+Each data format has a default separator associated with it (csv = comma, tsv = tab, dsv = colon), but the separator can be changed to any character (or even a string of characters) by setting the `separator` attribute on the table.
+
+"#
+    );
+
+    // The separator can be changed to any character...
+    let table = parse_table("[format=dsv,separator=;]\n|===\na;b;c\nd;e;f\n|===");
+    assert_eq!(all_texts(&table), ["a", "b", "c", "d", "e", "f"]);
+
+    // ...or even to a string of characters.
+    let table = parse_table("[format=csv,separator=::]\n|===\na::b::c\n|===");
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(all_texts(&table), ["a", "b", "c"]);
+}
+
+#[test]
+fn custom_separator_dsv_example() {
+    verifies!(
+        r#"
+Here's an example of a DSV table that uses a custom separator character (i.e., delimiter):
+
+.A DSV table with a custom separator
+[source]
+----
+[format=dsv,separator=;]
+|===
+a;b;c
+d;e;f
+|===
+----
+
+"#
+    );
+
+    // The DSV example with a custom `;` separator parses into two three-cell rows.
+    let table = parse_table("[format=dsv,separator=;]\n|===\na;b;c\nd;e;f\n|===");
+    assert_eq!(table.data_format(), DataFormat::Dsv);
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(all_texts(&table), ["a", "b", "c", "d", "e", "f"]);
+}
+
+#[test]
+fn tsv_via_csv_and_tab_separator() {
+    verifies!(
+        r#"
+TIP: To make a TSV table, you can set the `format` attribute to `csv` and the separator to `\t`.
+Though the `tsv` format is preferred.
+
+"#
+    );
+
+    // A TSV table can be produced with `format=csv` and the separator set to a
+    // tab (written `\t`); the preferred `tsv` format yields the same result.
+    let via_csv = parse_table("[format=csv,separator=\\t]\n|===\na\tb\tc\n|===");
+    assert_eq!(via_csv.data_format(), DataFormat::Csv);
+    assert_eq!(all_texts(&via_csv), ["a", "b", "c"]);
+
+    let via_tsv = parse_table("[format=tsv]\n|===\na\tb\tc\n|===");
+    assert_eq!(all_texts(&via_tsv), all_texts(&via_csv));
+}
+
+#[test]
+fn separator_independent_of_format() {
+    verifies!(
+        r#"
+The separator is independent of the processing rules for the format.
+If you set `format=dsv` and `separator=,`, the data will be processed using the DSV rules, even though the data looks like CSV.
+
+"#
+    );
+
+    // The same separator is processed by whichever format's rules are in effect.
+    // Under DSV a double quote is not an enclosing character, so it stays in the
+    // value and the separator still splits around it.
+    let table = parse_table("[format=dsv,separator=;]\n|===\n\"a;b\";c\n|===");
+    assert_eq!(table.data_format(), DataFormat::Dsv);
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(all_texts(&table), ["\"a", "b\"", "c"]);
+
+    // With the very same separator but `format=csv`, the double quotes instead
+    // enclose the value, so the separator inside them is literal.
+    let table = parse_table("[format=csv,separator=;]\n|===\n\"a;b\";c\n|===");
+    assert_eq!(table.data_format(), DataFormat::Csv);
+    assert_eq!(table.columns().len(), 2);
+    assert_eq!(all_texts(&table), ["a;b", "c"]);
+}
+
+non_normative!(
+    r#"
+== Shorthand notation for data tables
+
+"#
+);
+
+#[test]
+fn shorthand_csv_delimiter() {
+    verifies!(
+        r#"
+AsciiDoc provides shorthand notation for specifying the data format of a table.
+The first position of the table block delimiter (i.e., `|===`) can be replaced by a built-in delimiter to set the table format (e.g., `,===` for CSV).
+
+To make a CSV table, you can use `,===` as the table block delimiter:
+
+"#
+    );
+
+    // The `,===` shorthand delimiter sets the CSV format.
+    let table = parse_table(",===\nArtist,Track,Genre\n\nBaauer,Harlem Shake,Hip Hop\n,===");
+    assert_eq!(table.data_format(), DataFormat::Csv);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.columns().len(), 3);
+}
+
+#[test]
+fn shorthand_csv_example() {
+    verifies!(
+        r#"
+[source]
+----
+include::example$data.adoc[tag=s-csv]
+----
+
+.Result: Rendered CSV table using shorthand syntax
+[width=90%]
+include::example$data.adoc[tag=s-csv]
+
+"#
+    );
+
+    // `include::example$data.adoc[tag=s-csv]` expands to this shorthand CSV table.
+    let table = parse_table(",===\nArtist,Track,Genre\n\nBaauer,Harlem Shake,Hip Hop\n,===");
+    assert_eq!(table.data_format(), DataFormat::Csv);
+    assert!(table.header_row().is_some());
+    assert_eq!(
+        all_texts(&table),
+        [
+            "Artist",
+            "Track",
+            "Genre",
+            "Baauer",
+            "Harlem Shake",
+            "Hip Hop"
+        ]
+    );
+}
+
+#[test]
+fn shorthand_dsv_delimiter() {
+    verifies!(
+        r#"
+To make a DSV table, you can use `:===` as the table block delimiter:
+
+"#
+    );
+
+    // The `:===` shorthand delimiter sets the DSV format.
+    let table = parse_table(":===\nArtist:Track:Genre\n\nRobyn:Indestructible:Dance\n:===");
+    assert_eq!(table.data_format(), DataFormat::Dsv);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.columns().len(), 3);
+}
+
+#[test]
+fn shorthand_dsv_example() {
+    verifies!(
+        r#"
+[source]
+----
+include::example$data.adoc[tag=s-dsv]
+----
+
+.Result: Rendered DSV table using shorthand syntax
+[width=90%]
+include::example$data.adoc[tag=s-dsv]
+
+"#
+    );
+
+    // `include::example$data.adoc[tag=s-dsv]` expands to this shorthand DSV table.
+    let table = parse_table(":===\nArtist:Track:Genre\n\nRobyn:Indestructible:Dance\n:===");
+    assert_eq!(table.data_format(), DataFormat::Dsv);
+    assert!(table.header_row().is_some());
+    assert_eq!(
+        all_texts(&table),
+        [
+            "Artist",
+            "Track",
+            "Genre",
+            "Robyn",
+            "Indestructible",
+            "Dance"
+        ]
+    );
+}
+
+#[test]
+fn shorthand_implies_format() {
+    verifies!(
+        r#"
+When using either the CSV or DSV shorthand, you do not need to set the `format` attribute as it's implied.
+
+"#
+    );
+
+    // The shorthand implies the format, so no `format` attribute is required.
+    assert_eq!(
+        parse_table(",===\na,b,c\n,===").data_format(),
+        DataFormat::Csv
+    );
+    assert_eq!(
+        parse_table(":===\na:b:c\n:===").data_format(),
+        DataFormat::Dsv
+    );
+}
+
+#[test]
+fn tsv_has_no_shorthand_delimiter() {
+    verifies!(
+        r#"
+To make a TSV table, you can set the `format` attribute to `tsv` instead of having to set the `format` to `csv` and the separator to `\t`.
+In this case, you can use either `|===` or `,===` as the table block delimiter.
+There is no special delimited block notation for a TSV table.
+
+"#
+    );
+
+    // TSV is selected with `format=tsv`; there is no shorthand delimiter for it.
+    let table = parse_table("[format=tsv]\n|===\na\tb\tc\n|===");
+    assert_eq!(table.data_format(), DataFormat::Tsv);
+
+    // Either `|===` or `,===` may be used as the block delimiter for a TSV table.
+    let table = parse_table("[format=tsv]\n,===\na\tb\tc\n,===");
+    assert_eq!(table.data_format(), DataFormat::Tsv);
+    assert_eq!(all_texts(&table), ["a", "b", "c"]);
+}
+
+non_normative!(
+    r#"
+== Formatting cells in a data table
+
+"#
+);
+
+#[test]
+fn formatting_cells_via_cols_spec() {
+    verifies!(
+        r#"
+The delimited formats do not provide a way to express formatting of individual table cells.
+Instead, you can apply cell formatting to all cells in a given column using the `cols` spec on the table:
+
+"#
+    );
+
+    // The delimited formats carry no per-cell spec, so cell formatting is applied
+    // per column with the `cols` spec: here column 1 is a header column and
+    // column 2 is an AsciiDoc column.
+    let table = parse_table(
+        "[format=csv,cols=\"1h,1a\"]\n|===\nSky,image::sky.jpg[]\nForest,image::forest.jpg[]\n|===",
+    );
+    assert_eq!(table.columns()[0].style(), ColumnStyle::Header);
+    assert_eq!(table.columns()[1].style(), ColumnStyle::AsciiDoc);
+
+    // The second column's cells are parsed as AsciiDoc block content.
+    assert!(matches!(
+        table.body_rows()[0].cells()[1].content(),
+        TableCellContent::AsciiDoc(_)
+    ));
+}
+
+#[test]
+fn data_formatting_example() {
+    verifies!(
+        r#"
+[source]
+----
+[format=csv,cols="1h,1a"]
+|===
+Sky,image::sky.jpg[]
+Forest,image::forest.jpg[]
+|===
+----
+
+"#
+    );
+
+    // The `cols="1h,1a"` example applies a header style to the first column and
+    // the AsciiDoc style to the second.
+    let table = parse_table(
+        "[format=csv,cols=\"1h,1a\"]\n|===\nSky,image::sky.jpg[]\nForest,image::forest.jpg[]\n|===",
+    );
+    assert_eq!(table.columns()[0].style(), ColumnStyle::Header);
+    assert_eq!(table.columns()[1].style(), ColumnStyle::AsciiDoc);
+    assert!(matches!(
+        table.body_rows()[0].cells()[1].content(),
+        TableCellContent::AsciiDoc(_)
+    ));
+}
+
+#[test]
+fn data_tables_do_not_support_spans() {
+    verifies!(
+        r#"
+Data tables do not support cells that span multiple rows or columns, since that information can only be expressed at the cell level.
+You are advised to use the PSV format if you need that functionality.
+"#
+    );
+
+    // A data table cannot express a row or column span: a `2+` operator is
+    // ordinary cell data, spanning a single column.
+    let table = parse_table("[format=csv]\n|===\n2+,b,c\nd,e,f\n|===");
+    assert_eq!(table.columns().len(), 3);
+    let cell = &table.body_rows()[0].cells()[0];
+    assert_eq!(cell.colspan(), 1);
+    assert_eq!(cell.rowspan(), 1);
+    assert_eq!(simple_text(cell), "2+");
+}

--- a/parser/src/tests/asciidoc_lang/tables/duplicate_cells.rs
+++ b/parser/src/tests/asciidoc_lang/tables/duplicate_cells.rs
@@ -1,0 +1,214 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/duplicate-cells.adoc");
+
+non_normative!(
+    r#"
+= Duplicate Cells
+// clone, copy, replicate, duplicate
+
+The contents of a cell can be duplicated in consecutive cells.
+
+"#
+);
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Collect the rendered text of each cell in each body row of `table`.
+fn body_texts(table: &crate::blocks::TableBlock<'_>) -> Vec<Vec<String>> {
+    table
+        .body_rows()
+        .iter()
+        .map(|row| {
+            row.cells()
+                .iter()
+                .map(|cell| match cell.content() {
+                    crate::blocks::TableCellContent::Simple(content) => {
+                        content.rendered().to_string()
+                    }
+                    crate::blocks::TableCellContent::AsciiDoc(_) => {
+                        panic!("expected simple cell content")
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Collect the [`ColumnStyle`] of each cell in each body row of `table`.
+fn body_styles(table: &crate::blocks::TableBlock<'_>) -> Vec<Vec<crate::blocks::ColumnStyle>> {
+    table
+        .body_rows()
+        .iter()
+        .map(|row| row.cells().iter().map(|cell| cell.style()).collect())
+        .collect()
+}
+
+#[test]
+fn duplication_factor_and_operator() {
+    non_normative!(
+        r#"
+== Duplication factor and operator
+
+"#
+    );
+
+    verifies!(
+        r#"
+The duplication factor and operator are applied to a xref:add-cells-and-rows.adoc#specifiers[cell's specifier] and allow you to clone a cell's content and properties across consecutive cells.
+A duplication is the first operator in a cell specifier.
+
+====
+<**duplication factor**><**duplication operator**><horizontal alignment operator><vertical alignment operator><style operator>|<cell's content>
+====
+
+The [.term]*duplication factor* is a single integer (`<n>`) that indicates how many times the cell's content should be duplicated.
+
+The [.term]*duplication operator* is an asterisk (`+*+`) placed directly after the duplication factor (`+<n>*+`).
+The duplication operator tells the converter to interpret the duplication factor as part of a duplication instead of a span.
+
+"#
+    );
+
+    // The duplication factor is a single integer (`<n>`): a `<n>*` specifier
+    // clones the cell's content into `<n>` consecutive cells. Here `2*` produces
+    // two identical cells, leaving the trailing `|c` cell to complete the row.
+    // (The implicit column count is three, because each clone is counted as a
+    // separate column slot.)
+    let table = parse_table("|===\n2*|dup |c\n|===");
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(
+        body_texts(&table),
+        vec![vec!["dup".to_string(), "dup".to_string(), "c".to_string()]]
+    );
+
+    // The duplication factor is interpreted as a duplication, not a span, so each
+    // clone is an independent single-column cell (colspan 1) rather than one cell
+    // stretched across two columns. Contrast the span operator (`+`), which makes
+    // a single cell span the columns.
+    let dup = parse_table("|===\n2*|x\n|===");
+    assert_eq!(dup.body_rows()[0].cells().len(), 2);
+    assert_eq!(dup.body_rows()[0].cells()[0].colspan(), 1);
+    assert_eq!(dup.body_rows()[0].cells()[1].colspan(), 1);
+
+    let span = parse_table("|===\n2+|x\n|===");
+    assert_eq!(span.body_rows()[0].cells().len(), 1);
+    assert_eq!(span.body_rows()[0].cells()[0].colspan(), 2);
+
+    // A duplication is the first operator in the cell specifier: the duplication
+    // factor and operator come before any alignment or style operator. Here `3*e`
+    // is the duplication `3*` followed by the style operator `e`, so all three
+    // clones are emphasized.
+    let table = parse_table("|===\n3*e|x\n|===");
+    assert_eq!(
+        body_styles(&table),
+        vec![vec![
+            crate::blocks::ColumnStyle::Emphasis,
+            crate::blocks::ColumnStyle::Emphasis,
+            crate::blocks::ColumnStyle::Emphasis,
+        ]]
+    );
+}
+
+#[test]
+fn duplicate_a_cell_and_its_properties() {
+    non_normative!(
+        r#"
+== Duplicate a cell and its properties
+
+"#
+    );
+
+    verifies!(
+        r#"
+To duplicate a cell, enter the duplication factor and duplication operator (`+<n>*+`) in the cell specifier.
+Don't insert any spaces between the duplication, any alignment or style operators (if present), and the xref:add-cells-and-rows.adoc#cell-separator[cell's separator] (`|`).
+
+.Duplicate the contents of two cells
+[source#ex-clone]
+----
+include::example$cell.adoc[tag=clone]
+----
+
+The table from <<ex-clone>> is displayed below.
+
+.Result of <<ex-clone>>
+include::example$cell.adoc[tag=clone]
+"#
+    );
+
+    // Expansion of `example$cell.adoc[tag=clone]`. The `2*` cell clones its
+    // content into the first two columns of row 2, leaving the trailing `|Cell in
+    // column 3, row 2` cell to finish that row. The `3*e` cell clones its
+    // emphasized content into three cells: the first finishes row 3 (after the
+    // two plain cells) and the next two open row 4, which is then completed by the
+    // trailing `|Cell in column 3, row 4` cell.
+    let table = parse_table(
+        "|===\n|Column 1, header row |Column 2, header row |Column 3, header row\n\n2*|This cell is duplicated in columns 1 and 2 because its specifier contains a duplication of `2*`\n|Cell in column 3, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n3*e|This cell specifier contains the duplication `3*` and style operator `e`.\n\nThe cell's text is italicized and duplicated in column 3, row 3 and columns 1 and 2 on row 4.\n\n|Cell in column 3, row 4\n|===",
+    );
+
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(table.header_row().unwrap().cells().len(), 3);
+
+    // The `2*` cell's content is cloned verbatim into both of the first two
+    // columns; the `3*e` cell's content is cloned into three cells.
+    let dup_text = "This cell is duplicated in columns 1 and 2 because its specifier contains a duplication of <code>2*</code>";
+    let clone_text = "This cell specifier contains the duplication <code>3*</code> and style operator <code>e</code>.\n\nThe cell&#8217;s text is italicized and duplicated in column 3, row 3 and columns 1 and 2 on row 4.";
+    assert_eq!(
+        body_texts(&table),
+        vec![
+            vec![
+                dup_text.to_string(),
+                dup_text.to_string(),
+                "Cell in column 3, row 2".to_string(),
+            ],
+            vec![
+                "Cell in column 1, row 3".to_string(),
+                "Cell in column 2, row 3".to_string(),
+                clone_text.to_string(),
+            ],
+            vec![
+                clone_text.to_string(),
+                clone_text.to_string(),
+                "Cell in column 3, row 4".to_string(),
+            ],
+        ]
+    );
+
+    // The duplication clones the cell's properties as well as its content: the
+    // `3*e` style operator emphasizes every clone, while the cells with no style
+    // operator keep the default style.
+    assert_eq!(
+        body_styles(&table),
+        vec![
+            vec![
+                crate::blocks::ColumnStyle::Default,
+                crate::blocks::ColumnStyle::Default,
+                crate::blocks::ColumnStyle::Default,
+            ],
+            vec![
+                crate::blocks::ColumnStyle::Default,
+                crate::blocks::ColumnStyle::Default,
+                crate::blocks::ColumnStyle::Emphasis,
+            ],
+            vec![
+                crate::blocks::ColumnStyle::Emphasis,
+                crate::blocks::ColumnStyle::Emphasis,
+                crate::blocks::ColumnStyle::Default,
+            ],
+        ]
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
@@ -47,7 +47,8 @@ fn asciidoc_cell_text(doc: &crate::Document<'_>) -> String {
         .expect("expected a table block");
 
     match table.body_rows()[0].cells()[0].content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => blocks
+        crate::blocks::TableCellContent::AsciiDoc(cell) => cell
+            .blocks()
             .iter()
             .filter_map(|block| block.rendered_content())
             .collect::<Vec<_>>()
@@ -325,7 +326,8 @@ The `a` can also be specified on the column in the `cols` attribute on the table
         crate::blocks::TableCellContent::Simple(_)
     ));
     match row.cells()[1].content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+        crate::blocks::TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
             assert_eq!(blocks.len(), 1);
             assert_eq!(blocks[0].raw_context().as_ref(), "list");
         }
@@ -378,7 +380,8 @@ include::example$cell.adoc[tag=adoc]
         crate::blocks::TableCellContent::Simple(_)
     ));
     match row.cells()[1].content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+        crate::blocks::TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
             assert_eq!(blocks.len(), 2);
             assert_eq!(blocks[0].raw_context().as_ref(), "paragraph");
             assert_eq!(blocks[1].raw_context().as_ref(), "list");
@@ -395,7 +398,8 @@ include::example$cell.adoc[tag=adoc]
         crate::blocks::TableCellContent::Simple(_)
     ));
     match row.cells()[1].content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+        crate::blocks::TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
             assert_eq!(blocks.len(), 2);
             assert_eq!(blocks[0].raw_context().as_ref(), "paragraph");
             assert_eq!(blocks[1].raw_context().as_ref(), "listing");
@@ -422,7 +426,8 @@ As such, it inherits attributes from the parent document.
         })
         .expect("expected a table block");
     match table.body_rows()[0].cells()[0].content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+        crate::blocks::TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
             assert_eq!(blocks.len(), 1);
             match &blocks[0] {
                 crate::blocks::Block::Simple(simple) => {

--- a/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
@@ -173,9 +173,10 @@ include::example$cell.adoc[tag=styles]
     );
 
     // Expansion of `example$cell.adoc[tag=styles]`. Each body cell carries its
-    // own style operator (the span/duplication operators are recognized but
-    // their layout effect is not yet applied, so the cells flow into rows of
-    // two).
+    // own style operator. The `.3+` row span on the second cell carries its
+    // column down through the next two rows, so each of those rows needs only one
+    // explicit cell to be complete. (The duplication operator's layout effect is
+    // not yet applied, so the `2*>m` cell is a single cell.)
     let table = parse_table(
         "|===\n|Column 1 |Column 2\n\n2*>m|This content is duplicated across two columns (2*) and aligned to the right side of the cell (>).\n\nIt's rendered using a monospace font (m).\n\n.3+^.>s|This cell spans 3 rows (`3+`).\nThe content is centered horizontally (`+^+`), vertically aligned to the bottom of the cell (`.>`), and styled as strong (`s`).\ne|This content is italicized (`e`).\n\nm|This content is rendered using a monospace font (m).\n\ns|This content is bold (`s`).\n|===",
     );
@@ -183,7 +184,8 @@ include::example$cell.adoc[tag=styles]
         body_styles(&table),
         vec![
             vec![ColumnStyle::Monospace, ColumnStyle::Strong],
-            vec![ColumnStyle::Emphasis, ColumnStyle::Monospace],
+            vec![ColumnStyle::Emphasis],
+            vec![ColumnStyle::Monospace],
             vec![ColumnStyle::Strong],
         ]
     );

--- a/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
@@ -143,16 +143,20 @@ Don't insert any spaces between the `|` and the operator.
     // The style operator occupies the last position of the specifier, after any
     // span/duplication operator and the horizontal and vertical alignment
     // operators: `2*>m` (duplication, right, monospace) and `.3+^.>s` (row span,
-    // center, bottom, strong).
+    // center, bottom, strong). The `2*` duplication clones its cell, so the first
+    // two cells both carry the right-aligned monospace specifier; the `.3+^.>s`
+    // cell follows.
     let table =
         parse_table("|===\n|h\n\n2*>m|dup right mono\n.3+^.>s|span center bottom strong\n|===");
     let cells: Vec<&crate::blocks::TableCell<'_>> =
         table.body_rows().iter().flat_map(|r| r.cells()).collect();
     assert_eq!(cells[0].style(), ColumnStyle::Monospace);
     assert_eq!(cells[0].h_align(), HorizontalAlignment::Right);
-    assert_eq!(cells[1].style(), ColumnStyle::Strong);
-    assert_eq!(cells[1].h_align(), HorizontalAlignment::Center);
-    assert_eq!(cells[1].v_align(), VerticalAlignment::Bottom);
+    assert_eq!(cells[1].style(), ColumnStyle::Monospace);
+    assert_eq!(cells[1].h_align(), HorizontalAlignment::Right);
+    assert_eq!(cells[2].style(), ColumnStyle::Strong);
+    assert_eq!(cells[2].h_align(), HorizontalAlignment::Center);
+    assert_eq!(cells[2].v_align(), VerticalAlignment::Bottom);
 
     verifies!(
         r#"
@@ -173,18 +177,18 @@ include::example$cell.adoc[tag=styles]
     );
 
     // Expansion of `example$cell.adoc[tag=styles]`. Each body cell carries its
-    // own style operator. The `.3+` row span on the second cell carries its
-    // column down through the next two rows, so each of those rows needs only one
-    // explicit cell to be complete. (The duplication operator's layout effect is
-    // not yet applied, so the `2*>m` cell is a single cell.)
+    // own style operator. The `2*>m` duplication clones its monospace content
+    // into the two cells of the first row. The `.3+` row span on the next cell
+    // carries its column down through the two rows below it, so each of those
+    // rows needs only one explicit cell to be complete.
     let table = parse_table(
         "|===\n|Column 1 |Column 2\n\n2*>m|This content is duplicated across two columns (2*) and aligned to the right side of the cell (>).\n\nIt's rendered using a monospace font (m).\n\n.3+^.>s|This cell spans 3 rows (`3+`).\nThe content is centered horizontally (`+^+`), vertically aligned to the bottom of the cell (`.>`), and styled as strong (`s`).\ne|This content is italicized (`e`).\n\nm|This content is rendered using a monospace font (m).\n\ns|This content is bold (`s`).\n|===",
     );
     assert_eq!(
         body_styles(&table),
         vec![
-            vec![ColumnStyle::Monospace, ColumnStyle::Strong],
-            vec![ColumnStyle::Emphasis],
+            vec![ColumnStyle::Monospace, ColumnStyle::Monospace],
+            vec![ColumnStyle::Strong, ColumnStyle::Emphasis],
             vec![ColumnStyle::Monospace],
             vec![ColumnStyle::Strong],
         ]

--- a/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
@@ -1,0 +1,478 @@
+use crate::{document::InterpretedValue, tests::prelude::*};
+
+track_file!("docs/modules/tables/pages/format-cell-content.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Collect the [style](ColumnStyle) of each cell in each body row of `table`.
+fn body_styles(table: &crate::blocks::TableBlock<'_>) -> Vec<Vec<ColumnStyle>> {
+    table
+        .body_rows()
+        .iter()
+        .map(|row| row.cells().iter().map(|cell| cell.style()).collect())
+        .collect()
+}
+
+/// Return the rendered text of a [`Simple`](crate::blocks::TableCellContent)
+/// cell, panicking if the cell holds AsciiDoc block content instead.
+fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
+    match cell.content() {
+        crate::blocks::TableCellContent::Simple(content) => content.rendered().to_string(),
+        crate::blocks::TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
+    }
+}
+
+/// Find the first table in `doc` and return the joined rendered text of the
+/// AsciiDoc blocks in its first body cell.
+fn asciidoc_cell_text(doc: &crate::Document<'_>) -> String {
+    let table = doc
+        .nested_blocks()
+        .find_map(|b| match b {
+            crate::blocks::Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .expect("expected a table block");
+
+    match table.body_rows()[0].cells()[0].content() {
+        crate::blocks::TableCellContent::AsciiDoc(blocks) => blocks
+            .iter()
+            .filter_map(|block| block.rendered_content())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        other => panic!("expected nested AsciiDoc blocks, got {other:?}"),
+    }
+}
+
+non_normative!(
+    r#"
+= Format Content by Cell
+
+"#
+);
+
+#[test]
+fn cell_styles_and_their_operators() {
+    non_normative!(
+        r#"
+== Cell styles and their operators
+
+"#
+    );
+
+    verifies!(
+        r#"
+You can style all of the content in an individual cell by adding a style operator to the xref:add-cells-and-rows.adoc#specifiers[cell's specifier].
+
+"#
+    );
+
+    // A style operator on a cell specifier styles all of that cell's content.
+    // Each operator maps to its corresponding style.
+    let table = parse_table("|===\n|h\n\na|adoc\ne|emph\nh|head\nl|lit\nm|mono\ns|strong\n|===");
+    assert_eq!(
+        body_styles(&table),
+        vec![
+            vec![ColumnStyle::AsciiDoc],
+            vec![ColumnStyle::Emphasis],
+            vec![ColumnStyle::Header],
+            vec![ColumnStyle::Literal],
+            vec![ColumnStyle::Monospace],
+            vec![ColumnStyle::Strong],
+        ]
+    );
+
+    verifies!(
+        r#"
+include::partial$style-operators.adoc[]
+
+When a style operator isn't explicitly assigned to a cell specifier (or xref:format-column-content.adoc[column specifier]), the cell falls back to the default (`d`) style and is processed as regular paragraph text.
+(The explicit `d` style is only needed if you want to revert the cell style based to a normal (default) cell when a style is applied to the column.)
+
+"#
+    );
+
+    // With no style operator and no column style, a cell falls back to the
+    // default (`d`) style.
+    let table = parse_table("|===\n|h\n\n|plain\n|===");
+    assert_eq!(body_styles(&table), vec![vec![ColumnStyle::Default]]);
+
+    // The explicit `d` operator only matters when the column carries a style: it
+    // reverts that one cell to the default while its siblings keep the column's
+    // style.
+    let table = parse_table("[cols=\"m,m\"]\n|===\n|h1 |h2\n\nd|reverted |still monospace\n|===");
+    assert_eq!(
+        body_styles(&table),
+        vec![vec![ColumnStyle::Default, ColumnStyle::Monospace]]
+    );
+}
+
+#[test]
+fn apply_a_style_to_a_table_cell() {
+    non_normative!(
+        r#"
+== Apply a style to a table cell
+
+"#
+    );
+
+    verifies!(
+        r#"
+The style operator is always entered last in a xref:add-cells-and-rows.adoc#specifiers[cell specifier].
+Don't insert any spaces between the `|` and the operator.
+
+====
+<factor><span or duplication operator><horizontal alignment operator><vertical alignment operator><**style operator**>|<cell's content>
+====
+
+"#
+    );
+
+    // The style operator occupies the last position of the specifier, after any
+    // span/duplication operator and the horizontal and vertical alignment
+    // operators: `2*>m` (duplication, right, monospace) and `.3+^.>s` (row span,
+    // center, bottom, strong).
+    let table =
+        parse_table("|===\n|h\n\n2*>m|dup right mono\n.3+^.>s|span center bottom strong\n|===");
+    let cells: Vec<&crate::blocks::TableCell<'_>> =
+        table.body_rows().iter().flat_map(|r| r.cells()).collect();
+    assert_eq!(cells[0].style(), ColumnStyle::Monospace);
+    assert_eq!(cells[0].h_align(), HorizontalAlignment::Right);
+    assert_eq!(cells[1].style(), ColumnStyle::Strong);
+    assert_eq!(cells[1].h_align(), HorizontalAlignment::Center);
+    assert_eq!(cells[1].v_align(), VerticalAlignment::Bottom);
+
+    verifies!(
+        r#"
+Let's apply a style operator to each cell in <<ex-cell-styles>>.
+
+.Apply a style operator to a cell
+[source#ex-cell-styles]
+----
+include::example$cell.adoc[tag=styles]
+----
+
+The table from <<ex-cell-styles>> is rendered below.
+
+.Result of <<ex-cell-styles>>
+include::example$cell.adoc[tag=styles]
+
+"#
+    );
+
+    // Expansion of `example$cell.adoc[tag=styles]`. Each body cell carries its
+    // own style operator (the span/duplication operators are recognized but
+    // their layout effect is not yet applied, so the cells flow into rows of
+    // two).
+    let table = parse_table(
+        "|===\n|Column 1 |Column 2\n\n2*>m|This content is duplicated across two columns (2*) and aligned to the right side of the cell (>).\n\nIt's rendered using a monospace font (m).\n\n.3+^.>s|This cell spans 3 rows (`3+`).\nThe content is centered horizontally (`+^+`), vertically aligned to the bottom of the cell (`.>`), and styled as strong (`s`).\ne|This content is italicized (`e`).\n\nm|This content is rendered using a monospace font (m).\n\ns|This content is bold (`s`).\n|===",
+    );
+    assert_eq!(
+        body_styles(&table),
+        vec![
+            vec![ColumnStyle::Monospace, ColumnStyle::Strong],
+            vec![ColumnStyle::Emphasis, ColumnStyle::Monospace],
+            vec![ColumnStyle::Strong],
+        ]
+    );
+}
+
+#[test]
+fn override_the_column_style_on_a_cell() {
+    non_normative!(
+        r#"
+[#override-column-style]
+== Override the column style on a cell
+
+"#
+    );
+
+    verifies!(
+        r#"
+When you assign a style operator to a cell, it overrides the xref:format-column-content.adoc[column's style operator].
+In <<ex-override>>, the style operator assigned to the first column is overridden on two cells.
+The header row also overrides style operators.
+However, inline formatting markup is applied in addition to the style specified by an operator.
+
+"#
+    );
+
+    verifies!(
+        r#"
+.Override the column style using a cell style operator
+[source#ex-override]
+----
+[cols="m,m"] <.>
+|===
+|Column 1, header row |Column 2, header row <.>
+
+|This content is rendered using a monospace font because the column's specifier includes the `m` operator.
+|This content is rendered using a monospace font because the column's specifier includes the `m` operator.
+
+s|This content is rendered as bold paragraph text because the `s` operator in the cell's specifier overrides the style operator in the column specifier. <.>
+|*This content is rendered using a monospace font because the column's specifier includes the `m` operator.
+It's also bold because it's marked up with the inline syntax for bold formatting.* <.>
+
+d|This content is rendered as regular paragraph text because the `d` operator in the cell's specifier overrides the style operator in the column specifier. <.>
+|This content is rendered using a monospace font because the column's specifier includes the `m` operator.
+|===
+----
+<.> The monospace operator (`m`) is assigned to both columns.
+<.> The header row ignores any style operators assigned via column or cell specifiers.
+<.> The strong operator (`s`) is assigned to this cell's specifier, overriding the column's monospace style.
+<.> Inline formatting is applied in addition to the style assigned via a column specifier.
+<.> The default operator (`d`) is assigned to this cell's specifier, resetting it to the default text style.
+
+The table from <<ex-override>> is displayed below.
+
+.Result of <<ex-override>>
+[cols="m,m"]
+|===
+|Column 1, header row |Column 2, header row
+
+|This content is rendered using a monospace font because the column's specifier includes the `m` operator.
+|This content is rendered using a monospace font because the column's specifier includes the `m` operator.
+
+s|This content is rendered as bold paragraph text because the `s` operator in the cell's specifier overrides the style operator in the column specifier.
+|*This content is rendered using a monospace font because the column's specifier includes the `m` operator.
+It's also bold because it's marked up with the inline syntax for bold formatting.*
+
+d|This content is rendered as regular paragraph text because the `d` operator in the cell's specifier overrides the style operator in the column specifier.
+|This content is rendered using a monospace font because the column's specifier includes the `m` operator.
+|===
+
+"#
+    );
+
+    // Expansion of `example$ex-override`. The column style operator (`m`) is
+    // overridden by the cell style operators `s` and `d`; cells without an
+    // operator inherit the column's monospace style.
+    let table = parse_table(
+        "[cols=\"m,m\"]\n|===\n|Column 1, header row |Column 2, header row\n\n|This content is rendered using a monospace font because the column's specifier includes the `m` operator.\n|This content is rendered using a monospace font because the column's specifier includes the `m` operator.\n\ns|This content is rendered as bold paragraph text because the `s` operator in the cell's specifier overrides the style operator in the column specifier.\n|*This content is rendered using a monospace font because the column's specifier includes the `m` operator.\nIt's also bold because it's marked up with the inline syntax for bold formatting.*\n\nd|This content is rendered as regular paragraph text because the `d` operator in the cell's specifier overrides the style operator in the column specifier.\n|This content is rendered using a monospace font because the column's specifier includes the `m` operator.\n|===",
+    );
+
+    // A cell style operator overrides the column's style; a cell with no operator
+    // inherits it.
+    assert_eq!(
+        body_styles(&table),
+        vec![
+            vec![ColumnStyle::Monospace, ColumnStyle::Monospace],
+            vec![ColumnStyle::Strong, ColumnStyle::Monospace],
+            vec![ColumnStyle::Default, ColumnStyle::Monospace],
+        ]
+    );
+
+    // The header row overrides (ignores) style operators: both header cells stay
+    // the default style even though their column carries the `m` operator.
+    let header = table.header_row().unwrap();
+    assert_eq!(
+        header.cells().iter().map(|c| c.style()).collect::<Vec<_>>(),
+        vec![ColumnStyle::Default, ColumnStyle::Default]
+    );
+
+    // Inline formatting markup is applied in addition to the style operator: the
+    // monospace cell whose content is wrapped in `*...*` still renders a strong
+    // span.
+    let bold_in_mono = &table.body_rows()[1].cells()[1];
+    assert_eq!(bold_in_mono.style(), ColumnStyle::Monospace);
+    assert!(simple_text(bold_in_mono).contains("<strong>"));
+}
+
+#[test]
+fn use_asciidoc_block_elements_in_a_table_cell() {
+    non_normative!(
+        r#"
+[#a-operator]
+== Use AsciiDoc block elements in a table cell
+
+"#
+    );
+
+    verifies!(
+        r#"
+To use AsciiDoc block elements, such as delimited source blocks and lists, in a cell, place the `a` operator directly in front of the xref:add-cells-and-rows.adoc#cell-separator[cell's separator] (`|`).
+Don't insert any spaces between the `|` and the operator.
+The `a` can also be specified on the column in the `cols` attribute on the table.
+
+"#
+    );
+
+    // A cell prefixed with the `a` operator parses its content as a nested
+    // sequence of blocks; a cell with no operator keeps the same markup as inline
+    // text.
+    let table = parse_table("|===\n|Normal |AsciiDoc\n\n|* not a list\na|* a list\n|===");
+    let row = &table.body_rows()[0];
+    assert!(matches!(
+        row.cells()[0].content(),
+        crate::blocks::TableCellContent::Simple(_)
+    ));
+    match row.cells()[1].content() {
+        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+            assert_eq!(blocks.len(), 1);
+            assert_eq!(blocks[0].raw_context().as_ref(), "list");
+        }
+        other => panic!("expected nested AsciiDoc blocks, got {other:?}"),
+    }
+
+    // The `a` operator can equally be set on the column via the `cols` attribute,
+    // which makes every cell in that column an AsciiDoc cell.
+    let table = parse_table("[cols=\"a,d\"]\n|===\n|h1 |h2\n\n|* a list\n|* not a list\n|===");
+    let row = &table.body_rows()[0];
+    assert!(matches!(
+        row.cells()[0].content(),
+        crate::blocks::TableCellContent::AsciiDoc(_)
+    ));
+    assert!(matches!(
+        row.cells()[1].content(),
+        crate::blocks::TableCellContent::Simple(_)
+    ));
+
+    verifies!(
+        r#"
+.Apply the AsciiDoc block style operator to two cells
+[source#ex-asciidoc]
+....
+include::example$cell.adoc[tag=adoc]
+....
+
+The table from <<ex-asciidoc>> is rendered below.
+
+.Result of <<ex-asciidoc>>
+include::example$cell.adoc[tag=adoc]
+
+"#
+    );
+
+    // Expansion of `example$cell.adoc[tag=adoc]`. In each row the first cell has
+    // no operator (its list / listing markup stays inline text), while the second
+    // cell's `a` operator parses the same markup as nested AsciiDoc blocks.
+    let table = parse_table(
+        "|===\n|Normal Style |AsciiDoc Style\n\n|This cell isn't prefixed with an `a`, so the processor doesn't interpret the following lines as an AsciiDoc list.\n\n* List item 1\n* List item 2\n* List item 3\n\na|This cell is prefixed with an `a`, so the processor interprets the following lines as an AsciiDoc list.\n\n* List item 1\n* List item 2\n* List item 3\n\n|This cell isn't prefixed with an `a`, so the processor doesn't interpret the listing block delimiters or the `source` style.\n\n[source,python]\n----\nimport os\nprint (\"%s\" %(os.uname()))\n----\n\na|This cell is prefixed with an `a`, so the listing block is processed and rendered according to the `source` style rules.\n\n[source,python]\n----\nimport os\nprint \"%s\" %(os.uname())\n----\n\n|===",
+    );
+    assert_eq!(table.body_rows().len(), 2);
+
+    // First row: the list markup. The plain cell keeps it inline; the `a` cell
+    // parses its leading sentence as a paragraph and the following lines as a
+    // list block.
+    let row = &table.body_rows()[0];
+    assert!(matches!(
+        row.cells()[0].content(),
+        crate::blocks::TableCellContent::Simple(_)
+    ));
+    match row.cells()[1].content() {
+        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+            assert_eq!(blocks.len(), 2);
+            assert_eq!(blocks[0].raw_context().as_ref(), "paragraph");
+            assert_eq!(blocks[1].raw_context().as_ref(), "list");
+        }
+        other => panic!("expected nested AsciiDoc blocks, got {other:?}"),
+    }
+
+    // Second row: the source listing. The plain cell keeps it inline; the `a`
+    // cell parses its leading sentence as a paragraph and the delimited block as
+    // a listing block.
+    let row = &table.body_rows()[1];
+    assert!(matches!(
+        row.cells()[0].content(),
+        crate::blocks::TableCellContent::Simple(_)
+    ));
+    match row.cells()[1].content() {
+        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+            assert_eq!(blocks.len(), 2);
+            assert_eq!(blocks[0].raw_context().as_ref(), "paragraph");
+            assert_eq!(blocks[1].raw_context().as_ref(), "listing");
+        }
+        other => panic!("expected nested AsciiDoc blocks, got {other:?}"),
+    }
+
+    verifies!(
+        r#"
+An AsciiDoc table cell effectively creates a nested document.
+As such, it inherits attributes from the parent document.
+"#
+    );
+
+    // An AsciiDoc cell inherits attributes from the parent document: a `{name}`
+    // reference inside the cell resolves to the value set on the parent.
+    let mut parser = Parser::default();
+    let doc = parser.parse(":name: Tester\n\n|===\n|h\n\na|Hello {name}\n|===");
+    let table = doc
+        .nested_blocks()
+        .find_map(|b| match b {
+            crate::blocks::Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .expect("expected a table block");
+    match table.body_rows()[0].cells()[0].content() {
+        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+            assert_eq!(blocks.len(), 1);
+            match &blocks[0] {
+                crate::blocks::Block::Simple(simple) => {
+                    assert_eq!(simple.content().rendered(), "Hello Tester");
+                }
+                other => panic!("expected a simple block, got {other:?}"),
+            }
+        }
+        other => panic!("expected nested AsciiDoc blocks, got {other:?}"),
+    }
+
+    verifies!(
+        r#"
+If an attribute is set or explicitly unset in the parent document, it _cannot_ be modified in the AsciiDoc table cell.
+There are a handful of exceptions to this rule, which includes doctype, toc, notitle (and its complement, showtitle), and compat-mode.
+"#
+    );
+
+    // An attribute set in the parent is locked inside the cell: a reassignment
+    // (placed before the reference, so it would take effect if it were honored)
+    // is ignored, so the cell still sees the inherited value. Asciidoctor only
+    // locks attributes that are *set*, not ones explicitly unset, so the crate
+    // follows suit; see the unit tests in `blocks::tests::table` for the full
+    // set/unset/exception matrix.
+    let mut parser = Parser::default();
+    let doc = parser
+        .parse(":locked: parent\n\n|===\n|h\n\na|\n:locked: child\n\nvalue is {locked}\n|===");
+    assert_eq!(asciidoc_cell_text(&doc), "value is parent");
+
+    // One of the carved-out exceptions (here `compat-mode`) may still be modified
+    // inside the cell even though the parent set it.
+    let mut parser = Parser::default();
+    let doc = parser
+        .parse(":compat-mode: parent\n\n|===\n|h\n\na|\n:compat-mode: child\n\nmode is {compat-mode}\n|===");
+    assert_eq!(asciidoc_cell_text(&doc), "mode is child");
+
+    verifies!(
+        r#"
+Any newly defined attributes in the AsciiDoc table do not impact the attributes in the parent document.
+Instead, these attributes are scoped to the table cell.
+
+"#
+    );
+
+    // An attribute newly defined inside an AsciiDoc cell is scoped to that cell
+    // and does not leak back into the parent document.
+    let mut parser = Parser::default();
+    let _ = parser.parse("|===\n|h\n\na|\n:scoped: value\n\nbody\n|===");
+    assert_eq!(parser.attribute_value("scoped"), InterpretedValue::Unset);
+
+    non_normative!(
+        r#"
+If the AsciiDoc table cell starts with a preprocessor directive, that directive should be placed on the line after the cell separator.
+While it can be placed on the same line as the cell separator, that style is not recommended.
+That's because the preprocessor directive that starts after the cell separator must be treated with special handling and is thus limited to a single line (for example, a multiline preprocessor conditional is not allow in this case).
+By starting the contents of the AsciiDoc table cell on the line after the cell separator, the contents will be parsed as normal.
+"#
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/format_column_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_column_content.rs
@@ -31,6 +31,16 @@ fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
     }
 }
 
+/// Parse `source` as a standalone document and return the rendered HTML of its
+/// first (paragraph) block.
+fn rendered_paragraph(source: &str) -> String {
+    let doc = Parser::default().parse(source);
+    let crate::blocks::Block::Simple(para) = &doc.nested_blocks().next().unwrap() else {
+        panic!("expected a paragraph");
+    };
+    para.content().rendered().to_string()
+}
+
 non_normative!(
     r#"
 = Format Content by Column
@@ -81,12 +91,33 @@ You can style all of the content in a column by adding a style operator to a col
     );
     assert_eq!(table.body_rows().len(), 2);
 
-    non_normative!(
+    verifies!(
         r#"
 include::partial$style-operators.adoc[]
 
 "#
     );
+
+    // Expansion of `partial$style-operators.adoc`: a three-column reference
+    // table listing each style and its operator. Its first row is an implicit
+    // header (non-empty first line followed by a blank line), and it has one
+    // body row per documented style (AsciiDoc, Default, Emphasis, Header,
+    // Literal, Monospace, Strong).
+    let style_operators = parse_table(
+        "|===\n|Style |Operator |Description\n\n|AsciiDoc\n|`a`\n|Supports block elements (lists, delimited blocks, and block macros).\nThis style effectively creates a nested, standalone AsciiDoc document.\nThe parent document's implicit attributes, such as `doctitle`, are shadowed and custom attributes are inherited.\n// what does \"shadowed\" actually mean???\n\n|Default\n|`d`\n|All of the markup that is permitted in a paragraph (i.e., inline formatting, inline macros) is supported.\n\n|Emphasis\n|`e`\n|Text is italicized.\n\n|Header\n|`h`\n|Applies the header semantics and styles to the text and cell borders.\n\n|Literal\n|`l`\n|Content is treated as if it were inside a literal block.\n\n|Monospace\n|`m`\n|Text is rendered using a monospace font.\n\n|Strong\n|`s`\n|Text is bold.\n|===",
+    );
+    assert_eq!(style_operators.columns().len(), 3);
+    assert_eq!(
+        style_operators
+            .header_row()
+            .unwrap()
+            .cells()
+            .iter()
+            .map(simple_text)
+            .collect::<Vec<_>>(),
+        vec!["Style", "Operator", "Description"]
+    );
+    assert_eq!(style_operators.body_rows().len(), 7);
 
     verifies!(
         r#"
@@ -168,7 +199,7 @@ A style operator is always placed in the last position on a column's specifier o
         assert_eq!(column.v_align(), VerticalAlignment::Bottom);
     }
 
-    non_normative!(
+    verifies!(
         r#"
 Let's apply a different style to each column in <<ex-style>>.
 
@@ -191,23 +222,16 @@ Let's apply a different style to each column in <<ex-style>>.
 |===
 ----
 
-The table from <<ex-style>> is displayed below.
 "#
     );
 
-    verifies!(
-        r#"
-Note that the style applied to each column doesn't affect the xref:add-header-row.adoc[header row] or override any inline formatting.
-
-"#
-    );
-
-    // Each column carries its own style operator.
-    let table = parse_table(
-        "[cols=\"h,m,s,e\"]\n|===\n|Column 1 |Column 2 |Column 3 |Column 4\n\n|This column's content and borders are rendered using the table header (`h`) styles.\n|This column's content is rendered using a monospace font (m).\n|This column's content is bold (`s`).\n|This column's content is italicized (`e`).\n|===",
+    // The `ex-style` example applies a different style operator to each of the
+    // four columns.
+    let ex_style = parse_table(
+        "[cols=\"h,m,s,e\"]\n|===\n|Column 1 |Column 2 |Column 3 |Column 4\n\n|This column's content and borders are rendered using the table header (`h`) styles.\n|This column's content is rendered using a monospace font (m).\n|This column's content is bold (`s`).\n|This column's content is italicized (`e`).\n|This column's content and borders are rendered using the table header (`h`) styles.\n|This column's content is rendered using a monospace font (m).\n|This column's content is bold (`s`).\n|This column's content is italicized (`e`).\n|===",
     );
     assert_eq!(
-        column_styles(&table),
+        column_styles(&ex_style),
         vec![
             ColumnStyle::Header,
             ColumnStyle::Monospace,
@@ -216,26 +240,11 @@ Note that the style applied to each column doesn't affect the xref:add-header-ro
         ]
     );
 
-    // The style doesn't affect the header row: each header cell holds plain
-    // inline content with no style applied, even though its column is styled.
-    let header = table.header_row().unwrap();
-    let header_text: Vec<String> = header.cells().iter().map(simple_text).collect();
-    assert_eq!(
-        header_text,
-        vec!["Column 1", "Column 2", "Column 3", "Column 4"]
-    );
-
-    // The style doesn't override inline formatting either: the body cell in the
-    // header-styled column still resolves its inline backtick markup to a
-    // monospace span.
-    let body = &table.body_rows()[0];
-    assert!(simple_text(&body.cells()[0]).contains("<code>h</code>"));
-}
-
-#[test]
-fn use_asciidoc_block_elements_in_a_column() {
-    non_normative!(
+    verifies!(
         r#"
+The table from <<ex-style>> is displayed below.
+Note that the style applied to each column doesn't affect the xref:add-header-row.adoc[header row] or override any inline formatting.
+
 .Result of <<ex-style>>
 [cols="h,m,s,e"]
 |===
@@ -252,8 +261,48 @@ fn use_asciidoc_block_elements_in_a_column() {
 |This column's content is italicized (`e`).
 |===
 
+"#
+    );
+
+    // The rendered result of <<ex-style>>: the style doesn't affect the header
+    // row (each header cell holds plain inline content with no style applied,
+    // even though its column is styled)...
+    let ex_style_result = parse_table(
+        "[cols=\"h,m,s,e\"]\n|===\n|Column 1 |Column 2 |Column 3 |Column 4\n\n|This column's content and borders are rendered using the table header (`h`) styles.\n|This column's content is rendered using a monospace font (m).\n|This column's content is bold (`s`).\n|This column's content is italicized (`e`).\n|This column's content and borders are rendered using the table header (`h`) styles.\n|This column's content is rendered using a monospace font (m).\n|This column's content is bold (`s`).\n|This column's content is italicized (`e`).\n|===",
+    );
+    let header = ex_style_result.header_row().unwrap();
+    let header_text: Vec<String> = header.cells().iter().map(simple_text).collect();
+    assert_eq!(
+        header_text,
+        vec!["Column 1", "Column 2", "Column 3", "Column 4"]
+    );
+
+    // ...nor does it override inline formatting: the body cell in the
+    // header-styled column still resolves its inline backtick markup to a
+    // monospace span.
+    let body = &ex_style_result.body_rows()[0];
+    assert!(simple_text(&body.cells()[0]).contains("<code>h</code>"));
+
+    verifies!(
+        r#"
 Additionally, if a xref:format-cell-content.adoc#override-column-style[cell specifier contains a style operator], that style will override a column's style operator.
 
+"#
+    );
+
+    // The cross-reference to the cell-specifier override behavior renders as a
+    // link to the format-cell-content page.
+    let rendered = rendered_paragraph(
+        "Additionally, if a xref:format-cell-content.adoc#override-column-style[cell specifier contains a style operator], that style will override a column's style operator.",
+    );
+    assert!(rendered.contains("<a href="));
+    assert!(rendered.contains("cell specifier contains a style operator</a>"));
+}
+
+#[test]
+fn use_asciidoc_block_elements_in_a_column() {
+    non_normative!(
+        r#"
 == Use AsciiDoc block elements in a column
 
 "#
@@ -274,7 +323,7 @@ To use AsciiDoc block elements, such as delimited source blocks and lists, in a 
         vec![ColumnStyle::AsciiDoc, ColumnStyle::Default]
     );
 
-    non_normative!(
+    verifies!(
         r#"
 .Apply the AsciiDoc block style operator to the first column
 [source#ex-asciidoc]
@@ -310,26 +359,21 @@ print ("%s" %(os.uname()))
 "#
     );
 
-    verifies!(
-        r#"
-The AsciiDoc block style effectively creates a nested, standalone AsciiDoc document in each cell in the column.
-"#
-    );
-
-    // The AsciiDoc-styled column parses each of its cells as a nested sequence
-    // of blocks, while the default-styled column leaves the same markup as
-    // inline content.
-    let table = parse_table(
+    // The `ex-asciidoc` example applies the AsciiDoc block style (`a`) to the
+    // first column, so its cells parse nested block content (a list, then a
+    // delimited source block) while the default-styled column keeps the same
+    // markup as inline content.
+    let ex_asciidoc = parse_table(
         "[cols=\"2a,2\"]\n|===\n|Column with the `a` style operator applied to its specifier |Column using the default style\n\n|\n* List item 1\n* List item 2\n* List item 3\n|\n* List item 1\n* List item 2\n* List item 3\n\n|\n[source,python]\n----\nimport os\nprint \"%s\" %(os.uname())\n----\n|\n[source,python]\n----\nimport os\nprint (\"%s\" %(os.uname()))\n----\n|===",
     );
     assert_eq!(
-        column_styles(&table),
+        column_styles(&ex_asciidoc),
         vec![ColumnStyle::AsciiDoc, ColumnStyle::Default]
     );
 
     // First body row: the AsciiDoc cell parses a list block; the default cell
     // keeps the list markup as plain inline text.
-    let row = &table.body_rows()[0];
+    let row = &ex_asciidoc.body_rows()[0];
     match row.cells()[0].content() {
         crate::blocks::TableCellContent::AsciiDoc(cell) => {
             let blocks = cell.blocks();
@@ -344,7 +388,7 @@ The AsciiDoc block style effectively creates a nested, standalone AsciiDoc docum
     ));
 
     // Second body row: the AsciiDoc cell parses the delimited source block.
-    let row = &table.body_rows()[1];
+    let row = &ex_asciidoc.body_rows()[1];
     match row.cells()[0].content() {
         crate::blocks::TableCellContent::AsciiDoc(cell) => {
             let blocks = cell.blocks();
@@ -353,6 +397,12 @@ The AsciiDoc block style effectively creates a nested, standalone AsciiDoc docum
         }
         other => panic!("expected nested AsciiDoc blocks, got {other:?}"),
     }
+
+    verifies!(
+        r#"
+The AsciiDoc block style effectively creates a nested, standalone AsciiDoc document in each cell in the column.
+"#
+    );
 
     // A full structural comparison of a minimal AsciiDoc cell: its content is a
     // nested list block parsed as a standalone document fragment.
@@ -459,6 +509,11 @@ The AsciiDoc block style effectively creates a nested, standalone AsciiDoc docum
 The parent document's implicit attributes, such as `doctitle`, are shadowed and custom attributes are inherited.
 // what does "shadowed" actually mean???
 
+"#
+    );
+
+    verifies!(
+        r#"
 .Result of <<ex-asciidoc>>
 [cols="2a,2"]
 |===
@@ -488,7 +543,37 @@ print ("%s" %(os.uname()))
 ----
 |===
 
+"#
+    );
+
+    // The rendered result of <<ex-asciidoc>>: the first column is AsciiDoc, the
+    // second is default, and every body cell in the AsciiDoc column renders as
+    // nested block content.
+    let ex_asciidoc_result = parse_table(
+        "[cols=\"2a,2\"]\n|===\n|Column with the `a` style operator applied to its specifier |Column using the default style\n\n|\n* List item 1\n* List item 2\n* List item 3\n|\n* List item 1\n* List item 2\n* List item 3\n\n|\n[source,python]\n----\nimport os\nprint \"%s\" %(os.uname())\n----\n\n|\n[source,python]\n----\nimport os\nprint (\"%s\" %(os.uname()))\n----\n|===",
+    );
+    assert_eq!(
+        column_styles(&ex_asciidoc_result),
+        vec![ColumnStyle::AsciiDoc, ColumnStyle::Default]
+    );
+    for row in ex_asciidoc_result.body_rows() {
+        assert!(matches!(
+            row.cells()[0].content(),
+            crate::blocks::TableCellContent::AsciiDoc(_)
+        ));
+    }
+
+    verifies!(
+        r#"
 You can also apply the xref:format-cell-content.adoc#a-operator[AsciiDoc block style operator to individual cells].
 "#
     );
+
+    // The closing cross-reference renders as a link to the format-cell-content
+    // page's section on the per-cell AsciiDoc operator.
+    let rendered = rendered_paragraph(
+        "You can also apply the xref:format-cell-content.adoc#a-operator[AsciiDoc block style operator to individual cells].",
+    );
+    assert!(rendered.contains("<a href="));
+    assert!(rendered.contains("AsciiDoc block style operator to individual cells</a>"));
 }

--- a/parser/src/tests/asciidoc_lang/tables/format_column_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_column_content.rs
@@ -1,0 +1,492 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/format-column-content.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Collect each column's style.
+fn column_styles(table: &crate::blocks::TableBlock<'_>) -> Vec<ColumnStyle> {
+    table.columns().iter().map(|c| c.style()).collect()
+}
+
+/// Return the rendered text of a [`Simple`](crate::blocks::TableCellContent)
+/// cell, panicking if the cell holds AsciiDoc block content instead.
+fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
+    match cell.content() {
+        crate::blocks::TableCellContent::Simple(content) => content.rendered().to_string(),
+        crate::blocks::TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
+    }
+}
+
+non_normative!(
+    r#"
+= Format Content by Column
+
+"#
+);
+
+#[test]
+fn intro() {
+    verifies!(
+        r#"
+A column style operator is applied to a column specifier and xref:add-columns.adoc#cols-attribute[assigned to the cols attribute].
+
+"#
+    );
+
+    // A style operator on a column specifier in the `cols` attribute is applied
+    // to that column.
+    let table = parse_table("[cols=\"e\"]\n|===\n|content\n|===");
+    assert_eq!(column_styles(&table), vec![ColumnStyle::Emphasis]);
+}
+
+#[test]
+fn column_styles_and_their_operators() {
+    non_normative!(
+        r#"
+[#cols-style]
+== Column styles and their operators
+
+"#
+    );
+
+    verifies!(
+        r#"
+You can style all of the content in a column by adding a style operator to a column's specifier.
+
+"#
+    );
+
+    // The style operator governs the whole column: every body cell in the
+    // column is processed with the column's style. (The two adjacent rows are
+    // both body rows because no blank line follows the first, so neither
+    // becomes a header.)
+    let table = parse_table("[cols=\"s,m\"]\n|===\n|a |b\n|c |d\n|===");
+    assert_eq!(
+        column_styles(&table),
+        vec![ColumnStyle::Strong, ColumnStyle::Monospace]
+    );
+    assert_eq!(table.body_rows().len(), 2);
+
+    non_normative!(
+        r#"
+include::partial$style-operators.adoc[]
+
+"#
+    );
+
+    verifies!(
+        r#"
+When a style operator isn't explicitly applied to a column specifier, the `d` style is assigned automatically and the column is processed as paragraph text.
+
+"#
+    );
+
+    // With no style operator, a column is assigned the default (`d`) style.
+    let table = parse_table("[cols=\"1,1\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_styles(&table),
+        vec![ColumnStyle::Default, ColumnStyle::Default]
+    );
+
+    // The default style can also be requested explicitly with the `d` operator.
+    let table = parse_table("[cols=\"d,d\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_styles(&table),
+        vec![ColumnStyle::Default, ColumnStyle::Default]
+    );
+}
+
+#[test]
+fn apply_a_style_operator_to_a_column() {
+    non_normative!(
+        r#"
+== Apply a style operator to a column
+
+"#
+    );
+
+    verifies!(
+        r#"
+A style operator is always placed in the last position on a column's specifier or multiplier.
+
+* `[cols=">pass:q[#e#],.^3pass:q[#s#]"]` A style operator is placed directly after any other operators and the column width in the column's specifier.
+* `[cols="pass:q[#h#],pass:q[#e#]"]` When a column width isn't specified, the style operator can represent both the column and the column's content style.
+* `[cols="3*.>pass:q[#m#]"]` When a multiplier is present, the style operator is placed after any horizontal and vertical alignment operators.
+
+"#
+    );
+
+    // The style operator follows any alignment operators and the column width.
+    let table = parse_table("[cols=\">e,.^3s\"]\n|===\n|a |b\n|===");
+    let columns = table.columns();
+    assert_eq!(columns[0].h_align(), HorizontalAlignment::Right);
+    assert_eq!(columns[0].width(), 1);
+    assert_eq!(columns[0].style(), ColumnStyle::Emphasis);
+    assert_eq!(columns[1].v_align(), VerticalAlignment::Middle);
+    assert_eq!(columns[1].width(), 3);
+    assert_eq!(columns[1].style(), ColumnStyle::Strong);
+
+    // When a column width isn't specified, the style operator can represent both
+    // the column and its content style.
+    let table = parse_table("[cols=\"h,e\"]\n|===\n|a |b\n|===");
+    let columns = table.columns();
+    assert_eq!(
+        (columns[0].width(), columns[0].style()),
+        (1, ColumnStyle::Header)
+    );
+    assert_eq!(
+        (columns[1].width(), columns[1].style()),
+        (1, ColumnStyle::Emphasis)
+    );
+
+    // When a multiplier is present, the style operator follows the alignment
+    // operators on the (single) specifier that the multiplier repeats.
+    let table = parse_table("[cols=\"3*.>m\"]\n|===\n|a |b |c\n|===");
+    assert_eq!(
+        column_styles(&table),
+        vec![
+            ColumnStyle::Monospace,
+            ColumnStyle::Monospace,
+            ColumnStyle::Monospace
+        ]
+    );
+    for column in table.columns() {
+        assert_eq!(column.v_align(), VerticalAlignment::Bottom);
+    }
+
+    non_normative!(
+        r#"
+Let's apply a different style to each column in <<ex-style>>.
+
+.Add a style operator to each column
+[source#ex-style]
+----
+[cols="h,m,s,e"]
+|===
+|Column 1 |Column 2 |Column 3 |Column 4
+
+|This column's content and borders are rendered using the table header (`h`) styles.
+|This column's content is rendered using a monospace font (m).
+|This column's content is bold (`s`).
+|This column's content is italicized (`e`).
+
+|This column's content and borders are rendered using the table header (`h`) styles.
+|This column's content is rendered using a monospace font (m).
+|This column's content is bold (`s`).
+|This column's content is italicized (`e`).
+|===
+----
+
+The table from <<ex-style>> is displayed below.
+"#
+    );
+
+    verifies!(
+        r#"
+Note that the style applied to each column doesn't affect the xref:add-header-row.adoc[header row] or override any inline formatting.
+
+"#
+    );
+
+    // Each column carries its own style operator.
+    let table = parse_table(
+        "[cols=\"h,m,s,e\"]\n|===\n|Column 1 |Column 2 |Column 3 |Column 4\n\n|This column's content and borders are rendered using the table header (`h`) styles.\n|This column's content is rendered using a monospace font (m).\n|This column's content is bold (`s`).\n|This column's content is italicized (`e`).\n|===",
+    );
+    assert_eq!(
+        column_styles(&table),
+        vec![
+            ColumnStyle::Header,
+            ColumnStyle::Monospace,
+            ColumnStyle::Strong,
+            ColumnStyle::Emphasis,
+        ]
+    );
+
+    // The style doesn't affect the header row: each header cell holds plain
+    // inline content with no style applied, even though its column is styled.
+    let header = table.header_row().unwrap();
+    let header_text: Vec<String> = header.cells().iter().map(simple_text).collect();
+    assert_eq!(
+        header_text,
+        vec!["Column 1", "Column 2", "Column 3", "Column 4"]
+    );
+
+    // The style doesn't override inline formatting either: the body cell in the
+    // header-styled column still resolves its inline backtick markup to a
+    // monospace span.
+    let body = &table.body_rows()[0];
+    assert!(simple_text(&body.cells()[0]).contains("<code>h</code>"));
+}
+
+#[test]
+fn use_asciidoc_block_elements_in_a_column() {
+    non_normative!(
+        r#"
+.Result of <<ex-style>>
+[cols="h,m,s,e"]
+|===
+|Column 1 |Column 2 |Column 3 |Column 4
+
+|This column's content and borders are rendered using the table header (`h`) styles.
+|This column's content is rendered using a monospace font (m).
+|This column's content is bold (`s`).
+|This column's content is italicized (`e`).
+
+|This column's content and borders are rendered using the table header (`h`) styles.
+|This column's content is rendered using a monospace font (m).
+|This column's content is bold (`s`).
+|This column's content is italicized (`e`).
+|===
+
+Additionally, if a xref:format-cell-content.adoc#override-column-style[cell specifier contains a style operator], that style will override a column's style operator.
+
+== Use AsciiDoc block elements in a column
+
+"#
+    );
+
+    verifies!(
+        r#"
+To use AsciiDoc block elements, such as delimited source blocks and lists, in a column, place the lowercase letter `a` on the column specifier.
+
+"#
+    );
+
+    // The `a` operator marks a column as AsciiDoc; other columns keep the
+    // default style.
+    let table = parse_table("[cols=\"2a,2\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_styles(&table),
+        vec![ColumnStyle::AsciiDoc, ColumnStyle::Default]
+    );
+
+    non_normative!(
+        r#"
+.Apply the AsciiDoc block style operator to the first column
+[source#ex-asciidoc]
+....
+[cols="2a,2"]
+|===
+|Column with the `a` style operator applied to its specifier |Column using the default style
+
+|
+* List item 1
+* List item 2
+* List item 3
+|
+* List item 1
+* List item 2
+* List item 3
+
+|
+[source,python]
+----
+import os
+print "%s" %(os.uname())
+----
+|
+[source,python]
+----
+import os
+print ("%s" %(os.uname()))
+----
+|===
+....
+
+"#
+    );
+
+    verifies!(
+        r#"
+The AsciiDoc block style effectively creates a nested, standalone AsciiDoc document in each cell in the column.
+"#
+    );
+
+    // The AsciiDoc-styled column parses each of its cells as a nested sequence
+    // of blocks, while the default-styled column leaves the same markup as
+    // inline content.
+    let table = parse_table(
+        "[cols=\"2a,2\"]\n|===\n|Column with the `a` style operator applied to its specifier |Column using the default style\n\n|\n* List item 1\n* List item 2\n* List item 3\n|\n* List item 1\n* List item 2\n* List item 3\n\n|\n[source,python]\n----\nimport os\nprint \"%s\" %(os.uname())\n----\n|\n[source,python]\n----\nimport os\nprint (\"%s\" %(os.uname()))\n----\n|===",
+    );
+    assert_eq!(
+        column_styles(&table),
+        vec![ColumnStyle::AsciiDoc, ColumnStyle::Default]
+    );
+
+    // First body row: the AsciiDoc cell parses a list block; the default cell
+    // keeps the list markup as plain inline text.
+    let row = &table.body_rows()[0];
+    match row.cells()[0].content() {
+        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+            assert_eq!(blocks.len(), 1);
+            assert_eq!(blocks[0].raw_context().as_ref(), "list");
+        }
+        other => panic!("expected nested AsciiDoc blocks, got {other:?}"),
+    }
+    assert!(matches!(
+        row.cells()[1].content(),
+        crate::blocks::TableCellContent::Simple(_)
+    ));
+
+    // Second body row: the AsciiDoc cell parses the delimited source block.
+    let row = &table.body_rows()[1];
+    match row.cells()[0].content() {
+        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+            assert_eq!(blocks.len(), 1);
+            assert_eq!(blocks[0].raw_context().as_ref(), "listing");
+        }
+        other => panic!("expected nested AsciiDoc blocks, got {other:?}"),
+    }
+
+    // A full structural comparison of a minimal AsciiDoc cell: its content is a
+    // nested list block parsed as a standalone document fragment.
+    use crate::blocks::ListType;
+    assert_eq!(
+        TableBlock {
+            columns: &[TableColumn {
+                width: 1,
+                h_align: HorizontalAlignment::Left,
+                v_align: VerticalAlignment::Top,
+                style: ColumnStyle::AsciiDoc,
+            }],
+            header_row: None,
+            body_rows: &[TableRow {
+                cells: &[TableCell {
+                    content: TableCellContent::AsciiDoc(&[Block::List(ListBlock {
+                        type_: ListType::Unordered,
+                        items: &[Block::ListItem(ListItem {
+                            marker: ListItemMarker::Asterisks(Span {
+                                data: "*",
+                                line: 3,
+                                col: 3,
+                                offset: 18,
+                            }),
+                            blocks: &[Block::Simple(SimpleBlock {
+                                content: Content {
+                                    original: Span {
+                                        data: "item one",
+                                        line: 3,
+                                        col: 5,
+                                        offset: 20,
+                                    },
+                                    rendered: "item one",
+                                },
+                                source: Span {
+                                    data: "item one",
+                                    line: 3,
+                                    col: 5,
+                                    offset: 20,
+                                },
+                                style: SimpleBlockStyle::Paragraph,
+                                title_source: None,
+                                title: None,
+                                anchor: None,
+                                anchor_reftext: None,
+                                attrlist: None,
+                            })],
+                            source: Span {
+                                data: "* item one",
+                                line: 3,
+                                col: 3,
+                                offset: 18,
+                            },
+                            anchor: None,
+                            anchor_reftext: None,
+                            attrlist: None,
+                        })],
+                        source: Span {
+                            data: "* item one",
+                            line: 3,
+                            col: 3,
+                            offset: 18,
+                        },
+                        title_source: None,
+                        title: None,
+                        anchor: None,
+                        anchor_reftext: None,
+                        attrlist: None,
+                    })]),
+                }],
+            }],
+            footer_row: None,
+            source: Span {
+                data: "[cols=\"a\"]\n|===\n| * item one\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            title_source: None,
+            title: None,
+            caption: None,
+            anchor: None,
+            anchor_reftext: None,
+            attrlist: Some(Attrlist {
+                attributes: &[ElementAttribute {
+                    name: Some("cols"),
+                    shorthand_items: &[],
+                    value: "a",
+                }],
+                anchor: None,
+                source: Span {
+                    data: "cols=\"a\"",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+            }),
+        },
+        parse_table("[cols=\"a\"]\n|===\n| * item one\n|===")
+    );
+
+    non_normative!(
+        r#"
+The parent document's implicit attributes, such as `doctitle`, are shadowed and custom attributes are inherited.
+// what does "shadowed" actually mean???
+
+.Result of <<ex-asciidoc>>
+[cols="2a,2"]
+|===
+|Column with the `a` style operator applied to its specifier |Column using the default style
+
+|
+* List item 1
+* List item 2
+* List item 3
+|
+* List item 1
+* List item 2
+* List item 3
+
+|
+[source,python]
+----
+import os
+print "%s" %(os.uname())
+----
+
+|
+[source,python]
+----
+import os
+print ("%s" %(os.uname()))
+----
+|===
+
+You can also apply the xref:format-cell-content.adoc#a-operator[AsciiDoc block style operator to individual cells].
+"#
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/format_column_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_column_content.rs
@@ -331,7 +331,8 @@ The AsciiDoc block style effectively creates a nested, standalone AsciiDoc docum
     // keeps the list markup as plain inline text.
     let row = &table.body_rows()[0];
     match row.cells()[0].content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+        crate::blocks::TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
             assert_eq!(blocks.len(), 1);
             assert_eq!(blocks[0].raw_context().as_ref(), "list");
         }
@@ -345,7 +346,8 @@ The AsciiDoc block style effectively creates a nested, standalone AsciiDoc docum
     // Second body row: the AsciiDoc cell parses the delimited source block.
     let row = &table.body_rows()[1];
     match row.cells()[0].content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+        crate::blocks::TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
             assert_eq!(blocks.len(), 1);
             assert_eq!(blocks[0].raw_context().as_ref(), "listing");
         }

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -1,0 +1,1 @@
+mod build_a_basic_table;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -10,4 +10,5 @@ mod build_a_basic_table;
 mod customize_title_label;
 mod format_cell_content;
 mod format_column_content;
+mod span_cells;
 mod turn_off_title_label;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -1,3 +1,4 @@
 mod add_title;
 mod build_a_basic_table;
 mod customize_title_label;
+mod turn_off_title_label;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -6,6 +6,7 @@ mod add_title;
 mod adjust_column_widths;
 mod align_by_cell;
 mod align_by_column;
+mod assign_a_role;
 mod borders;
 mod build_a_basic_table;
 mod customize_title_label;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -1,1 +1,2 @@
+mod add_title;
 mod build_a_basic_table;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -8,5 +8,6 @@ mod align_by_cell;
 mod align_by_column;
 mod build_a_basic_table;
 mod customize_title_label;
+mod format_cell_content;
 mod format_column_content;
 mod turn_off_title_label;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -13,3 +13,4 @@ mod format_cell_content;
 mod format_column_content;
 mod span_cells;
 mod turn_off_title_label;
+mod width;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -6,6 +6,7 @@ mod add_title;
 mod adjust_column_widths;
 mod align_by_cell;
 mod align_by_column;
+mod borders;
 mod build_a_basic_table;
 mod customize_title_label;
 mod duplicate_cells;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -1,6 +1,7 @@
 mod add_columns;
 mod add_title;
 mod adjust_column_widths;
+mod align_by_column;
 mod build_a_basic_table;
 mod customize_title_label;
 mod turn_off_title_label;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -1,5 +1,6 @@
 mod add_cells_and_rows;
 mod add_columns;
+mod add_header_row;
 mod add_title;
 mod adjust_column_widths;
 mod align_by_column;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -4,4 +4,5 @@ mod adjust_column_widths;
 mod align_by_column;
 mod build_a_basic_table;
 mod customize_title_label;
+mod format_column_content;
 mod turn_off_title_label;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -1,2 +1,3 @@
 mod add_title;
 mod build_a_basic_table;
+mod customize_title_label;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -13,6 +13,7 @@ mod customize_title_label;
 mod duplicate_cells;
 mod format_cell_content;
 mod format_column_content;
+mod nested;
 mod orientation;
 mod span_cells;
 mod striping;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -10,6 +10,7 @@ mod assign_a_role;
 mod borders;
 mod build_a_basic_table;
 mod customize_title_label;
+mod data_format;
 mod duplicate_cells;
 mod format_cell_content;
 mod format_column_content;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -18,5 +18,6 @@ mod nested;
 mod orientation;
 mod span_cells;
 mod striping;
+mod table_ref;
 mod turn_off_title_label;
 mod width;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -1,3 +1,4 @@
+mod add_columns;
 mod add_title;
 mod build_a_basic_table;
 mod customize_title_label;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -1,5 +1,6 @@
 mod add_columns;
 mod add_title;
+mod adjust_column_widths;
 mod build_a_basic_table;
 mod customize_title_label;
 mod turn_off_title_label;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -1,5 +1,6 @@
 mod add_cells_and_rows;
 mod add_columns;
+mod add_footer_row;
 mod add_header_row;
 mod add_title;
 mod adjust_column_widths;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -12,6 +12,7 @@ mod customize_title_label;
 mod duplicate_cells;
 mod format_cell_content;
 mod format_column_content;
+mod orientation;
 mod span_cells;
 mod striping;
 mod turn_off_title_label;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -8,6 +8,7 @@ mod align_by_cell;
 mod align_by_column;
 mod build_a_basic_table;
 mod customize_title_label;
+mod duplicate_cells;
 mod format_cell_content;
 mod format_column_content;
 mod span_cells;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -4,6 +4,7 @@ mod add_footer_row;
 mod add_header_row;
 mod add_title;
 mod adjust_column_widths;
+mod align_by_cell;
 mod align_by_column;
 mod build_a_basic_table;
 mod customize_title_label;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -1,3 +1,4 @@
+mod add_cells_and_rows;
 mod add_columns;
 mod add_title;
 mod adjust_column_widths;

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -13,5 +13,6 @@ mod duplicate_cells;
 mod format_cell_content;
 mod format_column_content;
 mod span_cells;
+mod striping;
 mod turn_off_title_label;
 mod width;

--- a/parser/src/tests/asciidoc_lang/tables/nested.rs
+++ b/parser/src/tests/asciidoc_lang/tables/nested.rs
@@ -20,12 +20,11 @@ fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
 /// Return the single nested [`TableBlock`] held by `cell`, panicking if the
 /// cell is not an [`AsciiDoc`](crate::blocks::TableCellContent::AsciiDoc) cell
 /// or does not contain exactly one table.
-fn nested_table<'a, 'src>(
-    cell: &'a crate::blocks::TableCell<'src>,
-) -> &'a crate::blocks::TableBlock<'src> {
+fn nested_table<'a>(cell: &'a crate::blocks::TableCell<'_>) -> &'a crate::blocks::TableBlock<'a> {
     match cell.content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
-            let tables: Vec<&crate::blocks::TableBlock<'src>> = blocks
+        crate::blocks::TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
+            let tables: Vec<&crate::blocks::TableBlock<'_>> = blocks
                 .iter()
                 .filter_map(|block| match block {
                     crate::blocks::Block::Table(table) => Some(table),
@@ -81,7 +80,8 @@ To distinguish the inner table from the enclosing one, you need to use `!===` as
     // The AsciiDoc cell holds a nested table in addition to its normal block
     // content (the leading `Cell 2.2` paragraph).
     match last_cell.content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+        crate::blocks::TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
             assert!(
                 blocks
                     .iter()

--- a/parser/src/tests/asciidoc_lang/tables/nested.rs
+++ b/parser/src/tests/asciidoc_lang/tables/nested.rs
@@ -1,0 +1,181 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/nested.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Return the single nested [`TableBlock`] held by `cell`, panicking if the
+/// cell is not an [`AsciiDoc`](crate::blocks::TableCellContent::AsciiDoc) cell
+/// or does not contain exactly one table.
+fn nested_table<'a, 'src>(
+    cell: &'a crate::blocks::TableCell<'src>,
+) -> &'a crate::blocks::TableBlock<'src> {
+    match cell.content() {
+        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+            let tables: Vec<&crate::blocks::TableBlock<'src>> = blocks
+                .iter()
+                .filter_map(|block| match block {
+                    crate::blocks::Block::Table(table) => Some(table),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(tables.len(), 1, "expected exactly one nested table");
+            tables[0]
+        }
+        other => panic!("expected an AsciiDoc cell, got {other:?}"),
+    }
+}
+
+/// Return the rendered text of a [`Simple`](crate::blocks::TableCellContent)
+/// cell.
+fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
+    match cell.content() {
+        crate::blocks::TableCellContent::Simple(content) => content.rendered().to_string(),
+        crate::blocks::TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
+    }
+}
+
+// The `tag=nested` example from the page: an outer two-column table whose last
+// cell carries the AsciiDoc style (`a`) and holds a nested table. The nested
+// table has its own column spec, delimiter (`!===`), and cell separator (`!`).
+const NESTED_EXAMPLE: &str = "[cols=\"1,2a\"]\n|===\n| Col 1 | Col 2\n\n| Cell 1.1\n| Cell 1.2\n\n| Cell 2.1\n| Cell 2.2\n\n[cols=\"2,1\"]\n!===\n! Col1 ! Col2\n\n! C11\n! C12\n\n!===\n\n|===";
+
+non_normative!(
+    r#"
+= Nesting Tables
+
+"#
+);
+
+#[test]
+fn distinguish_inner_from_outer() {
+    verifies!(
+        r#"
+Table cells marked with the AsciiDoc table style (`a`) support nested tables in addition to normal block content.
+To distinguish the inner table from the enclosing one, you need to use `!===` as the table delimiter and a cell separator that differs from that used for the enclosing table.
+"#
+    );
+
+    // The outer table separates its cells with the default vertical bar (`|`).
+    // Its last column carries the AsciiDoc style (`a`), so the last body cell
+    // holds block content rather than inline content.
+    let outer = parse_table(NESTED_EXAMPLE);
+    assert_eq!(outer.body_rows().len(), 2);
+
+    let last_cell = &outer.body_rows()[1].cells()[1];
+    assert_eq!(last_cell.style(), ColumnStyle::AsciiDoc);
+
+    // The AsciiDoc cell holds a nested table in addition to its normal block
+    // content (the leading `Cell 2.2` paragraph).
+    match last_cell.content() {
+        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+            assert!(
+                blocks
+                    .iter()
+                    .any(|b| matches!(b, crate::blocks::Block::Table(_))),
+                "expected a nested table among the cell's blocks"
+            );
+            assert!(
+                blocks
+                    .iter()
+                    .any(|b| !matches!(b, crate::blocks::Block::Table(_))),
+                "expected normal block content alongside the nested table"
+            );
+        }
+        other => panic!("expected an AsciiDoc cell, got {other:?}"),
+    }
+
+    // The inner table is delimited by `!===` and separates its cells with `!`,
+    // which differs from the outer table's `|`. Because the separators differ,
+    // the outer table's `|` scan does not break the inner table apart: the inner
+    // `!`-separated cells are parsed as a complete two-column table.
+    let inner = nested_table(last_cell);
+    assert_eq!(inner.header_row().unwrap().cells().len(), 2);
+    assert_eq!(inner.body_rows().len(), 1);
+    assert_eq!(inner.body_rows()[0].cells().len(), 2);
+    assert_eq!(simple_text(&inner.body_rows()[0].cells()[0]), "C11");
+    assert_eq!(simple_text(&inner.body_rows()[0].cells()[1]), "C12");
+
+    // A `!===` table at the top level (not inside an AsciiDoc cell) is still a
+    // table — `parse_table` would panic if the `!===` delimiter were not
+    // recognized — but it separates on the default `|`, so the `|` begins the
+    // cell and a bare `!` is literal text that does not begin a cell.
+    let top_level = parse_table("!===\n| a ! b\n!===");
+    assert_eq!(top_level.body_rows()[0].cells().len(), 1);
+    assert_eq!(simple_text(&top_level.body_rows()[0].cells()[0]), "a ! b");
+
+    // The same top-level `!===` table behaves identically to its `|===`
+    // counterpart, confirming the leading delimiter character does not change
+    // the (top-level) default separator.
+    let pipe_level = parse_table("|===\n| a ! b\n|===");
+    assert_eq!(
+        simple_text(&top_level.body_rows()[0].cells()[0]),
+        simple_text(&pipe_level.body_rows()[0].cells()[0]),
+    );
+}
+
+#[test]
+fn default_separator_and_override() {
+    verifies!(
+        r#"
+The default cell separator for a nested table is `!`, though you can choose another character by defining the `separator` attribute on the table.
+
+"#
+    );
+
+    // With no `separator` attribute, the nested table's cell separator defaults
+    // to `!`: the `!`-prefixed tokens begin cells and a `|` would be literal.
+    let outer = parse_table("|===\na|\n!===\n! one ! two\n!===\n|===");
+    let inner = nested_table(&outer.body_rows()[0].cells()[0]);
+    assert_eq!(inner.body_rows()[0].cells().len(), 2);
+    assert_eq!(simple_text(&inner.body_rows()[0].cells()[0]), "one");
+    assert_eq!(simple_text(&inner.body_rows()[0].cells()[1]), "two");
+
+    // The `separator` attribute overrides the default: here the nested table
+    // separates on `:` instead, so the `:`-prefixed tokens begin cells.
+    let outer = parse_table("|===\na|\n[separator=:]\n!===\n:one :two\n!===\n|===");
+    let inner = nested_table(&outer.body_rows()[0].cells()[0]);
+    assert_eq!(inner.body_rows()[0].cells().len(), 2);
+    assert_eq!(simple_text(&inner.body_rows()[0].cells()[0]), "one");
+    assert_eq!(simple_text(&inner.body_rows()[0].cells()[1]), "two");
+
+    // The `separator` attribute applies to an outer table as well, replacing the
+    // default `|` with the chosen character.
+    let outer = parse_table("[separator=;]\n|===\n;one ;two\n|===");
+    assert_eq!(outer.body_rows()[0].cells().len(), 2);
+    assert_eq!(simple_text(&outer.body_rows()[0].cells()[0]), "one");
+    assert_eq!(simple_text(&outer.body_rows()[0].cells()[1]), "two");
+}
+
+non_normative!(
+    r#"
+NOTE: Although nested tables are not technically valid in DocBook 5.0, the DocBook toolchain processes them anyway.
+
+The following example contains a nested table in the last cell.
+Notice the nested table has its own format, independent of that of the outer table:
+
+[source]
+----
+include::example$table.adoc[tag=nested]
+----
+
+.Result: A nested table
+include::example$table.adoc[tag=nested]
+
+We recommend using nested tables sparingly.
+There's usually a better way to present the information.
+"#
+);

--- a/parser/src/tests/asciidoc_lang/tables/nested.rs
+++ b/parser/src/tests/asciidoc_lang/tables/nested.rs
@@ -164,6 +164,13 @@ non_normative!(
     r#"
 NOTE: Although nested tables are not technically valid in DocBook 5.0, the DocBook toolchain processes them anyway.
 
+"#
+);
+
+#[test]
+fn nested_table_example() {
+    verifies!(
+        r#"
 The following example contains a nested table in the last cell.
 Notice the nested table has its own format, independent of that of the outer table:
 
@@ -175,6 +182,47 @@ include::example$table.adoc[tag=nested]
 .Result: A nested table
 include::example$table.adoc[tag=nested]
 
+"#
+    );
+
+    // Expansion of `example$table.adoc[tag=nested]`, which is identical to
+    // `NESTED_EXAMPLE`: a two-column outer table whose AsciiDoc-styled (`a`) last
+    // cell carries a nested table.
+    let outer = parse_table(NESTED_EXAMPLE);
+    assert_eq!(outer.columns().len(), 2);
+    assert_eq!(outer.body_rows().len(), 2);
+
+    let last_cell = &outer.body_rows()[1].cells()[1];
+    assert_eq!(last_cell.style(), ColumnStyle::AsciiDoc);
+
+    // The nested table renders with its own format, independent of the outer
+    // table: its own column spec produces a two-cell implicit header row
+    // (`Col1`/`Col2`) followed by one body row (`C11`/`C12`).
+    let inner = nested_table(last_cell);
+    assert_eq!(inner.columns().len(), 2);
+    assert_eq!(
+        inner
+            .header_row()
+            .unwrap()
+            .cells()
+            .iter()
+            .map(simple_text)
+            .collect::<Vec<_>>(),
+        vec!["Col1", "Col2"]
+    );
+    assert_eq!(inner.body_rows().len(), 1);
+    assert_eq!(
+        inner.body_rows()[0]
+            .cells()
+            .iter()
+            .map(simple_text)
+            .collect::<Vec<_>>(),
+        vec!["C11", "C12"]
+    );
+}
+
+non_normative!(
+    r#"
 We recommend using nested tables sparingly.
 There's usually a better way to present the information.
 "#

--- a/parser/src/tests/asciidoc_lang/tables/orientation.rs
+++ b/parser/src/tests/asciidoc_lang/tables/orientation.rs
@@ -1,0 +1,33 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/orientation.adoc");
+
+// This entire page is considered non-normative because table orientation
+// (the `rotate` option and `orientation` attribute) only affects rendering, and
+// as the page itself notes, it is implemented solely by the DocBook backend.
+// This crate doesn't do rendering.
+non_normative!(
+    r#"
+= Table Orientation
+
+== Landscape
+
+A table can be displayed in landscape (rotated 90 degrees counterclockwise) using the `rotate` option (preferred).
+
+[source]
+----
+[%rotate]
+include::example$table.adoc[tag=base]
+----
+
+A table can also be displayed in landscape using the `orientation` attribute.
+
+[source]
+----
+[orientation=landscape]
+include::example$table.adoc[tag=base]
+----
+
+Currently, this is only implemented by the DocBook backend (it sets the attribute `orient="land"`).
+"#
+);

--- a/parser/src/tests/asciidoc_lang/tables/span_cells.rs
+++ b/parser/src/tests/asciidoc_lang/tables/span_cells.rs
@@ -1,0 +1,225 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/span-cells.adoc");
+
+non_normative!(
+    r#"
+= Span Columns and Rows
+
+A table cell can span more than one column and row.
+
+"#
+);
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Collect the `(colspan, rowspan)` of each cell in each body row of `table`.
+fn body_spans(table: &crate::blocks::TableBlock<'_>) -> Vec<Vec<(usize, usize)>> {
+    table
+        .body_rows()
+        .iter()
+        .map(|row| {
+            row.cells()
+                .iter()
+                .map(|cell| (cell.colspan(), cell.rowspan()))
+                .collect()
+        })
+        .collect()
+}
+
+#[test]
+fn span_factor_and_operator() {
+    non_normative!(
+        r#"
+== Span factor and operator
+
+"#
+    );
+
+    verifies!(
+        r#"
+With a [.term]*span* a table cell can stretch across adjacent columns, rows, or a block of adjacent columns and rows.
+A span consists of a span factor and a span operator.
+
+The [.term]*span factor* indicates the number columns, rows, or columns and rows a cell should span.
+
+[[col-factor]]Column span factor:: A single integer (`<n>`) that represents the number of consecutive columns a cell should span.
+[[row-factor]]Row span factor:: A single integer prefixed with a dot (`.<n>`) that represents the number of consecutive rows a cell should span.
+[[block-factor]]Block span factor:: Two integers (`<n>.<n>`) that represent a block of adjacent columns and rows a cell should span.
+The first integer, `<n>`, is the column span factor.
+The second integer, which is prefixed with a dot, `.<n>`, is the row span factor.
+
+The [.term]*span operator* is a plus sign (`\+`) placed directly after the span factor (`<n>.<n>+`).
+The span operator tells the converter to interpret the span factor as part of a span instead of a duplication.
+
+A span is the first operator in a xref:add-cells-and-rows.adoc#specifiers[cell specifier].
+
+====
+<**span factor**><**span operator**><horizontal alignment operator><vertical alignment operator><style operator>|<cell's content>
+====
+
+"#
+    );
+
+    // A column span factor (`<n>`) followed by the span operator (`+`) makes the
+    // cell span `<n>` consecutive columns (and a single row).
+    let table = parse_table("|===\n3+|x\n|===");
+    assert_eq!(body_spans(&table), vec![vec![(3, 1)]]);
+
+    // A row span factor (`.<n>`) followed by the span operator makes the cell
+    // span `<n>` consecutive rows (and a single column).
+    let table = parse_table("|===\n.2+|x\n|===");
+    assert_eq!(body_spans(&table), vec![vec![(1, 2)]]);
+
+    // A block span factor (`<n>.<n>`): the first integer is the column span and
+    // the second (dot-prefixed) integer is the row span.
+    let table = parse_table("|===\n2.3+|x\n|===");
+    assert_eq!(body_spans(&table), vec![vec![(2, 3)]]);
+}
+
+#[test]
+fn span_multiple_columns() {
+    non_normative!(
+        r#"
+== Span multiple columns
+
+"#
+    );
+
+    verifies!(
+        r#"
+To have a cell span consecutive columns, enter the <<col-factor,column span factor>> and span operator (`<n>+`) in the cell specifier.
+Don't insert any spaces between the span, any alignment or style operators (if present), and the xref:add-cells-and-rows.adoc#cell-separator[cell's separator] (`|`).
+
+.Span three columns with a cell
+[source#ex-span-columns]
+----
+include::example$cell.adoc[tag=span-cols]
+----
+
+The table from <<ex-span-columns>> is displayed below.
+
+.Result of <<ex-span-columns>>
+include::example$cell.adoc[tag=span-cols]
+
+"#
+    );
+
+    // Expansion of `example$cell.adoc[tag=span-cols]`. The `3+` cell spans the
+    // first three columns of its row, leaving room for a single trailing cell;
+    // the rows above and below it are ordinary four-cell rows.
+    let table = parse_table(
+        "|===\n|Column 1, header row |Column 2, header row |Column 3, header row |Column 4, header row\n\n3+|This cell spans columns 1, 2, and 3 because its specifier contains a span of `3+`\n|Cell in column 4, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|Cell in column 3, row 3\n|Cell in column 4, row 3\n|===",
+    );
+
+    assert_eq!(table.columns().len(), 4);
+    assert_eq!(table.header_row().unwrap().cells().len(), 4);
+    assert_eq!(
+        body_spans(&table),
+        vec![vec![(3, 1), (1, 1)], vec![(1, 1), (1, 1), (1, 1), (1, 1)],]
+    );
+}
+
+#[test]
+fn span_multiple_rows() {
+    non_normative!(
+        r#"
+== Span multiple rows
+
+"#
+    );
+
+    verifies!(
+        r#"
+To have a cell span consecutive rows, enter the <<row-factor,row span factor>> and span operator (`.<n>+`) in the cell specifier.
+Remember to prefix the span factor with a dot (`.`).
+Don't insert any spaces between the span, any alignment or style operators (if present), and the xref:add-cells-and-rows.adoc#cell-separator[cell's separator] (`|`).
+
+.Span two rows with a cell
+[source#ex-span-rows]
+----
+include::example$cell.adoc[tag=span-rows]
+----
+
+The table from <<ex-span-rows>> is displayed below.
+
+.Result of <<ex-span-rows>>
+include::example$cell.adoc[tag=span-rows]
+
+"#
+    );
+
+    // Expansion of `example$cell.adoc[tag=span-rows]`. The `.2+` cell spans rows
+    // 2 and 3 in the first column, so it carries that column down into row 3,
+    // which then needs only its single remaining cell.
+    let table = parse_table(
+        "|===\n|Column 1, header row |Column 2, header row\n\n.2+|This cell spans rows 2 and 3 because its specifier contains a span of `.2+`\n|Cell in column 2, row 2\n\n|Cell in column 2, row 3\n\n|Cell in column 1, row 4\n|Cell in column 2, row 4\n|===",
+    );
+
+    assert_eq!(table.columns().len(), 2);
+    assert_eq!(table.header_row().unwrap().cells().len(), 2);
+    assert_eq!(
+        body_spans(&table),
+        vec![vec![(1, 2), (1, 1)], vec![(1, 1)], vec![(1, 1), (1, 1)],]
+    );
+}
+
+#[test]
+fn span_columns_and_rows() {
+    non_normative!(
+        r#"
+== Span columns and rows
+
+"#
+    );
+
+    verifies!(
+        r#"
+A single cell can span a block of adjacent columns and rows.
+Enter the column span factor (`<n>`), followed by the row span factor (`.<n>`), and then the span operator (`+`).
+
+.Span two columns and three rows with a single cell
+[source#ex-block]
+----
+include::example$cell.adoc[tag=span-block]
+----
+
+The table from <<ex-block>> is displayed below.
+
+.Result of <<ex-block>>
+include::example$cell.adoc[tag=span-block]
+"#
+    );
+
+    // Expansion of `example$cell.adoc[tag=span-block]`. The `2.3+` cell spans
+    // columns 2 and 3 across rows 2, 3, and 4, so it carries two columns down
+    // into the two rows below it; each of those rows then needs only its two
+    // remaining (first- and last-column) cells.
+    let table = parse_table(
+        "|===\n|Column 1, header row |Column 2, header row |Column 3, header row |Column 4, header row\n\n|Cell in column 1, row 2\n2.3+|This cell spans columns 2 and 3 and rows 2, 3, and 4 because its specifier contains a span of `2.3+`\n|Cell in column 4, row 2\n\n|Cell in column 1, row 3\n|Cell in column 4, row 3\n\n|Cell in column 1, row 4\n|Cell in column 4, row 4\n|===",
+    );
+
+    assert_eq!(table.columns().len(), 4);
+    assert_eq!(table.header_row().unwrap().cells().len(), 4);
+    assert_eq!(
+        body_spans(&table),
+        vec![
+            vec![(1, 1), (2, 3), (1, 1)],
+            vec![(1, 1), (1, 1)],
+            vec![(1, 1), (1, 1)],
+        ]
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/striping.rs
+++ b/parser/src/tests/asciidoc_lang/tables/striping.rs
@@ -1,0 +1,248 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/striping.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Return the first [`TableBlock`] in `doc`.
+///
+/// Used by the tests that exercise the `table-stripes` document attribute: that
+/// attribute must be set in the document header, so the whole document is
+/// parsed rather than a single block.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn first_table<'a>(doc: &'a crate::Document<'a>) -> &'a crate::blocks::TableBlock<'a> {
+    doc.nested_blocks()
+        .find_map(|block| match block {
+            crate::blocks::Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .expect("expected a table block")
+}
+
+// A minimal table (no attribute line of its own) used as the base for the
+// `stripes` / `table-stripes` assertions, which care only about the table-level
+// value and not the table's shape.
+const BASE: &str = "|===\n|A1\n|B1\n|===";
+
+non_normative!(
+    r#"
+= Table Striping
+
+"#
+);
+
+#[test]
+fn intro() {
+    verifies!(
+        r#"
+You can add zebra-striping to rows of a table.
+When this feature is enabled, the specified rows are shaded using a background color to create a zebra striping effect.
+
+"#
+    );
+
+    // With no `stripes` attribute, a table is not striped.
+    assert_eq!(parse_table(BASE).stripes(), Stripes::None);
+
+    // The note below describes a rendering concern (CSS and the stylesheet), not
+    // anything this parser models.
+    non_normative!(
+        r#"
+NOTE: In the HTML output, table striping is done using CSS and thus depends on the stylesheet to supply the necessary styles.
+The default stylesheet for Asciidoctor includes the necessary styles for table striping.
+
+"#
+    );
+}
+
+#[test]
+fn striping_attributes() {
+    non_normative!(
+        r#"
+== Striping attributes
+
+"#
+    );
+
+    verifies!(
+        r#"
+Which rows are striped is controlled using the `stripes` attribute on the table.
+The stripes attribute defaults to the value `none` (implied value), which means rows are not striped by default.
+This default can be changed by setting the `table-stripes` document attribute.
+You can override the default value by setting the stripes attribute on the table.
+
+"#
+    );
+
+    // The stripes default to `none`, both when the attribute is absent and when
+    // it is given the implied value `none`.
+    assert_eq!(parse_table(BASE).stripes(), Stripes::None);
+    let src = format!("[stripes=none]\n{BASE}");
+    assert_eq!(parse_table(&src).stripes(), Stripes::None);
+
+    // The `table-stripes` document attribute changes the default for tables that
+    // don't set their own `stripes`.
+    let src = format!(":table-stripes: odd\n\n{BASE}");
+    let doc = Parser::default().parse(&src);
+    assert_eq!(first_table(&doc).stripes(), Stripes::Odd);
+
+    // An explicit `stripes` on the table overrides the document attribute.
+    let src = format!(":table-stripes: odd\n\n[stripes=even]\n{BASE}");
+    let doc = Parser::default().parse(&src);
+    assert_eq!(first_table(&doc).stripes(), Stripes::Even);
+
+    verifies!(
+        r#"
+The `stripes` attribute on a table and the `table-stripes` document attribute accept the following values:
+
+* `none` - no rows are shaded (default)
+* `even` - even rows are shaded
+* `odd` - odd rows are shaded
+* `all` - all rows are shaded
+* `hover` - the row under the mouse cursor is shaded (HTML only)
+
+"#
+    );
+
+    // Each documented value resolves to its corresponding variant.
+    let src = format!("[stripes=none]\n{BASE}");
+    assert_eq!(parse_table(&src).stripes(), Stripes::None);
+    let src = format!("[stripes=even]\n{BASE}");
+    assert_eq!(parse_table(&src).stripes(), Stripes::Even);
+    let src = format!("[stripes=odd]\n{BASE}");
+    assert_eq!(parse_table(&src).stripes(), Stripes::Odd);
+    let src = format!("[stripes=all]\n{BASE}");
+    assert_eq!(parse_table(&src).stripes(), Stripes::All);
+    let src = format!("[stripes=hover]\n{BASE}");
+    assert_eq!(parse_table(&src).stripes(), Stripes::Hover);
+
+    // An unrecognized value falls back to the default.
+    let src = format!("[stripes=bogus]\n{BASE}");
+    assert_eq!(parse_table(&src).stripes(), Stripes::None);
+}
+
+#[test]
+fn stripes_block_attribute() {
+    non_normative!(
+        r#"
+== stripes block attribute
+
+"#
+    );
+
+    verifies!(
+        r#"
+In the following example, the stripes are enabled for even rows in the table body (the row that contains A2 and B2).
+
+[source]
+----
+[cols=2*,stripes=even]
+|===
+|A1
+|B1
+|A2
+|B2
+|A3
+|B3
+|===
+----
+
+"#
+    );
+
+    // The example table: two columns, three body rows, with even-row striping.
+    let src = "[cols=2*,stripes=even]\n|===\n|A1\n|B1\n|A2\n|B2\n|A3\n|B3\n|===";
+    let table = parse_table(src);
+    assert_eq!(table.stripes(), Stripes::Even);
+    assert_eq!(table.columns().len(), 2);
+    assert!(table.header_row().is_none());
+    assert_eq!(table.body_rows().len(), 3);
+
+    verifies!(
+        r#"
+Under the covers, the stripes attribute applies the CSS class `stripes-<value>` (e.g., `stripes-none`) to the table tag.
+As a shorthand, you can simply apply the CSS class to the table directly using a role.
+
+[source]
+----
+[.stripes-even,cols=2*]
+|===
+|A1
+|B1
+|A2
+|B2
+|A3
+|B3
+|===
+----
+
+"#
+    );
+
+    // The role shorthand applies the `stripes-even` CSS class directly without
+    // setting the `stripes` attribute, so the parsed `stripes` value stays
+    // `none` and the class is reported among the table's roles instead.
+    let src = "[.stripes-even,cols=2*]\n|===\n|A1\n|B1\n|A2\n|B2\n|A3\n|B3\n|===";
+    let table = parse_table(src);
+    assert_eq!(table.stripes(), Stripes::None);
+    assert!(table.attrlist().unwrap().roles().contains(&"stripes-even"));
+}
+
+#[test]
+fn table_stripes_attribute() {
+    non_normative!(
+        r#"
+== table-stripes attribute
+
+"#
+    );
+
+    verifies!(
+        r#"
+If you want to apply stripes to all tables in the document, set the `table-stripes` attribute in the document header.
+You can still override this setting per table.
+
+[source]
+----
+= Document Title
+:table-stripes: even
+
+[cols=2*]
+|===
+|A1
+|B1
+|A2
+|B2
+|A3
+|B3
+|===
+----
+"#
+    );
+
+    // The document-header attribute stripes every table that doesn't set its
+    // own `stripes`.
+    let src = "= Document Title\n:table-stripes: even\n\n[cols=2*]\n|===\n|A1\n|B1\n|A2\n|B2\n|A3\n|B3\n|===";
+    let doc = Parser::default().parse(src);
+    assert_eq!(first_table(&doc).stripes(), Stripes::Even);
+
+    // A table can still override the document-wide setting.
+    let src =
+        "= Document Title\n:table-stripes: even\n\n[stripes=odd,cols=2*]\n|===\n|A1\n|B1\n|===";
+    let doc = Parser::default().parse(src);
+    assert_eq!(first_table(&doc).stripes(), Stripes::Odd);
+}

--- a/parser/src/tests/asciidoc_lang/tables/table_ref.rs
+++ b/parser/src/tests/asciidoc_lang/tables/table_ref.rs
@@ -31,12 +31,11 @@ fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
 /// Return the single nested [`TableBlock`] held by an AsciiDoc `cell`.
 ///
 /// [`TableBlock`]: crate::blocks::TableBlock
-fn nested_table<'a, 'src>(
-    cell: &'a crate::blocks::TableCell<'src>,
-) -> &'a crate::blocks::TableBlock<'src> {
+fn nested_table<'a>(cell: &'a crate::blocks::TableCell<'_>) -> &'a crate::blocks::TableBlock<'a> {
     match cell.content() {
-        TableCellContent::AsciiDoc(blocks) => {
-            let tables: Vec<&crate::blocks::TableBlock<'src>> = blocks
+        TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
+            let tables: Vec<&crate::blocks::TableBlock<'_>> = blocks
                 .iter()
                 .filter_map(|block| match block {
                     crate::blocks::Block::Table(table) => Some(table),

--- a/parser/src/tests/asciidoc_lang/tables/table_ref.rs
+++ b/parser/src/tests/asciidoc_lang/tables/table_ref.rs
@@ -1,0 +1,664 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/table-ref.adoc");
+
+use crate::blocks::{DataFormat, TableCellContent};
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Return the rendered text of a [`Simple`](TableCellContent::Simple) cell,
+/// panicking if the cell holds AsciiDoc block content.
+fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
+    match cell.content() {
+        TableCellContent::Simple(content) => content.rendered().to_string(),
+        TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
+    }
+}
+
+/// Return the single nested [`TableBlock`] held by an AsciiDoc `cell`.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn nested_table<'a, 'src>(
+    cell: &'a crate::blocks::TableCell<'src>,
+) -> &'a crate::blocks::TableBlock<'src> {
+    match cell.content() {
+        TableCellContent::AsciiDoc(blocks) => {
+            let tables: Vec<&crate::blocks::TableBlock<'src>> = blocks
+                .iter()
+                .filter_map(|block| match block {
+                    crate::blocks::Block::Table(table) => Some(table),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(tables.len(), 1, "expected exactly one nested table");
+            tables[0]
+        }
+        other => panic!("expected an AsciiDoc cell, got {other:?}"),
+    }
+}
+
+// This page is a single reference table; each of its rows describes one
+// table-level attribute. The intro (page title, `cols` spec, table delimiter,
+// and header row) carries no rule to verify.
+non_normative!(
+    r#"
+= Table Syntax and Attribute Reference
+:navtitle: Table Reference
+
+[cols="1m,2,1m,2,2"]
+|===
+|Attribute |Description |Value |Description |Notes
+
+"#
+);
+
+#[test]
+fn caption_attribute() {
+    verifies!(
+        r#"
+|caption
+|defines the title label on a single table
+d|user-defined
+|
+|
+
+"#
+    );
+
+    // An explicit `caption` defines a user-defined title label on the single
+    // table it is set on, used verbatim (including its trailing space) and with
+    // no automatically incremented number.
+    let table = parse_table("[caption=\"Spec Table. \"]\n.A titled table\n|===\n|a\n|===");
+    assert_eq!(table.caption(), Some("Spec Table. "));
+}
+
+#[test]
+fn cols_attribute() {
+    verifies!(
+        r#"
+|cols
+|comma-separated list of column specifiers
+d|specifiers
+|Specifies the number of columns and the distribution ratio and default formatting for each column. See xref:add-columns.adoc[] for details
+|
+
+"#
+    );
+
+    // A comma-separated list of column specifiers sets the number of columns, the
+    // per-column distribution ratio, and the default formatting for each column.
+    // The page's own spec, `1m,2,1m,2,2`, declares five columns: the first and
+    // third are width 1 with the monospace style, the rest are width 2 with the
+    // default style.
+    let table = parse_table("[cols=\"1m,2,1m,2,2\"]\n|===\n|a |b |c |d |e\n|===");
+    assert_eq!(table.columns().len(), 5);
+
+    assert_eq!(table.columns()[0].width(), 1);
+    assert_eq!(table.columns()[0].style(), ColumnStyle::Monospace);
+    assert_eq!(table.columns()[1].width(), 2);
+    assert_eq!(table.columns()[1].style(), ColumnStyle::Default);
+    assert_eq!(table.columns()[2].width(), 1);
+    assert_eq!(table.columns()[2].style(), ColumnStyle::Monospace);
+    assert_eq!(table.columns()[3].width(), 2);
+    assert_eq!(table.columns()[3].style(), ColumnStyle::Default);
+    assert_eq!(table.columns()[4].width(), 2);
+    assert_eq!(table.columns()[4].style(), ColumnStyle::Default);
+}
+
+#[test]
+fn format_attribute() {
+    verifies!(
+        r#"
+.4+|format
+.4+|data format of the table's contents
+|psv
+|cells are delimited by `separator` (default `{vbar}`) (aka prefix-separated values)
+.4+|
+
+|dsv
+|cells are delimited by a colon (`:`) (aka delimiter-separated values)
+
+|csv
+|cells are delimited by a comma (`,`) (aka comma-separated values)
+
+|tsv
+|cells are delimited by a tab character (aka tab-separated values)
+
+"#
+    );
+
+    // The `format` attribute selects the data format. PSV is the default, and its
+    // cells are delimited by the `separator` (default `|`), placed in front of
+    // each cell.
+    assert_eq!(
+        parse_table("|===\n|a |b\n|===").data_format(),
+        DataFormat::Psv
+    );
+    assert_eq!(
+        parse_table("[format=psv]\n|===\n|a |b\n|===").data_format(),
+        DataFormat::Psv
+    );
+
+    // DSV cells are delimited by a colon (`:`).
+    assert_eq!(
+        parse_table("[format=dsv]\n|===\na:b\n|===").data_format(),
+        DataFormat::Dsv
+    );
+
+    // CSV cells are delimited by a comma (`,`).
+    assert_eq!(
+        parse_table("[format=csv]\n|===\na,b\n|===").data_format(),
+        DataFormat::Csv
+    );
+
+    // TSV cells are delimited by a tab character.
+    assert_eq!(
+        parse_table("[format=tsv]\n|===\na\tb\n|===").data_format(),
+        DataFormat::Tsv
+    );
+}
+
+#[test]
+fn separator_attribute() {
+    verifies!(
+        r#"
+.3+|separator
+.3+|character used to separate cells
+|{vbar}
+|default for top-level tables
+.3+|
+|!
+|default for nested tables
+d|user-defined
+|any single character or `\t` for tab (e.g., `{brvbar}` or `%`).
+_Ideally a character not found in the cell content._
+
+"#
+    );
+
+    // The default separator for a top-level table is the vertical bar (`|`), so
+    // each `|` begins a new cell.
+    let table = parse_table("|===\n|a |b\n|===");
+    assert_eq!(table.body_rows()[0].cells().len(), 2);
+
+    // The default separator for a nested table is the exclamation mark (`!`).
+    let outer = parse_table("[cols=\"1a\"]\n|===\na|\n!===\n! x ! y\n!===\n|===");
+    let inner = nested_table(&outer.body_rows()[0].cells()[0]);
+    assert_eq!(inner.body_rows()[0].cells().len(), 2);
+    assert_eq!(simple_text(&inner.body_rows()[0].cells()[0]), "x");
+    assert_eq!(simple_text(&inner.body_rows()[0].cells()[1]), "y");
+
+    // A user-defined separator can be any single character (here `%`), after
+    // which the original cell separator (`|`) is ordinary text within a cell. As
+    // in Asciidoctor's PSV, the separator only begins a new cell when it follows
+    // whitespace, so that boundary whitespace is necessarily trimmed from the
+    // preceding cell; the explicit assertion messages make a trimming regression
+    // fail loudly rather than silently.
+    let table = parse_table("[separator=%]\n|===\n%a | b %c\n|===");
+    assert_eq!(table.body_rows()[0].cells().len(), 2);
+    assert_eq!(
+        simple_text(&table.body_rows()[0].cells()[0]),
+        "a | b",
+        "the literal `|` is kept and the boundary whitespace before `%` is trimmed"
+    );
+    assert_eq!(
+        simple_text(&table.body_rows()[0].cells()[1]),
+        "c",
+        "content after the separator forms the next cell"
+    );
+}
+
+#[test]
+fn frame_attribute() {
+    verifies!(
+        r#"
+.4+|frame
+.4+|draws a border around the table
+|all
+|border on all sides (default)
+.4+|
+
+|ends
+|border on top and bottom ends
+
+|none
+|no borders
+
+|sides
+|border on left and right sides
+
+"#
+    );
+
+    // The `frame` attribute draws a border around the table. `all` (the default)
+    // borders every side; `ends` borders the top and bottom; `none` removes the
+    // border; `sides` borders the left and right.
+    assert_eq!(parse_table("|===\n|a\n|===").frame(), Frame::All);
+    assert_eq!(
+        parse_table("[frame=all]\n|===\n|a\n|===").frame(),
+        Frame::All
+    );
+    assert_eq!(
+        parse_table("[frame=ends]\n|===\n|a\n|===").frame(),
+        Frame::Ends
+    );
+    assert_eq!(
+        parse_table("[frame=none]\n|===\n|a\n|===").frame(),
+        Frame::None
+    );
+    assert_eq!(
+        parse_table("[frame=sides]\n|===\n|a\n|===").frame(),
+        Frame::Sides
+    );
+}
+
+#[test]
+fn grid_attribute() {
+    verifies!(
+        r#"
+.4+|grid
+.4+|draws boundary lines between rows and columns
+|all
+|draws boundary lines around each cell (default)
+.4+|
+
+|cols
+|draws boundary lines between columns
+
+|rows
+|draws boundary lines between rows
+
+|none
+|no boundary lines
+
+"#
+    );
+
+    // The `grid` attribute draws boundary lines between cells. `all` (the default)
+    // borders every cell; `cols` borders between columns; `rows` borders between
+    // rows; `none` removes the boundary lines.
+    assert_eq!(parse_table("|===\n|a\n|===").grid(), Grid::All);
+    assert_eq!(parse_table("[grid=all]\n|===\n|a\n|===").grid(), Grid::All);
+    assert_eq!(
+        parse_table("[grid=cols]\n|===\n|a\n|===").grid(),
+        Grid::Cols
+    );
+    assert_eq!(
+        parse_table("[grid=rows]\n|===\n|a\n|===").grid(),
+        Grid::Rows
+    );
+    assert_eq!(
+        parse_table("[grid=none]\n|===\n|a\n|===").grid(),
+        Grid::None
+    );
+}
+
+#[test]
+fn stripes_attribute() {
+    verifies!(
+        r#"
+.5+|stripes
+.5+|controls row shading (via background color)
+|none
+|no rows are shaded (default)
+.5+|
+
+|even
+|even rows are shaded
+
+|odd
+|odd rows are shaded
+
+|hover
+|row under the mouse cursor is shaded (HTML only)
+
+|all
+|all rows are shaded
+
+"#
+    );
+
+    // The `stripes` attribute controls which rows are shaded. `none` (the default)
+    // shades nothing; `even` and `odd` shade alternating rows; `hover` shades the
+    // row under the mouse cursor; `all` shades every row.
+    assert_eq!(parse_table("|===\n|a\n|===").stripes(), Stripes::None);
+    assert_eq!(
+        parse_table("[stripes=none]\n|===\n|a\n|===").stripes(),
+        Stripes::None
+    );
+    assert_eq!(
+        parse_table("[stripes=even]\n|===\n|a\n|===").stripes(),
+        Stripes::Even
+    );
+    assert_eq!(
+        parse_table("[stripes=odd]\n|===\n|a\n|===").stripes(),
+        Stripes::Odd
+    );
+    assert_eq!(
+        parse_table("[stripes=hover]\n|===\n|a\n|===").stripes(),
+        Stripes::Hover
+    );
+    assert_eq!(
+        parse_table("[stripes=all]\n|===\n|a\n|===").stripes(),
+        Stripes::All
+    );
+}
+
+#[test]
+fn align_attribute() {
+    verifies!(
+        r#"
+.3+|align
+.3+|horizontally aligns a table with restricted width
+|left
+|aligns to left side of page (default)
+.3+|Not recognized by Asciidoctor.
+To align the table, use an alignment role (e.g., `[role=center]` or `[.center]`).
+The alignment roles work for both HTML and PDF output.
+Alignment roles and the `float` attributes are mutually exclusive.
+
+|right
+|aligns to right side of page
+
+|center
+|horizontally aligns to center of page
+
+"#
+    );
+
+    // `align` is not recognized by Asciidoctor, and this crate matches that: the
+    // attribute is accepted but given no special meaning. Whatever value it is
+    // set to, the table's structure is unchanged and its columns keep their
+    // default left alignment (alignment is expressed instead with a role or with
+    // column/cell specifiers).
+    for value in ["left", "right", "center"] {
+        let src = format!("[align={value}]\n|===\n|a |b\n|===");
+        let table = parse_table(&src);
+        assert_eq!(table.columns().len(), 2);
+        assert_eq!(table.columns()[0].h_align(), HorizontalAlignment::Left);
+        assert_eq!(table.columns()[1].h_align(), HorizontalAlignment::Left);
+    }
+}
+
+#[test]
+fn float_attribute() {
+    verifies!(
+        r#"
+.2+|float
+.2+|floats the table to the specified side of the page
+|left
+|floats the table to the left side of the page (default)
+.2+|Applies to HTML output only.
+Must be used in conjunction with the table's `width` attribute to take effect.
+The `float` and `align` attributes are mutually exclusive.
+
+|right
+|floats the table to the right side of the page
+
+"#
+    );
+
+    // `float` only floats the table in HTML output; this crate does no rendering,
+    // so the attribute is accepted but leaves the parsed table unchanged.
+    for value in ["left", "right"] {
+        let src = format!("[float={value},width=50%]\n|===\n|a |b\n|===");
+        let table = parse_table(&src);
+        assert_eq!(table.columns().len(), 2);
+        assert_eq!(table.width(), Some(50));
+    }
+}
+
+#[test]
+fn halign_attribute() {
+    verifies!(
+        r#"
+.3+|halign
+.3+|horizontally aligns all of the cell contents in a table
+|left
+|aligns the contents of the cells to the left (default)
+.3+|Not recognized by Asciidoctor.
+Define instead using column or cell specifiers (e.g., `3*>`), which take precedence over this value.
+
+|right
+|aligns the contents of the cells to the right
+
+|center
+|aligns the contents to the cell centers
+
+"#
+    );
+
+    // `halign` is not recognized by Asciidoctor, and this crate matches that:
+    // whatever value it is set to, the columns retain their default left
+    // alignment (a column or cell specifier must be used instead).
+    for value in ["left", "right", "center"] {
+        let src = format!("[halign={value}]\n|===\n|a |b\n|===");
+        let table = parse_table(&src);
+        assert_eq!(table.columns()[0].h_align(), HorizontalAlignment::Left);
+        assert_eq!(table.columns()[1].h_align(), HorizontalAlignment::Left);
+    }
+}
+
+#[test]
+fn valign_attribute() {
+    verifies!(
+        r#"
+.3+|valign
+.3+|vertically aligns all of the cell contents in a table
+|top
+|aligns the cell contents to the top of the cell (default)
+.3+|Not recognized by Asciidoctor.
+Define instead using column or cell specifiers (e.g., `3*.>`), which take precedence over this value.
+
+|bottom
+|aligns the cell contents to the bottom of the cell
+
+|middle
+|aligns the cell contents to the middle of the cell
+
+"#
+    );
+
+    // `valign` is not recognized by Asciidoctor, and this crate matches that:
+    // whatever value it is set to, the columns retain their default top alignment
+    // (a column or cell specifier must be used instead).
+    for value in ["top", "bottom", "middle"] {
+        let src = format!("[valign={value}]\n|===\n|a |b\n|===");
+        let table = parse_table(&src);
+        assert_eq!(table.columns()[0].v_align(), VerticalAlignment::Top);
+        assert_eq!(table.columns()[1].v_align(), VerticalAlignment::Top);
+    }
+}
+
+#[test]
+fn orientation_attribute() {
+    verifies!(
+        r#"
+|orientation
+|rotates the table
+|landscape
+|rotated 90 degrees counterclockwise
+|Equivalent to setting the rotate option, which is preferred.
+DocBook only.
+
+"#
+    );
+
+    // `orientation` only rotates the table in the DocBook backend (it sets
+    // `orient="land"`); this crate does no rendering, so the attribute is accepted
+    // but leaves the parsed table unchanged.
+    let table = parse_table("[orientation=landscape]\n|===\n|a |b\n|===");
+    assert_eq!(table.columns().len(), 2);
+}
+
+#[test]
+fn options_attribute() {
+    verifies!(
+        r#"
+.6+|options
+.6+|comma separated list of option names
+|header
+|promotes first row to the table header
+.2+d|header and footer rows are omitted by default
+
+|footer
+|promotes last row to the table footer
+
+"#
+    );
+
+    // Header and footer rows are omitted by default: a table whose rows run
+    // together (no blank line that would implicitly promote a header) has neither.
+    let plain = parse_table("|===\n|a |b\n|c |d\n|===");
+    assert!(plain.header_row().is_none());
+    assert!(plain.footer_row().is_none());
+
+    // The `header` option promotes the first row to the table header.
+    let with_header = parse_table("[%header]\n|===\n|H1 |H2\n|a |b\n|===");
+    assert!(with_header.header_row().is_some());
+
+    // The `footer` option promotes the last row to the table footer.
+    let with_footer = parse_table("[%footer]\n|===\n|a |b\n|c |d\n|===");
+    assert!(with_footer.footer_row().is_some());
+
+    verifies!(
+        r#"
+|breakable
+|allows the table to split across a page (default)
+.2+d|Mutually exclusive.
+DocBook only (specifically for generating PDF output).
+
+|unbreakable
+|prevents the table from being split across a page
+
+"#
+    );
+
+    // The `breakable`/`unbreakable` options only control page splitting in DocBook
+    // PDF output; this crate does no rendering, so either option is accepted but
+    // leaves the parsed table unchanged.
+    for option in ["breakable", "unbreakable"] {
+        let src = format!("[%{option}]\n|===\n|a |b\n|===");
+        let table = parse_table(&src);
+        assert_eq!(table.columns().len(), 2);
+    }
+
+    verifies!(
+        r#"
+|autowidth
+|disables explicit column widths (ignores distribution ratios in `cols` attribute)
+|
+
+"#
+    );
+
+    // The `autowidth` option disables explicit column widths, sizing the table
+    // and each of its columns to their content.
+    let table = parse_table("[%autowidth,cols=\"2,1\"]\n|===\n|a |b\n|===");
+    assert!(table.is_autowidth());
+    assert!(table.columns().iter().all(|c| c.is_autowidth()));
+}
+
+#[test]
+fn rotate_option() {
+    verifies!(
+        r#"
+|rotate
+|Prints the table in landscape
+d|Equivalent to setting the orientation to landscape.
+DocBook only.
+
+"#
+    );
+
+    // The `rotate` option only prints the table in landscape in the DocBook
+    // backend (equivalent to `orientation=landscape`); this crate does no
+    // rendering, so the option is accepted but leaves the parsed table unchanged.
+    let table = parse_table("[%rotate]\n|===\n|a |b\n|===");
+    assert_eq!(table.columns().len(), 2);
+}
+
+#[test]
+fn role_attribute() {
+    verifies!(
+        r#"
+.4+|role
+.4+|comma-separated list of role names
+|left
+|floats the table to the left margin
+.3+d|The role is the preferred way to specify the alignment of a table with restricted width.
+May be specified using role shorthand (e.g., `[.center]`).
+
+|right
+|floats the table to the right
+
+|center
+|aligns the table to center
+
+|stretch
+|stretches an autowidth table to the width of the page
+|
+
+"#
+    );
+
+    // The `role` attribute holds a comma-separated list of role names. Each of
+    // the documented alignment roles (`left`, `right`, `center`, `stretch`) is
+    // captured on the table; the alignment/float/stretch behavior they imply is
+    // a rendering concern this crate does not implement.
+    for role in ["left", "right", "center", "stretch"] {
+        let src = format!("[role={role}]\n|===\n|a\n|===");
+        let table = parse_table(&src);
+        assert_eq!(table.roles(), vec![role]);
+    }
+
+    // The role shorthand (e.g. `[.center]`) captures the same role.
+    let table = parse_table("[.center]\n|===\n|a\n|===");
+    assert_eq!(table.roles(), vec!["center"]);
+}
+
+#[test]
+fn width_attribute() {
+    verifies!(
+        r#"
+|width
+|the table width relative to the available page width
+d|user defined value
+|a percentage value between 0% and 100%
+|
+"#
+    );
+
+    // The `width` attribute sets the table width as a user-defined percentage of
+    // the available page width. The trailing `%` is optional.
+    assert_eq!(parse_table("[width=50%]\n|===\n|a\n|===").width(), Some(50));
+    assert_eq!(parse_table("[width=75]\n|===\n|a\n|===").width(), Some(75));
+    assert_eq!(
+        parse_table("[width=100%]\n|===\n|a\n|===").width(),
+        Some(100)
+    );
+
+    // When the attribute is absent, the table spans the available width and no
+    // explicit width is reported.
+    assert_eq!(parse_table("|===\n|a\n|===").width(), None);
+}
+
+// The closing table delimiter carries no rule to verify.
+non_normative!(
+    r#"
+|===
+"#
+);

--- a/parser/src/tests/asciidoc_lang/tables/turn_off_title_label.rs
+++ b/parser/src/tests/asciidoc_lang/tables/turn_off_title_label.rs
@@ -1,0 +1,124 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/turn-off-title-label.adoc");
+
+non_normative!(
+    r#"
+= Turn Off the Title Label
+:table-caption!:
+
+"#
+);
+
+#[test]
+fn disable_the_label_using_table_caption() {
+    non_normative!(
+        r#"
+== Disable the label using table-caption
+
+"#
+    );
+
+    verifies!(
+        r#"
+You can disable the title label for all of the tables in a document by unsetting the `table-caption` document attribute.
+
+[source]
+----
+= Title of Document
+:table-caption!: <.>
+
+.A table with a title but no label
+|===
+|Value |Result |Notes
+
+|Null |A mystery |See Appendix R
+|===
+----
+<.> In an attribute entry, enter the name of the attribute, `table-caption`, and append a bang (`!`) to the end of the name.
+This unsets the attribute.
+
+When `table-caption` is unset, table titles aren't preceded by a label and label number.
+
+.A table with a title but no label
+|===
+|Value |Result |Notes
+
+|Null |A mystery |See Appendix R
+|===
+
+"#
+    );
+
+    // Unsetting `table-caption` in the document header suppresses the label for
+    // every titled table: the title still renders inside the table's
+    // `<caption class="title">`, but with no "Table <n>." prefix in front of it.
+    let doc = Parser::default().parse(
+        "= Title of Document\n:table-caption!:\n\n.A table with a title but no label\n|===\n|Value |Result |Notes\n\n|Null |A mystery |See Appendix R\n|===",
+    );
+
+    assert_xpath(
+        &doc,
+        "//caption[text()=\"A table with a title but no label\"]",
+        1,
+    );
+    assert_xpath(&doc, "//caption", 1);
+}
+
+#[test]
+fn disable_the_label_using_caption() {
+    non_normative!(
+        r#"
+== Disable the label using caption
+
+"#
+    );
+
+    verifies!(
+        r#"
+To remove the label on an individual table, assign an empty value to the `caption` attribute.
+
+[source]
+----
+[caption=] <.>
+.A table with a title but no label
+[cols="2,1"]
+|===
+|Lots and lots of data |A little data
+
+|834,734 |3
+|3,999,271.5601 |5
+|===
+----
+<.> Enter the attribute's name, `caption`, in an attribute list directly above the table title, followed by an equals sign (`=`).
+Don't enter a value after the `=`.
+
+The table from the previous example is displayed below.
+
+[caption=]
+.A table with a title but no label
+[cols="2,1"]
+|===
+|Lots and lots of data |A little data
+
+|834,734 |3
+|3,999,271.5601 |5
+|===
+"#
+    );
+
+    // An empty `caption` attribute removes the label on this individual table
+    // only: the title renders inside the table's `<caption class="title">` with
+    // no "Table <n>." prefix, and the table is skipped by the document-wide
+    // counter rather than consuming a number.
+    let doc = Parser::default().parse(
+        "[caption=]\n.A table with a title but no label\n[cols=\"2,1\"]\n|===\n|Lots and lots of data |A little data\n\n|834,734 |3\n|3,999,271.5601 |5\n|===",
+    );
+
+    assert_xpath(
+        &doc,
+        "//caption[text()=\"A table with a title but no label\"]",
+        1,
+    );
+    assert_xpath(&doc, "//caption", 1);
+}

--- a/parser/src/tests/asciidoc_lang/tables/width.rs
+++ b/parser/src/tests/asciidoc_lang/tables/width.rs
@@ -1,0 +1,280 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/width.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Collect each column's `(width, autowidth)` pair.
+fn column_widths(table: &crate::blocks::TableBlock<'_>) -> Vec<(usize, bool)> {
+    table
+        .columns()
+        .iter()
+        .map(|c| (c.width(), c.is_autowidth()))
+        .collect()
+}
+
+// Expansion of `include::example$row.adoc[tag=base-h]`: the standard
+// three-column table with a header row and two body rows used throughout the
+// table documentation.
+const BASE_H: &str = "|===\n|Column 1, header row |Column 2, header row |Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|Cell in column 3, row 3\n|===";
+
+non_normative!(
+    r#"
+= Table Width
+
+"#
+);
+
+#[test]
+fn fixed_width() {
+    verifies!(
+        r#"
+By default, a table will span the width of the content area.
+
+"#
+    );
+
+    // With no `width` attribute the table has no fixed width (it spans the
+    // content area) and is not autowidth.
+    let table = parse_table(BASE_H);
+    assert_eq!(table.width(), None);
+    assert!(!table.is_autowidth());
+
+    non_normative!(
+        r#"
+== Fixed width
+
+"#
+    );
+
+    verifies!(
+        r#"
+To constrain the width of the table to a fixed value, set the `width` attribute in the table's attribute list.
+The width is an integer percentage value ranging from 1 to 100.
+The `%` sign is optional.
+
+"#
+    );
+
+    // The `width` attribute constrains the table to a fixed percentage; the
+    // trailing `%` is optional, so `75%` and `75` are equivalent.
+    let src = format!("[width=75%]\n{BASE_H}");
+    assert_eq!(parse_table(&src).width(), Some(75));
+
+    let src = format!("[width=75]\n{BASE_H}");
+    assert_eq!(parse_table(&src).width(), Some(75));
+
+    // A value outside the 1-to-100 range (or one that isn't an integer) is
+    // ignored.
+    let src = format!("[width=0]\n{BASE_H}");
+    assert_eq!(parse_table(&src).width(), None);
+    let src = format!("[width=150]\n{BASE_H}");
+    assert_eq!(parse_table(&src).width(), None);
+    let src = format!("[width=wide]\n{BASE_H}");
+    assert_eq!(parse_table(&src).width(), None);
+
+    verifies!(
+        r#"
+.Table with width set to 75%
+[source#ex-fixed]
+----
+[width=75%]
+include::example$row.adoc[tag=base-h]
+----
+
+.Result of <<ex-fixed>>
+[width=75%]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    // The fixed width applies to the standard three-column table; the columns
+    // themselves keep their default proportional width and are not autowidth.
+    let src = format!("[width=75%]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert_eq!(table.width(), Some(75));
+    assert_eq!(
+        column_widths(&table),
+        vec![(1, false), (1, false), (1, false)]
+    );
+    assert!(table.header_row().is_some());
+    assert_eq!(table.body_rows().len(), 2);
+}
+
+#[test]
+fn autowidth() {
+    non_normative!(
+        r#"
+== Autowidth
+
+"#
+    );
+
+    verifies!(
+        r#"
+Alternately, you can make the width fit the content by setting the `autowidth` option.
+The columns inherit this setting, so individual columns will also be sized according to the content.
+
+"#
+    );
+
+    // The `autowidth` option makes the table fit its content; it has no fixed
+    // width, and every column inherits the setting (each becomes autowidth).
+    let src = format!("[%autowidth]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert!(table.is_autowidth());
+    assert_eq!(table.width(), None);
+    assert_eq!(column_widths(&table), vec![(1, true), (1, true), (1, true)]);
+
+    verifies!(
+        r#"
+.Table using autowidth
+[source#ex-auto]
+----
+[%autowidth]
+include::example$row.adoc[tag=base-h]
+----
+
+.Result of <<ex-auto>>
+[%autowidth]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    // The autowidth table from <<ex-auto>> applied to the standard three-column
+    // table: the table is autowidth, every column is autowidth, and the header
+    // and body rows are otherwise unchanged.
+    let src = format!("[%autowidth]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert!(table.is_autowidth());
+    assert_eq!(column_widths(&table), vec![(1, true), (1, true), (1, true)]);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.body_rows().len(), 2);
+
+    verifies!(
+        r#"
+If you want each column to have an automatic width, but want the table to span the width of the content area, add the `stretch` role to the table.
+(Alternatively, you can set the `width` attribute to `100%`.)
+
+"#
+    );
+
+    // Adding the `stretch` role keeps the columns autowidth while the role
+    // records the intent to span the content area.
+    let src = format!("[%autowidth.stretch]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert!(table.is_autowidth());
+    assert_eq!(column_widths(&table), vec![(1, true), (1, true), (1, true)]);
+    assert!(table.attrlist().unwrap().roles().contains(&"stretch"));
+
+    // Alternatively, setting the `width` attribute to `100%` spans the content
+    // area.
+    let src = format!("[width=100%]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert_eq!(table.width(), Some(100));
+
+    verifies!(
+        r#"
+.Full-width table with autowidth columns
+[source#ex-stretch]
+----
+[%autowidth.stretch]
+include::example$row.adoc[tag=base-h]
+----
+
+The table from <<ex-stretch>> is rendered below.
+The columns are sized to the content, but the table spans the width of the page.
+
+.Result of <<ex-stretch>>
+[%autowidth.stretch]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    // <<ex-stretch>>: the columns are sized to their content (each autowidth)
+    // while the `stretch` role records that the table spans the full page
+    // width.
+    let src = format!("[%autowidth.stretch]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert!(table.is_autowidth());
+    assert_eq!(column_widths(&table), vec![(1, true), (1, true), (1, true)]);
+    assert!(table.attrlist().unwrap().roles().contains(&"stretch"));
+
+    // The DocBook converter is out of scope for this parser, so the warning
+    // below describes downstream behavior we don't model.
+    non_normative!(
+        r#"
+WARNING: The `autowidth` option is not recognized by the DocBook converter.
+
+"#
+    );
+}
+
+#[test]
+fn mix_fixed_and_autowidth_columns() {
+    non_normative!(
+        r#"
+== Mix fixed and autowidth columns
+
+"#
+    );
+
+    verifies!(
+        r#"
+If you want to apply `autowidth` only to certain columns, use the special value `~` as the width of the column.
+In this case, width values are assumed to be a percentage value (i.e., 100-based).
+
+"#
+    );
+
+    verifies!(
+        r#"
+.Table with fixed and autowidth columns
+[source#ex-mix]
+----
+[cols="25h,~,~"]
+|===
+|small |as big as the column needs to be |the rest
+|===
+----
+
+.Result of <<ex-mix>>
+[cols="25h,~,~"]
+|===
+|small |as big as the column needs to be |the rest
+|===
+"#
+    );
+
+    // <<ex-mix>>: the `~` width value marks an individual column as autowidth;
+    // the other columns keep their explicit (percentage-based) width. Here the
+    // first column is a 25% header column and the remaining two are autowidth.
+    let table = parse_table(
+        "[cols=\"25h,~,~\"]\n|===\n|small |as big as the column needs to be |the rest\n|===",
+    );
+    assert_eq!(
+        column_widths(&table),
+        vec![(25, false), (1, true), (1, true)]
+    );
+    assert_eq!(table.columns()[0].style(), ColumnStyle::Header);
+
+    // Only the `~` columns are autowidth; the table itself carries no
+    // `autowidth` option.
+    assert!(!table.is_autowidth());
+}

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -2471,9 +2471,13 @@ mod description_lists_dlist {
             assert_xpath(&doc, "//dl/dt/following-sibling::dd", 2);
             assert_xpath(&doc, "(//dl/dt)[1][normalize-space(text()) = \"term1\"]", 1);
 
+            // The `--` renders as a spaced em dash (thin space, em dash, thin
+            // space); the test DOM now decodes numeric character references the
+            // way a browser's `text()` does, so this asserts the decoded
+            // characters rather than the raw `&#8201;&#8212;&#8201;` entities.
             assert_xpath(
                 &doc,
-                "(//dl/dt)[1]/following-sibling::dd/p[text() = \"def1&#8201;&#8212;&#8201;and a note\"]",
+                "(//dl/dt)[1]/following-sibling::dd/p[text() = \"def1\u{2009}\u{2014}\u{2009}and a note\"]",
                 1,
             );
 

--- a/parser/src/tests/asciidoctor_rb/mod.rs
+++ b/parser/src/tests/asciidoctor_rb/mod.rs
@@ -1,3 +1,25 @@
+//! Behavioral tests ported 1:1 from Ruby Asciidoctor's `test/*_test.rb` suites.
+//!
+//! Porting conventions (see the existing modules for worked examples):
+//!
+//! * One Rust module per Ruby file (`<suite>_test.rs`); nested Ruby `context`
+//!   blocks become nested `mod`s, and each Ruby `test 'name'` becomes a
+//!   `#[test] fn name()`.
+//! * Ruby `assert_xpath` / `assert_css` / `assert_output_contains` /
+//!   `refute_output_contains` map to the same-named helpers in
+//!   [`crate::tests::assert_dom`], run against `doc.to_virtual_dom()`. Use a
+//!   full-AST `assert_eq!(doc, Document { .. })` where the Ruby test inspects
+//!   parser state (warnings, source spans, catalog) rather than HTML.
+//! * DocBook and other non-HTML backends are out of scope: such tests are
+//!   omitted with a `// Backend-specific test omitted: DocBook.` note. Compat
+//!   mode is likewise disregarded.
+//! * Tests blocked on an unimplemented (but planned) feature are kept as
+//!   `#[ignore]`d stubs whose body preserves the Ruby assertions in
+//!   `todo!("..")` calls, tagged with a tracking-issue `TODO`. Features that
+//!   are explicitly out of scope are omitted with a one-line `// NOTE:`.
+//! * Expected values track the crate's *actual* output, not the Ruby HTML
+//!   string, when the two differ.
+
 // The tests in this tree are adapted from the Ruby implementation of
 // Asciidoctor, which comes with the following license:
 
@@ -27,3 +49,4 @@
 mod lists_test;
 mod paragraphs_test;
 mod substitutions_test;
+mod tables_test;

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1,0 +1,1791 @@
+// Adapted from Asciidoctor's tables test suite, found in
+// https://github.com/asciidoctor/asciidoctor/blob/main/test/tables_test.rb.
+//
+// IMPORTANT: In porting this, I've disregarded compatibility mode (stated
+// limitation of `asciidoc-parser` crate) and alternate (non-HTML) back ends.
+
+mod psv {
+    use crate::tests::prelude::{inline_file_handler::InlineFileHandler, *};
+
+    #[test]
+    fn converts_simple_psv_table() {
+        let doc = Parser::default().parse("|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table.tableblock.frame-all.grid-all.stretch", 1);
+        assert_css(&doc, "table > colgroup > col[width=\"33.3333%\"]", 2);
+        // Ruby uses `col:last-of-type`; the indexed XPath form is equivalent.
+        assert_xpath(&doc, "(/table/colgroup/col)[3][@width=\"33.3334%\"]", 1);
+        assert_css(&doc, "table tr", 3);
+        assert_css(&doc, "table > tbody > tr", 3);
+        assert_css(&doc, "table td", 9);
+        assert_css(
+            &doc,
+            "table > tbody > tr > td.tableblock.halign-left.valign-top > p.tableblock",
+            9,
+        );
+
+        let cells = [["A", "B", "C"], ["a", "b", "c"], ["1", "2", "3"]];
+        for (rowi, row) in cells.iter().enumerate() {
+            assert_xpath(
+                &doc,
+                &format!("(/table/tbody/tr)[{}]/td", rowi + 1),
+                row.len(),
+            );
+            assert_xpath(
+                &doc,
+                &format!("(/table/tbody/tr)[{}]/td/p", rowi + 1),
+                row.len(),
+            );
+            for (celli, cell) in row.iter().enumerate() {
+                assert_xpath(
+                    &doc,
+                    &format!("(//tr)[{}]/td[{}]/p[text()='{cell}']", rowi + 1, celli + 1),
+                    1,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn should_add_direction_css_class_if_float_attribute_is_set_on_table() {
+        let doc = Parser::default()
+            .parse("[float=left]\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======");
+
+        assert_css(&doc, "table.left", 1);
+    }
+
+    #[test]
+    fn should_set_stripes_class_if_stripes_option_is_set() {
+        let doc = Parser::default()
+            .parse("[stripes=odd]\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======");
+
+        assert_css(&doc, "table.stripes-odd", 1);
+    }
+
+    #[test]
+    fn outputs_a_caption_on_simple_psv_table() {
+        let doc = Parser::default()
+            .parse(".Simple psv table\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======");
+
+        assert_xpath(
+            &doc,
+            "/table/caption[@class=\"title\"][text()=\"Table 1. Simple psv table\"]",
+            1,
+        );
+        assert_xpath(&doc, "/table/caption/following-sibling::colgroup", 1);
+    }
+
+    #[test]
+    fn only_increments_table_counter_for_tables_that_have_a_title() {
+        let doc = Parser::default().parse(
+            ".First numbered table\n|=======\n|1 |2 |3\n|=======\n\n|=======\n|4 |5 |6\n|=======\n\n.Second numbered table\n|=======\n|7 |8 |9\n|=======",
+        );
+
+        assert_xpath(&doc, "/table", 3);
+        assert_xpath(&doc, "(/table)[1]/caption", 1);
+        assert_xpath(
+            &doc,
+            "(/table)[1]/caption[text()=\"Table 1. First numbered table\"]",
+            1,
+        );
+        assert_xpath(&doc, "(/table)[2]/caption", 0);
+        assert_xpath(&doc, "(/table)[3]/caption", 1);
+        assert_xpath(
+            &doc,
+            "(/table)[3]/caption[text()=\"Table 2. Second numbered table\"]",
+            1,
+        );
+    }
+
+    #[test]
+    fn uses_explicit_caption_in_front_of_title_in_place_of_default_caption_and_number() {
+        let doc = Parser::default().parse(
+            "[caption=\"All the Data. \"]\n.Simple psv table\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======",
+        );
+
+        assert_xpath(
+            &doc,
+            "/table/caption[@class=\"title\"][text()=\"All the Data. Simple psv table\"]",
+            1,
+        );
+        assert_xpath(&doc, "/table/caption/following-sibling::colgroup", 1);
+    }
+
+    #[test]
+    fn disables_caption_when_caption_attribute_on_table_is_empty() {
+        let doc = Parser::default().parse(
+            "[caption=]\n.Simple psv table\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======",
+        );
+
+        assert_xpath(
+            &doc,
+            "/table/caption[@class=\"title\"][text()=\"Simple psv table\"]",
+            1,
+        );
+        assert_xpath(&doc, "/table/caption/following-sibling::colgroup", 1);
+    }
+
+    #[test]
+    fn disables_caption_when_caption_attribute_on_table_is_empty_string() {
+        let doc = Parser::default().parse(
+            "[caption=\"\"]\n.Simple psv table\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======",
+        );
+
+        assert_xpath(
+            &doc,
+            "/table/caption[@class=\"title\"][text()=\"Simple psv table\"]",
+            1,
+        );
+        assert_xpath(&doc, "/table/caption/following-sibling::colgroup", 1);
+    }
+
+    #[test]
+    fn disables_caption_on_table_when_table_caption_document_attribute_is_unset() {
+        let doc = Parser::default().parse(
+            ":!table-caption:\n\n.Simple psv table\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======",
+        );
+
+        assert_xpath(
+            &doc,
+            "/table/caption[@class=\"title\"][text()=\"Simple psv table\"]",
+            1,
+        );
+        assert_xpath(&doc, "/table/caption/following-sibling::colgroup", 1);
+    }
+
+    #[test]
+    fn ignores_escaped_separators() {
+        let doc = Parser::default().parse("|===\n|A \\| here| a \\| there\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > tbody > tr", 1);
+        assert_css(&doc, "table > tbody > tr > td", 2);
+        assert_xpath(&doc, "/table/tbody/tr/td[1]/p[text()=\"A | here\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr/td[2]/p[text()=\"a | there\"]", 1);
+    }
+
+    #[test]
+    fn preserves_escaped_delimiters_at_the_end_of_the_line() {
+        let doc = Parser::default()
+            .parse("[%header,cols=\"1,1\"]\n|===\n|A |B\\|\n|A1 |B1\\|\n|A2 |B2\\|\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead > tr", 1);
+        assert_xpath(&doc, "(/table/thead/tr)[1]/th", 2);
+        assert_xpath(&doc, "/table/thead/tr[1]/th[2][text()=\"B|\"]", 1);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 2);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p[text()=\"B1|\"]", 1);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 2);
+        assert_xpath(&doc, "/table/tbody/tr[2]/td[2]/p[text()=\"B2|\"]", 1);
+    }
+
+    #[test]
+    fn should_treat_trailing_pipe_as_an_empty_cell() {
+        let doc = Parser::default().parse("|===\n|A1 |\n|B1 |B2\n|C1 |C2\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > tbody > tr", 3);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td", 2);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[1]/p[text()=\"A1\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p", 0);
+        assert_xpath(&doc, "/table/tbody/tr[2]/td[1]/p[text()=\"B1\"]", 1);
+    }
+
+    #[test]
+    fn should_auto_recover_with_warning_if_missing_leading_separator_on_first_cell() {
+        let doc = Parser::default().parse("|===\nA | here| a | there\n| x\n| y\n| z\n| end\n|===");
+
+        // The content before the first separator (`A`) is recovered as the first
+        // cell, so the first row has four cells and the table four columns.
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_css(&doc, "table > tbody > tr > td", 8);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[1]/p[text()=\"A\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p[text()=\"here\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[3]/p[text()=\"a\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[4]/p[text()=\"there\"]", 1);
+
+        // The recovery logs an error pointing at the offending line (line 2).
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::TableMissingLeadingSeparator
+        );
+        assert_eq!(warnings[0].source.line(), 2);
+    }
+
+    #[test]
+    fn performs_normal_substitutions_on_cell_content() {
+        let doc = Parser::default()
+            .parse(":show_title: Cool new show\n|===\n|{show_title} |Coming soon...\n|===");
+
+        assert_xpath(&doc, "//tbody/tr/td[1]/p[text()=\"Cool new show\"]", 1);
+        assert_xpath(
+            &doc,
+            "//tbody/tr/td[2]/p[text()='Coming soon\u{2026}\u{200b}']",
+            1,
+        );
+    }
+
+    #[test]
+    fn should_only_substitute_specialchars_for_literal_table_cells() {
+        let doc = Parser::default().parse("|===\nl|one\n*two*\nthree\n<four>\n|===");
+
+        // Ruby compares the serialized `<pre>one\n*two*\nthree\n&lt;four&gt;</pre>`;
+        // the test DOM decodes entities in `text()`, so this asserts the decoded
+        // content (formatting markup left literal, specialchars escaped then
+        // decoded back).
+        assert_css(&doc, "table pre", 1);
+        assert_xpath(&doc, "/table//pre[text()=\"one\n*two*\nthree\n<four>\"]", 1);
+    }
+
+    #[test]
+    fn should_preserve_leading_spaces_but_not_leading_newlines_or_trailing_spaces_in_literal_table_cells()
+     {
+        let doc =
+            Parser::default().parse("[cols=2*]\n|===\nl|\n  one\n  two\nthree\n\n  | normal\n|===");
+
+        assert_css(&doc, "table pre", 1);
+        assert_xpath(&doc, "/table//pre[text()=\"  one\n  two\nthree\"]", 1);
+    }
+
+    #[test]
+    fn should_ignore_v_table_cell_style() {
+        let doc =
+            Parser::default().parse("[cols=2*]\n|===\nv|\n  one\n  two\nthree\n\n  | normal\n|===");
+
+        // The unrecognized `v` style is ignored, so the cell renders as a normal
+        // paragraph (`p.tableblock`) with leading newlines and trailing spaces
+        // stripped but interior indentation preserved.
+        assert_xpath(
+            &doc,
+            "(/table/tbody/tr/td)[1]/p[@class=\"tableblock\"][text()=\"one\n  two\nthree\"]",
+            1,
+        );
+    }
+
+    #[test]
+    fn table_and_column_width_not_assigned_when_autowidth_option_is_specified() {
+        let doc = Parser::default()
+            .parse("[options=\"autowidth\"]\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table.fit-content", 1);
+        assert_css(&doc, "table[style*=\"width\"]", 0);
+        assert_css(&doc, "table colgroup col", 3);
+        assert_css(&doc, "table colgroup col[style*=\"width\"]", 0);
+    }
+
+    #[test]
+    fn does_not_assign_column_width_for_autowidth_columns_in_html_output() {
+        let doc = Parser::default()
+            .parse("[cols=\"15%,3*~\"]\n|=======\n|A |B |C |D\n|a |b |c |d\n|1 |2 |3 |4\n|=======");
+
+        // The fixed first column keeps its computed percentage in `colpcwidth`
+        // and carries the HTML `width` attribute; it is not autowidth.
+        assert_xpath(&doc, "(/table/colgroup/col)[1][@colpcwidth=\"15\"]", 1);
+        assert_xpath(&doc, "(/table/colgroup/col)[1][@width=\"15%\"]", 1);
+        assert_xpath(&doc, "(/table/colgroup/col)[1][@autowidth-option]", 0);
+
+        // Each autowidth column still has a computed `colpcwidth` (the remaining
+        // space shared three ways, truncated to four places with the balance
+        // donated to the last column) and the `autowidth-option` marker, but no
+        // HTML `width` attribute.
+        for i in 2..=3 {
+            assert_xpath(
+                &doc,
+                &format!("(/table/colgroup/col)[{i}][@colpcwidth=\"28.3333\"]"),
+                1,
+            );
+        }
+        assert_xpath(&doc, "(/table/colgroup/col)[4][@colpcwidth=\"28.3334\"]", 1);
+        for i in 2..=4 {
+            assert_xpath(
+                &doc,
+                &format!("(/table/colgroup/col)[{i}][@autowidth-option]"),
+                1,
+            );
+            assert_xpath(&doc, &format!("(/table/colgroup/col)[{i}][@width]"), 0);
+        }
+
+        // The HTML-output expectations from the Ruby test: every column renders a
+        // `<col>`, but only the single fixed column carries a `width` attribute.
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table colgroup col", 4);
+        assert_css(&doc, "table colgroup col[width]", 1);
+        assert_css(&doc, "table colgroup col[width=\"15%\"]", 1);
+        assert_css(&doc, "table colgroup col[autowidth-option]", 3);
+    }
+
+    #[test]
+    fn can_assign_autowidth_to_all_columns_even_when_table_has_a_width() {
+        let doc = Parser::default().parse(
+            "[cols=\"4*~\",width=50%]\n|=======\n|A |B |C |D\n|a |b |c |d\n|1 |2 |3 |4\n|=======",
+        );
+
+        // Every column is autowidth, so each takes an equal 25% share in
+        // `colpcwidth` and carries the `autowidth-option` marker; none carries an
+        // HTML `width` attribute even though the table itself has a width.
+        for i in 1..=4 {
+            assert_xpath(
+                &doc,
+                &format!("(/table/colgroup/col)[{i}][@colpcwidth=\"25\"]"),
+                1,
+            );
+            assert_xpath(
+                &doc,
+                &format!("(/table/colgroup/col)[{i}][@autowidth-option]"),
+                1,
+            );
+            assert_xpath(&doc, &format!("(/table/colgroup/col)[{i}][@width]"), 0);
+        }
+
+        // The explicit table width is still rendered, and no column carries a
+        // width-bearing `style` (the Ruby HTML-output expectations).
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table[width=\"50%\"]", 1);
+        assert_css(&doc, "table colgroup col", 4);
+        assert_css(&doc, "table colgroup col[style]", 0);
+        assert_css(&doc, "table colgroup col[autowidth-option]", 4);
+    }
+
+    // Backend-specific test omitted: DocBook ("equally distributes remaining
+    // column width to autowidth columns in DocBook output").
+
+    // Backend-specific test omitted: DocBook ("should compute column widths
+    // based on pagewidth when width is set on table in DocBook output").
+
+    #[test]
+    fn explicit_table_width_is_used_even_when_autowidth_option_is_specified() {
+        let doc = Parser::default()
+            .parse("[%autowidth,width=75%]\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table[width]", 1);
+        assert_css(&doc, "table colgroup col", 3);
+        assert_css(&doc, "table colgroup col[style*=\"width\"]", 0);
+    }
+
+    #[test]
+    fn first_row_sets_number_of_columns_when_not_specified() {
+        let doc =
+            Parser::default().parse("|===\n|first |second |third |fourth\n|1 |2 |3\n|4\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 4);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 4);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 4);
+    }
+
+    #[test]
+    fn colspec_attribute_using_asterisk_syntax_sets_number_of_columns() {
+        let doc = Parser::default().parse("[cols=\"3*\"]\n|===\n|A |B |C |a |b |c |1 |2 |3\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > tbody > tr", 3);
+    }
+
+    #[test]
+    fn table_with_explicit_column_count_can_have_multiple_rows_on_a_single_line() {
+        let doc = Parser::default().parse("[cols=\"3*\"]\n|===\n|one |two\n|1 |2 |a |b\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 2);
+    }
+
+    #[test]
+    fn table_with_explicit_deprecated_colspec_syntax_can_have_multiple_rows_on_a_single_line() {
+        let doc = Parser::default().parse("[cols=\"3\"]\n|===\n|one |two\n|1 |2 |a |b\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 2);
+    }
+
+    #[test]
+    fn columns_are_added_for_empty_records_in_colspec_attribute() {
+        let doc = Parser::default().parse("[cols=\"<,\"]\n|===\n|one |two\n|1 |2 |a |b\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > tbody > tr", 3);
+    }
+
+    #[test]
+    fn cols_may_be_separated_by_semi_colon_instead_of_comma() {
+        let doc = Parser::default().parse("[cols=\"1s;3m\"]\n|===\n| strong\n| mono\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "col[width=\"25%\"]", 1);
+        assert_css(&doc, "col[width=\"75%\"]", 1);
+        assert_xpath(&doc, "(//td)[1]//strong", 1);
+        assert_xpath(&doc, "(//td)[2]//code", 1);
+    }
+
+    #[test]
+    fn cols_attribute_may_include_spaces() {
+        let doc = Parser::default().parse("[cols=\" 1, 1 \"]\n|===\n|one |two |1 |2 |a |b\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "col[width=\"50%\"]", 2);
+        assert_css(&doc, "table > tbody > tr", 3);
+    }
+
+    #[test]
+    fn blank_cols_attribute_should_be_ignored() {
+        let doc = Parser::default().parse("[cols=\" \"]\n|===\n|one |two\n|1 |2 |a |b\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "col[width=\"50%\"]", 2);
+        assert_css(&doc, "table > tbody > tr", 3);
+    }
+
+    #[test]
+    fn empty_cols_attribute_should_be_ignored() {
+        let doc = Parser::default().parse("[cols=\"\"]\n|===\n|one |two\n|1 |2 |a |b\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "col[width=\"50%\"]", 2);
+        assert_css(&doc, "table > tbody > tr", 3);
+    }
+
+    #[test]
+    fn table_with_header_and_footer() {
+        let doc = Parser::default().parse(
+            "[options=\"header,footer\"]\n|===\n|Item       |Quantity\n|Item 1     |1\n|Item 2     |2\n|Item 3     |3\n|Total      |6\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 1);
+        assert_css(&doc, "table > thead > tr", 1);
+        assert_css(&doc, "table > thead > tr > th", 2);
+        assert_css(&doc, "table > tfoot", 1);
+        assert_css(&doc, "table > tfoot > tr", 1);
+        assert_css(&doc, "table > tfoot > tr > td", 2);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 3);
+
+        // Ruby additionally asserts the section order is thead, tbody, tfoot;
+        // the renderer emits them in that order.
+        assert_xpath(&doc, "/table/thead/following-sibling::tbody", 1);
+        assert_xpath(&doc, "/table/tbody/following-sibling::tfoot", 1);
+    }
+
+    // Backend-specific test omitted: DocBook ("table with header and footer
+    // docbook").
+
+    // Backend-specific test omitted: DocBook ("should set horizontal and
+    // vertical alignment when converting to DocBook").
+
+    #[test]
+    fn should_preserve_frame_value_ends_when_converting_to_html() {
+        let doc = Parser::default().parse("[frame=ends]\n|===\n|A |B |C\n|===");
+
+        assert_css(&doc, "table.frame-ends", 1);
+    }
+
+    #[test]
+    fn should_normalize_frame_value_topbot_as_ends_when_converting_to_html() {
+        let doc = Parser::default().parse("[frame=topbot]\n|===\n|A |B |C\n|===");
+
+        assert_css(&doc, "table.frame-ends", 1);
+    }
+
+    // Backend-specific test omitted: DocBook ("should preserve frame value
+    // topbot when converting to DocBook").
+
+    // Backend-specific test omitted: DocBook ("should convert frame value ends
+    // to topbot when converting to DocBook").
+
+    // Backend-specific test omitted: DocBook ("table with landscape orientation
+    // in DocBook").
+
+    #[test]
+    fn table_with_implicit_header_row() {
+        let doc = Parser::default()
+            .parse("|===\n|Column 1 |Column 2\n\n|Data A1\n|Data B1\n\n|Data A2\n|Data B2\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 1);
+        assert_css(&doc, "table > thead > tr", 1);
+        assert_css(&doc, "table > thead > tr > th", 2);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 2);
+    }
+
+    #[test]
+    fn table_with_implicit_header_row_only() {
+        let doc = Parser::default().parse("|===\n|Column 1 |Column 2\n\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 1);
+        assert_css(&doc, "table > thead > tr", 1);
+        assert_css(&doc, "table > thead > tr > th", 2);
+        assert_css(&doc, "table > tbody", 0);
+    }
+
+    #[test]
+    fn table_with_implicit_header_row_when_other_options_set() {
+        let doc = Parser::default()
+            .parse("[%autowidth]\n|===\n|Column 1 |Column 2\n\n|Data A1\n|Data B1\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table[style*=\"width\"]", 0);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 1);
+        assert_css(&doc, "table > thead > tr", 1);
+        assert_css(&doc, "table > thead > tr > th", 2);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 1);
+    }
+
+    #[test]
+    fn no_implicit_header_row_if_second_line_not_blank() {
+        let doc = Parser::default()
+            .parse("|===\n|Column 1 |Column 2\n|Data A1\n|Data B1\n\n|Data A2\n|Data B2\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 0);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 3);
+    }
+
+    #[test]
+    fn no_implicit_header_row_if_cell_in_first_line_spans_multiple_lines() {
+        let doc =
+            Parser::default().parse("[cols=2*]\n|===\n|A1\n\n\nA1 continued|B1\n\n|A2\n|B2\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 0);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(//td)[1]/p", 2);
+    }
+
+    #[test]
+    fn should_format_first_cell_as_literal_if_there_is_no_implicit_header_row_and_column_has_l_style()
+     {
+        let doc = Parser::default().parse("[cols=\"1l,1\"]\n|===\n|literal\n|normal\n|===");
+
+        assert_css(&doc, "tbody pre", 1);
+        assert_css(&doc, "tbody p.tableblock", 1);
+    }
+
+    #[test]
+    fn should_format_first_cell_as_asciidoc_if_there_is_no_implicit_header_row_and_column_has_a_style()
+     {
+        let doc = Parser::default().parse("[cols=\"1a,1\"]\n|===\n| * list\n| normal\n|===");
+
+        assert_css(&doc, "tbody .ulist", 1);
+        assert_css(&doc, "tbody p.tableblock", 1);
+    }
+
+    #[test]
+    fn should_interpret_leading_indent_if_first_cell_is_asciidoc_and_there_is_no_implicit_header_row()
+     {
+        let doc = Parser::default().parse("[cols=\"1a,1\"]\n|===\n|\n  literal\n| normal\n|===");
+
+        assert_css(&doc, "tbody pre", 1);
+        assert_css(&doc, "tbody p.tableblock", 1);
+    }
+
+    #[test]
+    fn should_format_first_cell_as_asciidoc_if_there_is_no_implicit_header_row_and_cell_has_a_style()
+     {
+        let doc = Parser::default().parse("|===\na| * list\n| normal\n|===");
+
+        assert_css(&doc, "tbody .ulist", 1);
+        assert_css(&doc, "tbody p.tableblock", 1);
+    }
+
+    #[test]
+    fn no_implicit_header_row_if_asciidoc_cell_in_first_line_spans_multiple_lines() {
+        let doc = Parser::default().parse(
+            "[cols=2*]\n|===\na|contains AsciiDoc content\n\n* a\n* b\n* c\na|contains no AsciiDoc content\n\njust text\n|A2\n|B2\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 0);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(//td)[1]//ul", 1);
+    }
+
+    #[test]
+    fn no_implicit_header_row_if_first_line_blank() {
+        let doc = Parser::default().parse(
+            "|===\n\n|Column 1 |Column 2\n\n|Data A1\n|Data B1\n\n|Data A2\n|Data B2\n\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 0);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 3);
+    }
+
+    #[test]
+    fn no_implicit_header_row_if_noheader_option_is_specified() {
+        let doc = Parser::default().parse(
+            "[%noheader]\n|===\n|Column 1 |Column 2\n\n|Data A1\n|Data B1\n\n|Data A2\n|Data B2\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 0);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 3);
+    }
+
+    #[test]
+    fn styles_not_applied_to_header_cells() {
+        let doc = Parser::default().parse(
+            "[cols=\"1h,1s,1e\",options=\"header,footer\"]\n|===\n|Name |Occupation| Website\n|Octocat |Social coding| https://github.com\n|Name |Occupation| Website\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > thead > tr > th", 3);
+        assert_css(&doc, "table > thead > tr > th > *", 0);
+
+        assert_css(&doc, "table > tfoot > tr > th", 1);
+        assert_css(&doc, "table > tfoot > tr > td", 2);
+        assert_css(&doc, "table > tfoot > tr > td > p > strong", 1);
+        assert_css(&doc, "table > tfoot > tr > td > p > em", 1);
+
+        assert_css(&doc, "table > tbody > tr > th", 1);
+        assert_css(&doc, "table > tbody > tr > td", 2);
+        assert_css(&doc, "table > tbody > tr > td > p.header", 0);
+        assert_css(&doc, "table > tbody > tr > td > p > strong", 1);
+        assert_css(&doc, "table > tbody > tr > td > p > em > a", 1);
+    }
+
+    #[test]
+    fn should_apply_text_formatting_to_cells_in_implicit_header_row_when_column_has_a_style() {
+        let doc = Parser::default()
+            .parse("[cols=\"2*a\"]\n|===\n| _foo_ | *bar*\n\n| * list item\n| paragraph\n|===");
+
+        assert_xpath(&doc, "(//thead/tr/th)[1]/em[text()=\"foo\"]", 1);
+        assert_xpath(&doc, "(//thead/tr/th)[2]/strong[text()=\"bar\"]", 1);
+        assert_css(&doc, "tbody .ulist", 1);
+        assert_css(&doc, "tbody .paragraph", 1);
+    }
+
+    #[test]
+    fn should_apply_style_and_text_formatting_to_cells_in_first_row_if_no_implicit_header() {
+        let doc = Parser::default()
+            .parse("[cols=\"s,e\"]\n|===\n| _strong_ | *emphasis*\n| strong\n| emphasis\n|===");
+
+        assert_xpath(
+            &doc,
+            "((//tbody/tr)[1]/td)[1]//strong/em[text()=\"strong\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((//tbody/tr)[1]/td)[2]//em/strong[text()=\"emphasis\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((//tbody/tr)[2]/td)[1]//strong[text()=\"strong\"]",
+            1,
+        );
+        assert_xpath(&doc, "((//tbody/tr)[2]/td)[2]//em[text()=\"emphasis\"]", 1);
+    }
+
+    #[test]
+    fn vertical_table_headers_use_th_element_instead_of_header_class() {
+        let doc = Parser::default().parse(
+            "[cols=\"1h,1s,1e\"]\n|===\n\n|Name |Occupation| Website\n\n|Octocat |Social coding| https://github.com\n\n|Name |Occupation| Website\n\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > tbody > tr > th", 3);
+        assert_css(&doc, "table > tbody > tr > td", 6);
+        assert_css(&doc, "table > tbody > tr .header", 0);
+        assert_css(&doc, "table > tbody > tr > td > p > strong", 3);
+        assert_css(&doc, "table > tbody > tr > td > p > em", 3);
+        assert_css(&doc, "table > tbody > tr > td > p > em > a", 1);
+    }
+
+    #[test]
+    fn supports_horizontal_and_vertical_source_data_with_blank_lines_and_table_header() {
+        let doc = Parser::default().parse(
+            ".Horizontal and vertical source data\n[width=\"80%\",cols=\"3,^2,^2,10\",options=\"header\"]\n|===\n|Date |Duration |Avg HR |Notes\n\n|22-Aug-08 |10:24 | 157 |\nWorked out MSHR (max sustainable heart rate) by going hard\nfor this interval.\n\n|22-Aug-08 |23:03 | 152 |\nBack-to-back with previous interval.\n\n|24-Aug-08 |40:00 | 145 |\nModerately hard interspersed with 3x 3min intervals (2 min\nhard + 1 min really hard taking the HR up to 160).\n\nI am getting in shape!\n\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table[width=\"80%\"]", 1);
+        assert_xpath(
+            &doc,
+            "/table/caption[@class=\"title\"][text()=\"Table 1. Horizontal and vertical source data\"]",
+            1,
+        );
+        assert_css(&doc, "table > colgroup > col", 4);
+        // Ruby uses `col:nth-child(N)`; the indexed XPath form is equivalent.
+        assert_xpath(&doc, "(/table/colgroup/col)[1][@width=\"17.647%\"]", 1);
+        assert_xpath(&doc, "(/table/colgroup/col)[2][@width=\"11.7647%\"]", 1);
+        assert_xpath(&doc, "(/table/colgroup/col)[3][@width=\"11.7647%\"]", 1);
+        assert_xpath(&doc, "(/table/colgroup/col)[4][@width=\"58.8236%\"]", 1);
+        assert_css(&doc, "table > thead", 1);
+        assert_css(&doc, "table > thead > tr", 1);
+        assert_css(&doc, "table > thead > tr > th", 4);
+        assert_css(&doc, "table > tbody > tr", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 4);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 4);
+        assert_xpath(&doc, "(/table/tbody/tr)[3]/td", 4);
+        assert_xpath(
+            &doc,
+            "/table/tbody/tr[1]/td[4]/p[text()='Worked out MSHR (max sustainable heart rate) by going hard\nfor this interval.']",
+            1,
+        );
+        assert_xpath(&doc, "(/table/tbody/tr)[3]/td[4]/p", 2);
+        assert_xpath(
+            &doc,
+            "/table/tbody/tr[3]/td[4]/p[2][text()=\"I am getting in shape!\"]",
+            1,
+        );
+    }
+
+    #[test]
+    fn percentages_as_column_widths() {
+        let doc =
+            Parser::default().parse("[cols=\"<.^10%,<90%\"]\n|===\n|column A |column B\n|===");
+
+        assert_xpath(&doc, "/table/colgroup/col", 2);
+        assert_xpath(&doc, "(/table/colgroup/col)[1][@width=\"10%\"]", 1);
+        assert_xpath(&doc, "(/table/colgroup/col)[2][@width=\"90%\"]", 1);
+    }
+
+    #[test]
+    fn spans_alignments_and_styles() {
+        let doc = Parser::default().parse(
+            "[cols=\"e,m,^,>s\",width=\"25%\"]\n|===\n|1 >s|2 |3 |4\n^|5 2.2+^.^|6 .3+<.>m|7\n^|8\nd|9 2+>|10\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col[width=\"25%\"]", 4);
+        assert_css(&doc, "table > tbody > tr", 4);
+        assert_css(&doc, "table > tbody > tr > td", 10);
+
+        // Ruby uses `tr:nth-child(N)` / `td:nth-child(N)`; the indexed XPath form
+        // is equivalent and supported by the test DOM.
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 4);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[3]/td", 1);
+        assert_xpath(&doc, "(/table/tbody/tr)[4]/td", 2);
+
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[1]/td)[1][@class=\"halign-left valign-top\"]/p/em",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[1]/td)[2][@class=\"halign-right valign-top\"]/p/strong",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[1]/td)[3][@class=\"halign-center valign-top\"]/p",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[1]/td)[3][@class=\"halign-center valign-top\"]/p/*",
+            0,
+        );
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[1]/td)[4][@class=\"halign-right valign-top\"]/p/strong",
+            1,
+        );
+
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[2]/td)[1][@class=\"halign-center valign-top\"]/p/em",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[2]/td)[2][@class=\"halign-center valign-middle\"][@colspan=\"2\"][@rowspan=\"2\"]/p/code",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[2]/td)[3][@class=\"halign-left valign-bottom\"][@rowspan=\"3\"]/p/code",
+            1,
+        );
+
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[3]/td)[1][@class=\"halign-center valign-top\"]/p/em",
+            1,
+        );
+
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[4]/td)[1][@class=\"halign-left valign-top\"]/p",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[4]/td)[1][@class=\"halign-left valign-top\"]/p/em",
+            0,
+        );
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[4]/td)[2][@class=\"halign-right valign-top\"][@colspan=\"2\"]/p/code",
+            1,
+        );
+    }
+
+    #[test]
+    fn sets_up_columns_correctly_if_first_row_has_cell_that_spans_columns() {
+        let doc =
+            Parser::default().parse("|===\n2+^|AAA |CCC\n|AAA |BBB |CCC\n|AAA |BBB |CCC\n|===");
+
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 2);
+        assert_xpath(&doc, "((/table/tbody/tr)[1]/td)[1][@colspan=\"2\"]", 1);
+        // Ruby uses `td:nth-child(1)[colspan]` / `td:nth-child(2):not([colspan])`;
+        // since row 1 has exactly one cell carrying a colspan, asserting the row
+        // has a single colspanned cell is equivalent.
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td[@colspan]", 1);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td[@colspan]", 0);
+        assert_xpath(&doc, "(/table/tbody/tr)[3]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[3]/td[@colspan]", 0);
+    }
+
+    #[test]
+    fn supports_repeating_cells() {
+        let doc = Parser::default().parse("|===\n3*|A\n|1 3*|2\n|b |c\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[3]/td", 3);
+
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[1]/p[text()=\"A\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p[text()=\"A\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[3]/p[text()=\"A\"]", 1);
+
+        assert_xpath(&doc, "/table/tbody/tr[2]/td[1]/p[text()=\"1\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[2]/td[2]/p[text()=\"2\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[2]/td[3]/p[text()=\"2\"]", 1);
+
+        assert_xpath(&doc, "/table/tbody/tr[3]/td[1]/p[text()=\"2\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[3]/td[2]/p[text()=\"b\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[3]/td[3]/p[text()=\"c\"]", 1);
+    }
+
+    // Backend-specific test omitted: DocBook ("calculates colnames correctly
+    // when using implicit column count and single cell with colspan").
+
+    // Backend-specific test omitted: DocBook ("calculates colnames correctly
+    // when using implicit column count and cells with mixed colspans").
+
+    // Backend-specific test omitted: DocBook ("assigns unique column names for
+    // table with implicit column count and colspans in first row").
+
+    #[test]
+    fn should_drop_row_but_preserve_remaining_rows_after_cell_with_colspan_exceeds_number_of_columns()
+     {
+        let doc = Parser::default().parse("[cols=2*]\n|===\n3+|A\n|B\na|C\n\nmore C\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table tr", 1);
+        assert_xpath(&doc, "/table/tbody/tr/td[1]/p[text()=\"B\"]", 1);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::TableCellExceedsColumnCount
+        );
+        assert_eq!(warnings[0].source.line(), 3);
+    }
+
+    #[test]
+    fn should_drop_last_row_if_last_cell_in_table_has_colspan_that_exceeds_specified_number_of_columns()
+     {
+        let doc = Parser::default().parse("[cols=2*]\n|===\n|a 2+|b\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table *", 0);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::TableCellExceedsColumnCount
+        );
+        assert_eq!(warnings[0].source.line(), 3);
+    }
+
+    #[test]
+    fn should_drop_last_row_if_last_cell_in_table_has_colspan_that_exceeds_implicit_number_of_columns()
+     {
+        let doc = Parser::default().parse("|===\n|a |b\n|c 2+|d\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table tr", 1);
+        assert_xpath(&doc, "/table/tbody/tr/td[1]/p[text()=\"a\"]", 1);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::TableCellExceedsColumnCount
+        );
+        assert_eq!(warnings[0].source.line(), 3);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/548): The crate
+    // mis-groups cells into rows when a leading row's colspans overflow the
+    // column count: for this input it produces seven single-cell rows instead of
+    // dropping the overflowing first row and forming one row of seven cells.
+    // Enable once row grouping accounts for the dropped colspan row.
+    fn should_take_colspan_into_account_when_taking_cells_for_row() {
+        let doc = Parser::default()
+            .parse("[cols=7]\n|===\n2+|a 2+|b 2+|c 2+|d\n|e |f |g |h |i |j |k\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table tr", 1);
+        assert_css(&doc, "table tr td", 7);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::TableCellExceedsColumnCount
+        );
+    }
+
+    #[test]
+    fn should_drop_incomplete_row_at_end_of_table_and_log_an_error() {
+        let doc = Parser::default().parse("[cols=2*]\n|===\n|a |b\n|c |d\n|e\n|===");
+
+        // The incomplete `|e` row is dropped, leaving two rows, and an error is
+        // logged against its line (line 5).
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table tr", 2);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::TableDroppingIncompleteRowAtEndOfTable
+        );
+        assert_eq!(warnings[0].source.line(), 5);
+    }
+
+    #[test]
+    fn should_apply_cell_style_for_column_to_repeated_content() {
+        let doc = Parser::default().parse(
+            "[cols=\",^l\"]\n|===\n|Paragraphs |Literal\n\n2*|The discussion about what is good,\nwhat is beautiful, what is noble,\nwhat is pure, and what is true\ncould always go on.\n\nWhy is that important?\nWhy would I like to do that?\n\nBecause that's the only conversation worth having.\n\nAnd whether it goes on or not after I die, I don't know.\nBut, I do know that it is the conversation I want to have while I am still alive.\n\nWhich means that to me the offer of certainty,\nthe offer of complete security,\nthe offer of an impermeable faith that can't give way\nis an offer of something not worth having.\n\nI want to live my life taking the risk all the time\nthat I don't know anything like enough yet...\nthat I haven't understood enough...\nthat I can't know enough...\nthat I am always hungrily operating on the margins\nof a potentially great harvest of future knowledge and wisdom.\n\nI wouldn't have it any other way.\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 1);
+        assert_css(&doc, "table > thead > tr", 1);
+        assert_css(&doc, "table > thead > tr > th", 2);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 1);
+        assert_css(&doc, "table > tbody > tr > td", 2);
+
+        // The duplicated cell (`2*|`) is cloned into both columns, and each clone
+        // takes its own column's style: the first (default) column renders the
+        // content as seven paragraphs, the second (`^l`) column as a single
+        // centered literal block. (Ruby uses `td:nth-child(N)`; the equivalent
+        // positional `td[N]` is expressed in XPath here.)
+        assert_xpath(
+            &doc,
+            "/table/tbody/tr/td[1][@class=\"halign-left valign-top\"]/p[@class=\"tableblock\"]",
+            7,
+        );
+        assert_xpath(
+            &doc,
+            "/table/tbody/tr/td[2][@class=\"halign-center valign-top\"]/div[@class=\"literal\"]/pre",
+            1,
+        );
+
+        // The literal block preserves every line of the cell, including the blank
+        // lines between paragraphs (26 lines total).
+        let vdom = doc.to_virtual_dom();
+        let pre = query_xpath(&vdom, "/table/tbody/tr/td[2]//pre");
+        assert_eq!(pre.len(), 1);
+        assert_eq!(
+            pre[0].text.as_deref().unwrap_or_default().lines().count(),
+            26
+        );
+    }
+
+    #[test]
+    fn should_not_split_paragraph_at_line_containing_only_blank_that_is_directly_adjacent_to_non_blank_lines()
+     {
+        let doc = Parser::default().parse(
+            "|===\n|paragraph\n{blank}\nstill one paragraph\n{blank}\nstill one paragraph\n|===",
+        );
+
+        // Each `{blank}` line renders as an empty line but is not blank in the
+        // source, so the cell stays a single paragraph.
+        assert_css(&doc, "p.tableblock", 1);
+    }
+
+    #[test]
+    fn should_strip_trailing_newlines_when_splitting_paragraphs() {
+        let doc = Parser::default()
+            .parse("|===\n|first wrapped\nparagraph\n\nsecond paragraph\n\nthird paragraph\n|===");
+
+        assert_xpath(
+            &doc,
+            "(//p[@class=\"tableblock\"])[1][text()=\"first wrapped\nparagraph\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "(//p[@class=\"tableblock\"])[2][text()=\"second paragraph\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "(//p[@class=\"tableblock\"])[3][text()=\"third paragraph\"]",
+            1,
+        );
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/456): The
+    // admonition inside the open block does not render as `.admonitionblock`.
+    // Enable when admonitions are implemented.
+    fn basic_asciidoc_cell() {
+        let doc = Parser::default().parse("|===\na|--\nNOTE: content\n\ncontent\n--\n|===");
+
+        assert_css(&doc, "table.tableblock", 1);
+        assert_css(&doc, "table.tableblock td.tableblock", 1);
+        assert_css(&doc, "table.tableblock td.tableblock .openblock", 1);
+        assert_css(
+            &doc,
+            "table.tableblock td.tableblock .openblock .admonitionblock",
+            1,
+        );
+        assert_css(
+            &doc,
+            "table.tableblock td.tableblock .openblock .paragraph",
+            1,
+        );
+    }
+
+    #[test]
+    fn asciidoc_table_cell_should_be_wrapped_in_div_with_class_content() {
+        let doc = Parser::default().parse("|===\na|AsciiDoc table cell\n|===");
+
+        assert_css(&doc, "table.tableblock td.tableblock > div.content", 1);
+        assert_css(
+            &doc,
+            "table.tableblock td.tableblock > div.content > div.paragraph",
+            1,
+        );
+    }
+
+    #[test]
+    fn doctype_can_be_set_in_asciidoc_table_cell() {
+        let doc = Parser::default().parse("|===\na|\n:doctype: inline\n\ncontent\n|===");
+
+        // An `inline` doctype renders the cell's lone paragraph as bare inline
+        // content, with no `.paragraph` wrapper.
+        assert_css(&doc, "table.tableblock", 1);
+        assert_css(&doc, "table.tableblock .paragraph", 0);
+    }
+
+    #[test]
+    fn should_reset_doctype_to_default_in_asciidoc_table_cell() {
+        // The parent is a `book`, but a cell resets to the default `article`
+        // doctype, so `{doctype}` is `article` and only the
+        // `backend-html5-doctype-article` derived attribute is defined (an
+        // undefined reference is left literal).
+        let doc = Parser::default().parse(
+            "= Book Title\n:doctype: book\n\n== Chapter 1\n\n|===\na|\n= AsciiDoc Table Cell\n\ndoctype={doctype}\n{backend-html5-doctype-article}\n{backend-html5-doctype-book}\n|===",
+        );
+
+        assert_rendered_contains(&doc, "doctype=article");
+        refute_rendered_contains(&doc, "{backend-html5-doctype-article}");
+        assert_rendered_contains(&doc, "{backend-html5-doctype-book}");
+    }
+
+    #[test]
+    fn should_update_doctype_related_attributes_in_asciidoc_table_cell_when_doctype_is_set() {
+        // Setting `:doctype: book` in the cell updates `{doctype}` and the
+        // derived `backend-html5-doctype-*` attribute accordingly.
+        let doc = Parser::default().parse(
+            "= Document Title\n:doctype: article\n\n== Chapter 1\n\n|===\na|\n= AsciiDoc Table Cell\n:doctype: book\n\ndoctype={doctype}\n{backend-html5-doctype-book}\n{backend-html5-doctype-article}\n|===",
+        );
+
+        assert_rendered_contains(&doc, "doctype=book");
+        refute_rendered_contains(&doc, "{backend-html5-doctype-book}");
+        assert_rendered_contains(&doc, "{backend-html5-doctype-article}");
+    }
+
+    // Deferred: "should not allow AsciiDoc table cell to set a document
+    // attribute that was hard set by the API" (Ruby 1457) observes the lock via
+    // a NOTE admonition's icon, and admonitions are not implemented. The same
+    // API-lock path is covered by
+    // `should_not_allow_locked_attribute_unset_in_parent_document_to_be_set_in_asciidoc_table_cell`.
+
+    // Deferred: "should not allow AsciiDoc table cell to set a document
+    // attribute that was hard unset by the API" (Ruby 1472) — same admonition
+    // dependency as above.
+
+    #[test]
+    fn should_keep_attribute_unset_in_asciidoc_table_cell_if_unset_in_parent_document() {
+        // `sectids` and `table-caption` are unset in the parent and stay unset
+        // in the cell: the headings get no id, and both the outer table and the
+        // nested table render their title as a bare `<caption>`.
+        let doc = Parser::default().parse(
+            ":!sectids:\n:!table-caption:\n\n== Outer Heading\n\n.Outer Table\n|===\na|\n\n== Inner Heading\n\n.Inner Table\n!===\n! table cell\n!===\n|===",
+        );
+
+        assert_xpath(&doc, "//h2[@id]", 0);
+        assert_xpath(&doc, "//caption[text()=\"Outer Table\"]", 1);
+        assert_xpath(&doc, "//caption[text()=\"Inner Table\"]", 1);
+    }
+
+    #[test]
+    fn should_allow_attribute_unset_in_parent_document_to_be_set_in_asciidoc_table_cell() {
+        // `sectids` is unset in the parent header (not locked), so the cell may
+        // set it: the heading after `:sectids:` in the cell gets an id.
+        let doc = Parser::default().parse(
+            ":!sectids:\n\n== No ID\n\n|===\na|\n\n== No ID\n\n:sectids:\n\n== Has ID\n|===",
+        );
+
+        assert_css(&doc, "h2", 3);
+        assert_xpath(&doc, "(//h2)[1][@id]", 0);
+        assert_xpath(&doc, "(//h2)[2][@id]", 0);
+        assert_xpath(&doc, "(//h2)[3][@id=\"_has_id\"]", 1);
+    }
+
+    #[test]
+    fn should_not_allow_locked_attribute_unset_in_parent_document_to_be_set_in_asciidoc_table_cell()
+    {
+        // `sectids` is hard unset by the API, so the cell's `:sectids:` is
+        // ignored and no heading gets an id.
+        let doc = Parser::default()
+            .with_intrinsic_attribute_bool("sectids", false, ModificationContext::ApiOnly)
+            .parse("== No ID\n\n|===\na|\n\n== No ID\n\n:sectids:\n\n== Has ID\n|===");
+
+        assert_css(&doc, "h2", 3);
+        assert_xpath(&doc, "//h2[@id]", 0);
+    }
+
+    #[test]
+    fn showtitle_can_be_enabled_in_asciidoc_table_cell_if_unset_in_parent_document() {
+        // The parent hides its title; the cell shows its own. (`showtitle` and
+        // `notitle` are complements, so both spellings are exercised.)
+        for (parent, cell) in [(":!showtitle:", ":showtitle:"), (":notitle:", ":!notitle:")] {
+            let doc = Parser::default().parse(&format!(
+                "= Document Title\n{parent}\n\n|===\na|\n= Nested Document Title\n{cell}\n\ncontent\n|==="
+            ));
+            assert_css(&doc, "h1", 1);
+            assert_css(&doc, ".tableblock h1", 1);
+        }
+    }
+
+    #[test]
+    fn showtitle_can_be_enabled_in_asciidoc_table_cell_if_unset_by_api() {
+        for (name, value, cell) in [
+            ("showtitle", false, ":showtitle:"),
+            ("notitle", true, ":!notitle:"),
+        ] {
+            let doc = Parser::default()
+                .with_intrinsic_attribute_bool(name, value, ModificationContext::ApiOnly)
+                .parse(&format!(
+                    "= Document Title\n\n|===\na|\n= Nested Document Title\n{cell}\n\ncontent\n|==="
+                ));
+            assert_css(&doc, "h1", 1);
+            assert_css(&doc, ".tableblock h1", 1);
+        }
+    }
+
+    #[test]
+    fn showtitle_can_be_disabled_in_asciidoc_table_cell_if_set_in_parent_document() {
+        // The parent shows its title; the cell hides its own.
+        for (parent, cell) in [(":showtitle:", ":!showtitle:"), (":!notitle:", ":notitle:")] {
+            let doc = Parser::default().parse(&format!(
+                "= Document Title\n{parent}\n\n|===\na|\n= Nested Document Title\n{cell}\n\ncontent\n|==="
+            ));
+            assert_css(&doc, "h1", 1);
+            assert_css(&doc, ".tableblock h1", 0);
+        }
+    }
+
+    #[test]
+    fn showtitle_can_be_disabled_in_asciidoc_table_cell_if_set_by_api() {
+        for (name, value, cell) in [
+            ("showtitle", true, ":!showtitle:"),
+            ("notitle", false, ":notitle:"),
+        ] {
+            let doc = Parser::default()
+                .with_intrinsic_attribute_bool(name, value, ModificationContext::ApiOnly)
+                .parse(&format!(
+                    "= Document Title\n\n|===\na|\n= Nested Document Title\n{cell}\n\ncontent\n|==="
+                ));
+            assert_css(&doc, "h1", 1);
+            assert_css(&doc, ".tableblock h1", 0);
+        }
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/456): The
+    // NOTE admonition and nested blocks do not render as `.admonitionblock` /
+    // `.dlist` inside the cell. Enable when admonitions are implemented.
+    fn asciidoc_content() {
+        let doc = Parser::default().parse(
+            "[cols=\"1e,1,5a\"]\n|===\n|Name |Backends |Description\n\n|badges |xhtml11, html5 |\nLink badges.\n\n[NOTE]\n====\nThe path names are relative.\n====\n|docinfo |All backends |\nThese attributes control docinfo:\n\ndocinfo:: Include x\ndocinfo1:: Include y\n|===",
+        );
+
+        assert_css(&doc, "table.tableblock > tbody > tr", 2);
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[1]/td)[3]//*[@class=\"admonitionblock\"]",
+            1,
+        );
+        assert_xpath(&doc, "((/table/tbody/tr)[2]/td)[3]//*[@class=\"dlist\"]", 1);
+    }
+
+    #[test]
+    fn should_preserve_leading_indentation_in_contents_of_asciidoc_table_cell_if_contents_starts_with_newline()
+     {
+        let doc = Parser::default().parse("|===\na|\n $ command\na| paragraph\n|===");
+
+        // Source-map line numbers: the table starts on line 1; cell 1's
+        // separator is on line 2 and its inner document begins on line 3 (the
+        // indented `$ command`); cell 2 is on line 4.
+        let table = match doc.nested_blocks().next() {
+            Some(crate::blocks::Block::Table(table)) => table,
+            other => panic!("expected a table block, got {other:?}"),
+        };
+        assert_eq!(table.span().line(), 1);
+
+        let cell1 = &table.body_rows()[0].cells()[0];
+        assert_eq!(cell1.span().line(), 2);
+        let crate::blocks::TableCellContent::AsciiDoc(inner) = cell1.content() else {
+            panic!("expected an AsciiDoc cell");
+        };
+        assert_eq!(inner.blocks()[0].span().line(), 3);
+
+        let cell2 = &table.body_rows()[1].cells()[0];
+        assert_eq!(cell2.span().line(), 4);
+
+        assert_css(&doc, "td", 2);
+        assert_xpath(&doc, "(//td)[1]//*[@class=\"literalblock\"]", 1);
+        assert_xpath(&doc, "(//td)[2]//*[@class=\"paragraph\"]", 1);
+        assert_xpath(&doc, "(//pre)[1][text()=\"$ command\"]", 1);
+        assert_xpath(&doc, "(//p)[1][text()=\"paragraph\"]", 1);
+    }
+
+    #[test]
+    fn preprocessor_directive_on_first_line_of_an_asciidoc_table_cell_should_be_processed() {
+        let handler =
+            InlineFileHandler::from_pairs([("fixtures/include-file.adoc", "included content")]);
+        let mut parser = Parser::default().with_include_file_handler(handler);
+        let doc = parser.parse("|===\na|include::fixtures/include-file.adoc[]\n|===");
+
+        // The `include::` on the cell's first line is expanded, so the cell holds
+        // the included content rather than the literal directive.
+        assert_rendered_contains(&doc, "included content");
+    }
+
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/542): Deferred:
+    // "error about unresolved preprocessor directive on first line of an AsciiDoc
+    // table cell should have correct cursor" (Ruby 1728) asserts the file/line
+    // cursor of the unresolved-directive error, which needs the cell's nested
+    // source map threaded back to the parent — not yet implemented.
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/543):
+    // Cross-reference resolution from inside an AsciiDoc table cell to a
+    // reference in the main document.
+    fn cross_reference_link_in_an_asciidoc_table_cell_should_resolve_to_reference_in_main_document()
+    {
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/543):
+    // Cataloging an anchor at the start of an AsciiDoc table cell as a document
+    // reference.
+    fn should_discover_anchor_at_start_of_cell_and_register_it_as_a_reference() {}
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/543):
+    // Cataloging an anchor at the start of a cell in an implicit header row when
+    // the column has a style.
+    fn should_catalog_anchor_at_start_of_cell_in_implicit_header_row_when_column_has_a_style() {}
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/543):
+    // Cataloging an anchor at the start of a cell in an explicit header row when
+    // the column has a style.
+    fn should_catalog_anchor_at_start_of_cell_in_explicit_header_row_when_column_has_a_style() {}
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/543):
+    // Cataloging an anchor at the start of a cell in the first row.
+    fn should_catalog_anchor_at_start_of_cell_in_first_row() {}
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/544):
+    // Footnotes must not be shared between an AsciiDoc table cell and the main
+    // document.
+    fn footnotes_should_not_be_shared_between_an_asciidoc_table_cell_and_the_main_document() {}
+
+    // Backend-specific test omitted: DocBook ("callout numbers should be
+    // globally unique, including AsciiDoc table cells"). Out of scope: it
+    // asserts only against DocBook output (`backend: 'docbook'`, `//co` /
+    // `//callout` elements), which the crate does not target.
+
+    // Out of scope (omitted): compatibility mode is a stated limitation of the
+    // crate, so the three "compat mode ... in AsciiDoc table cell" tests are not
+    // ported.
+
+    #[test]
+    fn nested_table() {
+        let doc = Parser::default().parse(
+            "[cols=\"1,2a\"]\n|===\n|Normal cell\n|Cell with nested table\n[cols=\"2,1\"]\n!===\n!Nested table cell 1 !Nested table cell 2\n!===\n|===",
+        );
+
+        assert_css(&doc, "table", 2);
+        assert_css(&doc, "table table", 1);
+        // Ruby uses `td:nth-child(2) table`; the nested table sits in the second
+        // cell of the (single) outer row.
+        assert_xpath(&doc, "/table/tbody/tr/td[2]//table", 1);
+        assert_xpath(&doc, "/table/tbody/tr/td[2]//table/tbody/tr/td", 2);
+    }
+
+    #[test]
+    fn can_set_format_of_nested_table_to_psv() {
+        let doc = Parser::default().parse(
+            "[cols=\"2*\"]\n|===\n|normal cell\na|\n[format=psv]\n!===\n!nested cell\n!===\n|===",
+        );
+
+        assert_css(&doc, "table", 2);
+        assert_css(&doc, "table table", 1);
+        assert_xpath(&doc, "/table/tbody/tr/td[2]//table", 1);
+        assert_xpath(&doc, "/table/tbody/tr/td[2]//table/tbody/tr/td", 1);
+    }
+
+    // Attribute/option inheritance into the nested AsciiDoc-cell document is
+    // implemented; the following remain unported for narrower reasons. The
+    // `to_dir` test needs the nested cell exposed as an introspectable document
+    // object carrying inherited options; the `toc` tests need TOC rendering (a
+    // separate unimplemented feature).
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/545): AsciiDoc
+    // table cell should expose the nested document for introspection of inherited
+    // options (here, `to_dir`).
+    fn asciidoc_table_cell_should_inherit_to_dir_option_from_parent_document() {}
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/546): AsciiDoc
+    // table cell should not inherit the toc setting.
+    fn asciidoc_table_cell_should_not_inherit_toc_setting_from_parent_document() {}
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/546): enabling
+    // toc in an AsciiDoc table cell.
+    fn should_be_able_to_enable_toc_in_an_asciidoc_table_cell() {}
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/546): enabling
+    // toc in an AsciiDoc table cell even if hard unset by the API.
+    fn should_be_able_to_enable_toc_in_an_asciidoc_table_cell_even_if_hard_unset_by_api() {}
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/546): enabling
+    // toc in both the outer document and an AsciiDoc table cell.
+    fn should_be_able_to_enable_toc_in_both_outer_document_and_in_an_asciidoc_table_cell() {}
+
+    #[test]
+    fn document_in_an_asciidoc_table_cell_should_not_see_doctitle_of_parent() {
+        let doc = Parser::default()
+            .parse("= Document Title\n\n[cols=\"1a\"]\n|===\n|AsciiDoc content\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > tbody > tr > td", 1);
+
+        // The cell is its own (nested) document and does not inherit the parent's
+        // doctitle, so its lone paragraph is not promoted into a preamble: the
+        // cell renders a bare `.paragraph`, never a `#preamble`.
+        assert_css(&doc, "table > tbody > tr > td #preamble", 0);
+        assert_css(&doc, "table > tbody > tr > td .paragraph", 1);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/547):
+    // per-cell background colors depend on the `{set:cellbgcolor:...}` /
+    // `{set:cellbgcolor!}` attribute-assignment reference, which the
+    // substitution layer does not implement. `{set:...}` is of uncertain status
+    // in the AsciiDoc language, so this is deferred pending that decision.
+    fn cell_background_color() {}
+
+    #[test]
+    fn should_warn_if_table_block_is_not_terminated() {
+        let doc = Parser::default().parse("outside\n\n|===\n|\ninside\n\nstill inside\n\neof");
+
+        assert_xpath(&doc, "/table", 1);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].warning, WarningType::UnterminatedDelimitedBlock);
+        assert_eq!(warnings[0].source.line(), 3);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/542): an
+    // unterminated example block inside an AsciiDoc table cell that is itself
+    // attached to a list item — Asciidoctor reports the warning at the inner
+    // block's line (9). Enable once the cursor/line of nested-cell warnings is
+    // tracked (same nested-cell source-map work as #542).
+    fn should_show_correct_line_number_in_warning_about_unterminated_block_inside_asciidoc_table_cell()
+     {
+        let doc = Parser::default().parse(
+            "outside\n\n* list item\n+\n|===\n|cell\na|inside\n\n====\nunterminated example block\n|===\n\neof",
+        );
+
+        assert_xpath(&doc, "//ul//table", 1);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.warning == WarningType::UnterminatedDelimitedBlock
+                    && w.source.line() == 9)
+        );
+    }
+
+    #[test]
+    fn custom_separator_for_an_asciidoc_table_cell() {
+        let doc = Parser::default().parse(
+            "[cols=2,separator=!]\n|===\n!Pipe output to vim\na!\n----\nasciidoctor -o - -s test.adoc | view -\n----\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > tbody > tr", 1);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 2);
+        assert_xpath(&doc, "((/table/tbody/tr)[1]/td)[1]//p", 1);
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[1]/td)[2]//*[@class=\"listingblock\"]",
+            1,
+        );
+    }
+
+    // Backend-specific tests omitted: DocBook ("table with breakable option
+    // docbook 5", "table with unbreakable option docbook 5").
+
+    #[test]
+    fn no_implicit_header_row_if_cell_in_first_line_is_quoted_and_spans_multiple_lines() {
+        let doc =
+            Parser::default().parse("[cols=2*l]\n,===\n\"A1\n\nA1 continued\",B1\nA2,B2\n,===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 0);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(//td)[1]//pre[text()=\"A1\n\nA1 continued\"]", 1);
+    }
+}
+
+mod dsv {
+    use crate::tests::prelude::*;
+
+    #[test]
+    fn converts_simple_dsv_table() {
+        let doc = Parser::default().parse(
+            "[width=\"75%\",format=\"dsv\"]\n|===\nroot:x:0:0:root:/root:/bin/bash\nbin:x:1:1:bin:/bin:/sbin/nologin\nmysql:x:27:27:MySQL\\:Server:/var/lib/mysql:/bin/bash\ngdm:x:42:42::/var/lib/gdm:/sbin/nologin\nsshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/sbin/nologin\nnobody:x:99:99:Nobody:/:/sbin/nologin\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col[width=\"14.2857%\"]", 6);
+        // Ruby uses `col:last-of-type`; the indexed XPath form is equivalent.
+        assert_xpath(&doc, "(/table/colgroup/col)[7][@width=\"14.2858%\"]", 1);
+        assert_css(&doc, "table > tbody > tr", 6);
+        assert_xpath(&doc, "//tr[4]/td[5]/p/text()", 0);
+        assert_xpath(&doc, "//tr[3]/td[5]/p[text()=\"MySQL:Server\"]", 1);
+    }
+
+    #[test]
+    fn dsv_format_shorthand() {
+        let doc = Parser::default().parse(":===\na:b:c\n1:2:3\n:===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
+    }
+
+    #[test]
+    fn single_cell_in_dsv_table_should_only_produce_single_row() {
+        let doc = Parser::default().parse(":===\nsingle cell\n:===");
+
+        assert_css(&doc, "table td", 1);
+    }
+
+    #[test]
+    fn should_treat_trailing_colon_as_an_empty_cell() {
+        let doc = Parser::default().parse(":===\nA1:\nB1:B2\nC1:C2\n:===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > tbody > tr", 3);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td", 2);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[1]/p[text()=\"A1\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p", 0);
+        assert_xpath(&doc, "/table/tbody/tr[2]/td[1]/p[text()=\"B1\"]", 1);
+    }
+}
+
+mod csv {
+    use crate::tests::prelude::{inline_file_handler::InlineFileHandler, *};
+
+    #[test]
+    fn should_treat_trailing_comma_as_an_empty_cell() {
+        let doc = Parser::default().parse(",===\nA1,\nB1,B2\nC1,C2\n,===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > tbody > tr", 3);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td", 2);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[1]/p[text()=\"A1\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p", 0);
+        assert_xpath(&doc, "/table/tbody/tr[2]/td[1]/p[text()=\"B1\"]", 1);
+    }
+
+    #[test]
+    fn should_log_error_but_not_crash_if_cell_data_has_unclosed_quote() {
+        let doc = Parser::default().parse(",===\na,b\nc,\"\n,===");
+
+        // The unclosed quote recovers to an empty cell without crashing, and an
+        // error is logged for line 3 (the `c,"` line).
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table td", 4);
+        assert_xpath(&doc, "(//td)[4]/p", 0);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::TableCsvDataHasUnclosedQuote
+        );
+        assert_eq!(warnings[0].source.line(), 3);
+    }
+
+    #[test]
+    fn should_preserve_newlines_in_quoted_csv_values() {
+        let doc = Parser::default().parse(
+            "[cols=\"1,1,1l\"]\n,===\n\"A\nB\nC\",\"one\n\ntwo\n\nthree\",\"do\n\nre\n\nme\"\n,===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td", 3);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[1]/p[text()=\"A\nB\nC\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p", 3);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p[1][text()=\"one\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p[2][text()=\"two\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p[3][text()=\"three\"]", 1);
+        assert_xpath(
+            &doc,
+            "/table/tbody/tr[1]/td[3]//pre[text()=\"do\n\nre\n\nme\"]",
+            1,
+        );
+    }
+
+    #[test]
+    fn should_not_drop_trailing_empty_cell_in_tsv_data_when_loaded_from_an_include_file() {
+        // The `1\t2\t` record ends with a tab, so its third field is empty. The
+        // include is the delivery mechanism; the behavior under test is that the
+        // trailing empty cell survives.
+        let handler = InlineFileHandler::from_pairs([(
+            "fixtures/data.tsv",
+            "First\tSecond\tThird\na\tb\tc\n1\t2\t\nx\ty\tz\n",
+        )]);
+        let mut parser = Parser::default().with_include_file_handler(handler);
+        let doc = parser.parse("[%header,format=tsv]\n|===\ninclude::fixtures/data.tsv[]\n|===");
+
+        assert_css(&doc, "table > tbody > tr", 3);
+        assert_css(&doc, "table > tbody > tr:nth-child(1) > td", 3);
+        assert_css(&doc, "table > tbody > tr:nth-child(2) > td", 3);
+        assert_css(&doc, "table > tbody > tr:nth-child(3) > td", 3);
+        assert_css(
+            &doc,
+            "table > tbody > tr:nth-child(2) > td:nth-child(3):empty",
+            1,
+        );
+    }
+
+    #[test]
+    fn mixed_unquoted_records_and_quoted_records_with_escaped_quotes_commas_and_wrapped_lines() {
+        let doc = Parser::default().parse(
+            "[format=\"csv\",options=\"header\"]\n|===\nYear,Make,Model,Description,Price\n1997,Ford,E350,\"ac, abs, moon\",3000.00\n1999,Chevy,\"Venture \"\"Extended Edition\"\"\",\"\",4900.00\n1999,Chevy,\"Venture \"\"Extended Edition, Very Large\"\"\",,5000.00\n1996,Jeep,Grand Cherokee,\"MUST SELL!\nair, moon roof, loaded\",4799.00\n2000,Toyota,Tundra,\"\"\"This one's gonna to blow you're socks off,\"\" per the sticker\",10000.00\n2000,Toyota,Tundra,\"Check it, \"\"this one's gonna to blow you're socks off\"\", per the sticker\",10000.00\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col[width=\"20%\"]", 5);
+        assert_css(&doc, "table > thead > tr", 1);
+        assert_css(&doc, "table > tbody > tr", 6);
+        assert_xpath(
+            &doc,
+            "((//tbody/tr)[1]/td)[4]/p[text()=\"ac, abs, moon\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((//tbody/tr)[2]/td)[3]/p[text()='Venture \"Extended Edition\"']",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((//tbody/tr)[4]/td)[4]/p[text()=\"MUST SELL!\nair, moon roof, loaded\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((//tbody/tr)[5]/td)[4]/p[text()='\"This one\u{2019}s gonna to blow you\u{2019}re socks off,\" per the sticker']",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((//tbody/tr)[6]/td)[4]/p[text()='Check it, \"this one\u{2019}s gonna to blow you\u{2019}re socks off\", per the sticker']",
+            1,
+        );
+    }
+
+    #[test]
+    fn should_allow_quotes_around_a_csv_value_to_be_on_their_own_lines() {
+        let doc = Parser::default().parse("[cols=2*]\n,===\n\"\nA\n\",\"\nB\n\"\n,===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > tbody > tr", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td", 2);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[1]/p[text()=\"A\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p[text()=\"B\"]", 1);
+    }
+
+    #[test]
+    fn csv_format_shorthand() {
+        let doc = Parser::default().parse(",===\na,b,c\n1,2,3\n,===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
+    }
+
+    #[test]
+    fn tsv_as_format() {
+        let doc = Parser::default().parse("[format=tsv]\n,===\na\tb\tc\n1\t2\t3\n,===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
+    }
+
+    #[test]
+    fn custom_csv_separator() {
+        let doc = Parser::default().parse("[format=csv,separator=;]\n|===\na;b;c\n1;2;3\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
+    }
+
+    #[test]
+    fn tab_as_separator() {
+        let doc = Parser::default().parse("[separator=\\t]\n,===\na\tb\tc\n1\t2\t3\n,===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
+    }
+
+    #[test]
+    fn single_cell_in_csv_table_should_only_produce_single_row() {
+        let doc = Parser::default().parse(",===\nsingle cell\n,===");
+
+        assert_css(&doc, "table td", 1);
+    }
+
+    #[test]
+    fn cell_formatted_with_asciidoc_style() {
+        let doc = Parser::default().parse(
+            "[cols=\"1,1,1a\",separator=;]\n,===\nelement;description;example\n\nthematic break,a visible break; also known as a horizontal rule;---\n,===",
+        );
+
+        assert_css(&doc, "table tbody hr", 1);
+    }
+
+    #[test]
+    fn should_strip_whitespace_around_contents_of_asciidoc_cell() {
+        let doc = Parser::default().parse(
+            "[cols=\"1,1,1a\",separator=;]\n,===\nelement;description;example\n\nparagraph;contiguous lines of words and phrases;\"\n  one sentence, one line\n  \"\n,===",
+        );
+
+        assert_xpath(
+            &doc,
+            "/table/tbody//*[@class=\"paragraph\"]/p[text()=\"one sentence, one line\"]",
+            1,
+        );
+    }
+}

--- a/parser/src/tests/assert_dom/css.rs
+++ b/parser/src/tests/assert_dom/css.rs
@@ -13,6 +13,9 @@ use crate::tests::assert_dom::virtual_dom::VirtualNode;
 /// - `tag > child` - Find direct children only
 /// - `tag:first-of-type` - Find first occurrence of tag among siblings
 /// - `tag:not(selector)` - Find elements that do NOT match the inner selector
+/// - `tag:nth-child(N)` - Find the element that is the Nth child of its parent
+/// - `tag:empty` - Find elements with no children and no text
+/// - Pseudo-classes may be chained, e.g. `td:nth-child(3):empty`
 ///
 /// # Example
 ///
@@ -25,40 +28,58 @@ use crate::tests::assert_dom::virtual_dom::VirtualNode;
 pub(crate) fn query_css<'a>(root: &'a VirtualNode, selector: &str) -> Vec<&'a VirtualNode> {
     let selector = selector.trim();
 
+    // A descendant selector can reach the same node through more than one
+    // matching ancestor (e.g. `.tableblock h1` where both the `<table>` and the
+    // `<td>` carry the `tableblock` class). De-duplicate so each node is counted
+    // once, matching a real CSS engine.
+    let mut seen: Vec<*const VirtualNode> = Vec::new();
     query_descendant_or_self(root, selector)
+        .into_iter()
+        .filter(|node| {
+            let ptr = *node as *const VirtualNode;
+            if seen.contains(&ptr) {
+                false
+            } else {
+                seen.push(ptr);
+                true
+            }
+        })
+        .collect()
 }
 
-/// Finds the position of a space that acts as a descendant combinator.
-/// Returns `None` if there are no descendant combinator spaces.
+/// Finds the position of the first space that acts as a descendant combinator,
+/// scanning the whole pattern. Returns `None` if there are none.
 ///
-/// This distinguishes between:
+/// A space is a descendant combinator only when it is not merely whitespace
+/// padding a `>` or `+` combinator. This distinguishes between:
 /// - `div p` - space is a descendant combinator
-/// - `div > p` - space is just whitespace around `>`
-/// - `div + p` - space is just whitespace around `+`
+/// - `div > p` - spaces are just whitespace around `>`
+/// - `div + p` - spaces are just whitespace around `+`
+/// - `a > b c` - the space before `c` is a descendant combinator even though it
+///   follows a `>` combinator earlier in the pattern
 fn find_descendant_combinator_space(pattern: &str) -> Option<usize> {
-    let gt_pos = pattern.find('>');
-    let plus_pos = pattern.find('+');
-
-    // Find first space.
     for (i, ch) in pattern.char_indices() {
-        if ch == ' ' {
-            // Check if this space is before any `>` or `+` combinator.
-            let before_gt = gt_pos.is_none_or(|gt| i < gt);
-            let before_plus = plus_pos.is_none_or(|plus| i < plus);
-
-            if before_gt && before_plus {
-                // This space comes before any other combinators.
-                // Check if the next non-whitespace character is a combinator.
-                let rest = pattern[i..].trim_start();
-                if rest.starts_with('>') || rest.starts_with('+') {
-                    // This is whitespace before a combinator, not a descendant combinator.
-                    continue;
-                }
-
-                // This is a descendant combinator.
-                return Some(i);
-            }
+        if ch != ' ' {
+            continue;
         }
+
+        // Whitespace immediately before a `>`/`+` combinator is not a descendant
+        // combinator (e.g. the space in `div >`).
+        let rest = pattern[i..].trim_start();
+        if rest.starts_with('>') || rest.starts_with('+') {
+            continue;
+        }
+
+        // Whitespace immediately after a `>`/`+` combinator (or leading the
+        // pattern) is not a descendant combinator either (e.g. the space in
+        // `div > p`).
+        let prev = pattern[..i].trim_end();
+        if prev.is_empty() || prev.ends_with('>') || prev.ends_with('+') {
+            continue;
+        }
+
+        // A simple selector on both sides: this is a descendant combinator.
+        return Some(i);
     }
 
     None
@@ -207,6 +228,32 @@ fn query_with_direct_child_constraint<'a>(
     // Find which combinator appears first to process them in order.
     let plus_pos = pattern.find('+');
     let gt_pos = pattern.find('>');
+    let space_pos = find_descendant_combinator_space(pattern);
+
+    // Process a descendant combinator first if it is the leftmost combinator
+    // (e.g. the ` ` in `td .paragraph`, reached after stripping the preceding
+    // `>` steps of `table > tbody > tr > td .paragraph`). The constrained child
+    // matches a direct child; the rest is an unconstrained descendant search.
+    if let Some(space) = space_pos
+        && gt_pos.is_none_or(|gt| space < gt)
+        && plus_pos.is_none_or(|plus| space < plus)
+    {
+        let (first, rest) = pattern.split_at(space);
+        let first = first.trim();
+        let rest = rest.trim();
+
+        let mut results = Vec::new();
+        for child in &node.children {
+            if matches_selector_with_context(child, first, Some(node)) {
+                // The descendant combinator excludes the matched child itself, so
+                // search its subtrees rather than the child node.
+                for grandchild in &child.children {
+                    results.extend(query_descendant_or_self(grandchild, rest));
+                }
+            }
+        }
+        return results;
+    }
 
     // Process `>` first if it appears before `+`.
     if let Some(gt) = gt_pos
@@ -302,7 +349,8 @@ fn query_with_direct_child_constraint<'a>(
 /// - ID selector: `[@id="foo"]` or `#foo`
 /// - Text content: `[text()="value"]`
 /// - Index: `[1]`, `[2]`, etc. (handled by `apply_numeric_predicate`)
-/// - Pseudo-selectors: `:first-of-type`
+/// - Pseudo-selectors: `:first-of-type`, `:not(...)`, `:nth-child(N)`, `:empty`
+///   (and chains thereof, e.g. `:nth-child(3):empty`)
 fn matches_selector_with_context(
     node: &VirtualNode,
     selector: &str,
@@ -392,8 +440,39 @@ fn matches_selector_with_context(
     true
 }
 
-/// Checks if a node matches a pseudo-selector.
+/// Checks if a node matches a pseudo-selector, which may be a chain of several
+/// pseudo-classes (e.g. `nth-child(3):empty`). Every pseudo-class in the chain
+/// must match.
 fn matches_pseudo_selector(node: &VirtualNode, pseudo: &str, parent: Option<&VirtualNode>) -> bool {
+    split_pseudo_chain(pseudo.trim())
+        .iter()
+        .all(|part| matches_single_pseudo(node, part, parent))
+}
+
+/// Splits a pseudo-selector chain on top-level `:` separators, leaving colons
+/// inside parentheses (e.g. a nested `:not(...)`) untouched.
+/// `nth-child(3):empty` becomes `["nth-child(3)", "empty"]`.
+fn split_pseudo_chain(pseudo: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0;
+    for (i, ch) in pseudo.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => depth = depth.saturating_sub(1),
+            ':' if depth == 0 => {
+                parts.push(&pseudo[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    parts.push(&pseudo[start..]);
+    parts.into_iter().filter(|p| !p.is_empty()).collect()
+}
+
+/// Checks if a node matches a single pseudo-class.
+fn matches_single_pseudo(node: &VirtualNode, pseudo: &str, parent: Option<&VirtualNode>) -> bool {
     let pseudo = pseudo.trim();
 
     // Handle :not() pseudo-class.
@@ -403,6 +482,20 @@ fn matches_pseudo_selector(node: &VirtualNode, pseudo: &str, parent: Option<&Vir
             return !matches_inner_not_selector(node, inner.trim());
         }
         return false; // Malformed :not().
+    }
+
+    // Handle :nth-child(N) pseudo-class (1-indexed position among siblings).
+    if let Some(arg) = pseudo.strip_prefix("nth-child(") {
+        if let Some(arg) = arg.strip_suffix(')')
+            && let Ok(n) = arg.trim().parse::<usize>()
+            && let Some(parent) = parent
+        {
+            return parent
+                .children
+                .get(n.wrapping_sub(1))
+                .is_some_and(|child| std::ptr::eq(child as *const _, node as *const _));
+        }
+        return false; // Malformed or unsupported :nth-child() argument.
     }
 
     match pseudo {
@@ -564,9 +657,61 @@ fn matches_single_predicate(node: &VirtualNode, predicate: &str) -> bool {
         }
     }
 
+    // CSS-style attribute substring selector: [attr*="value"]. As with the
+    // exact-match form below, `class` and `id` live on their own node fields
+    // rather than in `attributes`; `class` is matched against the rendered
+    // (space-joined) class list so the substring may span class boundaries.
+    if let Some((attr_name, value_part)) = predicate.split_once("*=") {
+        let attr_name = attr_name.trim();
+        let value = unquote_attr_value(value_part);
+        return match attr_name {
+            "class" => node.classes.join(" ").contains(value.as_str()),
+            "id" => node
+                .id
+                .as_deref()
+                .is_some_and(|id| id.contains(value.as_str())),
+            _ => node
+                .attributes
+                .get(attr_name)
+                .is_some_and(|v| v.contains(&value)),
+        };
+    }
+
+    // CSS-style attribute value selector without the `@` prefix:
+    // [attr="value"]. (The `@`-prefixed form is handled above.)
+    if let Some((attr_name, value_part)) = predicate.split_once('=') {
+        let attr_name = attr_name.trim();
+        let value = unquote_attr_value(value_part);
+        match attr_name {
+            "class" => {
+                return value
+                    .split_whitespace()
+                    .all(|c| node.classes.iter().any(|nc| nc == c));
+            }
+            "id" => return node.id.as_deref() == Some(value.as_str()),
+            _ => return node.attributes.get(attr_name).map(|v| v.as_str()) == Some(value.as_str()),
+        }
+    }
+
     // Numeric predicate [N]: Would need to be handled by caller with context.
     // For now, just return `true` to pass through.
     true
+}
+
+/// Strips surrounding single or double quotes (and whitespace) from a CSS
+/// attribute selector value.
+fn unquote_attr_value(value_part: &str) -> String {
+    let trimmed = value_part.trim();
+    let unquoted = trimmed
+        .strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .or_else(|| {
+            trimmed
+                .strip_prefix('\'')
+                .and_then(|s| s.strip_suffix('\''))
+        })
+        .unwrap_or(trimmed);
+    unescape_css_string(unquoted)
 }
 
 /// Unescapes CSS string literals.
@@ -686,6 +831,53 @@ mod tests {
     }
 
     #[test]
+    fn query_nth_child_and_pseudo_chain() {
+        // A two-row, three-column table whose middle row has an empty trailing
+        // cell. Exercises `:nth-child(N)` and a pseudo chain (`:nth-child(3):empty`).
+        let doc = Parser::default().parse("[format=csv]\n|===\na,b,c\n1,2,\n|===");
+        let vdom = doc.to_virtual_dom();
+
+        assert_eq!(query_css(&vdom, "tbody > tr").len(), 2);
+        assert_eq!(query_css(&vdom, "tbody > tr:nth-child(1) > td").len(), 3);
+        assert_eq!(query_css(&vdom, "tbody > tr:nth-child(2) > td").len(), 3);
+
+        // Only the second row's third cell is empty.
+        assert_eq!(
+            query_css(&vdom, "tbody > tr:nth-child(2) > td:nth-child(3):empty").len(),
+            1
+        );
+        assert_eq!(
+            query_css(&vdom, "tbody > tr:nth-child(1) > td:nth-child(3):empty").len(),
+            0
+        );
+
+        // A position that no sibling occupies matches nothing.
+        assert_eq!(query_css(&vdom, "tbody > tr:nth-child(3)").len(), 0);
+    }
+
+    #[test]
+    fn query_child_chain_then_descendant() {
+        // A chain of `>` child combinators followed by a trailing descendant
+        // combinator (`a > b > c d`). The descendant step is reached only after
+        // the preceding `>` steps are stripped, so it must be handled inside the
+        // direct-child traversal, not just at the top level.
+        let doc = Parser::default().parse("[cols=\"1a\"]\n|===\n|AsciiDoc content\n|===");
+        let vdom = doc.to_virtual_dom();
+
+        // The paragraph sits at td > div.content > div.paragraph, i.e. it is a
+        // descendant (not a direct child) of the `td`.
+        assert_eq!(query_css(&vdom, "table > tbody > tr > td").len(), 1);
+        assert_eq!(
+            query_css(&vdom, "table > tbody > tr > td .paragraph").len(),
+            1
+        );
+
+        // A descendant step that itself precedes a further child combinator
+        // (`td .content > .paragraph`) is also handled.
+        assert_eq!(query_css(&vdom, "td .content > .paragraph").len(), 1);
+    }
+
+    #[test]
     fn query_full_ulist_selector() {
         let doc = Parser::default().parse("* bullet 1\n. numbered 1.1");
         let vdom = doc.to_virtual_dom();
@@ -707,6 +899,29 @@ mod tests {
 
         // Verify the attribute value.
         assert_eq!(result[0].attributes.get("start"), Some(&"2".to_string()));
+    }
+
+    #[test]
+    fn query_attribute_substring_selector() {
+        // The `[attr*="value"]` substring selector must consult the dedicated
+        // `class` and `id` node fields, not just `attributes`.
+        let node = VirtualNode::new("table")
+            .with_classes(["tableblock", "fit-content"])
+            .with_id("results")
+            .with_attribute("style", "width: 50%;");
+
+        // `class` matches against the space-joined class list.
+        assert_eq!(query_css(&node, "table[class*=\"fit\"]").len(), 1);
+        assert_eq!(query_css(&node, "table[class*=\"block\"]").len(), 1);
+        assert_eq!(query_css(&node, "table[class*=\"nope\"]").len(), 0);
+
+        // `id` matches against the id field.
+        assert_eq!(query_css(&node, "table[id*=\"sult\"]").len(), 1);
+        assert_eq!(query_css(&node, "table[id*=\"nope\"]").len(), 0);
+
+        // An ordinary attribute matches against its value.
+        assert_eq!(query_css(&node, "table[style*=\"width\"]").len(), 1);
+        assert_eq!(query_css(&node, "table[style*=\"height\"]").len(), 0);
     }
 
     #[test]

--- a/parser/src/tests/assert_dom/mod.rs
+++ b/parser/src/tests/assert_dom/mod.rs
@@ -123,6 +123,54 @@ fn refute_block_contains<'src, B: IsBlock<'src>>(block: &'src B, text: &str) {
     }
 }
 
+/// Asserts that the document's rendered output (its virtual DOM text) contains
+/// the given text. Unlike [`assert_output_contains`], this descends into table
+/// cells, so it can see content nested in an AsciiDoc cell.
+///
+/// # Panics
+///
+/// Panics if the rendered text does not contain `text`.
+#[track_caller]
+pub(crate) fn assert_rendered_contains(doc: &Document, text: &str) {
+    let rendered = rendered_text(doc);
+    assert!(
+        rendered.contains(text),
+        "rendered output should contain {text:?}, but did not:\n\n{rendered}"
+    );
+}
+
+/// Refutes that the document's rendered output (its virtual DOM text) contains
+/// the given text.
+///
+/// # Panics
+///
+/// Panics if the rendered text contains `text`.
+#[track_caller]
+pub(crate) fn refute_rendered_contains(doc: &Document, text: &str) {
+    let rendered = rendered_text(doc);
+    assert!(
+        !rendered.contains(text),
+        "rendered output should not contain {text:?}, but did:\n\n{rendered}"
+    );
+}
+
+/// Collects all text in the document's virtual DOM, in document order.
+fn rendered_text(doc: &Document) -> String {
+    fn collect(node: &virtual_dom::VirtualNode, out: &mut String) {
+        if let Some(text) = &node.text {
+            out.push_str(text);
+            out.push('\n');
+        }
+        for child in &node.children {
+            collect(child, out);
+        }
+    }
+
+    let mut out = String::new();
+    collect(&doc.to_virtual_dom(), &mut out);
+    out
+}
+
 mod css;
 use css::*;
 

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -313,8 +313,9 @@ impl ToVirtualDom for Document<'_> {
 /// NOTE: Some block types (like lists) handle their titles internally, so we
 /// skip adding a separate title element for those.
 fn add_block_with_title<'a>(parent: &mut VirtualNode, block: &'a Block<'a>) {
-    // Check if this block type handles its own title internally.
-    let handles_title_internally = matches!(block, Block::List(_));
+    // Check if this block type handles its own title internally. Lists render
+    // their title inside the list wrapper; tables render it as a <caption>.
+    let handles_title_internally = matches!(block, Block::List(_) | Block::Table(_));
 
     // Add title as a separate sibling element if the block doesn't handle it
     // internally.
@@ -834,8 +835,19 @@ fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
     }
 
     if let Some(title) = table.title() {
-        node.children
-            .push(VirtualNode::new("caption").with_text(title.to_string()));
+        // A titled table renders a <caption class="title">. When the processor
+        // assigned an automatic caption (e.g. "Table 1. "), it is prepended to
+        // the title text.
+        let caption_text = match table.caption() {
+            Some(caption) => format!("{caption}{title}"),
+            None => title.to_string(),
+        };
+
+        node.children.push(
+            VirtualNode::new("caption")
+                .with_class("title")
+                .with_text(caption_text),
+        );
     }
 
     let mut colgroup = VirtualNode::new("colgroup");
@@ -1046,6 +1058,23 @@ mod tests {
         let code = para.children.iter().find(|c| c.tag == "code");
         assert!(code.is_some(), "Should have a <code> element");
         assert_eq!(code.unwrap().text.as_deref(), Some("code"));
+    }
+
+    #[test]
+    fn titled_table_renders_captioned_title() {
+        let doc = Parser::default().parse(".A table with a title\n|===\n|a |b\n|===");
+        let vdom = doc.to_virtual_dom();
+
+        let table = &vdom.children[0];
+        assert_eq!(table.tag, "table");
+
+        let caption = &table.children[0];
+        assert_eq!(caption.tag, "caption");
+        assert!(caption.classes.contains(&"title".to_string()));
+        assert_eq!(
+            caption.text.as_deref(),
+            Some("Table 1. A table with a title")
+        );
     }
 
     #[test]

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -13,7 +13,7 @@ use crate::{
     blocks::{
         Block, Break, CompoundDelimitedBlock, IsBlock, ListBlock, ListItem, ListItemMarker,
         ListType, MediaBlock, Preamble, RawDelimitedBlock, SectionBlock, SimpleBlock,
-        SimpleBlockStyle,
+        SimpleBlockStyle, TableBlock, TableRow,
     },
 };
 
@@ -396,6 +396,7 @@ impl ToVirtualDom for Block<'_> {
             Block::Media(media) => media_to_node(media),
             Block::RawDelimited(raw) => raw_delimited_to_node(raw),
             Block::CompoundDelimited(compound) => compound_delimited_to_node(compound),
+            Block::Table(table) => table_to_node(table),
             Block::Preamble(preamble) => preamble_to_node(preamble),
             Block::Break(break_) => break_to_node(break_),
             Block::DocumentAttribute(_) => {
@@ -818,6 +819,71 @@ fn compound_delimited_to_node<'a>(compound: &'a CompoundDelimitedBlock<'a>) -> V
     }
 
     node
+}
+
+fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
+    let mut node =
+        VirtualNode::new("table").with_classes(["tableblock", "frame-all", "grid-all", "stretch"]);
+
+    if let Some(id) = table.id() {
+        node = node.with_id(id);
+    }
+
+    for role in table.roles() {
+        node = node.with_class(role);
+    }
+
+    if let Some(title) = table.title() {
+        node.children
+            .push(VirtualNode::new("caption").with_text(title.to_string()));
+    }
+
+    let mut colgroup = VirtualNode::new("colgroup");
+    for _ in table.columns() {
+        colgroup.children.push(VirtualNode::new("col"));
+    }
+    node.children.push(colgroup);
+
+    if let Some(header) = table.header_row() {
+        let mut thead = VirtualNode::new("thead");
+        thead.children.push(table_row_to_node(header, "th", false));
+        node.children.push(thead);
+    }
+
+    if !table.body_rows().is_empty() {
+        let mut tbody = VirtualNode::new("tbody");
+        for row in table.body_rows() {
+            tbody.children.push(table_row_to_node(row, "td", true));
+        }
+        node.children.push(tbody);
+    }
+
+    node
+}
+
+fn table_row_to_node(row: &TableRow<'_>, cell_tag: &str, wrap_in_paragraph: bool) -> VirtualNode {
+    let mut tr = VirtualNode::new("tr");
+
+    for cell in row.cells() {
+        let mut cell_node =
+            VirtualNode::new(cell_tag).with_classes(["tableblock", "halign-left", "valign-top"]);
+
+        let rendered = cell.content().rendered().to_string();
+
+        if wrap_in_paragraph {
+            cell_node.children.push(
+                VirtualNode::new("p")
+                    .with_class("tableblock")
+                    .with_text(rendered),
+            );
+        } else {
+            cell_node = cell_node.with_text(rendered);
+        }
+
+        tr.children.push(cell_node);
+    }
+
+    tr
 }
 
 fn preamble_to_node<'a>(preamble: &'a Preamble<'a>) -> VirtualNode {

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -13,7 +13,7 @@ use crate::{
     blocks::{
         Block, Break, CompoundDelimitedBlock, IsBlock, ListBlock, ListItem, ListItemMarker,
         ListType, MediaBlock, Preamble, RawDelimitedBlock, SectionBlock, SimpleBlock,
-        SimpleBlockStyle, TableBlock, TableRow,
+        SimpleBlockStyle, TableBlock, TableCellContent, TableRow,
     },
 };
 
@@ -880,16 +880,29 @@ fn table_row_to_node(row: &TableRow<'_>, cell_tag: &str, wrap_in_paragraph: bool
         let mut cell_node =
             VirtualNode::new(cell_tag).with_classes(["tableblock", "halign-left", "valign-top"]);
 
-        let rendered = cell.content().rendered().to_string();
+        match cell.content() {
+            TableCellContent::Simple(content) => {
+                let rendered = content.rendered().to_string();
 
-        if wrap_in_paragraph {
-            cell_node.children.push(
-                VirtualNode::new("p")
-                    .with_class("tableblock")
-                    .with_text(rendered),
-            );
-        } else {
-            cell_node = cell_node.with_text(rendered);
+                if wrap_in_paragraph {
+                    cell_node.children.push(
+                        VirtualNode::new("p")
+                            .with_class("tableblock")
+                            .with_text(rendered),
+                    );
+                } else {
+                    cell_node = cell_node.with_text(rendered);
+                }
+            }
+
+            // An AsciiDoc-styled cell holds a nested sequence of blocks, which
+            // render directly into the cell rather than into a single
+            // paragraph.
+            TableCellContent::AsciiDoc(blocks) => {
+                for block in blocks {
+                    cell_node.children.push(block.to_virtual_dom());
+                }
+            }
         }
 
         tr.children.push(cell_node);

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -11,9 +11,10 @@ use regex::Regex;
 use crate::{
     Document, HasSpan,
     blocks::{
-        Block, Break, CompoundDelimitedBlock, IsBlock, ListBlock, ListItem, ListItemMarker,
-        ListType, MediaBlock, Preamble, RawDelimitedBlock, SectionBlock, SimpleBlock,
-        SimpleBlockStyle, TableBlock, TableCellContent, TableRow,
+        Block, Break, ColumnStyle, CompoundDelimitedBlock, Frame, Grid, HorizontalAlignment,
+        IsBlock, ListBlock, ListItem, ListItemMarker, ListType, MediaBlock, Preamble,
+        RawDelimitedBlock, SectionBlock, SimpleBlock, SimpleBlockStyle, Stripes, TableBlock,
+        TableCellContent, TableColumn, TableRow, VerticalAlignment,
     },
 };
 
@@ -22,11 +23,53 @@ use crate::{
 /// This simulates what a browser would do when parsing HTML and accessing
 /// text content via JavaScript's `textContent` or XPath's `text()`.
 fn decode_html_entities(s: &str) -> String {
+    let s = decode_numeric_entities(s);
     s.replace("&lt;", "<")
         .replace("&gt;", ">")
         .replace("&amp;", "&")
         .replace("&quot;", "\"")
         .replace("&apos;", "'")
+}
+
+/// Decodes numeric character references (`&#8230;` and `&#x2026;`) to their
+/// character equivalents, mirroring what a browser does when reading `text()`.
+/// Asciidoctor emits typographic replacements (ellipsis, dashes, zero-width
+/// spaces) as numeric references, so the test DOM must decode them to compare
+/// against the expected characters.
+fn decode_numeric_entities(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut rest = s;
+
+    while let Some(amp) = rest.find("&#") {
+        result.push_str(&rest[..amp]);
+        let after = &rest[amp + 2..];
+
+        let (digits, radix) = match after.strip_prefix(['x', 'X']) {
+            Some(hex) => (hex, 16),
+            None => (after, 10),
+        };
+
+        let end = digits.find(';');
+        let parsed = end
+            .map(|e| &digits[..e])
+            .and_then(|d| u32::from_str_radix(d, radix).ok())
+            .and_then(char::from_u32);
+
+        match (end, parsed) {
+            (Some(e), Some(ch)) => {
+                result.push(ch);
+                rest = &digits[e + 1..];
+            }
+            _ => {
+                // Not a well-formed numeric reference; keep the literal `&#`.
+                result.push_str("&#");
+                rest = after;
+            }
+        }
+    }
+
+    result.push_str(rest);
+    result
 }
 
 /// Parses simple HTML inline markup from text and returns a mix of text and
@@ -298,6 +341,14 @@ impl ToVirtualDom for Document<'_> {
             node = node.with_id(id);
         }
 
+        // The document title renders as an `<h1>` when it is shown (the
+        // effective `showtitle`/`notitle` state).
+        if self.show_doctitle()
+            && let Some(title) = self.doctitle()
+        {
+            node.children.push(VirtualNode::new("h1").with_text(title));
+        }
+
         // Add child blocks, including block titles as separate siblings.
         for block in self.nested_blocks() {
             add_block_with_title(&mut node, block);
@@ -477,6 +528,16 @@ fn list_block_to_node<'a>(list: &'a ListBlock<'a>) -> VirtualNode {
         && let Some(style) = list.marker_style()
     {
         list_element = list_element.with_class(style);
+    }
+
+    // For ordered lists whose explicit numbering does not start at 1, emit the
+    // implicit `start` attribute (matching Asciidoctor).
+    if list.type_() == ListType::Ordered
+        && let Some(Block::ListItem(first)) = list.nested_blocks().next()
+        && let Some(ordinal) = first.list_item_marker().ordinal_value()
+        && ordinal != 1
+    {
+        list_element = list_element.with_attribute("start", ordinal.to_string());
     }
 
     // Add all named attributes from the attrlist to the list element.
@@ -823,8 +884,38 @@ fn compound_delimited_to_node<'a>(compound: &'a CompoundDelimitedBlock<'a>) -> V
 }
 
 fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
-    let mut node =
-        VirtualNode::new("table").with_classes(["tableblock", "frame-all", "grid-all", "stretch"]);
+    // The table-level classes mirror Asciidoctor's HTML backend: always
+    // `tableblock`, then the frame and grid classes, then a width class.
+    let mut classes = vec![
+        "tableblock".to_string(),
+        frame_class(table.frame()).to_string(),
+        grid_class(table.grid()).to_string(),
+    ];
+
+    // A table whose columns are sized to their content renders `fit-content`; a
+    // full-width (default) table renders `stretch`; a table with an explicit
+    // width renders neither (the width travels in the `width` attribute).
+    let autowidth = table.columns().iter().any(TableColumn::is_autowidth);
+    if autowidth {
+        classes.push("fit-content".to_string());
+    } else if table.width().is_none() {
+        classes.push("stretch".to_string());
+    }
+
+    if let Some(stripes) = stripes_class(table.stripes()) {
+        classes.push(stripes.to_string());
+    }
+
+    // The `float` attribute renders as a bare direction class (e.g. `left`).
+    if let Some(float) = table
+        .attrlist()
+        .and_then(|a| a.named_attribute("float"))
+        .map(|a| a.value())
+    {
+        classes.push(float.to_string());
+    }
+
+    let mut node = VirtualNode::new("table").with_classes(classes);
 
     if let Some(id) = table.id() {
         node = node.with_id(id);
@@ -832,6 +923,12 @@ fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
 
     for role in table.roles() {
         node = node.with_class(role);
+    }
+
+    // An explicit table width is carried in the `width` attribute as a
+    // percentage, matching `table[width="50%"]`-style assertions.
+    if let Some(width) = table.width() {
+        node = node.with_attribute("width", format!("{width}%"));
     }
 
     if let Some(title) = table.title() {
@@ -850,58 +947,182 @@ fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
         );
     }
 
+    // A table with no rows at all (e.g. every row was dropped for exceeding the
+    // column count) renders as a bare `<table>` with no colgroup or sections.
+    if table.header_row().is_none() && table.body_rows().is_empty() && table.footer_row().is_none()
+    {
+        return node;
+    }
+
     let mut colgroup = VirtualNode::new("colgroup");
-    for _ in table.columns() {
-        colgroup.children.push(VirtualNode::new("col"));
+    for (column, pcwidth) in table.columns().iter().zip(column_pcwidths(table.columns())) {
+        // Every column exposes its computed percentage width in `colpcwidth`,
+        // mirroring the model attribute Asciidoctor assigns to each column.
+        let mut col = VirtualNode::new("col").with_attribute("colpcwidth", pcwidth.clone());
+
+        if column.is_autowidth() {
+            // An autowidth column is sized to its content: it carries the
+            // `autowidth-option` marker (present with an empty value) and no HTML
+            // `width` attribute.
+            col = col.with_attribute("autowidth-option", "");
+        } else {
+            // A proportional column emits its percentage as the HTML `width`.
+            col = col.with_attribute("width", format!("{pcwidth}%"));
+        }
+
+        colgroup.children.push(col);
     }
     node.children.push(colgroup);
 
     if let Some(header) = table.header_row() {
         let mut thead = VirtualNode::new("thead");
-        thead.children.push(table_row_to_node(header, "th", false));
+        thead.children.push(table_row_to_node(header, true, false));
         node.children.push(thead);
     }
 
     if !table.body_rows().is_empty() {
         let mut tbody = VirtualNode::new("tbody");
         for row in table.body_rows() {
-            tbody.children.push(table_row_to_node(row, "td", true));
+            tbody.children.push(table_row_to_node(row, false, true));
         }
         node.children.push(tbody);
+    }
+
+    // The footer renders after the body, so the section order is
+    // thead, tbody, tfoot.
+    if let Some(footer) = table.footer_row() {
+        let mut tfoot = VirtualNode::new("tfoot");
+        tfoot.children.push(table_row_to_node(footer, false, true));
+        node.children.push(tfoot);
     }
 
     node
 }
 
-fn table_row_to_node(row: &TableRow<'_>, cell_tag: &str, wrap_in_paragraph: bool) -> VirtualNode {
+/// Renders one table row. `header_row` marks the row as the table's header (its
+/// cells become `<th>` and their content is not wrapped in a paragraph);
+/// otherwise cells are `<td>` and body content is wrapped in a
+/// `<p class="tableblock">` (`wrap_in_paragraph`).
+fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bool) -> VirtualNode {
     let mut tr = VirtualNode::new("tr");
 
     for cell in row.cells() {
-        let mut cell_node =
-            VirtualNode::new(cell_tag).with_classes(["tableblock", "halign-left", "valign-top"]);
+        // A cell carrying the header style renders as a `<th>` even outside the
+        // header row; otherwise header rows use `<th>` and body/footer rows use
+        // `<td>`.
+        let cell_tag = if header_row || cell.style() == ColumnStyle::Header {
+            "th"
+        } else {
+            "td"
+        };
+
+        let mut cell_node = VirtualNode::new(cell_tag).with_classes([
+            "tableblock".to_string(),
+            halign_class(cell.h_align()).to_string(),
+            valign_class(cell.v_align()).to_string(),
+        ]);
+
+        if cell.colspan() > 1 {
+            cell_node = cell_node.with_attribute("colspan", cell.colspan().to_string());
+        }
+        if cell.rowspan() > 1 {
+            cell_node = cell_node.with_attribute("rowspan", cell.rowspan().to_string());
+        }
 
         match cell.content() {
             TableCellContent::Simple(content) => {
                 let rendered = content.rendered().to_string();
 
-                if wrap_in_paragraph {
-                    cell_node.children.push(
-                        VirtualNode::new("p")
-                            .with_class("tableblock")
-                            .with_text(rendered),
-                    );
-                } else {
-                    cell_node = cell_node.with_text(rendered);
+                match cell.style() {
+                    // A literal cell renders its content verbatim inside a
+                    // `<div class="literal"><pre>…</pre></div>`.
+                    ColumnStyle::Literal => {
+                        cell_node.children.push(
+                            VirtualNode::new("div")
+                                .with_class("literal")
+                                .with_child(VirtualNode::new("pre").with_html_content(rendered)),
+                        );
+                    }
+
+                    _ if !wrap_in_paragraph => {
+                        // Header-row cells place their content directly in the
+                        // cell, wrapped only by any style element.
+                        match style_wrapper(cell.style()) {
+                            Some(tag) => cell_node
+                                .children
+                                .push(VirtualNode::new(tag).with_html_content(rendered)),
+                            None => cell_node = cell_node.with_html_content(rendered),
+                        }
+                    }
+
+                    // An empty body cell renders as an empty `<td>` with no
+                    // paragraph.
+                    _ if rendered.is_empty() => {}
+
+                    style => match style_wrapper(style) {
+                        // A text-styled cell wraps its content in a
+                        // `<p class="tableblock">` with an inner style element
+                        // (`<strong>`, `<em>`, `<code>`).
+                        Some(tag) => {
+                            cell_node.children.push(
+                                VirtualNode::new("p")
+                                    .with_class("tableblock")
+                                    .with_child(VirtualNode::new(tag).with_html_content(rendered)),
+                            );
+                        }
+
+                        // A plain cell renders each blank-line-separated
+                        // paragraph as its own `<p class="tableblock">`, matching
+                        // Asciidoctor (the parser stores them as one cell with
+                        // embedded blank lines).
+                        None => {
+                            for para in
+                                split_cell_paragraphs(content.original().data(), content.rendered())
+                            {
+                                cell_node.children.push(
+                                    VirtualNode::new("p")
+                                        .with_class("tableblock")
+                                        .with_html_content(para),
+                                );
+                            }
+                        }
+                    },
                 }
             }
 
-            // An AsciiDoc-styled cell holds a nested sequence of blocks, which
-            // render directly into the cell rather than into a single
-            // paragraph.
-            TableCellContent::AsciiDoc(blocks) => {
-                for block in blocks {
-                    cell_node.children.push(block.to_virtual_dom());
+            // An AsciiDoc-styled cell holds a nested document, which renders into
+            // a `<div class="content">` wrapper inside the cell. The blocks
+            // render as they would at the top level of a document (e.g.
+            // paragraphs wrapped in `<div class="paragraph">`), so the cell
+            // reuses `add_block_with_title`.
+            TableCellContent::AsciiDoc(cell) => {
+                let mut content = VirtualNode::new("div").with_class("content");
+
+                // The nested document's title renders as an `<h1>` when shown.
+                if let Some(title) = cell.title() {
+                    content
+                        .children
+                        .push(VirtualNode::new("h1").with_text(title));
                 }
+
+                if cell.is_inline() {
+                    // An `inline` doctype renders block content as bare inline
+                    // content, without the `<div class="paragraph"><p>` wrapper.
+                    for block in cell.blocks() {
+                        match block.rendered_content() {
+                            Some(rendered) => {
+                                content.children.extend(parse_html_content(rendered));
+                            }
+                            None => add_block_with_title(&mut content, block),
+                        }
+                    }
+                } else {
+                    for block in cell.blocks() {
+                        add_block_with_title(&mut content, block);
+                    }
+                }
+
+                cell_node.children.push(content);
             }
         }
 
@@ -909,6 +1130,192 @@ fn table_row_to_node(row: &TableRow<'_>, cell_tag: &str, wrap_in_paragraph: bool
     }
 
     tr
+}
+
+/// Computes the `colpcwidth` (percentage width) that Asciidoctor assigns to
+/// every column, mirroring `Table#assign_column_widths`.
+///
+/// Each autowidth column takes an equal share of the space the fixed columns
+/// leave free (`(100 - fixed_total) / autowidth_count`); every column's
+/// percentage is then truncated to four decimal places and the rounding balance
+/// is donated to the final column so the widths sum to exactly 100. The value
+/// is returned for every column (including autowidth columns, which carry the
+/// percentage in the model even though the HTML backend omits their `width`
+/// attribute).
+fn column_pcwidths(columns: &[TableColumn]) -> Vec<String> {
+    let n = columns.len();
+    if n == 0 {
+        return vec![];
+    }
+
+    let fixed_total: usize = columns
+        .iter()
+        .filter(|c| !c.is_autowidth())
+        .map(TableColumn::width)
+        .sum();
+
+    // Resolve the effective per-column width and the base they are a percentage
+    // of. With autowidth columns present the base is the full 100% and each
+    // autowidth column takes an equal share of the remaining space (collapsing
+    // to zero when the fixed columns already exceed 100%); otherwise each
+    // column's own proportional width is taken over the sum of all widths.
+    let (effective, base): (Vec<f64>, f64) = if columns.iter().any(TableColumn::is_autowidth) {
+        let autowidth_count = columns.iter().filter(|c| c.is_autowidth()).count();
+        let (share, base) = if fixed_total > 100 {
+            (0.0, fixed_total as f64)
+        } else {
+            (
+                truncate4((100.0 - fixed_total as f64) / autowidth_count as f64),
+                100.0,
+            )
+        };
+        let effective = columns
+            .iter()
+            .map(|c| {
+                if c.is_autowidth() {
+                    share
+                } else {
+                    c.width() as f64
+                }
+            })
+            .collect();
+        (effective, base)
+    } else {
+        let base = if fixed_total == 0 {
+            n as f64
+        } else {
+            fixed_total as f64
+        };
+        (columns.iter().map(|c| c.width() as f64).collect(), base)
+    };
+
+    let mut pct: Vec<f64> = effective
+        .iter()
+        .map(|w| truncate4(w * 100.0 / base))
+        .collect();
+
+    // Donate the rounding balance to the final column.
+    let total: f64 = pct.iter().sum();
+    if (total - 100.0).abs() > 1e-9 {
+        let last = n - 1;
+        pct[last] = round4(100.0 - total + pct[last]);
+    }
+
+    pct.iter().map(|w| format_pcwidth(*w)).collect()
+}
+
+/// Splits a plain (non-styled) table cell's content into paragraphs, returning
+/// the rendered text of each.
+///
+/// A paragraph break is a blank line in the **source**, not the rendered text.
+/// This matters for an attribute reference such as `{blank}`: a line containing
+/// only `{blank}` renders as an empty line but is not blank in the source, so
+/// it must not split the paragraph (matching Asciidoctor). Inline substitution
+/// is line-preserving, so the source and rendered line counts line up; each
+/// non-blank source line contributes its rendered counterpart to the current
+/// paragraph. If the two ever diverge in length, fall back to splitting the
+/// rendered text on blank lines.
+fn split_cell_paragraphs(source: &str, rendered: &str) -> Vec<String> {
+    let source_lines: Vec<&str> = source.split('\n').collect();
+    let rendered_lines: Vec<&str> = rendered.split('\n').collect();
+
+    if source_lines.len() != rendered_lines.len() {
+        return rendered
+            .split("\n\n")
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty())
+            .collect();
+    }
+
+    let mut paragraphs: Vec<String> = vec![];
+    let mut current: Vec<&str> = vec![];
+    for (src, rendered) in source_lines.iter().zip(rendered_lines.iter()) {
+        if src.trim().is_empty() {
+            if !current.is_empty() {
+                paragraphs.push(current.join("\n").trim().to_string());
+                current.clear();
+            }
+        } else {
+            current.push(rendered);
+        }
+    }
+    if !current.is_empty() {
+        paragraphs.push(current.join("\n").trim().to_string());
+    }
+
+    paragraphs.retain(|p| !p.is_empty());
+    paragraphs
+}
+
+fn truncate4(x: f64) -> f64 {
+    (x * 10000.0).trunc() / 10000.0
+}
+
+fn round4(x: f64) -> f64 {
+    (x * 10000.0).round() / 10000.0
+}
+
+/// Formats a percentage width the way Asciidoctor serializes it: whole numbers
+/// have no decimal part, and fractional values keep up to four significant
+/// decimal places with trailing zeros trimmed (e.g. `50`, `17.647`, `33.3334`).
+fn format_pcwidth(x: f64) -> String {
+    let s = format!("{x:.4}");
+    let trimmed = s.trim_end_matches('0').trim_end_matches('.');
+    trimmed.to_string()
+}
+
+/// The inline element a text-styled cell wraps its content in, if any.
+fn style_wrapper(style: ColumnStyle) -> Option<&'static str> {
+    match style {
+        ColumnStyle::Strong => Some("strong"),
+        ColumnStyle::Emphasis => Some("em"),
+        ColumnStyle::Monospace => Some("code"),
+        _ => None,
+    }
+}
+
+fn frame_class(frame: Frame) -> &'static str {
+    match frame {
+        Frame::All => "frame-all",
+        Frame::Ends => "frame-ends",
+        Frame::Sides => "frame-sides",
+        Frame::None => "frame-none",
+    }
+}
+
+fn grid_class(grid: Grid) -> &'static str {
+    match grid {
+        Grid::All => "grid-all",
+        Grid::Rows => "grid-rows",
+        Grid::Cols => "grid-cols",
+        Grid::None => "grid-none",
+    }
+}
+
+fn stripes_class(stripes: Stripes) -> Option<&'static str> {
+    match stripes {
+        Stripes::None => None,
+        Stripes::Even => Some("stripes-even"),
+        Stripes::Odd => Some("stripes-odd"),
+        Stripes::All => Some("stripes-all"),
+        Stripes::Hover => Some("stripes-hover"),
+    }
+}
+
+fn halign_class(align: HorizontalAlignment) -> &'static str {
+    match align {
+        HorizontalAlignment::Left => "halign-left",
+        HorizontalAlignment::Center => "halign-center",
+        HorizontalAlignment::Right => "halign-right",
+    }
+}
+
+fn valign_class(align: VerticalAlignment) -> &'static str {
+    match align {
+        VerticalAlignment::Top => "valign-top",
+        VerticalAlignment::Middle => "valign-middle",
+        VerticalAlignment::Bottom => "valign-bottom",
+    }
 }
 
 fn preamble_to_node<'a>(preamble: &'a Preamble<'a>) -> VirtualNode {

--- a/parser/src/tests/assert_dom/xpath.rs
+++ b/parser/src/tests/assert_dom/xpath.rs
@@ -1133,6 +1133,18 @@ fn matches_single_predicate(node: &VirtualNode, predicate: &str) -> bool {
         }
     }
 
+    // Check for attribute-existence predicates `[@attr]` (no value).
+    if let Some(attr_name) = predicate.strip_prefix('@')
+        && !attr_name.contains('=')
+    {
+        let attr_name = attr_name.trim();
+        return match attr_name {
+            "class" => !node.classes.is_empty(),
+            "id" => node.id.is_some(),
+            _ => node.attributes.contains_key(attr_name),
+        };
+    }
+
     // Numeric predicate [N]: Would need to be handled by caller with context.
     // For now, just return `true` to pass through.
     true

--- a/parser/src/tests/fixtures/blocks/block.rs
+++ b/parser/src/tests/fixtures/blocks/block.rs
@@ -1,7 +1,7 @@
 use crate::tests::fixtures::{
     blocks::{
         Break, CompoundDelimitedBlock, ListBlock, ListItem, MediaBlock, Preamble,
-        RawDelimitedBlock, SectionBlock, SimpleBlock,
+        RawDelimitedBlock, SectionBlock, SimpleBlock, TableBlock,
     },
     document::Attribute,
 };
@@ -15,6 +15,7 @@ pub(crate) enum Block {
     ListItem(ListItem),
     RawDelimited(RawDelimitedBlock),
     CompoundDelimited(CompoundDelimitedBlock),
+    Table(TableBlock),
     Preamble(Preamble),
     Break(Break),
     DocumentAttribute(Attribute),
@@ -68,6 +69,11 @@ fn fixture_eq_observed(fixture: &Block, observed: &crate::blocks::Block) -> bool
 
         Block::CompoundDelimited(cdb_fixture) => match observed {
             crate::blocks::Block::CompoundDelimited(cdb_observed) => cdb_fixture == cdb_observed,
+            _ => false,
+        },
+
+        Block::Table(table_fixture) => match observed {
+            crate::blocks::Block::Table(table_observed) => table_fixture == table_observed,
             _ => false,
         },
 

--- a/parser/src/tests/fixtures/blocks/mod.rs
+++ b/parser/src/tests/fixtures/blocks/mod.rs
@@ -35,4 +35,4 @@ mod simple;
 pub(crate) use simple::SimpleBlock;
 
 mod table;
-pub(crate) use table::{TableBlock, TableCell, TableColumn, TableRow};
+pub(crate) use table::{TableBlock, TableCell, TableCellContent, TableColumn, TableRow};

--- a/parser/src/tests/fixtures/blocks/mod.rs
+++ b/parser/src/tests/fixtures/blocks/mod.rs
@@ -33,3 +33,6 @@ pub(crate) use section_number::SectionNumber;
 
 mod simple;
 pub(crate) use simple::SimpleBlock;
+
+mod table;
+pub(crate) use table::{TableBlock, TableCell, TableColumn, TableRow};

--- a/parser/src/tests/fixtures/blocks/table.rs
+++ b/parser/src/tests/fixtures/blocks/table.rs
@@ -2,8 +2,8 @@ use std::fmt;
 
 use crate::{
     HasSpan,
-    blocks::{HorizontalAlignment, IsBlock, VerticalAlignment},
-    tests::fixtures::{Span, attributes::Attrlist, content::Content},
+    blocks::{ColumnStyle, HorizontalAlignment, IsBlock, VerticalAlignment},
+    tests::fixtures::{Span, attributes::Attrlist, blocks::Block, content::Content},
 };
 
 #[derive(Eq, PartialEq)]
@@ -44,6 +44,7 @@ pub(crate) struct TableColumn {
     pub width: usize,
     pub h_align: HorizontalAlignment,
     pub v_align: VerticalAlignment,
+    pub style: ColumnStyle,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -53,7 +54,13 @@ pub(crate) struct TableRow {
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) struct TableCell {
-    pub content: Content,
+    pub content: TableCellContent,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum TableCellContent {
+    Simple(Content),
+    AsciiDoc(&'static [Block]),
 }
 
 impl<'src> PartialEq<crate::blocks::TableBlock<'src>> for TableBlock {
@@ -71,8 +78,21 @@ impl PartialEq<TableBlock> for crate::blocks::TableBlock<'_> {
 fn columns_eq(fixture: &[TableColumn], observed: &[crate::blocks::TableColumn]) -> bool {
     fixture.len() == observed.len()
         && fixture.iter().zip(observed.iter()).all(|(f, o)| {
-            f.width == o.width() && f.h_align == o.h_align() && f.v_align == o.v_align()
+            f.width == o.width()
+                && f.h_align == o.h_align()
+                && f.v_align == o.v_align()
+                && f.style == o.style()
         })
+}
+
+fn cell_content_eq(fixture: &TableCellContent, observed: &crate::blocks::TableCellContent) -> bool {
+    match (fixture, observed) {
+        (TableCellContent::Simple(f), crate::blocks::TableCellContent::Simple(o)) => f == o,
+        (TableCellContent::AsciiDoc(f), crate::blocks::TableCellContent::AsciiDoc(o)) => {
+            f.len() == o.len() && f.iter().zip(o.iter()).all(|(fb, ob)| fb == ob)
+        }
+        _ => false,
+    }
 }
 
 fn cells_eq(fixture: &[TableCell], observed: &[crate::blocks::TableCell]) -> bool {
@@ -80,7 +100,7 @@ fn cells_eq(fixture: &[TableCell], observed: &[crate::blocks::TableCell]) -> boo
         && fixture
             .iter()
             .zip(observed.iter())
-            .all(|(f, o)| f.content == *o.content())
+            .all(|(f, o)| cell_content_eq(&f.content, o.content()))
 }
 
 fn row_eq(fixture: &TableRow, observed: &crate::blocks::TableRow) -> bool {

--- a/parser/src/tests/fixtures/blocks/table.rs
+++ b/parser/src/tests/fixtures/blocks/table.rs
@@ -89,6 +89,7 @@ fn cell_content_eq(fixture: &TableCellContent, observed: &crate::blocks::TableCe
     match (fixture, observed) {
         (TableCellContent::Simple(f), crate::blocks::TableCellContent::Simple(o)) => f == o,
         (TableCellContent::AsciiDoc(f), crate::blocks::TableCellContent::AsciiDoc(o)) => {
+            let o = o.blocks();
             f.len() == o.len() && f.iter().zip(o.iter()).all(|(fb, ob)| fb == ob)
         }
         _ => false,

--- a/parser/src/tests/fixtures/blocks/table.rs
+++ b/parser/src/tests/fixtures/blocks/table.rs
@@ -15,6 +15,7 @@ pub(crate) struct TableBlock {
     pub source: Span,
     pub title_source: Option<Span>,
     pub title: Option<&'static str>,
+    pub caption: Option<&'static str>,
     pub anchor: Option<Span>,
     pub anchor_reftext: Option<Span>,
     pub attrlist: Option<Attrlist>,
@@ -30,6 +31,7 @@ impl fmt::Debug for TableBlock {
             .field("source", &self.source)
             .field("title_source", &self.title_source)
             .field("title", &self.title)
+            .field("caption", &self.caption)
             .field("anchor", &self.anchor)
             .field("anchor_reftext", &self.anchor_reftext)
             .field("attrlist", &self.attrlist)
@@ -135,6 +137,17 @@ fn fixture_eq_observed(fixture: &TableBlock, observed: &crate::blocks::TableBloc
     if let Some(ref fixture_title) = fixture.title
         && let Some(ref observed_title) = observed.title()
         && fixture_title != observed_title
+    {
+        return false;
+    }
+
+    if fixture.caption.is_some() != observed.caption().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_caption) = fixture.caption
+        && let Some(ref observed_caption) = observed.caption()
+        && fixture_caption != observed_caption
     {
         return false;
     }

--- a/parser/src/tests/fixtures/blocks/table.rs
+++ b/parser/src/tests/fixtures/blocks/table.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::{
     HasSpan,
-    blocks::IsBlock,
+    blocks::{HorizontalAlignment, IsBlock, VerticalAlignment},
     tests::fixtures::{Span, attributes::Attrlist, content::Content},
 };
 
@@ -42,6 +42,8 @@ impl fmt::Debug for TableBlock {
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) struct TableColumn {
     pub width: usize,
+    pub h_align: HorizontalAlignment,
+    pub v_align: VerticalAlignment,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -68,10 +70,9 @@ impl PartialEq<TableBlock> for crate::blocks::TableBlock<'_> {
 
 fn columns_eq(fixture: &[TableColumn], observed: &[crate::blocks::TableColumn]) -> bool {
     fixture.len() == observed.len()
-        && fixture
-            .iter()
-            .zip(observed.iter())
-            .all(|(f, o)| f.width == o.width())
+        && fixture.iter().zip(observed.iter()).all(|(f, o)| {
+            f.width == o.width() && f.h_align == o.h_align() && f.v_align == o.v_align()
+        })
 }
 
 fn cells_eq(fixture: &[TableCell], observed: &[crate::blocks::TableCell]) -> bool {

--- a/parser/src/tests/fixtures/blocks/table.rs
+++ b/parser/src/tests/fixtures/blocks/table.rs
@@ -1,0 +1,176 @@
+use std::fmt;
+
+use crate::{
+    HasSpan,
+    blocks::IsBlock,
+    tests::fixtures::{Span, attributes::Attrlist, content::Content},
+};
+
+#[derive(Eq, PartialEq)]
+pub(crate) struct TableBlock {
+    pub columns: &'static [TableColumn],
+    pub header_row: Option<TableRow>,
+    pub body_rows: &'static [TableRow],
+    pub footer_row: Option<TableRow>,
+    pub source: Span,
+    pub title_source: Option<Span>,
+    pub title: Option<&'static str>,
+    pub anchor: Option<Span>,
+    pub anchor_reftext: Option<Span>,
+    pub attrlist: Option<Attrlist>,
+}
+
+impl fmt::Debug for TableBlock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TableBlock")
+            .field("columns", &self.columns)
+            .field("header_row", &self.header_row)
+            .field("body_rows", &self.body_rows)
+            .field("footer_row", &self.footer_row)
+            .field("source", &self.source)
+            .field("title_source", &self.title_source)
+            .field("title", &self.title)
+            .field("anchor", &self.anchor)
+            .field("anchor_reftext", &self.anchor_reftext)
+            .field("attrlist", &self.attrlist)
+            .finish()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct TableColumn {
+    pub width: usize,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct TableRow {
+    pub cells: &'static [TableCell],
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct TableCell {
+    pub content: Content,
+}
+
+impl<'src> PartialEq<crate::blocks::TableBlock<'src>> for TableBlock {
+    fn eq(&self, other: &crate::blocks::TableBlock<'src>) -> bool {
+        fixture_eq_observed(self, other)
+    }
+}
+
+impl PartialEq<TableBlock> for crate::blocks::TableBlock<'_> {
+    fn eq(&self, other: &TableBlock) -> bool {
+        fixture_eq_observed(other, self)
+    }
+}
+
+fn columns_eq(fixture: &[TableColumn], observed: &[crate::blocks::TableColumn]) -> bool {
+    fixture.len() == observed.len()
+        && fixture
+            .iter()
+            .zip(observed.iter())
+            .all(|(f, o)| f.width == o.width())
+}
+
+fn cells_eq(fixture: &[TableCell], observed: &[crate::blocks::TableCell]) -> bool {
+    fixture.len() == observed.len()
+        && fixture
+            .iter()
+            .zip(observed.iter())
+            .all(|(f, o)| f.content == *o.content())
+}
+
+fn row_eq(fixture: &TableRow, observed: &crate::blocks::TableRow) -> bool {
+    cells_eq(fixture.cells, observed.cells())
+}
+
+fn rows_eq(fixture: &[TableRow], observed: &[crate::blocks::TableRow]) -> bool {
+    fixture.len() == observed.len()
+        && fixture
+            .iter()
+            .zip(observed.iter())
+            .all(|(f, o)| row_eq(f, o))
+}
+
+fn opt_row_eq(fixture: &Option<TableRow>, observed: Option<&crate::blocks::TableRow>) -> bool {
+    match (fixture, observed) {
+        (None, None) => true,
+        (Some(f), Some(o)) => row_eq(f, o),
+        _ => false,
+    }
+}
+
+fn fixture_eq_observed(fixture: &TableBlock, observed: &crate::blocks::TableBlock) -> bool {
+    if !columns_eq(fixture.columns, observed.columns()) {
+        return false;
+    }
+
+    if !opt_row_eq(&fixture.header_row, observed.header_row()) {
+        return false;
+    }
+
+    if !rows_eq(fixture.body_rows, observed.body_rows()) {
+        return false;
+    }
+
+    if !opt_row_eq(&fixture.footer_row, observed.footer_row()) {
+        return false;
+    }
+
+    if fixture.title_source.is_some() != observed.title_source().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_title_source) = fixture.title_source
+        && let Some(ref observed_title_source) = observed.title_source()
+        && fixture_title_source != observed_title_source
+    {
+        return false;
+    }
+
+    if fixture.title.is_some() != observed.title().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_title) = fixture.title
+        && let Some(ref observed_title) = observed.title()
+        && fixture_title != observed_title
+    {
+        return false;
+    }
+
+    if fixture.anchor.is_some() != observed.anchor().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_anchor) = fixture.anchor
+        && let Some(ref observed_anchor) = observed.anchor()
+        && fixture_anchor != observed_anchor
+    {
+        return false;
+    }
+
+    if fixture.anchor_reftext.is_some() != observed.anchor_reftext().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_anchor_reftext) = fixture.anchor_reftext
+        && let Some(ref observed_anchor_reftext) = observed.anchor_reftext()
+        && fixture_anchor_reftext != observed_anchor_reftext
+    {
+        return false;
+    }
+
+    if fixture.attrlist.is_some() != observed.attrlist().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_attrlist) = fixture.attrlist
+        && let Some(ref observed_attrlist) = observed.attrlist()
+        && &fixture_attrlist != observed_attrlist
+    {
+        return false;
+    }
+
+    fixture.source == observed.span()
+}

--- a/parser/src/tests/prelude.rs
+++ b/parser/src/tests/prelude.rs
@@ -6,7 +6,9 @@ pub(crate) use std::collections::HashMap;
 
 pub(crate) use crate::{
     HasSpan, Parser,
-    blocks::{HorizontalAlignment, IsBlock, SectionType, SimpleBlockStyle, VerticalAlignment},
+    blocks::{
+        ColumnStyle, HorizontalAlignment, IsBlock, SectionType, SimpleBlockStyle, VerticalAlignment,
+    },
     content::SubstitutionGroup,
     parser::ModificationContext,
     tests::{

--- a/parser/src/tests/prelude.rs
+++ b/parser/src/tests/prelude.rs
@@ -7,7 +7,8 @@ pub(crate) use std::collections::HashMap;
 pub(crate) use crate::{
     HasSpan, Parser,
     blocks::{
-        ColumnStyle, HorizontalAlignment, IsBlock, SectionType, SimpleBlockStyle, VerticalAlignment,
+        ColumnStyle, Frame, Grid, HorizontalAlignment, IsBlock, SectionType, SimpleBlockStyle,
+        VerticalAlignment,
     },
     content::SubstitutionGroup,
     parser::ModificationContext,

--- a/parser/src/tests/prelude.rs
+++ b/parser/src/tests/prelude.rs
@@ -8,7 +8,7 @@ pub(crate) use crate::{
     HasSpan, Parser,
     blocks::{
         ColumnStyle, Frame, Grid, HorizontalAlignment, IsBlock, SectionType, SimpleBlockStyle,
-        VerticalAlignment,
+        Stripes, VerticalAlignment,
     },
     content::SubstitutionGroup,
     parser::ModificationContext,

--- a/parser/src/tests/prelude.rs
+++ b/parser/src/tests/prelude.rs
@@ -6,7 +6,7 @@ pub(crate) use std::collections::HashMap;
 
 pub(crate) use crate::{
     HasSpan, Parser,
-    blocks::{IsBlock, SectionType, SimpleBlockStyle},
+    blocks::{HorizontalAlignment, IsBlock, SectionType, SimpleBlockStyle, VerticalAlignment},
     content::SubstitutionGroup,
     parser::ModificationContext,
     tests::{

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -82,6 +82,15 @@ pub enum WarningType {
 
     #[error("Dropping table cell because it exceeds the specified number of columns")]
     TableCellExceedsColumnCount,
+
+    #[error("Unclosed quote in CSV data; setting cell to empty")]
+    TableCsvDataHasUnclosedQuote,
+
+    #[error("Table is missing a leading separator; recovering automatically")]
+    TableMissingLeadingSeparator,
+
+    #[error("Dropping cells from incomplete row; detected end of table")]
+    TableDroppingIncompleteRowAtEndOfTable,
 }
 
 impl std::fmt::Debug for WarningType {
@@ -158,6 +167,18 @@ impl std::fmt::Debug for WarningType {
 
             WarningType::TableCellExceedsColumnCount => {
                 write!(f, "WarningType::TableCellExceedsColumnCount")
+            }
+
+            WarningType::TableCsvDataHasUnclosedQuote => {
+                write!(f, "WarningType::TableCsvDataHasUnclosedQuote")
+            }
+
+            WarningType::TableMissingLeadingSeparator => {
+                write!(f, "WarningType::TableMissingLeadingSeparator")
+            }
+
+            WarningType::TableDroppingIncompleteRowAtEndOfTable => {
+                write!(f, "WarningType::TableDroppingIncompleteRowAtEndOfTable")
             }
         }
     }
@@ -416,6 +437,30 @@ mod tests {
                 let warning = WarningType::TableCellExceedsColumnCount;
                 let debug_output = format!("{:?}", warning);
                 assert_eq!(debug_output, "WarningType::TableCellExceedsColumnCount");
+            }
+
+            #[test]
+            fn table_csv_data_has_unclosed_quote() {
+                let warning = WarningType::TableCsvDataHasUnclosedQuote;
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(debug_output, "WarningType::TableCsvDataHasUnclosedQuote");
+            }
+
+            #[test]
+            fn table_missing_leading_separator() {
+                let warning = WarningType::TableMissingLeadingSeparator;
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(debug_output, "WarningType::TableMissingLeadingSeparator");
+            }
+
+            #[test]
+            fn table_dropping_incomplete_row_at_end_of_table() {
+                let warning = WarningType::TableDroppingIncompleteRowAtEndOfTable;
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(
+                    debug_output,
+                    "WarningType::TableDroppingIncompleteRowAtEndOfTable"
+                );
             }
         }
     }

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -79,6 +79,9 @@ pub enum WarningType {
 
     #[error("List item index: expected {0}, got {1}")]
     ListItemOutOfSequence(String, String),
+
+    #[error("Dropping table cell because it exceeds the specified number of columns")]
+    TableCellExceedsColumnCount,
 }
 
 impl std::fmt::Debug for WarningType {
@@ -152,6 +155,10 @@ impl std::fmt::Debug for WarningType {
                 .field(expected)
                 .field(actual)
                 .finish(),
+
+            WarningType::TableCellExceedsColumnCount => {
+                write!(f, "WarningType::TableCellExceedsColumnCount")
+            }
         }
     }
 }
@@ -402,6 +409,13 @@ mod tests {
                     debug_output,
                     "WarningType::ListItemOutOfSequence(\"y\", \"z\")"
                 );
+            }
+
+            #[test]
+            fn table_cell_exceeds_column_count() {
+                let warning = WarningType::TableCellExceedsColumnCount;
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(debug_output, "WarningType::TableCellExceedsColumnCount");
             }
         }
     }


### PR DESCRIPTION
Long-running integration branch for **AsciiDoc tables**.

## What landed

Full PSV/CSV/TSV/DSV table support, parsed into a new `TableBlock` model, rendered through the virtual DOM, and covered line-by-line against the `tables` module of the AsciiDoc language spec (23 pages) plus a port of Ruby Asciidoctor's `table_test.rb`.

### Core parsing & model

- [x] Basic PSV table block parsing — new `TableBlock` / `TableRow` / `TableColumn` / `TableCell`, PSV cell scanner, `cols` widths + multipliers, implicit columns, implicit header rows, virtual-DOM rendering ([#509](https://github.com/asciidoc-rs/asciidoc-parser/pull/509)).
- [x] Cells, rows, and columns — cell separators, column specifiers, multipliers ([#522](https://github.com/asciidoc-rs/asciidoc-parser/pull/522), [#517](https://github.com/asciidoc-rs/asciidoc-parser/pull/517)).
- [x] Only honor attrlist shorthand in the first attribute position ([#524](https://github.com/asciidoc-rs/asciidoc-parser/pull/524)).

### Header & footer rows

- [x] `noheader` option ([#523](https://github.com/asciidoc-rs/asciidoc-parser/pull/523)).
- [x] `footer` option — promote the last row to a footer row ([#525](https://github.com/asciidoc-rs/asciidoc-parser/pull/525)).

### Data formats

- [x] CSV, TSV, and DSV table data formats (`,===` / `:===` shorthand, custom `separator`) ([#537](https://github.com/asciidoc-rs/asciidoc-parser/pull/537)).

### Alignment & formatting

- [x] Align content by column — horizontal/vertical alignment operators ([#519](https://github.com/asciidoc-rs/asciidoc-parser/pull/519)).
- [x] Align content by cell — per-cell alignment operators ([#526](https://github.com/asciidoc-rs/asciidoc-parser/pull/526)).
- [x] Format content by column — style operators ([#520](https://github.com/asciidoc-rs/asciidoc-parser/pull/520)).
- [x] Format content by cell — per-cell style operators incl. the `a` AsciiDoc-cell attribute lock ([#527](https://github.com/asciidoc-rs/asciidoc-parser/pull/527)).

### Spans & duplication

- [x] Span cells across columns and rows — span operator ([#528](https://github.com/asciidoc-rs/asciidoc-parser/pull/528)).
- [x] Duplicate cells across consecutive cells — duplication operator ([#530](https://github.com/asciidoc-rs/asciidoc-parser/pull/530)).

### Layout: widths, borders, striping, orientation

- [x] Column widths spec coverage ([#518](https://github.com/asciidoc-rs/asciidoc-parser/pull/518)).
- [x] Table and column `width` — `autowidth` option, `~` columns ([#531](https://github.com/asciidoc-rs/asciidoc-parser/pull/531)).
- [x] Borders — `frame` and `grid` attributes ([#532](https://github.com/asciidoc-rs/asciidoc-parser/pull/532)).
- [x] Row striping — `stripes` attribute and `table-stripes` document attribute ([#533](https://github.com/asciidoc-rs/asciidoc-parser/pull/533)).
- [x] Orientation page declared non-normative ([#534](https://github.com/asciidoc-rs/asciidoc-parser/pull/534)).

### Title, caption & role

- [x] Table title and automatic caption ([#510](https://github.com/asciidoc-rs/asciidoc-parser/pull/510)).
- [x] Customize the title label — `table-caption` and per-table caption ([#513](https://github.com/asciidoc-rs/asciidoc-parser/pull/513)).
- [x] Turn off the title label — unset `table-caption` / empty caption ([#516](https://github.com/asciidoc-rs/asciidoc-parser/pull/516)).
- [x] Assign a role to a table ([#535](https://github.com/asciidoc-rs/asciidoc-parser/pull/535)).

### Nested tables

- [x] Nest tables inside AsciiDoc cells — `!===` delimiter and `separator` attribute ([#536](https://github.com/asciidoc-rs/asciidoc-parser/pull/536)).

### Additional spec & test coverage

- [x] Table syntax and attribute reference page ([#539](https://github.com/asciidoc-rs/asciidoc-parser/pull/539)).
- [x] Port Ruby Asciidoctor table tests, fixing the parser divergences they surfaced ([#540](https://github.com/asciidoc-rs/asciidoc-parser/pull/540)).
- [x] Enable the subs-page "Tables" coverage tests previously blocked on #296 ([#549](https://github.com/asciidoc-rs/asciidoc-parser/pull/549)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
