### PR TITLE
chore: Replace unmaintained cargo-udeps action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,11 +311,13 @@ jobs:
       - name: Install nightly Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
-      - name: Run cargo-udeps
-        uses: aig787/cargo-udeps-action@v1
+      - name: Install cargo-udeps
+        uses: taiki-e/install-action@v2
         with:
-          version: latest
-          args: --all-targets --all-features
+          tool: cargo-udeps
+
+      - name: Run cargo-udeps
+        run: cargo +nightly udeps --all-targets --all-features
 
   benchmarks:
     name: Test performance on benchmarks


### PR DESCRIPTION
## What

Replaces `aig787/cargo-udeps-action@v1` with `taiki-e/install-action@v2` for installing cargo-udeps in the `unused_deps` CI job.

## Why

`aig787/cargo-udeps-action` is unmaintained (only release is `v1` from April 2024) and its `action.yml` still declares `using: 'node16'`, which triggers GitHub's deprecated Node runtime warning. It has no newer version that fixes this.

`taiki-e/install-action` is a well-maintained **composite** action, so it has no Node runtime to deprecate. cargo-udeps is run directly via the nightly toolchain already installed in the job (`cargo +nightly udeps --all-targets --all-features`).

## Audit

While here, I checked the `using:` runtime of every other action across all workflows — all are already on node24, composite, or docker. `aig787/cargo-udeps-action` was the only Node ≤20 offender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)