### PR TITLE
fix: Merge multiple block attribute-list lines

### DIFF
--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -210,10 +210,12 @@ impl<'src> Attrlist<'src> {
     }
 
     /// Return a mutable reference to the (1-based) `n`th positional attribute.
+    ///
+    /// `n` must be 1 or greater; the only caller is
+    /// [`merge_block_attribute_line`](Self::merge_block_attribute_line), which
+    /// always passes a positive position.
     fn nth_positional_mut(&mut self, n: usize) -> Option<&mut ElementAttribute<'src>> {
-        if n == 0 {
-            return None;
-        }
+        debug_assert!(n >= 1, "nth_positional_mut requires a 1-based position");
 
         self.attributes
             .iter_mut()

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -147,6 +147,80 @@ impl<'src> Attrlist<'src> {
         }
     }
 
+    /// Merge a subsequent block attribute line into this one.
+    ///
+    /// A block can be preceded by more than one attribute list line (optionally
+    /// straddling the block title). Asciidoctor merges every such line into a
+    /// single set of attributes, where a later line wins on a name (or
+    /// position) conflict and otherwise accumulates. This method folds `later`
+    /// into `self` using those semantics:
+    ///
+    /// * **Named attributes** accumulate; a later attribute with the same name
+    ///   replaces the earlier one (in place, preserving order).
+    /// * **Positional attributes** are matched by position. A later positional
+    ///   replaces the earlier one at the same position. The first positional
+    ///   additionally carries the block style and shorthand items (`#id`,
+    ///   `.role`, `%option`), which are merged via
+    ///   [`ElementAttribute::merge_block_style_shorthand`].
+    /// * The **anchor** is taken from the later line if it specifies one.
+    ///
+    /// The `source` span is left pointing at the first line, since the merged
+    /// attributes no longer correspond to a single contiguous span.
+    pub(crate) fn merge_block_attribute_line(&mut self, later: Attrlist<'src>) {
+        let Attrlist {
+            attributes: later_attributes,
+            anchor: later_anchor,
+            source: _,
+        } = later;
+
+        if later_anchor.is_some() {
+            self.anchor = later_anchor;
+        }
+
+        let mut positional_index = 0usize;
+
+        for attr in later_attributes {
+            if attr.name_str().is_some() {
+                if let Some(existing) = self
+                    .attributes
+                    .iter_mut()
+                    .find(|a| a.name_str() == attr.name_str())
+                {
+                    *existing = attr;
+                } else {
+                    self.attributes.push(attr);
+                }
+                continue;
+            }
+
+            positional_index += 1;
+
+            if positional_index == 1 {
+                if let Some(existing) = self.nth_positional_mut(1) {
+                    *existing = ElementAttribute::merge_block_style_shorthand(existing, &attr);
+                } else {
+                    self.attributes.push(attr);
+                }
+            } else if let Some(existing) = self.nth_positional_mut(positional_index) {
+                *existing = attr;
+            } else {
+                self.attributes.push(attr);
+            }
+        }
+    }
+
+    /// Return a mutable reference to the (1-based) `n`th positional attribute.
+    fn nth_positional_mut(&mut self, n: usize) -> Option<&mut ElementAttribute<'src>> {
+        if n == 0 {
+            return None;
+        }
+
+        self.attributes
+            .iter_mut()
+            .filter(|attr| attr.name_str().is_none())
+            .nth(n - 1)
+    }
+
     /// Returns an iterator over the attributes contained within
     /// this attrlist.
     pub fn attributes(&'src self) -> Iter<'src, ElementAttribute<'src>> {
@@ -1279,6 +1353,56 @@ mod tests {
                 warning: WarningType::EmptyShorthandItem,
             }]
         );
+    }
+
+    #[test]
+    fn merge_block_attribute_line_anchor_later_wins() {
+        let p = Parser::default();
+
+        let mut first = crate::attributes::Attrlist::parse(
+            crate::Span::new("[id1]"),
+            &p,
+            AttrlistContext::Block,
+        )
+        .unwrap_if_no_warnings()
+        .item;
+
+        let later = crate::attributes::Attrlist::parse(
+            crate::Span::new("[id2]"),
+            &p,
+            AttrlistContext::Block,
+        )
+        .unwrap_if_no_warnings()
+        .item;
+
+        assert_eq!(first.anchor(), Some("id1"));
+        first.merge_block_attribute_line(later);
+        assert_eq!(first.anchor(), Some("id2"));
+    }
+
+    #[test]
+    fn merge_block_attribute_line_anchor_retained_when_later_has_none() {
+        let p = Parser::default();
+
+        let mut first = crate::attributes::Attrlist::parse(
+            crate::Span::new("[id1]"),
+            &p,
+            AttrlistContext::Block,
+        )
+        .unwrap_if_no_warnings()
+        .item;
+
+        let later = crate::attributes::Attrlist::parse(
+            crate::Span::new("foo=bar"),
+            &p,
+            AttrlistContext::Block,
+        )
+        .unwrap_if_no_warnings()
+        .item;
+
+        first.merge_block_attribute_line(later);
+        assert_eq!(first.anchor(), Some("id1"));
+        assert_eq!(first.named_attribute("foo").unwrap().value(), "bar");
     }
 
     #[test]

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -1568,4 +1568,63 @@ mod tests {
             assert_eq!(offset, 28);
         }
     }
+
+    mod merge_block_style_shorthand {
+        use crate::{
+            attributes::{AttrlistContext, element_attribute::ParseShorthand},
+            strings::CowStr,
+            tests::prelude::*,
+        };
+
+        fn parse(value: &str) -> crate::attributes::ElementAttribute<'_> {
+            let p = Parser::default();
+            crate::attributes::ElementAttribute::parse(
+                &CowStr::from(value),
+                0,
+                &p,
+                ParseShorthand(true),
+                AttrlistContext::Block,
+            )
+            .0
+        }
+
+        #[test]
+        fn merges_disjoint_shorthand() {
+            let earlier = parse("#myid");
+            let later = parse(".myrole");
+
+            let merged =
+                crate::attributes::ElementAttribute::merge_block_style_shorthand(&earlier, &later);
+
+            assert!(merged.name().is_none());
+            assert_eq!(merged.id().unwrap(), "myid");
+            assert_eq!(merged.roles(), vec!["myrole"]);
+        }
+
+        #[test]
+        fn two_empty_positionals_stay_empty() {
+            // Merging two empty first positionals exercises the empty-value
+            // branch, which produces an attribute with no shorthand items.
+            let earlier = parse("");
+            let later = parse("");
+
+            let merged =
+                crate::attributes::ElementAttribute::merge_block_style_shorthand(&earlier, &later);
+
+            assert_eq!(
+                merged,
+                ElementAttribute {
+                    name: None,
+                    shorthand_items: &[],
+                    value: "",
+                }
+            );
+
+            assert!(merged.name().is_none());
+            assert!(merged.block_style().is_none());
+            assert!(merged.id().is_none());
+            assert!(merged.roles().is_empty());
+            assert!(merged.options().is_empty());
+        }
+    }
 }

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -352,7 +352,9 @@ impl<'src> ElementAttribute<'src> {
     /// re-encodes the merged shorthand so that the usual accessors continue to
     /// work.
     pub(crate) fn merge_block_style_shorthand(earlier: &Self, later: &Self) -> Self {
-        let block_style = later.block_style_internal().or(earlier.block_style_internal());
+        let block_style = later
+            .block_style_internal()
+            .or(earlier.block_style_internal());
         let id = later.id_internal().or(earlier.id_internal());
 
         let mut roles = earlier.roles_internal();

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -380,12 +380,24 @@ impl<'src> ElementAttribute<'src> {
             value.push_str(option);
         }
 
+        // The shorthand string is synthesized entirely from components that
+        // were already parsed and validated when their source lines were read
+        // (a block style, a non-empty ID, and non-empty roles/options, each
+        // separated by a single delimiter). Re-parsing it therefore can never
+        // produce a warning, so rather than plumb an always-empty warning list
+        // back to the caller we assert that invariant — turning a silent
+        // discard into an explicit, regression-guarded one.
         let mut warnings: Vec<WarningType> = vec![];
         let shorthand_item_indices = if value.is_empty() {
             vec![]
         } else {
             parse_shorthand_items(&value, &mut warnings)
         };
+
+        debug_assert!(
+            warnings.is_empty(),
+            "merging block-style shorthand should not produce warnings, got: {warnings:?}"
+        );
 
         Self {
             name: None,

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -117,7 +117,7 @@ impl<'src> ElementAttribute<'src> {
         )
     }
 
-    /// Return the attribute name, if one was found`.
+    /// Return the attribute name, if one was found.
     pub fn name(&'src self) -> Option<&'src str> {
         self.name_str()
     }
@@ -229,7 +229,7 @@ impl<'src> ElementAttribute<'src> {
     }
 
     /// Return any role attributes that were found in shorthand syntax.
-    ///     
+    ///
     /// You can assign one or more roles to blocks and most inline elements
     /// using the `role` attribute. The `role` attribute is a [named attribute].
     /// Even though the attribute name is singular, it may contain multiple
@@ -264,7 +264,7 @@ impl<'src> ElementAttribute<'src> {
     }
 
     /// Return any option attributes that were found in shorthand syntax.
-    ///     
+    ///
     /// The `options` attribute (often abbreviated as `opts`) is a versatile
     /// [named attribute] that can be assigned one or more values. It can be
     /// defined globally as document attribute as well as a block attribute on

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -119,11 +119,16 @@ impl<'src> ElementAttribute<'src> {
 
     /// Return the attribute name, if one was found`.
     pub fn name(&'src self) -> Option<&'src str> {
-        if let Some(ref name) = self.name {
-            Some(name.as_ref())
-        } else {
-            None
-        }
+        self.name_str()
+    }
+
+    /// Return the attribute name, if one was found.
+    ///
+    /// Unlike [`name`](Self::name), this borrows for the duration of the call
+    /// only, so it can be used on temporary `ElementAttribute` values (for
+    /// example while merging multiple attribute lists).
+    pub(crate) fn name_str(&self) -> Option<&str> {
+        self.name.as_deref()
     }
 
     /// Return the shorthand items, if applicable.
@@ -132,6 +137,12 @@ impl<'src> ElementAttribute<'src> {
     /// attribute is not of the appropriate kind, this will return an empty
     /// list.
     pub fn shorthand_items(&'src self) -> Vec<&'src str> {
+        self.shorthand_items_internal()
+    }
+
+    /// Same as [`shorthand_items`](Self::shorthand_items), but borrows for the
+    /// duration of the call only so it can be used on temporary values.
+    fn shorthand_items_internal(&self) -> Vec<&str> {
         let mut result = vec![];
         let value = self.value.as_ref();
 
@@ -160,7 +171,13 @@ impl<'src> ElementAttribute<'src> {
 
     /// Return the block style name from shorthand syntax.
     pub fn block_style(&'src self) -> Option<&'src str> {
-        self.shorthand_items()
+        self.block_style_internal()
+    }
+
+    /// Same as [`block_style`](Self::block_style), but borrows for the duration
+    /// of the call only.
+    fn block_style_internal(&self) -> Option<&str> {
+        self.shorthand_items_internal()
             .first()
             .filter(|v| !v.chars().any(is_shorthand_delimiter))
             .cloned()
@@ -200,8 +217,13 @@ impl<'src> ElementAttribute<'src> {
     /// * Goal 2
     /// ```
     pub fn id(&'src self) -> Option<&'src str> {
-        self.shorthand_items()
-            .iter()
+        self.id_internal()
+    }
+
+    /// Same as [`id`](Self::id), but borrows for the duration of the call only.
+    fn id_internal(&self) -> Option<&str> {
+        self.shorthand_items_internal()
+            .into_iter()
             .find(|v| v.starts_with('#'))
             .map(|v| &v[1..])
     }
@@ -228,8 +250,14 @@ impl<'src> ElementAttribute<'src> {
     ///
     /// [named attribute]: https://docs.asciidoctor.org/asciidoc/latest/attributes/positional-and-named-attributes/#named
     pub fn roles(&'src self) -> Vec<&'src str> {
-        self.shorthand_items()
-            .iter()
+        self.roles_internal()
+    }
+
+    /// Same as [`roles`](Self::roles), but borrows for the duration of the call
+    /// only.
+    fn roles_internal(&self) -> Vec<&str> {
+        self.shorthand_items_internal()
+            .into_iter()
             .filter(|span| span.starts_with('.'))
             .map(|span| &span[1..])
             .collect()
@@ -300,11 +328,68 @@ impl<'src> ElementAttribute<'src> {
     ///
     /// [named attribute]: https://docs.asciidoctor.org/asciidoc/latest/attributes/positional-and-named-attributes/#named
     pub fn options(&'src self) -> Vec<&'src str> {
-        self.shorthand_items()
-            .iter()
+        self.options_internal()
+    }
+
+    /// Same as [`options`](Self::options), but borrows for the duration of the
+    /// call only.
+    fn options_internal(&self) -> Vec<&str> {
+        self.shorthand_items_internal()
+            .into_iter()
             .filter(|v| v.starts_with('%'))
             .map(|v| &v[1..])
             .collect()
+    }
+
+    /// Merge the shorthand of two first-position (block style) attributes drawn
+    /// from separate block attribute lines, following Asciidoctor's semantics:
+    ///
+    /// * the block style and ID are taken from the later line if it specifies
+    ///   them, otherwise retained from the earlier line;
+    /// * roles and options accumulate, with the earlier line's values first.
+    ///
+    /// The result is a freshly synthesized positional attribute whose value
+    /// re-encodes the merged shorthand so that the usual accessors continue to
+    /// work.
+    pub(crate) fn merge_block_style_shorthand(earlier: &Self, later: &Self) -> Self {
+        let block_style = later.block_style_internal().or(earlier.block_style_internal());
+        let id = later.id_internal().or(earlier.id_internal());
+
+        let mut roles = earlier.roles_internal();
+        roles.extend(later.roles_internal());
+
+        let mut options = earlier.options_internal();
+        options.extend(later.options_internal());
+
+        let mut value = String::new();
+        if let Some(block_style) = block_style {
+            value.push_str(block_style);
+        }
+        if let Some(id) = id {
+            value.push('#');
+            value.push_str(id);
+        }
+        for role in &roles {
+            value.push('.');
+            value.push_str(role);
+        }
+        for option in &options {
+            value.push('%');
+            value.push_str(option);
+        }
+
+        let mut warnings: Vec<WarningType> = vec![];
+        let shorthand_item_indices = if value.is_empty() {
+            vec![]
+        } else {
+            parse_shorthand_items(&value, &mut warnings)
+        };
+
+        Self {
+            name: None,
+            value: CowStr::from(value),
+            shorthand_item_indices,
+        }
     }
 
     /// Return the attribute's value.

--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -127,22 +127,27 @@ impl<'src> BlockMetadata<'src> {
                 }
             }
 
-            // Try to parse an attribute list.
-            if attrlist.is_none()
-                && let Some(MatchAndWarnings {
-                    item:
-                        MatchedItem {
-                            item: attrlist_item,
-                            after: new_block_start,
-                        },
-                    warnings: mut attrlist_warnings,
-                }) = parse_maybe_attrlist_line(block_start, parser)
+            // Try to parse an attribute list. A block may be preceded by more
+            // than one attribute list line (optionally straddling the title);
+            // Asciidoctor merges them into a single set of attributes, with a
+            // later line winning on conflict and otherwise accumulating.
+            if let Some(MatchAndWarnings {
+                item:
+                    MatchedItem {
+                        item: attrlist_item,
+                        after: new_block_start,
+                    },
+                warnings: mut attrlist_warnings,
+            }) = parse_maybe_attrlist_line(block_start, parser)
             {
                 if !attrlist_warnings.is_empty() {
                     warnings.append(&mut attrlist_warnings);
                 }
 
-                attrlist = Some(attrlist_item);
+                match attrlist {
+                    Some(ref mut existing) => existing.merge_block_attribute_line(attrlist_item),
+                    None => attrlist = Some(attrlist_item),
+                }
                 block_start = new_block_start;
                 continue;
             }
@@ -507,5 +512,164 @@ mod tests {
                 },
             }
         );
+    }
+
+    mod merge_attribute_lines {
+        use crate::tests::prelude::*;
+
+        #[test]
+        fn two_non_conflicting_named() {
+            let metadata = crate::blocks::metadata::BlockMetadata::new(
+                "[foo=bar]\n[baz=qux]\ncontent\n",
+            );
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.named_attribute("foo").unwrap().value(), "bar");
+            assert_eq!(attrlist.named_attribute("baz").unwrap().value(), "qux");
+        }
+
+        #[test]
+        fn conflicting_named_later_wins() {
+            let metadata =
+                crate::blocks::metadata::BlockMetadata::new("[foo=bar]\n[foo=qux]\ncontent\n");
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.named_attribute("foo").unwrap().value(), "qux");
+
+            // Only one `foo` attribute should remain.
+            assert_eq!(
+                attrlist
+                    .attributes()
+                    .filter(|a| a.name() == Some("foo"))
+                    .count(),
+                1
+            );
+        }
+
+        #[test]
+        fn lines_straddling_a_title() {
+            let metadata = crate::blocks::metadata::BlockMetadata::new(
+                "[foo=bar]\n.My Title\n[baz=qux]\ncontent\n",
+            );
+
+            assert_eq!(metadata.title.as_deref(), Some("My Title"));
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.named_attribute("foo").unwrap().value(), "bar");
+            assert_eq!(attrlist.named_attribute("baz").unwrap().value(), "qux");
+        }
+
+        #[test]
+        fn combined_with_anchor() {
+            let metadata = crate::blocks::metadata::BlockMetadata::new(
+                "[foo=bar]\n[[my-anchor]]\n[baz=qux]\ncontent\n",
+            );
+
+            assert_eq!(
+                metadata.anchor.unwrap(),
+                Span {
+                    data: "my-anchor",
+                    line: 2,
+                    col: 3,
+                    offset: 12,
+                }
+            );
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.named_attribute("foo").unwrap().value(), "bar");
+            assert_eq!(attrlist.named_attribute("baz").unwrap().value(), "qux");
+        }
+
+        #[test]
+        fn block_style_later_wins() {
+            let metadata =
+                crate::blocks::metadata::BlockMetadata::new("[sidebar]\n[example]\ncontent\n");
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.block_style().unwrap(), "example");
+        }
+
+        #[test]
+        fn shorthand_id_and_role_across_lines() {
+            let metadata =
+                crate::blocks::metadata::BlockMetadata::new("[#myid]\n[.myrole]\ncontent\n");
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.id().unwrap(), "myid");
+            assert_eq!(attrlist.roles(), vec!["myrole"]);
+        }
+
+        #[test]
+        fn shorthand_roles_accumulate() {
+            let metadata =
+                crate::blocks::metadata::BlockMetadata::new("[.role1]\n[.role2]\ncontent\n");
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.roles(), vec!["role1", "role2"]);
+        }
+
+        #[test]
+        fn shorthand_id_later_wins() {
+            let metadata =
+                crate::blocks::metadata::BlockMetadata::new("[#id1]\n[#id2]\ncontent\n");
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.id().unwrap(), "id2");
+        }
+
+        #[test]
+        fn shorthand_options_accumulate() {
+            let metadata =
+                crate::blocks::metadata::BlockMetadata::new("[%opt1]\n[%opt2]\ncontent\n");
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.options(), vec!["opt1", "opt2"]);
+        }
+
+        #[test]
+        fn second_positional_later_wins() {
+            let metadata = crate::blocks::metadata::BlockMetadata::new(
+                "[quote,Author1]\n[quote,Author2]\ncontent\n",
+            );
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.block_style().unwrap(), "quote");
+            assert_eq!(attrlist.nth_attribute(2).unwrap().value(), "Author2");
+        }
+
+        #[test]
+        fn first_positional_only_on_later_line() {
+            let metadata =
+                crate::blocks::metadata::BlockMetadata::new("[foo=bar]\n[sidebar]\ncontent\n");
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.block_style().unwrap(), "sidebar");
+            assert_eq!(attrlist.named_attribute("foo").unwrap().value(), "bar");
+        }
+
+        #[test]
+        fn extra_positional_only_on_later_line() {
+            let metadata = crate::blocks::metadata::BlockMetadata::new(
+                "[quote]\n[quote,Author]\ncontent\n",
+            );
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.block_style().unwrap(), "quote");
+            assert_eq!(attrlist.nth_attribute(2).unwrap().value(), "Author");
+        }
+
+        #[test]
+        fn three_lines_mixed_with_title() {
+            let metadata = crate::blocks::metadata::BlockMetadata::new(
+                "[#id1]\n.Title\n[.r1.r2]\n[foo=bar]\ncontent\n",
+            );
+
+            assert_eq!(metadata.title.as_deref(), Some("Title"));
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.id().unwrap(), "id1");
+            assert_eq!(attrlist.roles(), vec!["r1", "r2"]);
+            assert_eq!(attrlist.named_attribute("foo").unwrap().value(), "bar");
+        }
     }
 }

--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -519,9 +519,8 @@ mod tests {
 
         #[test]
         fn two_non_conflicting_named() {
-            let metadata = crate::blocks::metadata::BlockMetadata::new(
-                "[foo=bar]\n[baz=qux]\ncontent\n",
-            );
+            let metadata =
+                crate::blocks::metadata::BlockMetadata::new("[foo=bar]\n[baz=qux]\ncontent\n");
 
             let attrlist = metadata.attrlist.as_ref().unwrap();
             assert_eq!(attrlist.named_attribute("foo").unwrap().value(), "bar");
@@ -610,8 +609,7 @@ mod tests {
 
         #[test]
         fn shorthand_id_later_wins() {
-            let metadata =
-                crate::blocks::metadata::BlockMetadata::new("[#id1]\n[#id2]\ncontent\n");
+            let metadata = crate::blocks::metadata::BlockMetadata::new("[#id1]\n[#id2]\ncontent\n");
 
             let attrlist = metadata.attrlist.as_ref().unwrap();
             assert_eq!(attrlist.id().unwrap(), "id2");
@@ -649,9 +647,8 @@ mod tests {
 
         #[test]
         fn extra_positional_only_on_later_line() {
-            let metadata = crate::blocks::metadata::BlockMetadata::new(
-                "[quote]\n[quote,Author]\ncontent\n",
-            );
+            let metadata =
+                crate::blocks::metadata::BlockMetadata::new("[quote]\n[quote,Author]\ncontent\n");
 
             let attrlist = metadata.attrlist.as_ref().unwrap();
             assert_eq!(attrlist.block_style().unwrap(), "quote");


### PR DESCRIPTION
## Problem

A block's metadata (title, anchor, attribute list) is parsed in `BlockMetadata::parse`. The loop captured at most one attribute-list line (`if attrlist.is_none()`), so when a block had two or more `[...]` lines — including lines straddling the block title — only the first was kept and the rest were left in the block body, breaking parsing.

## Fix

Asciidoctor merges every block attribute line into a single set of attributes: a later line wins on a name (or positional) conflict and otherwise accumulates. This PR matches that behavior.

- **`Attrlist::merge_block_attribute_line`** folds a later line into an existing attrlist:
  - **Named** attributes accumulate; a later attribute with the same name replaces the earlier one in place.
  - **Positional** attributes are matched by position; a later positional replaces the earlier one at the same slot.
  - The **first positional** carries the block style and shorthand items (`#id`, `.role`, `%option`), merged via `ElementAttribute::merge_block_style_shorthand` — block style and ID later-win-if-present, roles and options accumulate.
  - The **anchor** is taken from the later line if it specifies one.
- **`BlockMetadata::parse`** now consumes repeated attribute-list lines and merges them rather than keeping only the first.
- Refactored `ElementAttribute`'s `name`/`shorthand_items`/`block_style`/`id`/`roles`/`options` accessors to delegate to lifetime-flexible internal helpers, so they can be used on temporary values during the merge.

## Verifying merge semantics

The merge semantics for positional and shorthand attributes were verified against Ruby Asciidoctor 2.0.23 by dumping each block's attribute hash. Confirmed: named later-wins/accumulate; block-style & ID later-win-if-present; roles & options accumulate; positional slots later-win; anchor later-wins.

## Tests

Adds unit tests for: two non-conflicting named lines, conflicting names (later wins), lines straddling a title, lines combined with an anchor, block-style/ID/roles/options merge across lines, positional-slot override, and the positional "push" branches. Full `cargo test`, `cargo clippy -D warnings`, `cargo +nightly fmt`, and `cargo +nightly doc` all pass; spec coverage (`sdd`) unchanged (no spec pages document multi-line attribute merging, so no `verifies!` coverage applies).

> Note: implemented off `main` in its own branch; the `tables-*` feature branches are untouched. The originating table caption+cols example isn't expressible on `main` yet, so tests use supported block types (sidebar/quote) exercising the same metadata-parsing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)