### PR TITLE
feat: Add table title and automatic caption

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -3,6 +3,7 @@ use crate::{
     attributes::Attrlist,
     blocks::{ContentModel, IsBlock, metadata::BlockMetadata},
     content::{Content, SubstitutionGroup},
+    document::InterpretedValue,
     parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning},
     span::MatchedItem,
     strings::CowStr,
@@ -44,6 +45,7 @@ pub struct TableBlock<'src> {
     source: Span<'src>,
     title_source: Option<Span<'src>>,
     title: Option<String>,
+    caption: Option<String>,
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
@@ -136,6 +138,26 @@ impl<'src> TableBlock<'src> {
             !line1.after.is_empty() && line1.after.take_line().item.data().trim().is_empty();
         let has_header = opts_header || (!line1_blank && line2_blank);
 
+        // A titled table is given an automatic caption (e.g. "Table 1. ") that
+        // a processor prepends to the title. The label comes from the
+        // `table-caption` attribute (which defaults to "Table"); each captioned
+        // table consumes the next value of a document-wide table counter. When
+        // `table-caption` is unset, no caption (and no number) is assigned.
+        //
+        // Computed before the cell iterator below borrows `parser` immutably, so
+        // that the mutable counter update does not conflict with that borrow.
+        let caption = if metadata.title.is_some() {
+            match parser.attribute_value("table-caption") {
+                InterpretedValue::Value(label) if !label.is_empty() => {
+                    let number = parser.assign_table_number();
+                    Some(format!("{label} {number}. "))
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
+
         // Scan every cell in the table, in document order, then partition into
         // rows of `ncols` cells each.
         let mut cells = scan_cells(inside)
@@ -188,6 +210,7 @@ impl<'src> TableBlock<'src> {
                     source,
                     title_source: metadata.title_source,
                     title: metadata.title.clone(),
+                    caption,
                     anchor: metadata.anchor,
                     anchor_reftext: metadata.anchor_reftext,
                     attrlist: metadata.attrlist.clone(),
@@ -196,6 +219,16 @@ impl<'src> TableBlock<'src> {
             }),
             warnings,
         })
+    }
+
+    /// Returns the automatic caption assigned to this table, if any.
+    ///
+    /// A titled table is captioned with a label and number (e.g. `"Table 1. "`)
+    /// that a processor prepends to the [`title`](IsBlock::title). The caption
+    /// is absent when the table has no title or when the `table-caption`
+    /// attribute has been unset.
+    pub fn caption(&self) -> Option<&str> {
+        self.caption.as_deref()
     }
 
     /// Returns the columns of this table.

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -242,3 +242,72 @@ fn header_option_without_cells() {
     assert!(table.header_row().is_none());
     assert!(table.body_rows().is_empty());
 }
+
+#[test]
+fn titled_table_is_captioned() {
+    // A block title on a table produces both a title and an automatic caption
+    // ("Table 1. ") drawn from the default `table-caption` value.
+    let table = parse_table(".A table with a title\n|===\n|a |b\n|===");
+
+    assert_eq!(table.title(), Some("A table with a title"));
+    assert_eq!(table.caption(), Some("Table 1. "));
+}
+
+#[test]
+fn untitled_table_has_no_caption() {
+    // Without a title, a table is not captioned and does not consume a number.
+    let table = parse_table("|===\n|a |b\n|===");
+
+    assert!(table.title().is_none());
+    assert!(table.caption().is_none());
+}
+
+#[test]
+fn captioned_tables_are_numbered_in_document_order() {
+    // Only titled tables consume a number, and they are numbered in document
+    // order across the whole document.
+    let doc = Parser::default()
+        .parse(".First\n|===\n|a\n|===\n\n|===\n|b\n|===\n\n.Second\n|===\n|c\n|===");
+
+    let captions: Vec<Option<&str>> = doc
+        .nested_blocks()
+        .filter_map(|block| match block {
+            Block::Table(table) => Some(table.caption()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(captions, vec![Some("Table 1. "), None, Some("Table 2. ")]);
+}
+
+#[test]
+fn table_caption_can_be_relabeled() {
+    // The label portion of the caption is taken from the `table-caption`
+    // document attribute.
+    let doc = Parser::default().parse(":table-caption: Spreadsheet\n\n.Numbers\n|===\n|a\n|===");
+
+    let caption = doc.nested_blocks().find_map(|block| match block {
+        Block::Table(table) => table.caption().map(|c| c.to_string()),
+        _ => None,
+    });
+
+    assert_eq!(caption.as_deref(), Some("Spreadsheet 1. "));
+}
+
+#[test]
+fn unsetting_table_caption_suppresses_the_label() {
+    // When `table-caption` is unset, a titled table keeps its title but receives
+    // no caption (and no number).
+    let doc = Parser::default().parse(":!table-caption:\n\n.Numbers\n|===\n|a\n|===");
+
+    let table = doc
+        .nested_blocks()
+        .find_map(|block| match block {
+            Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .unwrap();
+
+    assert_eq!(table.title(), Some("Numbers"));
+    assert!(table.caption().is_none());
+}

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -5,6 +5,7 @@ use crate::{
     HasSpan, Parser, Span,
     blocks::{Block, ContentModel, IsBlock, TableBlock},
     content::SubstitutionGroup,
+    parser::ModificationContext,
 };
 
 /// Parse `source` as a single block and return the [`TableBlock`] it produced.
@@ -310,4 +311,32 @@ fn unsetting_table_caption_suppresses_the_label() {
 
     assert_eq!(table.title(), Some("Numbers"));
     assert!(table.caption().is_none());
+}
+
+#[test]
+fn empty_table_caption_suppresses_the_label() {
+    // An explicitly empty `table-caption` value (a distinct AsciiDoc operation
+    // from a hard unset, e.g. `:!table-caption:`) is also treated as "no label":
+    // each titled table keeps its title but receives no caption and does not
+    // consume a table number. This exercises the empty-label guard separately
+    // from the `Unset` path.
+    let mut parser = Parser::default().with_intrinsic_attribute(
+        "table-caption",
+        "",
+        ModificationContext::Anywhere,
+    );
+    let doc = parser.parse(".First\n|===\n|a\n|===\n\n.Second\n|===\n|b\n|===");
+
+    let observed: Vec<(Option<&str>, Option<&str>)> = doc
+        .nested_blocks()
+        .filter_map(|block| match block {
+            Block::Table(table) => Some((table.title(), table.caption())),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        observed,
+        vec![(Some("First"), None), (Some("Second"), None)]
+    );
 }

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -125,6 +125,15 @@ pub(super) fn built_in_attrs() -> HashMap<String, AttributeValue> {
         },
     );
 
+    attrs.insert(
+        "table-caption".to_owned(),
+        AttributeValue {
+            allowable_value: AllowableValue::Any,
+            modification_context: ModificationContext::Anywhere,
+            value: InterpretedValue::Set,
+        },
+    );
+
     // TO DO: Replace ./images with value of imagesdir if that is non-default.
     attrs.insert(
         "iconsdir".to_owned(),
@@ -142,6 +151,7 @@ pub(super) fn built_in_default_values() -> HashMap<String, String> {
     let mut defaults: HashMap<String, String> = HashMap::new();
 
     defaults.insert("example-caption".to_owned(), "Example".to_owned());
+    defaults.insert("table-caption".to_owned(), "Table".to_owned());
     defaults.insert("iconsdir".to_owned(), "./images/icons".to_owned());
     defaults.insert("sectnums".to_owned(), "all".to_owned());
     defaults.insert("toc".to_owned(), "auto".to_owned());

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -62,6 +62,10 @@ pub struct Parser {
     /// Section type of outermost section. (Used to determine whether to number
     /// child sections as a normal section or appendix.)
     pub(crate) topmost_section_type: SectionType,
+
+    /// Number most recently assigned to a captioned table. Incremented each
+    /// time a titled table receives an automatic caption (e.g. "Table 1.").
+    pub(crate) last_table_number: usize,
 }
 
 impl Default for Parser {
@@ -81,6 +85,7 @@ impl Default for Parser {
             },
             sectnumlevels: 3,
             topmost_section_type: SectionType::Normal,
+            last_table_number: 0,
         }
     }
 }
@@ -153,6 +158,9 @@ impl Parser {
 
         // Reset section numbering for each new document.
         self.last_section_number = SectionNumber::default();
+
+        // Reset table numbering for each new document.
+        self.last_table_number = 0;
 
         Document::parse(&preprocessed_source, source_map, self)
     }
@@ -515,6 +523,16 @@ impl Parser {
                 self.last_section_number.clone()
             }
         }
+    }
+
+    /// Assigns the next sequential number to a captioned table and returns it.
+    ///
+    /// Tables are numbered in document order, but only those that actually
+    /// receive a caption (i.e. titled tables for which the `table-caption`
+    /// attribute is set) consume a number.
+    pub(crate) fn assign_table_number(&mut self) -> usize {
+        self.last_table_number += 1;
+        self.last_table_number
     }
 }
 

--- a/parser/src/tests/asciidoc_lang/tables/add_title.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_title.rs
@@ -155,7 +155,7 @@ fn add_a_title_to_a_table() {
         }
     );
 
-    non_normative!(
+    verifies!(
         r#"
 The table from <<ex-title>> is displayed below.
 
@@ -168,17 +168,13 @@ The table from <<ex-title>> is displayed below.
 |Cell in column 2, row 2
 |===
 
-"#
-    );
-
-    verifies!(
-        r#"
 You'll notice in the above result, that the processor automatically added _Table 1._ in front of the table's title.
 "#
     );
 
-    // The processor prepends the automatic caption ("Table 1. ") to the block
-    // title, rendering both inside the table's `<caption class="title">`.
+    // The displayed table renders with the processor's automatic caption
+    // ("Table 1. ") prepended to the block title, both inside the table's
+    // `<caption class="title">`.
     assert_xpath(
         &doc,
         "//caption[text()=\"Table 1. A table with a title\"]",

--- a/parser/src/tests/asciidoc_lang/tables/add_title.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_title.rs
@@ -1,0 +1,193 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/add-title.adoc");
+
+non_normative!(
+    r#"
+= Add a Title to a Table
+:navtitle: Add a Title
+// TODO/FIX: When soft unset is used from the Antora playbook, and then the attribute is reset in the document, it doesn't use the default value, so "Table" has to be explicitly assigned. Otherwise the label is simply the incremented number (i.e., "1.").
+:table-caption: Table
+
+A table can have an optional title (i.e., table caption).
+To add a title to a table, use the block title syntax.
+
+"#
+);
+
+#[test]
+fn add_a_title_to_a_table() {
+    verifies!(
+        r#"
+.Add an optional title to a table
+[source#ex-title]
+----
+.A table with a title <.>
+[%autowidth]
+|===
+|Column 1, header row |Column 2, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|===
+----
+<.> On the line directly above the table's opening delimiter (or above its optional attribute line, as shown here), enter a dot (`.`) directly followed by the text of the title.
+
+"#
+    );
+
+    let source = ".A table with a title\n[%autowidth]\n|===\n|Column 1, header row |Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|===";
+
+    let doc = Parser::default().parse(source);
+
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Table(TableBlock {
+                columns: &[TableColumn { width: 1 }, TableColumn { width: 1 }],
+                header_row: Some(TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 1, header row",
+                                    line: 4,
+                                    col: 2,
+                                    offset: 41,
+                                },
+                                rendered: "Column 1, header row",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Column 2, header row",
+                                    line: 4,
+                                    col: 24,
+                                    offset: 63,
+                                },
+                                rendered: "Column 2, header row",
+                            },
+                        },
+                    ],
+                }),
+                body_rows: &[TableRow {
+                    cells: &[
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Cell in column 1, row 2",
+                                    line: 6,
+                                    col: 2,
+                                    offset: 86,
+                                },
+                                rendered: "Cell in column 1, row 2",
+                            },
+                        },
+                        TableCell {
+                            content: Content {
+                                original: Span {
+                                    data: "Cell in column 2, row 2",
+                                    line: 7,
+                                    col: 2,
+                                    offset: 111,
+                                },
+                                rendered: "Cell in column 2, row 2",
+                            },
+                        },
+                    ],
+                }],
+                footer_row: None,
+                source: Span {
+                    data: ".A table with a title\n[%autowidth]\n|===\n|Column 1, header row |Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|===",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: Some(Span {
+                    data: "A table with a title",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                }),
+                title: Some("A table with a title"),
+                caption: Some("Table 1. "),
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[ElementAttribute {
+                        name: None,
+                        shorthand_items: &["%autowidth"],
+                        value: "%autowidth",
+                    }],
+                    anchor: None,
+                    source: Span {
+                        data: "%autowidth",
+                        line: 2,
+                        col: 2,
+                        offset: 23,
+                    },
+                }),
+            })],
+            source: Span {
+                data: source,
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog::default(),
+        }
+    );
+
+    non_normative!(
+        r#"
+The table from <<ex-title>> is displayed below.
+
+.A table with a title
+[%autowidth]
+|===
+|Column 1, header row |Column 2, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|===
+
+"#
+    );
+
+    verifies!(
+        r#"
+You'll notice in the above result, that the processor automatically added _Table 1._ in front of the table's title.
+"#
+    );
+
+    // The processor prepends the automatic caption ("Table 1. ") to the block
+    // title, rendering both inside the table's `<caption class="title">`.
+    assert_xpath(
+        &doc,
+        "//caption[text()=\"Table 1. A table with a title\"]",
+        1,
+    );
+
+    non_normative!(
+        r#"
+This title label can be xref:customize-title-label.adoc[customized] or xref:turn-off-title-label.adoc[deactivated].
+"#
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
+++ b/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
@@ -216,6 +216,7 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                 },
                 title_source: None,
                 title: None,
+                caption: None,
                 anchor: None,
                 anchor_reftext: None,
                 attrlist: Some(Attrlist {
@@ -438,6 +439,7 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                 },
                 title_source: None,
                 title: None,
+                caption: None,
                 anchor: None,
                 anchor_reftext: None,
                 attrlist: Some(Attrlist {

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -1,1 +1,2 @@
+mod add_title;
 mod build_a_basic_table;

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -313,8 +313,9 @@ impl ToVirtualDom for Document<'_> {
 /// NOTE: Some block types (like lists) handle their titles internally, so we
 /// skip adding a separate title element for those.
 fn add_block_with_title<'a>(parent: &mut VirtualNode, block: &'a Block<'a>) {
-    // Check if this block type handles its own title internally.
-    let handles_title_internally = matches!(block, Block::List(_));
+    // Check if this block type handles its own title internally. Lists render
+    // their title inside the list wrapper; tables render it as a <caption>.
+    let handles_title_internally = matches!(block, Block::List(_) | Block::Table(_));
 
     // Add title as a separate sibling element if the block doesn't handle it
     // internally.
@@ -834,8 +835,19 @@ fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
     }
 
     if let Some(title) = table.title() {
-        node.children
-            .push(VirtualNode::new("caption").with_text(title.to_string()));
+        // A titled table renders a <caption class="title">. When the processor
+        // assigned an automatic caption (e.g. "Table 1. "), it is prepended to
+        // the title text.
+        let caption_text = match table.caption() {
+            Some(caption) => format!("{caption}{title}"),
+            None => title.to_string(),
+        };
+
+        node.children.push(
+            VirtualNode::new("caption")
+                .with_class("title")
+                .with_text(caption_text),
+        );
     }
 
     let mut colgroup = VirtualNode::new("colgroup");
@@ -1046,6 +1058,23 @@ mod tests {
         let code = para.children.iter().find(|c| c.tag == "code");
         assert!(code.is_some(), "Should have a <code> element");
         assert_eq!(code.unwrap().text.as_deref(), Some("code"));
+    }
+
+    #[test]
+    fn titled_table_renders_captioned_title() {
+        let doc = Parser::default().parse(".A table with a title\n|===\n|a |b\n|===");
+        let vdom = doc.to_virtual_dom();
+
+        let table = &vdom.children[0];
+        assert_eq!(table.tag, "table");
+
+        let caption = &table.children[0];
+        assert_eq!(caption.tag, "caption");
+        assert!(caption.classes.contains(&"title".to_string()));
+        assert_eq!(
+            caption.text.as_deref(),
+            Some("Table 1. A table with a title")
+        );
     }
 
     #[test]

--- a/parser/src/tests/fixtures/blocks/table.rs
+++ b/parser/src/tests/fixtures/blocks/table.rs
@@ -15,6 +15,7 @@ pub(crate) struct TableBlock {
     pub source: Span,
     pub title_source: Option<Span>,
     pub title: Option<&'static str>,
+    pub caption: Option<&'static str>,
     pub anchor: Option<Span>,
     pub anchor_reftext: Option<Span>,
     pub attrlist: Option<Attrlist>,
@@ -30,6 +31,7 @@ impl fmt::Debug for TableBlock {
             .field("source", &self.source)
             .field("title_source", &self.title_source)
             .field("title", &self.title)
+            .field("caption", &self.caption)
             .field("anchor", &self.anchor)
             .field("anchor_reftext", &self.anchor_reftext)
             .field("attrlist", &self.attrlist)
@@ -135,6 +137,17 @@ fn fixture_eq_observed(fixture: &TableBlock, observed: &crate::blocks::TableBloc
     if let Some(ref fixture_title) = fixture.title
         && let Some(ref observed_title) = observed.title()
         && fixture_title != observed_title
+    {
+        return false;
+    }
+
+    if fixture.caption.is_some() != observed.caption().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_caption) = fixture.caption
+        && let Some(ref observed_caption) = observed.caption()
+        && fixture_caption != observed_caption
     {
         return false;
     }


### PR DESCRIPTION
Child PR to the `tables` feature branch. Implements everything described on [`docs/modules/tables/pages/add-title.adoc`](https://github.com/asciidoc-rs/asciidoc-parser/blob/tables/docs/modules/tables/pages/add-title.adoc), following the patterns established in #509.

## What this adds

A block title on a table now produces both a **title** and an **automatic caption** — the `Table 1.` label a processor prepends to the title.

- **`TableBlock::caption`** is computed at parse time from the `table-caption` attribute and a document-wide table counter:
  - New `table-caption` built-in attribute (defaults to `Table`), mirroring the existing `example-caption`.
  - New `Parser::assign_table_number` counter (reset per document, like section numbering). Only titled tables whose label is set consume a number; an untitled table doesn't, and `:!table-caption:` suppresses both label and number.
- **Test virtual DOM** renders the title inside `<caption class="title">` prefixed by the caption (`Table 1. A table with a title`), matching Asciidoctor. Tables no longer also emit a duplicate `div.title` sibling.

## Tests

- Spec-coverage test `tables/add_title.rs` mirroring `add-title.adoc` line-by-line (`cd sdd && cargo run` reports full coverage of the normative lines).
- Table unit tests: captioning, document-order numbering (untitled tables skipped), relabeling via `table-caption`, and suppression via `:!table-caption:`.
- Virtual-DOM test for the rendered `<caption class="title">`.

All 1909 parser tests pass; `clippy --all-targets`, nightly `fmt`, and nightly `doc` (deny-warnings) are clean.

## Deferred

The `%autowidth` option is parsed into the attrlist but its width-class effect (`fit-content` vs `stretch`) is left for `width.adoc`. Customizing/turning off the label have their own pages (`customize-title-label.adoc`, `turn-off-title-label.adoc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)