### PR TITLE
feat: Align table content by column (alignment operators)

### DIFF
--- a/parser/src/blocks/mod.rs
+++ b/parser/src/blocks/mod.rs
@@ -65,7 +65,9 @@ mod simple;
 pub use simple::{SimpleBlock, SimpleBlockStyle};
 
 mod table;
-pub use table::{TableBlock, TableCell, TableColumn, TableRow};
+pub use table::{
+    HorizontalAlignment, TableBlock, TableCell, TableColumn, TableRow, VerticalAlignment,
+};
 
 #[cfg(test)]
 mod tests;

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -31,8 +31,9 @@ use crate::{
 ///
 /// * The CSV, TSV, and DSV data formats (and the `,===` / `:===` shorthand
 ///   delimiters).
-/// * Column specifiers and multipliers beyond a proportional width (alignment
-///   and style operators).
+/// * Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, `s`,
+///   and `v` operators); proportional width and the horizontal and vertical
+///   alignment operators are supported.
 /// * Cell specifiers (spans, duplication, per-cell alignment and style, and the
 ///   `a` AsciiDoc style that nests block content inside a cell).
 /// * Footer rows.
@@ -331,11 +332,14 @@ impl<'src> HasSpan<'src> for TableBlock<'src> {
 
 /// A column in a [`TableBlock`].
 ///
-/// For now a column carries only its proportional width. Alignment and style
-/// operators on the `cols` specifier are not yet modeled.
+/// A column carries its proportional width and the horizontal and vertical
+/// alignment applied to its cells' content. Style operators on the `cols`
+/// specifier are not yet modeled.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableColumn {
     width: usize,
+    h_align: HorizontalAlignment,
+    v_align: VerticalAlignment,
 }
 
 impl TableColumn {
@@ -344,12 +348,75 @@ impl TableColumn {
     pub fn width(&self) -> usize {
         self.width
     }
+
+    /// Returns the horizontal alignment applied to this column's content.
+    ///
+    /// The alignment comes from a horizontal alignment operator (`<`, `>`, or
+    /// `^`) on the column's specifier and defaults to
+    /// [`HorizontalAlignment::Left`].
+    pub fn h_align(&self) -> HorizontalAlignment {
+        self.h_align
+    }
+
+    /// Returns the vertical alignment applied to this column's content.
+    ///
+    /// The alignment comes from a vertical alignment operator (`.<`, `.>`, or
+    /// `.^`) on the column's specifier and defaults to
+    /// [`VerticalAlignment::Top`].
+    pub fn v_align(&self) -> VerticalAlignment {
+        self.v_align
+    }
 }
 
 impl Default for TableColumn {
     fn default() -> Self {
-        Self { width: 1 }
+        Self {
+            width: 1,
+            h_align: HorizontalAlignment::Left,
+            v_align: VerticalAlignment::Top,
+        }
     }
+}
+
+/// The horizontal alignment of a column's content.
+///
+/// Specified by a horizontal alignment operator at the start of a
+/// [column specifier](TableColumn): the less-than sign (`<`) for
+/// [`Left`](Self::Left), the greater-than sign (`>`) for
+/// [`Right`](Self::Right), and the caret (`^`) for [`Center`](Self::Center).
+/// The default is [`Left`](Self::Left).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HorizontalAlignment {
+    /// Content is aligned to the left side of the column (the `<` operator).
+    /// This is the default horizontal alignment.
+    Left,
+
+    /// Content is centered horizontally in the column (the `^` operator).
+    Center,
+
+    /// Content is aligned to the right side of the column (the `>` operator).
+    Right,
+}
+
+/// The vertical alignment of a column's content.
+///
+/// Specified by a vertical alignment operator on a
+/// [column specifier](TableColumn), always introduced by a dot (`.`): `.<` for
+/// [`Top`](Self::Top), `.>` for [`Bottom`](Self::Bottom), and `.^` for
+/// [`Middle`](Self::Middle). The default is [`Top`](Self::Top).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum VerticalAlignment {
+    /// Content is aligned to the top of the column's cells (the `.<` operator).
+    /// This is the default vertical alignment.
+    Top,
+
+    /// Content is centered vertically in the column's cells (the `.^`
+    /// operator).
+    Middle,
+
+    /// Content is aligned to the bottom of the column's cells (the `.>`
+    /// operator).
+    Bottom,
 }
 
 /// A row of cells in a [`TableBlock`].
@@ -400,8 +467,9 @@ impl<'src> TableCell<'src> {
 /// Parse the value of the `cols` attribute into a list of columns.
 ///
 /// The value is a comma-separated list of column specifiers. A specifier may be
-/// preceded by a multiplier (`<n>*`) that repeats the column `n` times. Only
-/// the proportional width portion of a specifier is currently interpreted.
+/// preceded by a multiplier (`<n>*`) that repeats the column `n` times. The
+/// alignment operators and proportional width of a specifier are interpreted;
+/// the style operator is not yet.
 fn parse_cols(value: &str) -> Vec<TableColumn> {
     let mut columns: Vec<TableColumn> = vec![];
 
@@ -425,24 +493,73 @@ fn parse_cols(value: &str) -> Vec<TableColumn> {
     columns
 }
 
-/// Parse a single column specifier, extracting its proportional width.
+/// Parse a single column specifier, extracting its alignment and proportional
+/// width.
 ///
-/// In a full column specifier the width is the single numeric token, optionally
-/// preceded by alignment operators and followed by a style operator (neither of
-/// which is interpreted yet). The width is therefore the first contiguous run
-/// of digits; a spec with no digits falls back to the default width. Taking the
-/// first run — rather than concatenating every digit in the spec — keeps
-/// unrelated digit groups from fusing once those operators are supported.
+/// A column specifier is positional: an optional horizontal alignment operator
+/// (`<`, `>`, or `^`) comes first, followed by an optional vertical alignment
+/// operator (`.<`, `.>`, or `.^`), followed by the width, and finally an
+/// optional style operator. When a multiplier (`<n>*`) is present, the
+/// operators follow the multiplier, so the `spec` passed here is the portion
+/// after the `*`.
+///
+/// The width is the first contiguous run of digits after any alignment
+/// operators; a spec with no digits falls back to the default width. Taking the
+/// first run — rather than concatenating every digit — keeps the width from
+/// fusing with digits in an as-yet-unmodeled style operator. The style operator
+/// is otherwise ignored.
 fn parse_col_spec(spec: &str) -> TableColumn {
-    let digits: String = spec
-        .chars()
-        .skip_while(|c| !c.is_ascii_digit())
-        .take_while(|c| c.is_ascii_digit())
-        .collect();
+    let mut rest = spec.trim();
 
-    match digits.parse::<usize>() {
-        Ok(width) if width > 0 => TableColumn { width },
-        _ => TableColumn::default(),
+    // Horizontal alignment operator (if present) always comes first.
+    let mut h_align = HorizontalAlignment::Left;
+    match rest.as_bytes().first() {
+        Some(b'<') => {
+            h_align = HorizontalAlignment::Left;
+            rest = &rest[1..];
+        }
+        Some(b'>') => {
+            h_align = HorizontalAlignment::Right;
+            rest = &rest[1..];
+        }
+        Some(b'^') => {
+            h_align = HorizontalAlignment::Center;
+            rest = &rest[1..];
+        }
+        _ => {}
+    }
+
+    // Vertical alignment operator (if present) follows, introduced by a dot.
+    let mut v_align = VerticalAlignment::Top;
+    if let Some(after_dot) = rest.strip_prefix('.') {
+        match after_dot.as_bytes().first() {
+            Some(b'<') => {
+                v_align = VerticalAlignment::Top;
+                rest = &after_dot[1..];
+            }
+            Some(b'>') => {
+                v_align = VerticalAlignment::Bottom;
+                rest = &after_dot[1..];
+            }
+            Some(b'^') => {
+                v_align = VerticalAlignment::Middle;
+                rest = &after_dot[1..];
+            }
+            _ => {}
+        }
+    }
+
+    // Width is the first run of digits after the alignment operators.
+    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    let width = match digits.parse::<usize>() {
+        Ok(width) if width > 0 => width,
+        _ => TableColumn::default().width,
+    };
+
+    TableColumn {
+        width,
+        h_align,
+        v_align,
     }
 }
 

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     HasSpan, Parser, Span,
-    blocks::{Block, ContentModel, IsBlock, TableBlock},
+    blocks::{Block, ContentModel, HorizontalAlignment, IsBlock, TableBlock, VerticalAlignment},
     content::SubstitutionGroup,
     parser::ModificationContext,
 };
@@ -429,4 +429,21 @@ fn empty_caption_attribute_does_not_consume_a_table_number() {
         .collect();
 
     assert_eq!(captions, vec![Some("Table 1. "), None, Some("Table 2. ")]);
+}
+
+#[test]
+fn malformed_vertical_operator_falls_back_to_defaults() {
+    // A dot in a column specifier introduces a vertical alignment operator, which
+    // must be followed by `<`, `>`, or `^`. When the dot is followed by anything
+    // else (here the letter `x`), the operator is malformed; rather than panic,
+    // the parser leaves the dot unconsumed so the column falls back to the
+    // default vertical alignment (top) and default width, and the stray text is
+    // ignored along with the as-yet-unmodeled style operator.
+    let table = parse_table("[cols=\".x,1\"]\n|===\n|a |b\n|===");
+
+    let columns = table.columns();
+    assert_eq!(columns.len(), 2);
+    assert_eq!(columns[0].width(), 1);
+    assert_eq!(columns[0].h_align(), HorizontalAlignment::Left);
+    assert_eq!(columns[0].v_align(), VerticalAlignment::Top);
 }

--- a/parser/src/tests/asciidoc_lang/tables/add_columns.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_columns.rs
@@ -116,10 +116,26 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 3 },
-                    TableColumn { width: 3 },
-                    TableColumn { width: 3 },
-                    TableColumn { width: 3 },
+                    TableColumn {
+                        width: 3,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 3,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 3,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 3,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
@@ -311,9 +327,21 @@ The integer `3`, combined with the `+*+` operator, indicates that the table will
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 1 },
-                    TableColumn { width: 1 },
-                    TableColumn { width: 1 },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: None,
                 body_rows: &[TableRow {
@@ -453,10 +481,26 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 5 },
-                    TableColumn { width: 1 },
-                    TableColumn { width: 1 },
-                    TableColumn { width: 1 },
+                    TableColumn {
+                        width: 5,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
@@ -680,9 +724,21 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 1 },
-                    TableColumn { width: 1 },
-                    TableColumn { width: 1 },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: None,
                 body_rows: &[

--- a/parser/src/tests/asciidoc_lang/tables/add_title.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_title.rs
@@ -58,7 +58,18 @@ fn add_a_title_to_a_table() {
                 },
             },
             blocks: &[Block::Table(TableBlock {
-                columns: &[TableColumn { width: 1 }, TableColumn { width: 1 }],
+                columns: &[
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    }
+                ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {

--- a/parser/src/tests/asciidoc_lang/tables/adjust_column_widths.rs
+++ b/parser/src/tests/asciidoc_lang/tables/adjust_column_widths.rs
@@ -52,9 +52,21 @@ When using the HTML5 backend with the default Asciidoctor stylesheet, tables str
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 1 },
-                    TableColumn { width: 1 },
-                    TableColumn { width: 1 },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: None,
                 body_rows: &[TableRow {
@@ -183,9 +195,21 @@ As seen below, the columns stretch across the width of the page according to the
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 2 },
-                    TableColumn { width: 1 },
-                    TableColumn { width: 3 },
+                    TableColumn {
+                        width: 2,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 3,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
@@ -392,9 +416,21 @@ The columns, displayed in the table below, have adjusted across the width of the
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 6 },
-                    TableColumn { width: 1 },
-                    TableColumn { width: 3 },
+                    TableColumn {
+                        width: 6,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 3,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
@@ -530,9 +566,21 @@ The columns, displayed in the table below, have adjusted across the width of the
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 6 },
-                    TableColumn { width: 1 },
-                    TableColumn { width: 2 },
+                    TableColumn {
+                        width: 6,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 2,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
@@ -713,9 +761,21 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 15 },
-                    TableColumn { width: 30 },
-                    TableColumn { width: 55 },
+                    TableColumn {
+                        width: 15,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 30,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 55,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
@@ -851,9 +911,21 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
             },
             blocks: &[Block::Table(TableBlock {
                 columns: &[
-                    TableColumn { width: 15 },
-                    TableColumn { width: 30 },
-                    TableColumn { width: 55 },
+                    TableColumn {
+                        width: 15,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 30,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 55,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
                 ],
                 header_row: Some(TableRow {
                     cells: &[

--- a/parser/src/tests/asciidoc_lang/tables/align_by_column.rs
+++ b/parser/src/tests/asciidoc_lang/tables/align_by_column.rs
@@ -635,7 +635,10 @@ centered vertically.
         ]
     );
 
-    non_normative!(
+    // Cell specifiers (and thus their per-cell alignment operators) are not yet
+    // parsed, so the override of a column's alignment by a cell's alignment can't
+    // be verified yet.
+    to_do_verifies!(
         r#"
 IMPORTANT: If there is an xref:align-by-cell.adoc[alignment operator on a cell's specifier], it will override the column's alignment operator.
 "#

--- a/parser/src/tests/asciidoc_lang/tables/align_by_column.rs
+++ b/parser/src/tests/asciidoc_lang/tables/align_by_column.rs
@@ -1,0 +1,643 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/align-by-column.adoc");
+
+non_normative!(
+    r#"
+= Align Content by Column
+// Using Wikipedia's names for the operators. For reference, see https://en.wikipedia.org/wiki/Less-than_sign
+
+The alignment operators allow you to horizontally and vertically align a column's content.
+They're applied to a column specifier and xref:add-columns.adoc#cols-attribute[assigned to the cols attribute].
+
+"#
+);
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Collect each column's `(width, horizontal alignment, vertical alignment)`.
+fn column_alignments(
+    table: &crate::blocks::TableBlock<'_>,
+) -> Vec<(usize, HorizontalAlignment, VerticalAlignment)> {
+    table
+        .columns()
+        .iter()
+        .map(|c| (c.width(), c.h_align(), c.v_align()))
+        .collect()
+}
+
+#[test]
+fn horizontal_alignment_operators() {
+    non_normative!(
+        r#"
+[#horizontal-operators]
+== Horizontal alignment operators
+
+"#
+    );
+
+    verifies!(
+        r#"
+Content can be horizontally aligned to the left or right side of the column as well as the center of the column.
+
+Flush left operator (<):: The less-than sign (`<`) left aligns the content.
+This is the default horizontal alignment.
+Flush right operator (>):: The greater-than sign (`>`) right aligns the content.
+Center operator (^):: The caret (`+^+`) centers the content.
+
+A horizontal alignment operator is entered in front a <<vertical-operators,vertical alignment operator>> (if present) and in front of a xref:adjust-column-widths.adoc[column's width] (if present).
+If the number of columns is assigned using a multiplier (`+<n>*+`), the horizontal alignment operator is placed directly after the multiplier operator (`+*+`).
+
+* `[cols="2,pass:q[#^#]1"]` A horizontal alignment operator is placed in front of the column width.
+* `[cols="pass:q[#>#].^1,2"]` A horizontal alignment operator is placed in front of a vertical alignment operator.
+* `[cols="pass:q[#>#],pass:q[#^#]"]` When a column width isn't specified, a horizontal alignment operator can represent both the column and the column content's alignment.
+* `[cols="3*pass:q[#>#]"]` The horizontal alignment operator is placed directly after a multiplier.
+
+"#
+    );
+
+    // The `<` operator is the default, so its presence does not change the
+    // alignment from the left.
+    let table = parse_table("[cols=\"<2,1\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (2, HorizontalAlignment::Left, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+
+    // A horizontal alignment operator is placed in front of the column width.
+    let table = parse_table("[cols=\"2,^1\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (2, HorizontalAlignment::Left, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Center, VerticalAlignment::Top),
+        ]
+    );
+
+    // A horizontal alignment operator is placed in front of a vertical alignment
+    // operator.
+    let table = parse_table("[cols=\">.^1,2\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Right, VerticalAlignment::Middle),
+            (2, HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+
+    // When a column width isn't specified, a horizontal alignment operator can
+    // represent both the column and the column content's alignment.
+    let table = parse_table("[cols=\">,^\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Right, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Center, VerticalAlignment::Top),
+        ]
+    );
+
+    // The horizontal alignment operator is placed directly after a multiplier.
+    let table = parse_table("[cols=\"3*>\"]\n|===\n|a |b |c\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Right, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Right, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Right, VerticalAlignment::Top),
+        ]
+    );
+}
+
+#[test]
+fn center_content_horizontally_in_a_column() {
+    non_normative!(
+        r#"
+=== Center content horizontally in a column
+
+"#
+    );
+
+    verifies!(
+        r#"
+To horizontally center the content in a column, place the `+^+` operator at the beginning of the xref:add-columns.adoc#col-specifier[column's specifier].
+
+.Center column content horizontally
+[source#ex-horizontal]
+----
+[cols="^4,1"]
+|===
+|This content is horizontally centered.
+|There isn't a horizontal alignment operator on this column's specifier, so the column falls back to the default horizontal alignment.
+Content is left-aligned by default.
+|===
+----
+
+The table from <<ex-horizontal>> is rendered below.
+
+.Result of <<ex-horizontal>>
+[cols="^4,1"]
+|===
+|This content is horizontally centered.
+|There isn't a horizontal alignment operator on this column's specifier, so the column falls back to the default horizontal alignment.
+Content is left-aligned by default.
+|===
+
+"#
+    );
+
+    let table = parse_table(
+        "[cols=\"^4,1\"]\n|===\n|This content is horizontally centered.\n|There isn't a horizontal alignment operator on this column's specifier, so the column falls back to the default horizontal alignment.\nContent is left-aligned by default.\n|===",
+    );
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (4, HorizontalAlignment::Center, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+
+    verifies!(
+        r#"
+When the columns are specified using the xref:add-columns.adoc#column-multiplier[multiplier], place the `+^+` operator after the multiplier operator (`+*+`).
+
+.Horizontal alignment and multiplier operator order
+[source#ex-horizontal-multiplier]
+----
+[cols="2*^",options=header]
+|===
+|Column name
+|Column name
+
+|This content is horizontally centered.
+|This content is also horizontally centered.
+|===
+----
+
+The table from <<ex-horizontal-multiplier>> is rendered below.
+
+.Result of <<ex-horizontal-multiplier>>
+[cols="2*^",options=header]
+|===
+|Column name
+|Column name
+
+|This content is horizontally centered.
+|This content is also horizontally centered.
+|===
+
+"#
+    );
+
+    let table = parse_table(
+        "[cols=\"2*^\",options=header]\n|===\n|Column name\n|Column name\n\n|This content is horizontally centered.\n|This content is also horizontally centered.\n|===",
+    );
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Center, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Center, VerticalAlignment::Top),
+        ]
+    );
+    assert!(table.header_row().is_some());
+}
+
+#[test]
+fn right_align_content_in_a_column() {
+    non_normative!(
+        r#"
+=== Right align content in a column
+
+"#
+    );
+
+    verifies!(
+        r#"
+To align the content in a column to its right side, place the `+>+` operator in front of the column's specifier.
+
+.Right align column content
+[source#ex-right]
+----
+[cols=">4,1"]
+|===
+|This content is aligned to the right side of the column.
+|There isn't a horizontal alignment operator on this column's specifier, so the column falls back to the default horizontal alignment.
+Content is left-aligned by default.
+|===
+----
+
+The table <<ex-right>> is rendered below.
+
+.Result of <<ex-right>>
+[cols=">4,1"]
+|===
+|This content is aligned to the right side of the column.
+|There isn't a horizontal alignment operator on this column's specifier, so the column falls back to the default horizontal alignment.
+Content is left-aligned by default.
+|===
+
+"#
+    );
+
+    let table = parse_table(
+        "[cols=\">4,1\"]\n|===\n|This content is aligned to the right side of the column.\n|There isn't a horizontal alignment operator on this column's specifier, so the column falls back to the default horizontal alignment.\nContent is left-aligned by default.\n|===",
+    );
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (4, HorizontalAlignment::Right, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+
+    verifies!(
+        r#"
+When the columns are specified using the xref:add-columns.adoc#column-multiplier[multiplier], place the `+>+` operator after the multiplier operator (`+*+`).
+
+.Right alignment and multiplier operator order
+[source#ex-right-multiplier]
+----
+[cols="2*>",options=header]
+|===
+|Column name
+|Column name
+
+|This content is aligned to the right side of the column.
+|This content is also aligned to the right side of the column.
+|===
+----
+
+The table from <<ex-right-multiplier>> is rendered below.
+
+.Result of <<ex-right-multiplier>>
+[cols="2*>",options=header]
+|===
+|Column name
+|Column name
+
+|This content is aligned to the right side of the column.
+|This content is also aligned to the right side of the column.
+|===
+
+"#
+    );
+
+    let table = parse_table(
+        "[cols=\"2*>\",options=header]\n|===\n|Column name\n|Column name\n\n|This content is aligned to the right side of the column.\n|This content is also aligned to the right side of the column.\n|===",
+    );
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Right, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Right, VerticalAlignment::Top),
+        ]
+    );
+    assert!(table.header_row().is_some());
+}
+
+#[test]
+fn vertical_alignment_operators() {
+    non_normative!(
+        r#"
+[#vertical-operators]
+== Vertical alignment operators
+
+"#
+    );
+
+    verifies!(
+        r#"
+Content can be vertically aligned to the top or bottom of a column's cells as well as the center of a column.
+Vertical alignment operators always begin with a dot (`.`).
+
+Flush top operator (.<):: The dot and less-than sign (`.<`) aligns the content to the top of the column's cells.
+This is the default vertical alignment.
+Flush bottom operator (.>):: The dot and greater-than sign (`.>`) aligns the content to the bottom of the column's cells.
+Center operator (.^):: The dot and caret (`+.^+`) centers the content vertically.
+
+A vertical alignment operator is entered directly after a <<horizontal-operators,horizontal alignment operator>> (if present) and before a xref:adjust-column-widths.adoc[column's width] (if present).
+If the number of columns is assigned using a multiplier (`+<n>*+`), the vertical alignment operator is placed directly after the horizontal alignment operator (if present).
+Otherwise, it's placed directly after the multiplier operator (`+*+`).
+
+* `[cols="2,pass:q[#.^#]1"]` A vertical alignment operator is placed in front of the column width.
+* `[cols=">pass:q[#.^#]1,2"]` The vertical alignment operator is placed after the horizontal alignment operator but before the column width.
+* `[cols="pass:q[#.^#],pass:q[#.>#]"]` When a column width doesn't need to be specified, a vertical alignment operator can represent both the column and the column content's alignment.
+* `[cols="3*pass:q[#.>#]"]` The vertical alignment operator is placed directly after a multiplier unless there is a horizontal alignment operator.
+Then it's placed after the horizontal alignment operator, (e.g., `[cols="3*^pass:q[#.>#]"]`)
+
+"#
+    );
+
+    // The `.<` operator is the default, so its presence does not change the
+    // alignment from the top.
+    let table = parse_table("[cols=\"2,.<1\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (2, HorizontalAlignment::Left, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+
+    // A vertical alignment operator is placed in front of the column width.
+    let table = parse_table("[cols=\"2,.^1\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (2, HorizontalAlignment::Left, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Middle),
+        ]
+    );
+
+    // The vertical alignment operator is placed after the horizontal alignment
+    // operator but before the column width.
+    let table = parse_table("[cols=\">.^1,2\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Right, VerticalAlignment::Middle),
+            (2, HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+
+    // When a column width doesn't need to be specified, a vertical alignment
+    // operator can represent both the column and the column content's alignment.
+    let table = parse_table("[cols=\".^,.>\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Left, VerticalAlignment::Middle),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Bottom),
+        ]
+    );
+
+    // The vertical alignment operator is placed directly after a multiplier when
+    // there is no horizontal alignment operator.
+    let table = parse_table("[cols=\"3*.>\"]\n|===\n|a |b |c\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Left, VerticalAlignment::Bottom),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Bottom),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Bottom),
+        ]
+    );
+
+    // When a horizontal alignment operator is present, the vertical alignment
+    // operator is placed after it.
+    let table = parse_table("[cols=\"3*^.>\"]\n|===\n|a |b |c\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Center, VerticalAlignment::Bottom),
+            (1, HorizontalAlignment::Center, VerticalAlignment::Bottom),
+            (1, HorizontalAlignment::Center, VerticalAlignment::Bottom),
+        ]
+    );
+}
+
+#[test]
+fn align_content_to_the_bottom_of_a_columns_cells() {
+    non_normative!(
+        r#"
+=== Align content to the bottom of a column's cells
+
+"#
+    );
+
+    verifies!(
+        r#"
+To align the content in a column to the bottom of each cell, place the `+.>+` operator directly in front of the xref:adjust-column-widths.adoc[column's width].
+
+.Bottom align column content
+[source#ex-bottom]
+----
+[cols=".>2,1"]
+|===
+|This content is vertically aligned to the bottom of the cell.
+|There isn't a vertical alignment operator on this column's specifier, so the column falls back to the default vertical alignment.
+Content is top-aligned by default.
+|===
+----
+
+The table from <<ex-bottom>> is rendered below.
+
+.Result of <<ex-bottom>>
+[cols=".>2,1"]
+|===
+|This content is vertically aligned to the bottom of the cell.
+|There isn't a vertical alignment operator on this column's specifier, so the column falls back to the default vertical alignment.
+Content is top-aligned by default.
+|===
+
+"#
+    );
+
+    let table = parse_table(
+        "[cols=\".>2,1\"]\n|===\n|This content is vertically aligned to the bottom of the cell.\n|There isn't a vertical alignment operator on this column's specifier, so the column falls back to the default vertical alignment.\nContent is top-aligned by default.\n|===",
+    );
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (2, HorizontalAlignment::Left, VerticalAlignment::Bottom),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+}
+
+#[test]
+fn center_content_vertically_in_a_column() {
+    non_normative!(
+        r#"
+=== Center content vertically in a column
+
+"#
+    );
+
+    verifies!(
+        r#"
+To vertically center the content in a column, place the `+.^+` operator directly in front of the xref:adjust-column-widths.adoc[column's width].
+
+.Center column content vertically
+[source#ex-vertical]
+----
+[cols=".^2,1"]
+|===
+|This content is centered vertically in the cell.
+|There isn't a vertical alignment operator on this column's specifier, so the column falls back to the default vertical alignment.
+Content is top-aligned by default.
+|===
+----
+
+The table from <<ex-vertical>> is rendered below.
+
+.Result of <<ex-vertical>>
+[cols=".^2,1"]
+|===
+|This content is centered vertically in the cell.
+|There isn't a vertical alignment operator on this column's specifier, so the column falls back to the default vertical alignment.
+Content is top-aligned by default.
+|===
+
+"#
+    );
+
+    let table = parse_table(
+        "[cols=\".^2,1\"]\n|===\n|This content is centered vertically in the cell.\n|There isn't a vertical alignment operator on this column's specifier, so the column falls back to the default vertical alignment.\nContent is top-aligned by default.\n|===",
+    );
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (2, HorizontalAlignment::Left, VerticalAlignment::Middle),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+
+    verifies!(
+        r#"
+To vertically align the content to the middle of the cells in all of the columns, enter the  `.^` operator after the xref:add-columns.adoc#column-multiplier[multiplier].
+
+.Vertical alignment and multiplier operator order
+[source#ex-vertical-multiplier]
+----
+[cols="2*.^",options=header]
+|===
+|Column name
+|Column name
+
+|This content is vertically centered.
+|This content is also vertically centered.
+|===
+----
+
+The table from <<ex-vertical-multiplier>> is rendered below.
+
+.Result of <<ex-vertical-multiplier>>
+[cols="2*.^",options=header]
+|===
+|Column name
+|Column name
+
+|This content is centered vertically in the cell.
+|This content is also centered vertically in the cell.
+|===
+
+"#
+    );
+
+    let table = parse_table(
+        "[cols=\"2*.^\",options=header]\n|===\n|Column name\n|Column name\n\n|This content is vertically centered.\n|This content is also vertically centered.\n|===",
+    );
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Left, VerticalAlignment::Middle),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Middle),
+        ]
+    );
+    assert!(table.header_row().is_some());
+
+    verifies!(
+        r#"
+When a horizontal alignment operator is also applied to the multiplier, then the vertical alignment operator is placed directly after the horizontal operator (e.g., `[cols="2*>.^"]`).
+
+"#
+    );
+
+    let table = parse_table("[cols=\"2*>.^\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (1, HorizontalAlignment::Right, VerticalAlignment::Middle),
+            (1, HorizontalAlignment::Right, VerticalAlignment::Middle),
+        ]
+    );
+}
+
+#[test]
+fn apply_horizontal_and_vertical_alignment_operators_to_the_same_column() {
+    non_normative!(
+        r#"
+== Apply horizontal and vertical alignment operators to the same column
+
+"#
+    );
+
+    verifies!(
+        r#"
+A column can have a vertical and horizontal alignment operator placed on its xref:add-columns.adoc#col-specifier[specifier].
+The <<horizontal-operators,horizontal operator>> always precedes the <<vertical-operators,vertical operator>>.
+Both operators precede the column width.
+When a xref:add-columns.adoc#column-multiplier[multiplier] is used, the operators are placed after the multiplier.
+
+.Horizontally and vertically align column content
+[source#ex-center]
+----
+[cols="^.>2,1,>.^1"]
+|===
+|Column name |Column name |Column name
+
+|This content is centered horizontally and aligned to the bottom
+of the cell.
+|There aren't any alignment operators on this column's specifier,
+so the column falls back to the default alignments.
+The default horizontal alignment is left-aligned.
+The default vertical alignment is top-aligned.
+|This content is aligned to the right side of the cell and
+centered vertically.
+|===
+----
+
+The table from <<ex-center>> is rendered below.
+
+.Result of <<ex-center>>
+[cols="^.>2,1,>.^1"]
+|===
+|Column name |Column name |Column name
+
+|This content is centered horizontally and aligned to the bottom
+of the cell.
+|There aren't any alignment operators on this column's specifier,
+so the column falls back to the default alignments.
+The default horizontal alignment is left-aligned.
+The default vertical alignment is top-aligned.
+|This content is aligned to the right side of the cell and
+centered vertically.
+|===
+
+"#
+    );
+
+    let table = parse_table(
+        "[cols=\"^.>2,1,>.^1\"]\n|===\n|Column name |Column name |Column name\n\n|This content is centered horizontally and aligned to the bottom\nof the cell.\n|There aren't any alignment operators on this column's specifier,\nso the column falls back to the default alignments.\nThe default horizontal alignment is left-aligned.\nThe default vertical alignment is top-aligned.\n|This content is aligned to the right side of the cell and\ncentered vertically.\n|===",
+    );
+    assert_eq!(
+        column_alignments(&table),
+        vec![
+            (2, HorizontalAlignment::Center, VerticalAlignment::Bottom),
+            (1, HorizontalAlignment::Left, VerticalAlignment::Top),
+            (1, HorizontalAlignment::Right, VerticalAlignment::Middle),
+        ]
+    );
+
+    non_normative!(
+        r#"
+IMPORTANT: If there is an xref:align-by-cell.adoc[alignment operator on a cell's specifier], it will override the column's alignment operator.
+"#
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
+++ b/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
@@ -125,7 +125,18 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                 },
             },
             blocks: &[Block::Table(TableBlock {
-                columns: &[TableColumn { width: 1 }, TableColumn { width: 1 }],
+                columns: &[
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    }
+                ],
                 header_row: None,
                 body_rows: &[
                     TableRow {
@@ -323,7 +334,18 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                 },
             },
             blocks: &[Block::Table(TableBlock {
-                columns: &[TableColumn { width: 1 }, TableColumn { width: 1 }],
+                columns: &[
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    },
+                    TableColumn {
+                        width: 1,
+                        h_align: HorizontalAlignment::Left,
+                        v_align: VerticalAlignment::Top,
+                    }
+                ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -1,6 +1,7 @@
 mod add_columns;
 mod add_title;
 mod adjust_column_widths;
+mod align_by_column;
 mod build_a_basic_table;
 mod customize_title_label;
 mod turn_off_title_label;

--- a/parser/src/tests/fixtures/blocks/table.rs
+++ b/parser/src/tests/fixtures/blocks/table.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::{
     HasSpan,
-    blocks::IsBlock,
+    blocks::{HorizontalAlignment, IsBlock, VerticalAlignment},
     tests::fixtures::{Span, attributes::Attrlist, content::Content},
 };
 
@@ -42,6 +42,8 @@ impl fmt::Debug for TableBlock {
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) struct TableColumn {
     pub width: usize,
+    pub h_align: HorizontalAlignment,
+    pub v_align: VerticalAlignment,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -68,10 +70,9 @@ impl PartialEq<TableBlock> for crate::blocks::TableBlock<'_> {
 
 fn columns_eq(fixture: &[TableColumn], observed: &[crate::blocks::TableColumn]) -> bool {
     fixture.len() == observed.len()
-        && fixture
-            .iter()
-            .zip(observed.iter())
-            .all(|(f, o)| f.width == o.width())
+        && fixture.iter().zip(observed.iter()).all(|(f, o)| {
+            f.width == o.width() && f.h_align == o.h_align() && f.v_align == o.v_align()
+        })
 }
 
 fn cells_eq(fixture: &[TableCell], observed: &[crate::blocks::TableCell]) -> bool {

--- a/parser/src/tests/prelude.rs
+++ b/parser/src/tests/prelude.rs
@@ -6,7 +6,7 @@ pub(crate) use std::collections::HashMap;
 
 pub(crate) use crate::{
     HasSpan, Parser,
-    blocks::{IsBlock, SectionType, SimpleBlockStyle},
+    blocks::{HorizontalAlignment, IsBlock, SectionType, SimpleBlockStyle, VerticalAlignment},
     content::SubstitutionGroup,
     parser::ModificationContext,
     tests::{


### PR DESCRIPTION
Implements all items on `docs/modules/tables/pages/align-by-column.adoc`: the horizontal and vertical column alignment operators for the `cols` attribute.

## What changed

- **`TableColumn`** now carries `h_align` and `v_align` in addition to `width`, with `h_align()` / `v_align()` accessors.
- New public enums `HorizontalAlignment` (`Left` / `Center` / `Right`) and `VerticalAlignment` (`Top` / `Middle` / `Bottom`), exported from `crate::blocks`. Defaults are `Left` / `Top`, matching Asciidoctor.
- **`parse_col_spec`** now parses the column specifier positionally: an optional horizontal operator (`<`, `>`, `^`), then an optional vertical operator (`.<`, `.>`, `.^`), then the width, then an (ignored) style operator. Operators placed after a `<n>*` multiplier are handled, since the multiplier split feeds the post-`*` text here.

## Verification

- New spec-coverage test file `tables/align_by_column.rs` mirrors the page line-for-line — **199/199 lines covered** per `sdd` — with parse assertions for every example (`^4,1`, `2*^`, `>4,1`, `2*>`, `.>2,1`, `.^2,1`, `2*.^`, `2*>.^`, `^.>2,1,>.^1`) plus each placement-rule bullet.
- Existing table tests updated for the new fields; full suite green (1953 passed).
- `cargo +nightly fmt --check`, `cargo clippy --all-targets`, and `cargo +nightly doc` all clean.

The style operators (`a`, `d`, `e`, `h`, `l`, `m`, `s`, `v`) remain out of scope, as noted in the updated "Not yet supported" doc comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)