### PR TITLE
feat: Turn off table title label (unset table-caption / empty caption)

### DIFF
--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -41,12 +41,12 @@ impl<'src> ElementAttribute<'src> {
                     match space.after.take_prefix("=") {
                         Some(equals) => {
                             let space = equals.after.take_whitespace_with_newline();
-                            if space.after.is_empty() || space.after.starts_with(',') {
-                                // TO DO: Is this a warning? Possible spec ambiguity.
-                                (None, source)
-                            } else {
-                                (Some(name.item), space.after)
-                            }
+                            // `name=` with nothing (or only a comma) after the `=`
+                            // is a named attribute with an empty value, not a
+                            // positional one. The empty value falls out of the
+                            // value scan below (`take_while(c != ',')` yields the
+                            // empty string), so the name is all we need to keep.
+                            (Some(name.item), space.after)
                         }
                         None => (None, source),
                     }
@@ -1141,9 +1141,12 @@ mod tests {
         }
 
         #[test]
-        fn fallback_if_no_value() {
+        fn named_with_empty_value() {
             let p = Parser::default();
 
+            // `name=` with nothing after the `=` is a named attribute whose value
+            // is the empty string (e.g. `[caption=]` clears a label), not a
+            // positional attribute with the literal value "abc=".
             let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
                 &CowStr::from("abc="),
                 0,
@@ -1157,13 +1160,13 @@ mod tests {
             assert_eq!(
                 element_attr,
                 ElementAttribute {
-                    name: None,
+                    name: Some("abc"),
                     shorthand_items: &[],
-                    value: "abc="
+                    value: ""
                 }
             );
 
-            assert!(element_attr.name().is_none());
+            assert_eq!(element_attr.name(), Some("abc"));
             assert!(element_attr.block_style().is_none());
             assert!(element_attr.id().is_none());
             assert!(element_attr.roles().is_empty());
@@ -1173,9 +1176,12 @@ mod tests {
         }
 
         #[test]
-        fn fallback_if_immediate_comma() {
+        fn named_with_empty_value_before_comma() {
             let p = Parser::default();
 
+            // `name=` immediately followed by a comma is likewise a named
+            // attribute with an empty value; parsing stops at the comma so the
+            // next attribute can be read separately.
             let (element_attr, offset, warning_types) = crate::attributes::ElementAttribute::parse(
                 &CowStr::from("abc=,def"),
                 0,
@@ -1189,13 +1195,13 @@ mod tests {
             assert_eq!(
                 element_attr,
                 ElementAttribute {
-                    name: None,
+                    name: Some("abc"),
                     shorthand_items: &[],
-                    value: "abc="
+                    value: ""
                 }
             );
 
-            assert!(element_attr.name().is_none());
+            assert_eq!(element_attr.name(), Some("abc"));
             assert!(element_attr.block_style().is_none());
             assert!(element_attr.id().is_none());
             assert!(element_attr.roles().is_empty());

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -144,11 +144,13 @@ impl<'src> TableBlock<'src> {
         // An explicit `caption` attribute on the table sets the label verbatim
         // (including any trailing whitespace) and is used as-is, with no
         // automatically incremented number; it applies even when
-        // `table-caption` has been unset. Otherwise the label comes from the
-        // `table-caption` attribute (which defaults to "Table"), and each such
-        // captioned table consumes the next value of a document-wide table
-        // counter. When `table-caption` is unset and no explicit `caption` is
-        // given, no caption (and no number) is assigned.
+        // `table-caption` has been unset. An explicitly empty `caption` (e.g.
+        // `[caption=]`) removes the label entirely, so the title renders with no
+        // prefix. Otherwise the label comes from the `table-caption` attribute
+        // (which defaults to "Table"), and each such captioned table consumes
+        // the next value of a document-wide table counter. When `table-caption`
+        // is unset and no explicit `caption` is given, no caption (and no
+        // number) is assigned.
         //
         // Computed before the cell iterator below borrows `parser` immutably, so
         // that the mutable counter update does not conflict with that borrow.
@@ -158,6 +160,7 @@ impl<'src> TableBlock<'src> {
                 .as_ref()
                 .and_then(|a| a.named_attribute("caption"))
             {
+                Some(attr) if attr.value().is_empty() => None,
                 Some(attr) => Some(attr.value().to_string()),
                 None => match parser.attribute_value("table-caption") {
                     InterpretedValue::Value(label) if !label.is_empty() => {
@@ -240,9 +243,10 @@ impl<'src> TableBlock<'src> {
     /// the [`title`](IsBlock::title). By default the label combines the
     /// `table-caption` attribute and an automatically incremented number (e.g.
     /// `"Table 1. "`). An explicit `caption` attribute on the table overrides
-    /// this with a verbatim label and no number. The caption is absent when the
-    /// table has no title, or when `table-caption` has been unset and no
-    /// explicit `caption` is given.
+    /// this with a verbatim label and no number; an explicitly empty `caption`
+    /// (e.g. `[caption=]`) removes the label entirely. The caption is absent
+    /// when the table has no title, when `table-caption` has been unset and no
+    /// explicit `caption` is given, or when an empty `caption` was supplied.
     pub fn caption(&self) -> Option<&str> {
         self.caption.as_deref()
     }

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -399,3 +399,34 @@ fn caption_attribute_is_ignored_without_a_title() {
     assert!(table.title().is_none());
     assert!(table.caption().is_none());
 }
+
+#[test]
+fn empty_caption_attribute_suppresses_the_label() {
+    // An explicitly empty `caption` (e.g. `[caption=]`) removes the label on the
+    // table: the title is kept but no caption (and no number) is assigned, so the
+    // title renders with no prefix.
+    let table = parse_table("[caption=]\n.A table with a title but no label\n|===\n|a\n|===");
+
+    assert_eq!(table.title(), Some("A table with a title but no label"));
+    assert!(table.caption().is_none());
+}
+
+#[test]
+fn empty_caption_attribute_does_not_consume_a_table_number() {
+    // A table whose label is removed with an empty `caption` is skipped by the
+    // document-wide counter, so a following `table-caption` table is numbered as
+    // if the unlabeled table were not there.
+    let doc = Parser::default().parse(
+        ".First\n|===\n|a\n|===\n\n[caption=]\n.Unlabeled\n|===\n|b\n|===\n\n.Third\n|===\n|c\n|===",
+    );
+
+    let captions: Vec<Option<&str>> = doc
+        .nested_blocks()
+        .filter_map(|block| match block {
+            Block::Table(table) => Some(table.caption()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(captions, vec![Some("Table 1. "), None, Some("Table 2. ")]);
+}

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -1,3 +1,4 @@
 mod add_title;
 mod build_a_basic_table;
 mod customize_title_label;
+mod turn_off_title_label;

--- a/parser/src/tests/asciidoc_lang/tables/turn_off_title_label.rs
+++ b/parser/src/tests/asciidoc_lang/tables/turn_off_title_label.rs
@@ -1,0 +1,124 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/turn-off-title-label.adoc");
+
+non_normative!(
+    r#"
+= Turn Off the Title Label
+:table-caption!:
+
+"#
+);
+
+#[test]
+fn disable_the_label_using_table_caption() {
+    non_normative!(
+        r#"
+== Disable the label using table-caption
+
+"#
+    );
+
+    verifies!(
+        r#"
+You can disable the title label for all of the tables in a document by unsetting the `table-caption` document attribute.
+
+[source]
+----
+= Title of Document
+:table-caption!: <.>
+
+.A table with a title but no label
+|===
+|Value |Result |Notes
+
+|Null |A mystery |See Appendix R
+|===
+----
+<.> In an attribute entry, enter the name of the attribute, `table-caption`, and append a bang (`!`) to the end of the name.
+This unsets the attribute.
+
+When `table-caption` is unset, table titles aren't preceded by a label and label number.
+
+.A table with a title but no label
+|===
+|Value |Result |Notes
+
+|Null |A mystery |See Appendix R
+|===
+
+"#
+    );
+
+    // Unsetting `table-caption` in the document header suppresses the label for
+    // every titled table: the title still renders inside the table's
+    // `<caption class="title">`, but with no "Table <n>." prefix in front of it.
+    let doc = Parser::default().parse(
+        "= Title of Document\n:table-caption!:\n\n.A table with a title but no label\n|===\n|Value |Result |Notes\n\n|Null |A mystery |See Appendix R\n|===",
+    );
+
+    assert_xpath(
+        &doc,
+        "//caption[text()=\"A table with a title but no label\"]",
+        1,
+    );
+    assert_xpath(&doc, "//caption", 1);
+}
+
+#[test]
+fn disable_the_label_using_caption() {
+    non_normative!(
+        r#"
+== Disable the label using caption
+
+"#
+    );
+
+    verifies!(
+        r#"
+To remove the label on an individual table, assign an empty value to the `caption` attribute.
+
+[source]
+----
+[caption=] <.>
+.A table with a title but no label
+[cols="2,1"]
+|===
+|Lots and lots of data |A little data
+
+|834,734 |3
+|3,999,271.5601 |5
+|===
+----
+<.> Enter the attribute's name, `caption`, in an attribute list directly above the table title, followed by an equals sign (`=`).
+Don't enter a value after the `=`.
+
+The table from the previous example is displayed below.
+
+[caption=]
+.A table with a title but no label
+[cols="2,1"]
+|===
+|Lots and lots of data |A little data
+
+|834,734 |3
+|3,999,271.5601 |5
+|===
+"#
+    );
+
+    // An empty `caption` attribute removes the label on this individual table
+    // only: the title renders inside the table's `<caption class="title">` with
+    // no "Table <n>." prefix, and the table is skipped by the document-wide
+    // counter rather than consuming a number.
+    let doc = Parser::default().parse(
+        "[caption=]\n.A table with a title but no label\n[cols=\"2,1\"]\n|===\n|Lots and lots of data |A little data\n\n|834,734 |3\n|3,999,271.5601 |5\n|===",
+    );
+
+    assert_xpath(
+        &doc,
+        "//caption[text()=\"A table with a title but no label\"]",
+        1,
+    );
+    assert_xpath(&doc, "//caption", 1);
+}


### PR DESCRIPTION
Implements everything described on `docs/modules/tables/pages/turn-off-title-label.adoc` — the two ways to remove a table's title label — building on the patterns from #509, #510, and #513.

## Behavior

**1. Disable the label for all tables — `:table-caption!:`**

Unsetting `table-caption` document-wide already suppressed the label (from #513). This page now carries spec-coverage for that path.

**2. Disable the label on one table — `[caption=]`**

An explicitly empty per-table `caption` now removes the label on that table only: the title renders with no prefix, and the table is skipped by the document-wide table counter (it does not consume a number).

## Parser change

Previously `[caption=]` fell through to the `table-caption` default and was incorrectly labeled `Table 1.`. The root cause was in `ElementAttribute` parsing: `name=` with an empty value (end-of-list or immediate comma) discarded the name and re-read the token as a positional `name=` value. This resolves the long-standing _"spec ambiguity"_ TODO and matches Asciidoctor, which renders an empty-caption table's title with no label.

- `name=` with an empty value is now a named attribute with an empty string value.
- `TableBlock` maps an empty `caption` attribute to no caption (no label, no number), distinct from the verbatim-label path.

## Tests

- Spec-coverage test mirroring `turn-off-title-label.adoc` (full normative-line coverage verified via `sdd`).
- Table unit tests: empty-caption suppression, and empty-caption counter-skipping.
- Updated the two `ElementAttribute` unit tests that pinned the old empty-named-value fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)