### PR TITLE
feat: Add basic PSV table block parsing

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -5,7 +5,7 @@ use crate::{
     attributes::Attrlist,
     blocks::{
         Break, CompoundDelimitedBlock, ContentModel, IsBlock, ListBlock, ListItem, ListItemMarker,
-        MediaBlock, Preamble, RawDelimitedBlock, SectionBlock, SimpleBlock,
+        MediaBlock, Preamble, RawDelimitedBlock, SectionBlock, SimpleBlock, TableBlock,
         metadata::BlockMetadata,
     },
     content::{Content, SubstitutionGroup},
@@ -61,6 +61,9 @@ pub enum Block<'src> {
     /// A delimited block that can contain other blocks.
     CompoundDelimited(CompoundDelimitedBlock<'src>),
 
+    /// A table block arranges content into a grid of rows and columns.
+    Table(TableBlock<'src>),
+
     /// Content between the end of the document header and the first section
     /// title in the document body is called the preamble.
     Preamble(Preamble<'src>),
@@ -90,6 +93,8 @@ impl<'src> std::fmt::Debug for Block<'src> {
                 .debug_tuple("Block::CompoundDelimited")
                 .field(block)
                 .finish(),
+
+            Block::Table(block) => f.debug_tuple("Block::Table").field(block).finish(),
 
             Block::Preamble(block) => f.debug_tuple("Block::Preamble").field(block).finish(),
             Block::Break(break_) => f.debug_tuple("Block::Break").field(break_).finish(),
@@ -153,6 +158,7 @@ impl<'src> Block<'src> {
             )
             && !first_line.contains("::")
             && !first_line.contains(";;")
+            && !TableBlock::is_table_delimiter(&first_line)
             && !ListItemMarker::starts_with_marker(first_line)
             && parent_list_markers.is_none()
             && let Some(MatchedItem {
@@ -252,6 +258,32 @@ impl<'src> Block<'src> {
                     item: Some(MatchedItem {
                         item: block,
                         after: cdb.after,
+                    }),
+                    warnings,
+                };
+            }
+
+            if let Some(mut table_maw) = TableBlock::parse(&metadata, parser)
+                && let Some(table) = table_maw.item
+            {
+                if !table_maw.warnings.is_empty() {
+                    warnings.append(&mut table_maw.warnings);
+                }
+
+                let block = Self::Table(table.item);
+
+                Self::register_block_id(
+                    block.id(),
+                    block.title(),
+                    block.span(),
+                    parser,
+                    &mut warnings,
+                );
+
+                return MatchAndWarnings {
+                    item: Some(MatchedItem {
+                        item: block,
+                        after: table.after,
                     }),
                     warnings,
                 };
@@ -456,6 +488,12 @@ impl<'src> Block<'src> {
             content.resolve_references(resolver, renderer, warnings);
         }
 
+        // Tables hold their resolvable content in cells rather than in a single
+        // `content_mut()` value, so they are resolved explicitly here.
+        if let Self::Table(table) = self {
+            table.resolve_references(resolver, renderer, warnings);
+        }
+
         for child in self.nested_blocks_mut() {
             child.resolve_references(resolver, renderer, warnings);
         }
@@ -472,6 +510,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.content_model(),
             Self::RawDelimited(b) => b.content_model(),
             Self::CompoundDelimited(b) => b.content_model(),
+            Self::Table(b) => b.content_model(),
             Self::Preamble(b) => b.content_model(),
             Self::Break(b) => b.content_model(),
             Self::DocumentAttribute(b) => b.content_model(),
@@ -487,6 +526,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.rendered_content(),
             Self::RawDelimited(b) => b.rendered_content(),
             Self::CompoundDelimited(b) => b.rendered_content(),
+            Self::Table(b) => b.rendered_content(),
             Self::Preamble(b) => b.rendered_content(),
             Self::Break(b) => b.rendered_content(),
             Self::DocumentAttribute(b) => b.rendered_content(),
@@ -502,6 +542,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.raw_context(),
             Self::RawDelimited(b) => b.raw_context(),
             Self::CompoundDelimited(b) => b.raw_context(),
+            Self::Table(b) => b.raw_context(),
             Self::Preamble(b) => b.raw_context(),
             Self::Break(b) => b.raw_context(),
             Self::DocumentAttribute(b) => b.raw_context(),
@@ -517,6 +558,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.nested_blocks(),
             Self::RawDelimited(b) => b.nested_blocks(),
             Self::CompoundDelimited(b) => b.nested_blocks(),
+            Self::Table(b) => b.nested_blocks(),
             Self::Preamble(b) => b.nested_blocks(),
             Self::Break(b) => b.nested_blocks(),
             Self::DocumentAttribute(b) => b.nested_blocks(),
@@ -532,6 +574,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.nested_blocks_mut(),
             Self::RawDelimited(b) => b.nested_blocks_mut(),
             Self::CompoundDelimited(b) => b.nested_blocks_mut(),
+            Self::Table(b) => b.nested_blocks_mut(),
             Self::Preamble(b) => b.nested_blocks_mut(),
             Self::Break(b) => b.nested_blocks_mut(),
             Self::DocumentAttribute(b) => b.nested_blocks_mut(),
@@ -547,6 +590,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.content_mut(),
             Self::RawDelimited(b) => b.content_mut(),
             Self::CompoundDelimited(b) => b.content_mut(),
+            Self::Table(b) => b.content_mut(),
             Self::Preamble(b) => b.content_mut(),
             Self::Break(b) => b.content_mut(),
             Self::DocumentAttribute(b) => b.content_mut(),
@@ -562,6 +606,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.title_source(),
             Self::RawDelimited(b) => b.title_source(),
             Self::CompoundDelimited(b) => b.title_source(),
+            Self::Table(b) => b.title_source(),
             Self::Preamble(b) => b.title_source(),
             Self::Break(b) => b.title_source(),
             Self::DocumentAttribute(b) => b.title_source(),
@@ -577,6 +622,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.title(),
             Self::RawDelimited(b) => b.title(),
             Self::CompoundDelimited(b) => b.title(),
+            Self::Table(b) => b.title(),
             Self::Preamble(b) => b.title(),
             Self::Break(b) => b.title(),
             Self::DocumentAttribute(b) => b.title(),
@@ -592,6 +638,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.anchor(),
             Self::RawDelimited(b) => b.anchor(),
             Self::CompoundDelimited(b) => b.anchor(),
+            Self::Table(b) => b.anchor(),
             Self::Preamble(b) => b.anchor(),
             Self::Break(b) => b.anchor(),
             Self::DocumentAttribute(b) => b.anchor(),
@@ -607,6 +654,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.anchor_reftext(),
             Self::RawDelimited(b) => b.anchor_reftext(),
             Self::CompoundDelimited(b) => b.anchor_reftext(),
+            Self::Table(b) => b.anchor_reftext(),
             Self::Preamble(b) => b.anchor_reftext(),
             Self::Break(b) => b.anchor_reftext(),
             Self::DocumentAttribute(b) => b.anchor_reftext(),
@@ -622,6 +670,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.attrlist(),
             Self::RawDelimited(b) => b.attrlist(),
             Self::CompoundDelimited(b) => b.attrlist(),
+            Self::Table(b) => b.attrlist(),
             Self::Preamble(b) => b.attrlist(),
             Self::Break(b) => b.attrlist(),
             Self::DocumentAttribute(b) => b.attrlist(),
@@ -637,6 +686,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.substitution_group(),
             Self::RawDelimited(b) => b.substitution_group(),
             Self::CompoundDelimited(b) => b.substitution_group(),
+            Self::Table(b) => b.substitution_group(),
             Self::Preamble(b) => b.substitution_group(),
             Self::Break(b) => b.substitution_group(),
             Self::DocumentAttribute(b) => b.substitution_group(),
@@ -654,6 +704,7 @@ impl<'src> HasSpan<'src> for Block<'src> {
             Self::ListItem(b) => b.span(),
             Self::RawDelimited(b) => b.span(),
             Self::CompoundDelimited(b) => b.span(),
+            Self::Table(b) => b.span(),
             Self::Preamble(b) => b.span(),
             Self::Break(b) => b.span(),
             Self::DocumentAttribute(b) => b.span(),

--- a/parser/src/blocks/mod.rs
+++ b/parser/src/blocks/mod.rs
@@ -64,5 +64,8 @@ pub use section::{SectionBlock, SectionNumber, SectionType};
 mod simple;
 pub use simple::{SimpleBlock, SimpleBlockStyle};
 
+mod table;
+pub use table::{TableBlock, TableCell, TableColumn, TableRow};
+
 #[cfg(test)]
 mod tests;

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1,0 +1,431 @@
+use crate::{
+    HasSpan, Parser, Span,
+    attributes::Attrlist,
+    blocks::{ContentModel, IsBlock, metadata::BlockMetadata},
+    content::{Content, SubstitutionGroup},
+    parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning},
+    span::MatchedItem,
+    strings::CowStr,
+    warnings::{MatchAndWarnings, Warning, WarningType},
+};
+
+/// A table is a delimited block that arranges content into a grid of rows and
+/// columns.
+///
+/// A table is introduced by a table delimiter (`|===`) and closed by a matching
+/// delimiter. Cells are separated using prefix-separated value (PSV) syntax: a
+/// vertical bar (`|`) at the start of a line or preceded by whitespace begins a
+/// new cell. Cells flow, in document order, into rows whose length is fixed by
+/// the number of columns.
+///
+/// The number of columns is determined either by the `cols` attribute or,
+/// implicitly, by the number of cells found in the first non-empty line after
+/// the opening delimiter.
+///
+/// # Not yet supported
+///
+/// This is an initial implementation covering the basic PSV table. The
+/// following table features are recognized by the wider AsciiDoc specification
+/// but are not yet implemented:
+///
+/// * The CSV, TSV, and DSV data formats (and the `,===` / `:===` shorthand
+///   delimiters).
+/// * Column specifiers and multipliers beyond a proportional width (alignment
+///   and style operators).
+/// * Cell specifiers (spans, duplication, per-cell alignment and style, and the
+///   `a` AsciiDoc style that nests block content inside a cell).
+/// * Footer rows.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TableBlock<'src> {
+    columns: Vec<TableColumn>,
+    header_row: Option<TableRow<'src>>,
+    body_rows: Vec<TableRow<'src>>,
+    footer_row: Option<TableRow<'src>>,
+    source: Span<'src>,
+    title_source: Option<Span<'src>>,
+    title: Option<String>,
+    anchor: Option<Span<'src>>,
+    anchor_reftext: Option<Span<'src>>,
+    attrlist: Option<Attrlist<'src>>,
+}
+
+impl<'src> TableBlock<'src> {
+    /// Returns `true` if `line` is a table delimiter.
+    ///
+    /// A table delimiter is a vertical bar (`|`) followed by three or more
+    /// equals signs (`===`).
+    ///
+    /// **NOTE:** The `,===` (CSV), `:===` (DSV), and `!===` (nested) shorthand
+    /// delimiters are not yet recognized.
+    pub(crate) fn is_table_delimiter(line: &Span<'src>) -> bool {
+        let data = line.data();
+        data.len() >= 4
+            && data.starts_with('|')
+            && data
+                .get(1..)
+                .is_some_and(|rest| rest.len() >= 3 && rest.bytes().all(|b| b == b'='))
+    }
+
+    pub(crate) fn parse(
+        metadata: &BlockMetadata<'src>,
+        parser: &mut Parser,
+    ) -> Option<MatchAndWarnings<'src, Option<MatchedItem<'src, Self>>>> {
+        let delimiter = metadata.block_start.take_normalized_line();
+
+        if !Self::is_table_delimiter(&delimiter.item) {
+            return None;
+        }
+
+        let delimiter_text = delimiter.item.data();
+
+        // Find the matching closing delimiter.
+        let mut next = delimiter.after;
+        let (closing_delimiter, after) = loop {
+            if next.is_empty() {
+                break (next, next);
+            }
+
+            let line = next.take_normalized_line();
+            if line.item.data() == delimiter_text {
+                break (line.item, line.after);
+            }
+            next = line.after;
+        };
+
+        let inside = delimiter.after.trim_remainder(closing_delimiter);
+
+        // Determine the number of columns, either from the `cols` attribute or
+        // implicitly from the number of cells in the first non-empty line.
+        let columns: Vec<TableColumn> = metadata
+            .attrlist
+            .as_ref()
+            .and_then(|a| a.named_attribute("cols"))
+            .map(|attr| parse_cols(attr.value()))
+            .unwrap_or_default();
+
+        let first_line_cells = scan_cells(inside.discard_empty_lines().take_line().item).len();
+
+        let ncols = if columns.is_empty() {
+            first_line_cells
+        } else {
+            columns.len()
+        };
+
+        let columns = if columns.is_empty() {
+            (0..ncols).map(|_| TableColumn::default()).collect()
+        } else {
+            columns
+        };
+
+        // The first row is an (implicit) header row when the line directly after
+        // the opening delimiter is non-empty and is itself followed by an empty
+        // line. The `header` option forces the same interpretation.
+        let opts_header = metadata
+            .attrlist
+            .as_ref()
+            .is_some_and(|a| a.has_option("header"));
+
+        // The blank line must genuinely exist after the first row; the end of the
+        // table (an empty remainder) does not count, so a single-row table is not
+        // mistaken for an all-header table.
+        let line1 = inside.take_line();
+        let line1_blank = line1.item.data().trim().is_empty();
+        let line2_blank =
+            !line1.after.is_empty() && line1.after.take_line().item.data().trim().is_empty();
+        let has_header = opts_header || (!line1_blank && line2_blank);
+
+        // Scan every cell in the table, in document order, then partition into
+        // rows of `ncols` cells each.
+        let mut cells = scan_cells(inside)
+            .into_iter()
+            .map(|raw| TableCell::parse(raw, parser));
+
+        let header_row = if has_header && ncols > 0 {
+            let row: Vec<TableCell<'src>> = cells.by_ref().take(ncols).collect();
+            if row.is_empty() {
+                None
+            } else {
+                Some(TableRow { cells: row })
+            }
+        } else {
+            None
+        };
+
+        let mut body_rows: Vec<TableRow<'src>> = vec![];
+        if ncols > 0 {
+            loop {
+                let row: Vec<TableCell<'src>> = cells.by_ref().take(ncols).collect();
+                if row.is_empty() {
+                    break;
+                }
+                body_rows.push(TableRow { cells: row });
+            }
+        }
+
+        let source = metadata
+            .source
+            .trim_remainder(closing_delimiter.discard_all())
+            .trim_trailing_whitespace();
+
+        let warnings = if closing_delimiter.is_empty() {
+            vec![Warning {
+                source: delimiter.item,
+                warning: WarningType::UnterminatedDelimitedBlock,
+            }]
+        } else {
+            vec![]
+        };
+
+        Some(MatchAndWarnings {
+            item: Some(MatchedItem {
+                item: Self {
+                    columns,
+                    header_row,
+                    body_rows,
+                    footer_row: None,
+                    source,
+                    title_source: metadata.title_source,
+                    title: metadata.title.clone(),
+                    anchor: metadata.anchor,
+                    anchor_reftext: metadata.anchor_reftext,
+                    attrlist: metadata.attrlist.clone(),
+                },
+                after,
+            }),
+            warnings,
+        })
+    }
+
+    /// Returns the columns of this table.
+    pub fn columns(&self) -> &[TableColumn] {
+        &self.columns
+    }
+
+    /// Returns the header row of this table, if one was declared.
+    pub fn header_row(&self) -> Option<&TableRow<'src>> {
+        self.header_row.as_ref()
+    }
+
+    /// Returns the body rows of this table.
+    pub fn body_rows(&self) -> &[TableRow<'src>] {
+        &self.body_rows
+    }
+
+    /// Returns the footer row of this table, if one was declared.
+    pub fn footer_row(&self) -> Option<&TableRow<'src>> {
+        self.footer_row.as_ref()
+    }
+
+    /// Resolves any deferred cross-references in this table's cells.
+    pub(crate) fn resolve_references(
+        &mut self,
+        resolver: &dyn ReferenceResolver,
+        renderer: &dyn InlineSubstitutionRenderer,
+        warnings: &mut Vec<ReferenceWarning>,
+    ) {
+        let rows = self
+            .header_row
+            .iter_mut()
+            .chain(self.body_rows.iter_mut())
+            .chain(self.footer_row.iter_mut());
+
+        for row in rows {
+            for cell in row.cells.iter_mut() {
+                cell.content
+                    .resolve_references(resolver, renderer, warnings);
+            }
+        }
+    }
+}
+
+impl<'src> IsBlock<'src> for TableBlock<'src> {
+    fn content_model(&self) -> ContentModel {
+        ContentModel::Table
+    }
+
+    fn raw_context(&self) -> CowStr<'src> {
+        "table".into()
+    }
+
+    fn title_source(&'src self) -> Option<Span<'src>> {
+        self.title_source
+    }
+
+    fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    fn anchor(&'src self) -> Option<Span<'src>> {
+        self.anchor
+    }
+
+    fn anchor_reftext(&'src self) -> Option<Span<'src>> {
+        self.anchor_reftext
+    }
+
+    fn attrlist(&'src self) -> Option<&'src Attrlist<'src>> {
+        self.attrlist.as_ref()
+    }
+}
+
+impl<'src> HasSpan<'src> for TableBlock<'src> {
+    fn span(&self) -> Span<'src> {
+        self.source
+    }
+}
+
+/// A column in a [`TableBlock`].
+///
+/// For now a column carries only its proportional width. Alignment and style
+/// operators on the `cols` specifier are not yet modeled.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TableColumn {
+    width: usize,
+}
+
+impl TableColumn {
+    /// Returns the proportional width of this column relative to the other
+    /// columns in the table.
+    pub fn width(&self) -> usize {
+        self.width
+    }
+}
+
+impl Default for TableColumn {
+    fn default() -> Self {
+        Self { width: 1 }
+    }
+}
+
+/// A row of cells in a [`TableBlock`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TableRow<'src> {
+    cells: Vec<TableCell<'src>>,
+}
+
+impl<'src> TableRow<'src> {
+    /// Returns the cells in this row.
+    pub fn cells(&self) -> &[TableCell<'src>] {
+        &self.cells
+    }
+}
+
+/// A single cell in a [`TableBlock`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TableCell<'src> {
+    content: Content<'src>,
+}
+
+impl<'src> TableCell<'src> {
+    /// Build a cell from the raw (untrimmed) span of its content.
+    ///
+    /// Leading and trailing whitespace is stripped, escaped cell separators
+    /// (`\|`) are unescaped, and normal inline substitutions are applied.
+    fn parse(raw: Span<'src>, parser: &Parser) -> Self {
+        let trimmed = trim_surrounding_whitespace(raw);
+        let data = trimmed.data();
+
+        let mut content = if data.contains("\\|") {
+            Content::from_filtered(trimmed, data.replace("\\|", "|"))
+        } else {
+            Content::from(trimmed)
+        };
+
+        SubstitutionGroup::Normal.apply(&mut content, parser, None);
+
+        Self { content }
+    }
+
+    /// Returns the interpreted content of this cell.
+    pub fn content(&self) -> &Content<'src> {
+        &self.content
+    }
+}
+
+/// Parse the value of the `cols` attribute into a list of columns.
+///
+/// The value is a comma-separated list of column specifiers. A specifier may be
+/// preceded by a multiplier (`<n>*`) that repeats the column `n` times. Only
+/// the proportional width portion of a specifier is currently interpreted.
+fn parse_cols(value: &str) -> Vec<TableColumn> {
+    let mut columns: Vec<TableColumn> = vec![];
+
+    for part in value.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+
+        if let Some((count, spec)) = part.split_once('*') {
+            let repeat = count.trim().parse::<usize>().unwrap_or(1).max(1);
+            let column = parse_col_spec(spec);
+            for _ in 0..repeat {
+                columns.push(column.clone());
+            }
+        } else {
+            columns.push(parse_col_spec(part));
+        }
+    }
+
+    columns
+}
+
+/// Parse a single column specifier, extracting its proportional width.
+///
+/// Alignment and style operators are not yet interpreted; any non-digit
+/// characters are ignored and the column falls back to the default width.
+fn parse_col_spec(spec: &str) -> TableColumn {
+    let digits: String = spec.chars().filter(|c| c.is_ascii_digit()).collect();
+    match digits.parse::<usize>() {
+        Ok(width) if width > 0 => TableColumn { width },
+        _ => TableColumn::default(),
+    }
+}
+
+/// Scan a region for PSV cell boundaries, returning the raw (untrimmed) span of
+/// each cell's content.
+///
+/// A cell boundary is a vertical bar (`|`) that appears at the start of a line
+/// or is preceded by whitespace, and that is not escaped with a leading
+/// backslash. Content before the first boundary is ignored.
+fn scan_cells(region: Span<'_>) -> Vec<Span<'_>> {
+    let bytes = region.data().as_bytes();
+    let len = bytes.len();
+
+    let mut cells: Vec<Span<'_>> = vec![];
+    let mut content_start: Option<usize> = None;
+    let mut i = 0;
+
+    while i < len {
+        if bytes.get(i) == Some(&b'|') {
+            let prev = i.checked_sub(1).and_then(|p| bytes.get(p)).copied();
+            let at_line_start = prev.is_none() || prev == Some(b'\n');
+            let after_space = prev == Some(b' ') || prev == Some(b'\t');
+            let escaped = prev == Some(b'\\');
+
+            if (at_line_start || after_space) && !escaped {
+                if let Some(start) = content_start {
+                    cells.push(region.slice(start..i));
+                }
+                content_start = Some(i + 1);
+            }
+        }
+
+        i += 1;
+    }
+
+    if let Some(start) = content_start {
+        cells.push(region.slice(start..len));
+    }
+
+    cells
+}
+
+/// Return the subspan of `s` with surrounding whitespace (including newlines)
+/// removed.
+fn trim_surrounding_whitespace(s: Span<'_>) -> Span<'_> {
+    let data = s.data();
+    let start = data.len() - data.trim_start().len();
+    let len = data.trim().len();
+    s.slice(start..start + len)
+}

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -59,11 +59,13 @@ impl<'src> TableBlock<'src> {
     /// delimiters are not yet recognized.
     pub(crate) fn is_table_delimiter(line: &Span<'src>) -> bool {
         let data = line.data();
+        // `len() >= 4` plus the leading `|` guarantees `rest` holds at least three
+        // bytes, so the closure only needs to confirm they are all `=`.
         data.len() >= 4
             && data.starts_with('|')
             && data
                 .get(1..)
-                .is_some_and(|rest| rest.len() >= 3 && rest.bytes().all(|b| b == b'='))
+                .is_some_and(|rest| rest.bytes().all(|b| b == b'='))
     }
 
     pub(crate) fn parse(
@@ -372,10 +374,19 @@ fn parse_cols(value: &str) -> Vec<TableColumn> {
 
 /// Parse a single column specifier, extracting its proportional width.
 ///
-/// Alignment and style operators are not yet interpreted; any non-digit
-/// characters are ignored and the column falls back to the default width.
+/// In a full column specifier the width is the single numeric token, optionally
+/// preceded by alignment operators and followed by a style operator (neither of
+/// which is interpreted yet). The width is therefore the first contiguous run
+/// of digits; a spec with no digits falls back to the default width. Taking the
+/// first run — rather than concatenating every digit in the spec — keeps
+/// unrelated digit groups from fusing once those operators are supported.
 fn parse_col_spec(spec: &str) -> TableColumn {
-    let digits: String = spec.chars().filter(|c| c.is_ascii_digit()).collect();
+    let digits: String = spec
+        .chars()
+        .skip_while(|c| !c.is_ascii_digit())
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+
     match digits.parse::<usize>() {
         Ok(width) if width > 0 => TableColumn { width },
         _ => TableColumn::default(),
@@ -386,8 +397,12 @@ fn parse_col_spec(spec: &str) -> TableColumn {
 /// each cell's content.
 ///
 /// A cell boundary is a vertical bar (`|`) that appears at the start of a line
-/// or is preceded by whitespace, and that is not escaped with a leading
-/// backslash. Content before the first boundary is ignored.
+/// or is preceded by whitespace. Content before the first boundary is ignored.
+///
+/// An escaped separator (`\|`) is preceded by a backslash — neither a line
+/// start nor whitespace — so it already fails the boundary test and needs no
+/// special handling here; the backslash is stripped later in
+/// [`TableCell::parse`].
 fn scan_cells(region: Span<'_>) -> Vec<Span<'_>> {
     let bytes = region.data().as_bytes();
     let len = bytes.len();
@@ -401,9 +416,8 @@ fn scan_cells(region: Span<'_>) -> Vec<Span<'_>> {
             let prev = i.checked_sub(1).and_then(|p| bytes.get(p)).copied();
             let at_line_start = prev.is_none() || prev == Some(b'\n');
             let after_space = prev == Some(b' ') || prev == Some(b'\t');
-            let escaped = prev == Some(b'\\');
 
-            if (at_line_start || after_space) && !escaped {
+            if at_line_start || after_space {
                 if let Some(start) = content_start {
                     cells.push(region.slice(start..i));
                 }

--- a/parser/src/blocks/tests/mod.rs
+++ b/parser/src/blocks/tests/mod.rs
@@ -12,6 +12,7 @@ mod media;
 mod raw_delimited;
 mod section;
 mod simple;
+mod table;
 
 mod content_model {
     use crate::blocks::ContentModel;

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -1,0 +1,174 @@
+//! Tests for the basic PSV table block, covering the examples in
+//! `docs/modules/tables/pages/build-a-basic-table.adoc`.
+
+use crate::{
+    Parser, Span,
+    blocks::{Block, ContentModel, IsBlock, TableBlock},
+};
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+fn parse_table(source: &str) -> TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = Block::parse(Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Collect the rendered content of every cell in a row.
+fn row_text(row: &crate::blocks::TableRow<'_>) -> Vec<String> {
+    row.cells()
+        .iter()
+        .map(|cell| cell.content().rendered().to_string())
+        .collect()
+}
+
+#[test]
+fn two_columns_three_rows() {
+    // From <<ex-rows>>: two columns via `cols`, three body rows, no header.
+    let table = parse_table(
+        "[cols=\"1,1\"]\n|===\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|===",
+    );
+
+    assert_eq!(table.content_model(), ContentModel::Table);
+    assert_eq!(table.raw_context().as_ref(), "table");
+    assert_eq!(table.columns().len(), 2);
+    assert!(table.header_row().is_none());
+
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(
+        rows,
+        vec![
+            vec![
+                "Cell in column 1, row 1".to_string(),
+                "Cell in column 2, row 1".to_string()
+            ],
+            vec![
+                "Cell in column 1, row 2".to_string(),
+                "Cell in column 2, row 2".to_string()
+            ],
+            vec![
+                "Cell in column 1, row 3".to_string(),
+                "Cell in column 2, row 3".to_string()
+            ],
+        ]
+    );
+}
+
+#[test]
+fn multiple_cells_on_one_line() {
+    // From <<ex-rows>>: a row may place several cells on a single line, each
+    // separated by a space followed by a vertical bar.
+    let table = parse_table(
+        "[cols=\"1,1\"]\n|===\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n\n|Cell in column 1, row 2 |Cell in column 2, row 2\n|Cell in column 1, row 3 |Cell in column 2, row 3\n|===",
+    );
+
+    assert_eq!(table.body_rows().len(), 3);
+    assert_eq!(
+        row_text(&table.body_rows()[2]),
+        vec![
+            "Cell in column 1, row 3".to_string(),
+            "Cell in column 2, row 3".to_string()
+        ]
+    );
+}
+
+#[test]
+fn implicit_header_row() {
+    // From <<ex-header>>: the first line after the delimiter is non-empty and is
+    // followed by a blank line, so it becomes the header row.
+    let table = parse_table(
+        "[cols=\"1,1\"]\n|===\n|Cell in column 1, header row |Cell in column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|===",
+    );
+
+    let header = table.header_row().unwrap();
+    assert_eq!(
+        row_text(header),
+        vec![
+            "Cell in column 1, header row".to_string(),
+            "Cell in column 2, header row".to_string()
+        ]
+    );
+
+    assert_eq!(table.body_rows().len(), 2);
+}
+
+#[test]
+fn implicit_columns_from_first_row() {
+    // From add-columns.adoc <<ex-implicit>>: with no `cols` attribute and a blank
+    // line before the first row, the column count comes from the first row's cell
+    // count and there is no header.
+    let table = parse_table(
+        "|===\n\n|Cell in column 1, row 1 |Cell in column 2, row 1 |Cell in column 3, row 1\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n|===",
+    );
+
+    assert_eq!(table.columns().len(), 3);
+    assert!(table.header_row().is_none());
+    assert_eq!(table.body_rows().len(), 2);
+    assert_eq!(
+        row_text(&table.body_rows()[0]),
+        vec![
+            "Cell in column 1, row 1".to_string(),
+            "Cell in column 2, row 1".to_string(),
+            "Cell in column 3, row 1".to_string()
+        ]
+    );
+}
+
+#[test]
+fn column_multiplier() {
+    // From add-columns.adoc: `cols="5,3*"` yields one column then three more.
+    let table = parse_table("[cols=\"5,3*\"]\n|===\n|a |b |c |d\n|===");
+
+    let widths: Vec<usize> = table.columns().iter().map(|c| c.width()).collect();
+    assert_eq!(widths, vec![5, 1, 1, 1]);
+}
+
+#[test]
+fn cell_content_is_substituted() {
+    // Cell content flows through the normal substitution pipeline.
+    let table = parse_table("|===\n|*bold* and _italic_\n|===");
+
+    assert_eq!(
+        row_text(&table.body_rows()[0]),
+        vec!["<strong>bold</strong> and <em>italic</em>".to_string()]
+    );
+}
+
+#[test]
+fn leading_and_trailing_whitespace_stripped() {
+    // From <<ex-more-cells>>: leading and trailing spaces around cell content are
+    // stripped.
+    let table = parse_table("[cols=\"1,1\"]\n|===\n|a |    b spaced\n|===");
+
+    assert_eq!(
+        row_text(&table.body_rows()[0]),
+        vec!["a".to_string(), "b spaced".to_string()]
+    );
+}
+
+#[test]
+fn block_is_recognized_via_debug() {
+    let mut parser = Parser::default();
+    let mi = Block::parse(Span::new("|===\n|a |b\n|==="), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    let debug_output = format!("{:?}", mi.item);
+    assert!(debug_output.starts_with("Block::Table"));
+}
+
+#[test]
+fn unterminated_table_warns() {
+    let mut parser = Parser::default();
+    let maw = Block::parse(Span::new("|===\n|a |b"), &mut parser);
+
+    assert!(maw.warnings.iter().any(|w| matches!(
+        w.warning,
+        crate::warnings::WarningType::UnterminatedDelimitedBlock
+    )));
+}

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -2,8 +2,9 @@
 //! `docs/modules/tables/pages/build-a-basic-table.adoc`.
 
 use crate::{
-    Parser, Span,
+    HasSpan, Parser, Span,
     blocks::{Block, ContentModel, IsBlock, TableBlock},
+    content::SubstitutionGroup,
 };
 
 /// Parse `source` as a single block and return the [`TableBlock`] it produced.
@@ -171,4 +172,73 @@ fn unterminated_table_warns() {
         w.warning,
         crate::warnings::WarningType::UnterminatedDelimitedBlock
     )));
+}
+
+#[test]
+fn block_level_accessors() {
+    // Exercise every `IsBlock`/`HasSpan` accessor through the `Block` enum
+    // (rather than the unwrapped `TableBlock`) so the delegating match arms in
+    // `block.rs` are covered.
+    let mut parser = Parser::default();
+    let block = Block::parse(Span::new("|===\n|a |b\n|==="), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap()
+        .item;
+
+    assert_eq!(block.content_model(), ContentModel::Table);
+    assert_eq!(block.raw_context().as_ref(), "table");
+    assert_eq!(block.resolved_context().as_ref(), "table");
+    assert!(block.rendered_content().is_none());
+    assert_eq!(block.nested_blocks().count(), 0);
+    assert!(block.declared_style().is_none());
+    assert!(block.id().is_none());
+    assert!(block.roles().is_empty());
+    assert!(block.options().is_empty());
+    assert!(block.title_source().is_none());
+    assert!(block.title().is_none());
+    assert!(block.anchor().is_none());
+    assert!(block.anchor_reftext().is_none());
+    assert!(block.attrlist().is_none());
+    assert_eq!(block.substitution_group(), SubstitutionGroup::Normal);
+    assert_eq!(block.span().data(), "|===\n|a |b\n|===");
+}
+
+#[test]
+fn escaped_cell_separator() {
+    // A backslash-escaped separator (`\|`) is not a cell boundary; the backslash
+    // is stripped from the rendered cell content.
+    let table = parse_table("|===\n|a \\| b\n|===");
+
+    assert_eq!(table.body_rows().len(), 1);
+    assert_eq!(row_text(&table.body_rows()[0]), vec!["a | b".to_string()]);
+}
+
+#[test]
+fn cols_with_empty_specifier() {
+    // Empty entries in the `cols` list (e.g. from a doubled comma) are skipped.
+    let table = parse_table("[cols=\"1,,1\"]\n|===\n|a |b\n|===");
+
+    assert_eq!(table.columns().len(), 2);
+}
+
+#[test]
+fn no_cols_and_first_line_without_a_cell() {
+    // With no `cols` attribute and a first line that contains no cell separator,
+    // the column count is zero and the body loop is skipped entirely.
+    let table = parse_table("|===\nnot a cell\n|===");
+
+    assert!(table.columns().is_empty());
+    assert!(table.header_row().is_none());
+    assert!(table.body_rows().is_empty());
+}
+
+#[test]
+fn header_option_without_cells() {
+    // The `header` option forces header handling even when the table has no
+    // cells, exercising the empty-header-row branch.
+    let table = parse_table("[%header,cols=\"1,1\"]\n|===\nnot a cell\n|===");
+
+    assert_eq!(table.columns().len(), 2);
+    assert!(table.header_row().is_none());
+    assert!(table.body_rows().is_empty());
 }

--- a/parser/src/tests/asciidoc_lang/attributes/options.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/options.rs
@@ -246,8 +246,6 @@ For instance, consider a table with the three built-in option values, `header`, 
         .unwrap_if_no_warnings()
         .unwrap();
 
-        // This source now parses as a table block; the options under test live on
-        // the table's attribute list.
         assert!(matches!(mi.item, crate::blocks::Block::Table(_)));
 
         assert_eq!(
@@ -509,8 +507,6 @@ Instead of using the shorthand notation, <<ex-table-formal>> shows how the value
         .unwrap_if_no_warnings()
         .unwrap();
 
-        // This source now parses as a table block; the options under test live on
-        // the table's attribute list.
         assert!(matches!(mi.item, crate::blocks::Block::Table(_)));
 
         assert_eq!(

--- a/parser/src/tests/asciidoc_lang/attributes/options.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/options.rs
@@ -246,53 +246,33 @@ For instance, consider a table with the three built-in option values, `header`, 
         .unwrap_if_no_warnings()
         .unwrap();
 
-        // IMPORTANT: This test will have to be revised once we parse tables.
+        // This source now parses as a table block; the options under test live on
+        // the table's attribute list.
+        assert!(matches!(mi.item, crate::blocks::Block::Table(_)));
 
         assert_eq!(
-            mi.item,
-            Block::Simple(SimpleBlock {
-                content: Content {
-                    original: Span {
-                        data: "|===\n|Cell A1 |Cell B1",
-                        line: 2,
-                        col: 1,
-                        offset: 36,
+            mi.item.attrlist().unwrap(),
+            Attrlist {
+                attributes: &[
+                    ElementAttribute {
+                        name: None,
+                        shorthand_items: &["%header", "%footer", "%autowidth",],
+                        value: "%header%footer%autowidth"
                     },
-                    rendered: "|===\n|Cell A1 |Cell B1",
-                },
-                source: Span {
-                    data: "[%header%footer%autowidth,cols=2*~]\n|===\n|Cell A1 |Cell B1",
-                    line: 1,
-                    col: 1,
-                    offset: 0,
-                },
-                style: SimpleBlockStyle::Paragraph,
-                title_source: None,
-                title: None,
+                    ElementAttribute {
+                        name: Some("cols"),
+                        shorthand_items: &[],
+                        value: "2*~"
+                    },
+                ],
                 anchor: None,
-                anchor_reftext: None,
-                attrlist: Some(Attrlist {
-                    attributes: &[
-                        ElementAttribute {
-                            name: None,
-                            shorthand_items: &["%header", "%footer", "%autowidth",],
-                            value: "%header%footer%autowidth"
-                        },
-                        ElementAttribute {
-                            name: Some("cols"),
-                            shorthand_items: &[],
-                            value: "2*~"
-                        },
-                    ],
-                    anchor: None,
-                    source: Span {
-                        data: "%header%footer%autowidth,cols=2*~",
-                        line: 1,
-                        col: 2,
-                        offset: 1,
-                    },
-                },),
-            },)
+                source: Span {
+                    data: "%header%footer%autowidth,cols=2*~",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+            },
         );
 
         let options = mi.item.options();
@@ -529,53 +509,33 @@ Instead of using the shorthand notation, <<ex-table-formal>> shows how the value
         .unwrap_if_no_warnings()
         .unwrap();
 
-        // IMPORTANT: This test will have to be revised once we support tables.
+        // This source now parses as a table block; the options under test live on
+        // the table's attribute list.
+        assert!(matches!(mi.item, crate::blocks::Block::Table(_)));
 
         assert_eq!(
-            mi.item,
-            Block::Simple(SimpleBlock {
-                content: Content {
-                    original: Span {
-                        data: "|===\n|Cell A1 |Cell B1",
-                        line: 2,
-                        col: 1,
-                        offset: 42,
+            mi.item.attrlist().unwrap(),
+            Attrlist {
+                attributes: &[
+                    ElementAttribute {
+                        name: Some("cols"),
+                        shorthand_items: &[],
+                        value: "2*~"
                     },
-                    rendered: "|===\n|Cell A1 |Cell B1",
-                },
-                source: Span {
-                    data: "[cols=2*~,opts=\"header,footer,autowidth\"]\n|===\n|Cell A1 |Cell B1",
-                    line: 1,
-                    col: 1,
-                    offset: 0,
-                },
-                style: SimpleBlockStyle::Paragraph,
-                title_source: None,
-                title: None,
+                    ElementAttribute {
+                        name: Some("opts"),
+                        shorthand_items: &[],
+                        value: "header,footer,autowidth"
+                    },
+                ],
                 anchor: None,
-                anchor_reftext: None,
-                attrlist: Some(Attrlist {
-                    attributes: &[
-                        ElementAttribute {
-                            name: Some("cols"),
-                            shorthand_items: &[],
-                            value: "2*~"
-                        },
-                        ElementAttribute {
-                            name: Some("opts"),
-                            shorthand_items: &[],
-                            value: "header,footer,autowidth"
-                        },
-                    ],
-                    anchor: None,
-                    source: Span {
-                        data: "cols=2*~,opts=\"header,footer,autowidth\"",
-                        line: 1,
-                        col: 2,
-                        offset: 1,
-                    },
-                },),
-            },)
+                source: Span {
+                    data: "cols=2*~,opts=\"header,footer,autowidth\"",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+            },
         );
 
         let options = mi.item.options();

--- a/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
@@ -489,45 +489,29 @@ Specifically, this syntax sets the `header`, `footer`, and `autowidth` options.
         .unwrap()
         .item;
 
+        // This source now parses as a table block; the shorthand options under
+        // test live on the table's attribute list.
+        assert!(matches!(block, crate::blocks::Block::Table(_)));
+
         assert_eq!(
-            block,
-            Block::Simple(SimpleBlock {
-                content: Content {
-                    original: Span {
-                        data: "|===\n|Header A |Header B\n|Footer A |Footer B\n|===",
-                        line: 2,
-                        col: 1,
-                        offset: 27,
-                    },
-                    rendered: "|===\n|Header A |Header B\n|Footer A |Footer B\n|===",
-                },
-                source: Span {
-                    data: "[%header%footer%autowidth]\n|===\n|Header A |Header B\n|Footer A |Footer B\n|===",
-                    line: 1,
-                    col: 1,
-                    offset: 0,
-                },
-                style: SimpleBlockStyle::Paragraph,
-                title_source: None,
-                title: None,
+            block.attrlist().unwrap(),
+            Attrlist {
+                attributes: &[ElementAttribute {
+                    name: None,
+                    shorthand_items: &["%header", "%footer", "%autowidth",],
+                    value: "%header%footer%autowidth"
+                },],
                 anchor: None,
-                anchor_reftext: None,
-                attrlist: Some(Attrlist {
-                    attributes: &[ElementAttribute {
-                        name: None,
-                        shorthand_items: &["%header", "%footer", "%autowidth",],
-                        value: "%header%footer%autowidth"
-                    },],
-                    anchor: None,
-                    source: Span {
-                        data: "%header%footer%autowidth",
-                        line: 1,
-                        col: 2,
-                        offset: 1,
-                    },
-                },),
-            },)
+                source: Span {
+                    data: "%header%footer%autowidth",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+            },
         );
+
+        assert_eq!(block.options(), vec!["header", "footer", "autowidth"]);
 
         verifies!(
             r#"

--- a/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
@@ -489,8 +489,6 @@ Specifically, this syntax sets the `header`, `footer`, and `autowidth` options.
         .unwrap()
         .item;
 
-        // This source now parses as a table block; the shorthand options under
-        // test live on the table's attribute list.
         assert!(matches!(block, crate::blocks::Block::Table(_)));
 
         assert_eq!(
@@ -844,10 +842,10 @@ If enclosing quotes are used, they are dropped from the parsed value and the pre
             r#"
  [#unset]
  === Unset a named attribute
- 
+
  To undefine a named attribute, set the value to `None` (case sensitive).
  // end::name[]
- 
+
 "#
         );
 

--- a/parser/src/tests/asciidoc_lang/mod.rs
+++ b/parser/src/tests/asciidoc_lang/mod.rs
@@ -33,5 +33,6 @@ mod pass;
 mod root;
 mod sections;
 mod subs;
+mod tables;
 mod text;
 mod verbatim;

--- a/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
+++ b/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
@@ -25,6 +25,11 @@ fn create_a_table_with_two_columns_and_three_rows() {
     non_normative!(
         r#"
 == Create a table with two columns and three rows
+"#
+    );
+
+    verifies!(
+        r#"
 
 In <<ex-cols>>, we'll assign the `cols` attribute a list of column specifiers.
 A column specifier represents a column.
@@ -83,11 +88,6 @@ You can enter xref:add-cells-and-rows.adoc[more than one cell or all of the cell
 The table from <<ex-rows>> is displayed below.
 It contains two columns and three rows of text positioned and styled using the default alignment, style, border, and width attribute values.
 
-"#
-    );
-
-    verifies!(
-        r#"
 [cols="1,1"]
 |===
 |Cell in column 1, row 1
@@ -96,6 +96,10 @@ It contains two columns and three rows of text positioned and styled using the d
 |Cell in column 1, row 2 |Cell in column 2, row 2
 |Cell in column 1, row 3 |Cell in column 2, row 3
 |===
+
+In addition to the xref:add-columns.adoc[cols attribute], you can identify the number of columns using a xref:add-columns.adoc#column-multiplier[column multiplier] or xref:add-columns.adoc#implicit-cols[the table's first row].
+However, the `cols` attribute is required to customize the xref:adjust-column-widths.adoc[width], xref:align-by-column.adoc[alignment], or xref:format-column-content.adoc[style] of a column.
+
 "#
     );
 
@@ -240,15 +244,6 @@ It contains two columns and three rows of text positioned and styled using the d
             catalog: Catalog::default(),
         }
     );
-
-    non_normative!(
-        r#"
-
-In addition to the xref:add-columns.adoc[cols attribute], you can identify the number of columns using a xref:add-columns.adoc#column-multiplier[column multiplier] or xref:add-columns.adoc#implicit-cols[the table's first row].
-However, the `cols` attribute is required to customize the xref:adjust-column-widths.adoc[width], xref:align-by-column.adoc[alignment], or xref:format-column-content.adoc[style] of a column.
-
-"#
-    );
 }
 
 #[test]
@@ -256,6 +251,11 @@ fn add_a_header_row_to_the_table() {
     non_normative!(
         r#"
 === Add a header row to the table
+"#
+    );
+
+    verifies!(
+        r#"
 
 Let's add a header row to the table in <<ex-header>>.
 You can implicitly identify the first row of a table as a header row by entering all of the first row's cells on the line directly after the opening table delimiter.
@@ -282,11 +282,6 @@ You can implicitly identify the first row of a table as a header row by entering
 
 The table from <<ex-header>> is displayed below.
 
-"#
-    );
-
-    verifies!(
-        r#"
 [cols="1,1"]
 |===
 |Cell in column 1, header row |Cell in column 2, header row
@@ -300,6 +295,8 @@ The table from <<ex-header>> is displayed below.
 |Cell in column 1, row 4
 |Cell in column 2, row 4
 |===
+
+A header row can also be identified by assigning xref:add-header-row.adoc[header to the options attribute].
 "#
     );
 
@@ -468,12 +465,5 @@ The table from <<ex-header>> is displayed below.
             source_map: SourceMap(&[]),
             catalog: Catalog::default(),
         }
-    );
-
-    non_normative!(
-        r#"
-
-A header row can also be identified by assigning xref:add-header-row.adoc[header to the options attribute].
-"#
     );
 }

--- a/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
+++ b/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
@@ -1,0 +1,479 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/build-a-basic-table.adoc");
+
+non_normative!(
+    r#"
+= Build a Basic Table
+:page-aliases: index.adoc
+
+A table is a delimited block that can have optional customizations, such as an ID and a title, as well as table-specific attributes, options, and roles.
+However, at its most basic, a table only needs columns and rows.
+
+On this page, you'll learn:
+
+* [x] How to set up an AsciiDoc table block and its attribute list.
+* [x] How to add columns to a table using the `cols` attribute.
+* [x] How to add cells to a table and arrange them into rows.
+* [x] How to designate a row as the table's header row.
+
+"#
+);
+
+#[test]
+fn create_a_table_with_two_columns_and_three_rows() {
+    non_normative!(
+        r#"
+== Create a table with two columns and three rows
+
+In <<ex-cols>>, we'll assign the `cols` attribute a list of column specifiers.
+A column specifier represents a column.
+
+.Set up a table with two columns
+[source#ex-cols]
+----
+[cols="1,1"] <.> <.>
+|=== <.>
+----
+<.> On a new line, create an attribute list.
+Set the `cols` attribute, followed by an equals sign (`=`).
+<.> Assign a list of comma-separated column specifiers enclosed in double quotation marks (`"`) to `cols`.
+Each column specifier represents a column.
+<.> On the line directly after the attribute list, enter the opening table delimiter.
+A table delimiter is one vertical bar followed by three equals signs (`|===`).
+This delimiter starts the table block.
+
+The table in <<ex-cols>> will contain two columns because there are two comma-separated entries in the list assigned to `cols`.
+Each entry in the list is called a column specifier.
+A [.term]*column specifier* represents a column and the width, alignment, and style properties assigned to that column.
+When each column specifier is the same number, in this case the integer `1`, all of the columns`' widths will be identical.
+Each column in <<ex-cols>> will be the same width regardless of how much content they contain.
+
+Next, let's add three rows to the table.
+Each row has the same number of cells.
+Since the table in <<ex-rows>> has two columns, each row will contain two cells.
+A cell starts with a vertical bar (`|`).
+
+.Add three rows to the table
+[source#ex-rows]
+----
+[cols="1,1"]
+|===
+|Cell in column 1, row 1 <.>
+|Cell in column 2, row 1 <.>
+<.>
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+
+|Cell in column 1, row 3
+|Cell in column 2, row 3 <.>
+|=== <.>
+----
+<.> To create a new cell, press kbd:[Shift+|].
+After the vertical bar (`|`), enter the content you want displayed in that cell.
+<.> On a new line, start another cell with a `|`.
+Each consecutive cell is placed in a separate, consecutive column in a row.
+<.> Rows are separated by one or more empty lines.
+<.> When you finish adding cells to your table, press kbd:[Enter] to go to a new line.
+<.> Enter the closing delimiter (`|===`) to end the table block.
+
+TIP: The suggestion to start each cell on its own line and to separate rows by empty lines is merely a stylistic choice.
+You can enter xref:add-cells-and-rows.adoc[more than one cell or all of the cells in a row on the same line] since the processor creates a new cell each time it encounters a vertical bar (`|`).
+
+The table from <<ex-rows>> is displayed below.
+It contains two columns and three rows of text positioned and styled using the default alignment, style, border, and width attribute values.
+
+"#
+    );
+
+    verifies!(
+        r#"
+[cols="1,1"]
+|===
+|Cell in column 1, row 1
+|Cell in column 2, row 1
+
+|Cell in column 1, row 2 |Cell in column 2, row 2
+|Cell in column 1, row 3 |Cell in column 2, row 3
+|===
+"#
+    );
+
+    let doc = Parser::default().parse(
+        "[cols=\"1,1\"]\n|===\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n\n|Cell in column 1, row 2 |Cell in column 2, row 2\n|Cell in column 1, row 3 |Cell in column 2, row 3\n|===",
+    );
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[TableColumn { width: 1 }, TableColumn { width: 1 }],
+                header_row: None,
+                body_rows: &[
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 1",
+                                        line: 3,
+                                        col: 2,
+                                        offset: 19,
+                                    },
+                                    rendered: "Cell in column 1, row 1",
+                                },
+                            },
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 1",
+                                        line: 4,
+                                        col: 2,
+                                        offset: 44,
+                                    },
+                                    rendered: "Cell in column 2, row 1",
+                                },
+                            },
+                        ],
+                    },
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 2",
+                                        line: 6,
+                                        col: 2,
+                                        offset: 70,
+                                    },
+                                    rendered: "Cell in column 1, row 2",
+                                },
+                            },
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 2",
+                                        line: 6,
+                                        col: 27,
+                                        offset: 95,
+                                    },
+                                    rendered: "Cell in column 2, row 2",
+                                },
+                            },
+                        ],
+                    },
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 3",
+                                        line: 7,
+                                        col: 2,
+                                        offset: 120,
+                                    },
+                                    rendered: "Cell in column 1, row 3",
+                                },
+                            },
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 3",
+                                        line: 7,
+                                        col: 27,
+                                        offset: 145,
+                                    },
+                                    rendered: "Cell in column 2, row 3",
+                                },
+                            },
+                        ],
+                    },
+                ],
+                footer_row: None,
+                source: Span {
+                    data: "[cols=\"1,1\"]\n|===\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n\n|Cell in column 1, row 2 |Cell in column 2, row 2\n|Cell in column 1, row 3 |Cell in column 2, row 3\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: Some("cols"),
+                        shorthand_items: &[],
+                        value: "1,1",
+                    }],
+                    anchor: None,
+                    source: Span {
+                        data: "cols=\"1,1\"",
+                        line: 1,
+                        col: 2,
+                        offset: 1,
+                    },
+                }),
+            })],
+            source: Span {
+                data: "[cols=\"1,1\"]\n|===\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n\n|Cell in column 1, row 2 |Cell in column 2, row 2\n|Cell in column 1, row 3 |Cell in column 2, row 3\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+
+    non_normative!(
+        r#"
+
+In addition to the xref:add-columns.adoc[cols attribute], you can identify the number of columns using a xref:add-columns.adoc#column-multiplier[column multiplier] or xref:add-columns.adoc#implicit-cols[the table's first row].
+However, the `cols` attribute is required to customize the xref:adjust-column-widths.adoc[width], xref:align-by-column.adoc[alignment], or xref:format-column-content.adoc[style] of a column.
+
+"#
+    );
+}
+
+#[test]
+fn add_a_header_row_to_the_table() {
+    non_normative!(
+        r#"
+=== Add a header row to the table
+
+Let's add a header row to the table in <<ex-header>>.
+You can implicitly identify the first row of a table as a header row by entering all of the first row's cells on the line directly after the opening table delimiter.
+
+.Add a header row to the table
+[source#ex-header]
+----
+[cols="1,1"]
+|===
+|Cell in column 1, header row |Cell in column 2, header row <.>
+<.>
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+
+|Cell in column 1, row 3
+|Cell in column 2, row 3
+
+|Cell in column 1, row 4
+|Cell in column 2, row 4
+|===
+----
+<.> On the line directly after the opening delimiter (`|===`), enter all of the first row's cells on a single line.
+<.> Leave the line directly after the header row empty.
+
+The table from <<ex-header>> is displayed below.
+
+"#
+    );
+
+    verifies!(
+        r#"
+[cols="1,1"]
+|===
+|Cell in column 1, header row |Cell in column 2, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+
+|Cell in column 1, row 3
+|Cell in column 2, row 3
+
+|Cell in column 1, row 4
+|Cell in column 2, row 4
+|===
+"#
+    );
+
+    let doc = Parser::default().parse(
+        "[cols=\"1,1\"]\n|===\n|Cell in column 1, header row |Cell in column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n\n|Cell in column 1, row 4\n|Cell in column 2, row 4\n|===",
+    );
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[TableColumn { width: 1 }, TableColumn { width: 1 }],
+                header_row: Some(TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Cell in column 1, header row",
+                                    line: 3,
+                                    col: 2,
+                                    offset: 19,
+                                },
+                                rendered: "Cell in column 1, header row",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Cell in column 2, header row",
+                                    line: 3,
+                                    col: 32,
+                                    offset: 49,
+                                },
+                                rendered: "Cell in column 2, header row",
+                            },
+                        },
+                    ],
+                }),
+                body_rows: &[
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 2",
+                                        line: 5,
+                                        col: 2,
+                                        offset: 80,
+                                    },
+                                    rendered: "Cell in column 1, row 2",
+                                },
+                            },
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 2",
+                                        line: 6,
+                                        col: 2,
+                                        offset: 105,
+                                    },
+                                    rendered: "Cell in column 2, row 2",
+                                },
+                            },
+                        ],
+                    },
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 3",
+                                        line: 8,
+                                        col: 2,
+                                        offset: 131,
+                                    },
+                                    rendered: "Cell in column 1, row 3",
+                                },
+                            },
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 3",
+                                        line: 9,
+                                        col: 2,
+                                        offset: 156,
+                                    },
+                                    rendered: "Cell in column 2, row 3",
+                                },
+                            },
+                        ],
+                    },
+                    TableRow {
+                        cells: &[
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 1, row 4",
+                                        line: 11,
+                                        col: 2,
+                                        offset: 182,
+                                    },
+                                    rendered: "Cell in column 1, row 4",
+                                },
+                            },
+                            TableCell {
+                                content: Content {
+                                    original: Span {
+                                        data: "Cell in column 2, row 4",
+                                        line: 12,
+                                        col: 2,
+                                        offset: 207,
+                                    },
+                                    rendered: "Cell in column 2, row 4",
+                                },
+                            },
+                        ],
+                    },
+                ],
+                footer_row: None,
+                source: Span {
+                    data: "[cols=\"1,1\"]\n|===\n|Cell in column 1, header row |Cell in column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n\n|Cell in column 1, row 4\n|Cell in column 2, row 4\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: Some("cols"),
+                        shorthand_items: &[],
+                        value: "1,1",
+                    }],
+                    anchor: None,
+                    source: Span {
+                        data: "cols=\"1,1\"",
+                        line: 1,
+                        col: 2,
+                        offset: 1,
+                    },
+                }),
+            })],
+            source: Span {
+                data: "[cols=\"1,1\"]\n|===\n|Cell in column 1, header row |Cell in column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n\n|Cell in column 1, row 4\n|Cell in column 2, row 4\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+
+    non_normative!(
+        r#"
+
+A header row can also be identified by assigning xref:add-header-row.adoc[header to the options attribute].
+"#
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -1,0 +1,1 @@
+mod build_a_basic_table;

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -13,7 +13,7 @@ use crate::{
     blocks::{
         Block, Break, CompoundDelimitedBlock, IsBlock, ListBlock, ListItem, ListItemMarker,
         ListType, MediaBlock, Preamble, RawDelimitedBlock, SectionBlock, SimpleBlock,
-        SimpleBlockStyle,
+        SimpleBlockStyle, TableBlock, TableRow,
     },
 };
 
@@ -396,6 +396,7 @@ impl ToVirtualDom for Block<'_> {
             Block::Media(media) => media_to_node(media),
             Block::RawDelimited(raw) => raw_delimited_to_node(raw),
             Block::CompoundDelimited(compound) => compound_delimited_to_node(compound),
+            Block::Table(table) => table_to_node(table),
             Block::Preamble(preamble) => preamble_to_node(preamble),
             Block::Break(break_) => break_to_node(break_),
             Block::DocumentAttribute(_) => {
@@ -818,6 +819,71 @@ fn compound_delimited_to_node<'a>(compound: &'a CompoundDelimitedBlock<'a>) -> V
     }
 
     node
+}
+
+fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
+    let mut node =
+        VirtualNode::new("table").with_classes(["tableblock", "frame-all", "grid-all", "stretch"]);
+
+    if let Some(id) = table.id() {
+        node = node.with_id(id);
+    }
+
+    for role in table.roles() {
+        node = node.with_class(role);
+    }
+
+    if let Some(title) = table.title() {
+        node.children
+            .push(VirtualNode::new("caption").with_text(title.to_string()));
+    }
+
+    let mut colgroup = VirtualNode::new("colgroup");
+    for _ in table.columns() {
+        colgroup.children.push(VirtualNode::new("col"));
+    }
+    node.children.push(colgroup);
+
+    if let Some(header) = table.header_row() {
+        let mut thead = VirtualNode::new("thead");
+        thead.children.push(table_row_to_node(header, "th", false));
+        node.children.push(thead);
+    }
+
+    if !table.body_rows().is_empty() {
+        let mut tbody = VirtualNode::new("tbody");
+        for row in table.body_rows() {
+            tbody.children.push(table_row_to_node(row, "td", true));
+        }
+        node.children.push(tbody);
+    }
+
+    node
+}
+
+fn table_row_to_node(row: &TableRow<'_>, cell_tag: &str, wrap_in_paragraph: bool) -> VirtualNode {
+    let mut tr = VirtualNode::new("tr");
+
+    for cell in row.cells() {
+        let mut cell_node =
+            VirtualNode::new(cell_tag).with_classes(["tableblock", "halign-left", "valign-top"]);
+
+        let rendered = cell.content().rendered().to_string();
+
+        if wrap_in_paragraph {
+            cell_node.children.push(
+                VirtualNode::new("p")
+                    .with_class("tableblock")
+                    .with_text(rendered),
+            );
+        } else {
+            cell_node = cell_node.with_text(rendered);
+        }
+
+        tr.children.push(cell_node);
+    }
+
+    tr
 }
 
 fn preamble_to_node<'a>(preamble: &'a Preamble<'a>) -> VirtualNode {

--- a/parser/src/tests/fixtures/blocks/block.rs
+++ b/parser/src/tests/fixtures/blocks/block.rs
@@ -1,7 +1,7 @@
 use crate::tests::fixtures::{
     blocks::{
         Break, CompoundDelimitedBlock, ListBlock, ListItem, MediaBlock, Preamble,
-        RawDelimitedBlock, SectionBlock, SimpleBlock,
+        RawDelimitedBlock, SectionBlock, SimpleBlock, TableBlock,
     },
     document::Attribute,
 };
@@ -15,6 +15,7 @@ pub(crate) enum Block {
     ListItem(ListItem),
     RawDelimited(RawDelimitedBlock),
     CompoundDelimited(CompoundDelimitedBlock),
+    Table(TableBlock),
     Preamble(Preamble),
     Break(Break),
     DocumentAttribute(Attribute),
@@ -68,6 +69,11 @@ fn fixture_eq_observed(fixture: &Block, observed: &crate::blocks::Block) -> bool
 
         Block::CompoundDelimited(cdb_fixture) => match observed {
             crate::blocks::Block::CompoundDelimited(cdb_observed) => cdb_fixture == cdb_observed,
+            _ => false,
+        },
+
+        Block::Table(table_fixture) => match observed {
+            crate::blocks::Block::Table(table_observed) => table_fixture == table_observed,
             _ => false,
         },
 

--- a/parser/src/tests/fixtures/blocks/mod.rs
+++ b/parser/src/tests/fixtures/blocks/mod.rs
@@ -33,3 +33,6 @@ pub(crate) use section_number::SectionNumber;
 
 mod simple;
 pub(crate) use simple::SimpleBlock;
+
+mod table;
+pub(crate) use table::{TableBlock, TableCell, TableColumn, TableRow};

--- a/parser/src/tests/fixtures/blocks/table.rs
+++ b/parser/src/tests/fixtures/blocks/table.rs
@@ -1,0 +1,176 @@
+use std::fmt;
+
+use crate::{
+    HasSpan,
+    blocks::IsBlock,
+    tests::fixtures::{Span, attributes::Attrlist, content::Content},
+};
+
+#[derive(Eq, PartialEq)]
+pub(crate) struct TableBlock {
+    pub columns: &'static [TableColumn],
+    pub header_row: Option<TableRow>,
+    pub body_rows: &'static [TableRow],
+    pub footer_row: Option<TableRow>,
+    pub source: Span,
+    pub title_source: Option<Span>,
+    pub title: Option<&'static str>,
+    pub anchor: Option<Span>,
+    pub anchor_reftext: Option<Span>,
+    pub attrlist: Option<Attrlist>,
+}
+
+impl fmt::Debug for TableBlock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TableBlock")
+            .field("columns", &self.columns)
+            .field("header_row", &self.header_row)
+            .field("body_rows", &self.body_rows)
+            .field("footer_row", &self.footer_row)
+            .field("source", &self.source)
+            .field("title_source", &self.title_source)
+            .field("title", &self.title)
+            .field("anchor", &self.anchor)
+            .field("anchor_reftext", &self.anchor_reftext)
+            .field("attrlist", &self.attrlist)
+            .finish()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct TableColumn {
+    pub width: usize,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct TableRow {
+    pub cells: &'static [TableCell],
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct TableCell {
+    pub content: Content,
+}
+
+impl<'src> PartialEq<crate::blocks::TableBlock<'src>> for TableBlock {
+    fn eq(&self, other: &crate::blocks::TableBlock<'src>) -> bool {
+        fixture_eq_observed(self, other)
+    }
+}
+
+impl PartialEq<TableBlock> for crate::blocks::TableBlock<'_> {
+    fn eq(&self, other: &TableBlock) -> bool {
+        fixture_eq_observed(other, self)
+    }
+}
+
+fn columns_eq(fixture: &[TableColumn], observed: &[crate::blocks::TableColumn]) -> bool {
+    fixture.len() == observed.len()
+        && fixture
+            .iter()
+            .zip(observed.iter())
+            .all(|(f, o)| f.width == o.width())
+}
+
+fn cells_eq(fixture: &[TableCell], observed: &[crate::blocks::TableCell]) -> bool {
+    fixture.len() == observed.len()
+        && fixture
+            .iter()
+            .zip(observed.iter())
+            .all(|(f, o)| f.content == *o.content())
+}
+
+fn row_eq(fixture: &TableRow, observed: &crate::blocks::TableRow) -> bool {
+    cells_eq(fixture.cells, observed.cells())
+}
+
+fn rows_eq(fixture: &[TableRow], observed: &[crate::blocks::TableRow]) -> bool {
+    fixture.len() == observed.len()
+        && fixture
+            .iter()
+            .zip(observed.iter())
+            .all(|(f, o)| row_eq(f, o))
+}
+
+fn opt_row_eq(fixture: &Option<TableRow>, observed: Option<&crate::blocks::TableRow>) -> bool {
+    match (fixture, observed) {
+        (None, None) => true,
+        (Some(f), Some(o)) => row_eq(f, o),
+        _ => false,
+    }
+}
+
+fn fixture_eq_observed(fixture: &TableBlock, observed: &crate::blocks::TableBlock) -> bool {
+    if !columns_eq(fixture.columns, observed.columns()) {
+        return false;
+    }
+
+    if !opt_row_eq(&fixture.header_row, observed.header_row()) {
+        return false;
+    }
+
+    if !rows_eq(fixture.body_rows, observed.body_rows()) {
+        return false;
+    }
+
+    if !opt_row_eq(&fixture.footer_row, observed.footer_row()) {
+        return false;
+    }
+
+    if fixture.title_source.is_some() != observed.title_source().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_title_source) = fixture.title_source
+        && let Some(ref observed_title_source) = observed.title_source()
+        && fixture_title_source != observed_title_source
+    {
+        return false;
+    }
+
+    if fixture.title.is_some() != observed.title().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_title) = fixture.title
+        && let Some(ref observed_title) = observed.title()
+        && fixture_title != observed_title
+    {
+        return false;
+    }
+
+    if fixture.anchor.is_some() != observed.anchor().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_anchor) = fixture.anchor
+        && let Some(ref observed_anchor) = observed.anchor()
+        && fixture_anchor != observed_anchor
+    {
+        return false;
+    }
+
+    if fixture.anchor_reftext.is_some() != observed.anchor_reftext().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_anchor_reftext) = fixture.anchor_reftext
+        && let Some(ref observed_anchor_reftext) = observed.anchor_reftext()
+        && fixture_anchor_reftext != observed_anchor_reftext
+    {
+        return false;
+    }
+
+    if fixture.attrlist.is_some() != observed.attrlist().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_attrlist) = fixture.attrlist
+        && let Some(ref observed_attrlist) = observed.attrlist()
+        && &fixture_attrlist != observed_attrlist
+    {
+        return false;
+    }
+
+    fixture.source == observed.span()
+}


### PR DESCRIPTION
First feature PR into the **`tables`** integration branch (umbrella: #508).

Implements the basic AsciiDoc table delimited block (`|===`), covering everything exercised by `docs/modules/tables/pages/build-a-basic-table.adoc`.

## What's here

- New `TableBlock` / `TableRow` / `TableColumn` / `TableCell` types and a PSV cell scanner (`parser/src/blocks/table.rs`), wired into the `Block` enum.
- `cols` widths, column multipliers, implicit column counts, implicit header-row detection, multiple-cells-per-line, and inline substitution of cell content.
- Test virtual DOM renders tables to `<table>`/`<thead>`/`<tbody>` HTML.
- Line-by-line spec-coverage test mirroring `build-a-basic-table.adoc`, plus table test fixtures for full `Document`-equality assertions.

Header detection was verified against Ruby Asciidoctor (a single-row table is body, not header; a header requires a genuine trailing blank line).

## Deferred (seams left in place)

CSV/TSV/DSV data formats and `,===`/`:===` delimiters; alignment/style operators; cell specifiers (spans, duplication, `a|` AsciiDoc cells); footer rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)