### PR TITLE
feat: Format table content by column (style operators)

### DIFF
--- a/parser/src/blocks/mod.rs
+++ b/parser/src/blocks/mod.rs
@@ -66,7 +66,8 @@ pub use simple::{SimpleBlock, SimpleBlockStyle};
 
 mod table;
 pub use table::{
-    HorizontalAlignment, TableBlock, TableCell, TableColumn, TableRow, VerticalAlignment,
+    ColumnStyle, HorizontalAlignment, TableBlock, TableCell, TableCellContent, TableColumn,
+    TableRow, VerticalAlignment,
 };
 
 #[cfg(test)]

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -538,8 +538,15 @@ impl<'src> TableCell<'src> {
 
         if style == ColumnStyle::AsciiDoc {
             // The AsciiDoc style effectively creates a nested, standalone
-            // AsciiDoc document in the cell.
+            // AsciiDoc document in the cell. It inherits the parent document's
+            // attributes, but any attribute it defines is scoped to the cell and
+            // must not leak back into the parent. Snapshot the attribute set
+            // before parsing and restore it afterward to enforce that boundary
+            // (matching Asciidoctor, where a `:foo:` set inside a cell is not
+            // visible after the table).
+            let saved_attributes = parser.attribute_values.clone();
             let mut maw = parse_blocks_until(trimmed, |_| false, parser);
+            parser.attribute_values = saved_attributes;
             warnings.append(&mut maw.warnings);
             return Self {
                 content: TableCellContent::AsciiDoc(maw.item.item),
@@ -702,15 +709,18 @@ fn parse_col_spec(spec: &str) -> TableColumn {
     rest = &rest[digits.len()..];
 
     // The style operator, if present, occupies the last position on the
-    // specifier.
-    let style = match rest.trim().as_bytes().first() {
-        Some(b'a') => ColumnStyle::AsciiDoc,
-        Some(b'd') => ColumnStyle::Default,
-        Some(b'e') => ColumnStyle::Emphasis,
-        Some(b'h') => ColumnStyle::Header,
-        Some(b'l') => ColumnStyle::Literal,
-        Some(b'm') => ColumnStyle::Monospace,
-        Some(b's') => ColumnStyle::Strong,
+    // specifier, so it is the entire remainder after the width. Matching the
+    // whole remainder (rather than just its first byte) means a malformed spec
+    // with trailing junk — e.g. `1em` — falls back to the default style instead
+    // of silently honoring the first letter and discarding the rest.
+    let style = match rest.trim() {
+        "a" => ColumnStyle::AsciiDoc,
+        "d" => ColumnStyle::Default,
+        "e" => ColumnStyle::Emphasis,
+        "h" => ColumnStyle::Header,
+        "l" => ColumnStyle::Literal,
+        "m" => ColumnStyle::Monospace,
+        "s" => ColumnStyle::Strong,
         _ => ColumnStyle::Default,
     };
 

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1,7 +1,9 @@
 use crate::{
     HasSpan, Parser, Span,
     attributes::Attrlist,
-    blocks::{ContentModel, IsBlock, metadata::BlockMetadata},
+    blocks::{
+        Block, ContentModel, IsBlock, metadata::BlockMetadata, parse_utils::parse_blocks_until,
+    },
     content::{Content, SubstitutionGroup},
     document::InterpretedValue,
     parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning},
@@ -31,12 +33,14 @@ use crate::{
 ///
 /// * The CSV, TSV, and DSV data formats (and the `,===` / `:===` shorthand
 ///   delimiters).
-/// * Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, `s`,
-///   and `v` operators); proportional width and the horizontal and vertical
-///   alignment operators are supported.
-/// * Cell specifiers (spans, duplication, per-cell alignment and style, and the
-///   `a` AsciiDoc style that nests block content inside a cell).
+/// * Cell specifiers (spans, duplication, per-cell alignment and style); the
+///   per-cell style operator that overrides a column's style operator is not
+///   yet recognized.
 /// * Footer rows.
+///
+/// Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, and `s`
+/// operators) are supported, along with proportional width and the horizontal
+/// and vertical alignment operators.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -177,9 +181,30 @@ impl<'src> TableBlock<'src> {
 
         // Scan every cell in the table, in document order, then partition into
         // rows of `ncols` cells each.
-        let mut cells = scan_cells(inside)
-            .into_iter()
-            .map(|raw| TableCell::parse(raw, parser));
+        //
+        // Each cell is processed according to the style of the column it falls
+        // in. The header row (when present) is the first `ncols` cells and is
+        // always processed as plain header content, regardless of the column
+        // styles, so that a style operator doesn't affect the header row.
+        let mut warnings: Vec<Warning<'src>> = vec![];
+        let raw_cells = scan_cells(inside);
+        let header_len = if has_header { ncols } else { 0 };
+
+        let mut cells = Vec::with_capacity(raw_cells.len());
+        for (idx, raw) in raw_cells.into_iter().enumerate() {
+            let style = if idx < header_len {
+                ColumnStyle::Default
+            } else {
+                // `idx % ncols` is in bounds whenever `ncols > 0`; an empty table
+                // (`ncols == 0`) has no columns, so the cell falls back to the
+                // default style.
+                columns
+                    .get(idx % ncols.max(1))
+                    .map_or(ColumnStyle::Default, |column| column.style)
+            };
+            cells.push(TableCell::parse(raw, style, parser, &mut warnings));
+        }
+        let mut cells = cells.into_iter();
 
         let header_row = if has_header && ncols > 0 {
             let row: Vec<TableCell<'src>> = cells.by_ref().take(ncols).collect();
@@ -208,14 +233,12 @@ impl<'src> TableBlock<'src> {
             .trim_remainder(closing_delimiter.discard_all())
             .trim_trailing_whitespace();
 
-        let warnings = if closing_delimiter.is_empty() {
-            vec![Warning {
+        if closing_delimiter.is_empty() {
+            warnings.push(Warning {
                 source: delimiter.item,
                 warning: WarningType::UnterminatedDelimitedBlock,
-            }]
-        } else {
-            vec![]
-        };
+            });
+        }
 
         Some(MatchAndWarnings {
             item: Some(MatchedItem {
@@ -287,8 +310,7 @@ impl<'src> TableBlock<'src> {
 
         for row in rows {
             for cell in row.cells.iter_mut() {
-                cell.content
-                    .resolve_references(resolver, renderer, warnings);
+                cell.resolve_references(resolver, renderer, warnings);
             }
         }
     }
@@ -332,14 +354,15 @@ impl<'src> HasSpan<'src> for TableBlock<'src> {
 
 /// A column in a [`TableBlock`].
 ///
-/// A column carries its proportional width and the horizontal and vertical
-/// alignment applied to its cells' content. Style operators on the `cols`
-/// specifier are not yet modeled.
+/// A column carries its proportional width, the horizontal and vertical
+/// alignment applied to its cells' content, and the [style](ColumnStyle) used
+/// to process and render that content.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableColumn {
     width: usize,
     h_align: HorizontalAlignment,
     v_align: VerticalAlignment,
+    style: ColumnStyle,
 }
 
 impl TableColumn {
@@ -366,6 +389,15 @@ impl TableColumn {
     pub fn v_align(&self) -> VerticalAlignment {
         self.v_align
     }
+
+    /// Returns the [style](ColumnStyle) applied to this column's content.
+    ///
+    /// The style comes from a style operator in the last position of the
+    /// column's specifier (`a`, `d`, `e`, `h`, `l`, `m`, or `s`) and defaults
+    /// to [`ColumnStyle::Default`].
+    pub fn style(&self) -> ColumnStyle {
+        self.style
+    }
 }
 
 impl Default for TableColumn {
@@ -374,8 +406,55 @@ impl Default for TableColumn {
             width: 1,
             h_align: HorizontalAlignment::Left,
             v_align: VerticalAlignment::Top,
+            style: ColumnStyle::Default,
         }
     }
+}
+
+/// The style applied to the content of a [column](TableColumn) (and, by
+/// extension, to each body cell in that column).
+///
+/// A style is specified by a style operator in the last position of a column
+/// specifier. When no style operator is present, [`Default`](Self::Default) is
+/// assigned and the column is processed as paragraph text.
+///
+/// The style governs both how a cell's content is parsed and how it is
+/// rendered: most styles leave the content as inline markup (changing only the
+/// surrounding formatting), [`Literal`](Self::Literal) processes the content
+/// verbatim, and [`AsciiDoc`](Self::AsciiDoc) parses the content as a nested,
+/// standalone AsciiDoc document.
+///
+/// The verse operator (`v`) recognized by older versions of AsciiDoc has been
+/// deprecated and is not modeled here.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ColumnStyle {
+    /// Block elements (lists, delimited blocks, and block macros) are
+    /// supported; the content is parsed as a nested, standalone AsciiDoc
+    /// document (the `a` operator).
+    AsciiDoc,
+
+    /// All of the markup permitted in a paragraph (inline formatting and inline
+    /// macros) is supported (the `d` operator). This is the default style,
+    /// assigned automatically when no style operator is present.
+    #[default]
+    Default,
+
+    /// Text is italicized (the `e` operator).
+    Emphasis,
+
+    /// The header semantics and styles are applied to the text and cell borders
+    /// (the `h` operator).
+    Header,
+
+    /// Content is treated as if it were inside a literal block (the `l`
+    /// operator).
+    Literal,
+
+    /// Text is rendered using a monospace font (the `m` operator).
+    Monospace,
+
+    /// Text is bold (the `s` operator).
+    Strong,
 }
 
 /// The horizontal alignment of a column's content.
@@ -435,16 +514,38 @@ impl<'src> TableRow<'src> {
 /// A single cell in a [`TableBlock`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableCell<'src> {
-    content: Content<'src>,
+    content: TableCellContent<'src>,
 }
 
 impl<'src> TableCell<'src> {
-    /// Build a cell from the raw (untrimmed) span of its content.
+    /// Build a cell from the raw (untrimmed) span of its content, processing it
+    /// according to the [style](ColumnStyle) of the column the cell belongs to.
     ///
-    /// Leading and trailing whitespace is stripped, escaped cell separators
-    /// (`\|`) are unescaped, and normal inline substitutions are applied.
-    fn parse(raw: Span<'src>, parser: &Parser) -> Self {
+    /// Leading and trailing whitespace is always stripped. For every style but
+    /// [`AsciiDoc`](ColumnStyle::AsciiDoc) the cell holds inline
+    /// [`Content`](TableCellContent::Simple): escaped cell separators (`\|`)
+    /// are unescaped and substitutions are applied — the verbatim group for
+    /// [`Literal`](ColumnStyle::Literal), the normal group otherwise. An
+    /// [`AsciiDoc`](ColumnStyle::AsciiDoc) cell instead parses its content as a
+    /// nested sequence of [blocks](TableCellContent::AsciiDoc).
+    fn parse(
+        raw: Span<'src>,
+        style: ColumnStyle,
+        parser: &mut Parser,
+        warnings: &mut Vec<Warning<'src>>,
+    ) -> Self {
         let trimmed = trim_surrounding_whitespace(raw);
+
+        if style == ColumnStyle::AsciiDoc {
+            // The AsciiDoc style effectively creates a nested, standalone
+            // AsciiDoc document in the cell.
+            let mut maw = parse_blocks_until(trimmed, |_| false, parser);
+            warnings.append(&mut maw.warnings);
+            return Self {
+                content: TableCellContent::AsciiDoc(maw.item.item),
+            };
+        }
+
         let data = trimmed.data();
 
         let mut content = if data.contains("\\|") {
@@ -453,15 +554,59 @@ impl<'src> TableCell<'src> {
             Content::from(trimmed)
         };
 
-        SubstitutionGroup::Normal.apply(&mut content, parser, None);
+        let substitutions = if style == ColumnStyle::Literal {
+            SubstitutionGroup::Verbatim
+        } else {
+            SubstitutionGroup::Normal
+        };
+        substitutions.apply(&mut content, parser, None);
 
-        Self { content }
+        Self {
+            content: TableCellContent::Simple(content),
+        }
     }
 
     /// Returns the interpreted content of this cell.
-    pub fn content(&self) -> &Content<'src> {
+    pub fn content(&self) -> &TableCellContent<'src> {
         &self.content
     }
+
+    /// Resolves any deferred cross-references in this cell's content.
+    fn resolve_references(
+        &mut self,
+        resolver: &dyn ReferenceResolver,
+        renderer: &dyn InlineSubstitutionRenderer,
+        warnings: &mut Vec<ReferenceWarning>,
+    ) {
+        match &mut self.content {
+            TableCellContent::Simple(content) => {
+                content.resolve_references(resolver, renderer, warnings);
+            }
+            TableCellContent::AsciiDoc(blocks) => {
+                for block in blocks.iter_mut() {
+                    block.resolve_references(resolver, renderer, warnings);
+                }
+            }
+        }
+    }
+}
+
+/// The interpreted content of a [`TableCell`].
+///
+/// The variant is determined by the [style](ColumnStyle) of the cell's column:
+/// an [`AsciiDoc`](ColumnStyle::AsciiDoc) column produces
+/// [`AsciiDoc`](Self::AsciiDoc) content, and every other style produces
+/// [`Simple`](Self::Simple) inline content.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TableCellContent<'src> {
+    /// Inline content: the cell's text after its substitutions (normal for most
+    /// styles, verbatim for [`Literal`](ColumnStyle::Literal)) have been
+    /// applied.
+    Simple(Content<'src>),
+
+    /// Block content: the cell's text parsed as a nested, standalone AsciiDoc
+    /// document. Produced by the [`AsciiDoc`](ColumnStyle::AsciiDoc) style.
+    AsciiDoc(Vec<Block<'src>>),
 }
 
 /// Parse the value of the `cols` attribute into a list of columns.
@@ -493,21 +638,20 @@ fn parse_cols(value: &str) -> Vec<TableColumn> {
     columns
 }
 
-/// Parse a single column specifier, extracting its alignment and proportional
-/// width.
+/// Parse a single column specifier, extracting its alignment, proportional
+/// width, and style.
 ///
 /// A column specifier is positional: an optional horizontal alignment operator
 /// (`<`, `>`, or `^`) comes first, followed by an optional vertical alignment
 /// operator (`.<`, `.>`, or `.^`), followed by the width, and finally an
-/// optional style operator. When a multiplier (`<n>*`) is present, the
-/// operators follow the multiplier, so the `spec` passed here is the portion
-/// after the `*`.
+/// optional style operator in the last position. When a multiplier (`<n>*`) is
+/// present, the operators follow the multiplier, so the `spec` passed here is
+/// the portion after the `*`.
 ///
 /// The width is the first contiguous run of digits after any alignment
-/// operators; a spec with no digits falls back to the default width. Taking the
-/// first run — rather than concatenating every digit — keeps the width from
-/// fusing with digits in an as-yet-unmodeled style operator. The style operator
-/// is otherwise ignored.
+/// operators; a spec with no digits falls back to the default width. The style
+/// operator is the trailing letter (`a`, `d`, `e`, `h`, `l`, `m`, or `s`); an
+/// unrecognized trailing letter leaves the style at its default.
 fn parse_col_spec(spec: &str) -> TableColumn {
     let mut rest = spec.trim();
 
@@ -555,11 +699,26 @@ fn parse_col_spec(spec: &str) -> TableColumn {
         Ok(width) if width > 0 => width,
         _ => TableColumn::default().width,
     };
+    rest = &rest[digits.len()..];
+
+    // The style operator, if present, occupies the last position on the
+    // specifier.
+    let style = match rest.trim().as_bytes().first() {
+        Some(b'a') => ColumnStyle::AsciiDoc,
+        Some(b'd') => ColumnStyle::Default,
+        Some(b'e') => ColumnStyle::Emphasis,
+        Some(b'h') => ColumnStyle::Header,
+        Some(b'l') => ColumnStyle::Literal,
+        Some(b'm') => ColumnStyle::Monospace,
+        Some(b's') => ColumnStyle::Strong,
+        _ => ColumnStyle::Default,
+    };
 
     TableColumn {
         width,
         h_align,
         v_align,
+        style,
     }
 }
 

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -4,8 +4,8 @@
 use crate::{
     HasSpan, Parser, Span,
     blocks::{
-        Block, ContentModel, HorizontalAlignment, IsBlock, TableBlock, TableCellContent,
-        VerticalAlignment,
+        Block, ColumnStyle, ContentModel, HorizontalAlignment, IsBlock, TableBlock,
+        TableCellContent, VerticalAlignment,
     },
     content::SubstitutionGroup,
     parser::ModificationContext,
@@ -446,8 +446,8 @@ fn malformed_vertical_operator_falls_back_to_defaults() {
     // must be followed by `<`, `>`, or `^`. When the dot is followed by anything
     // else (here the letter `x`), the operator is malformed; rather than panic,
     // the parser leaves the dot unconsumed so the column falls back to the
-    // default vertical alignment (top) and default width, and the stray text is
-    // ignored along with the as-yet-unmodeled style operator.
+    // default vertical alignment (top) and default width. The leftover `.x` is
+    // not a recognized single-letter style operator, so the style also defaults.
     let table = parse_table("[cols=\".x,1\"]\n|===\n|a |b\n|===");
 
     let columns = table.columns();
@@ -455,4 +455,106 @@ fn malformed_vertical_operator_falls_back_to_defaults() {
     assert_eq!(columns[0].width(), 1);
     assert_eq!(columns[0].h_align(), HorizontalAlignment::Left);
     assert_eq!(columns[0].v_align(), VerticalAlignment::Top);
+    assert_eq!(columns[0].style(), ColumnStyle::Default);
+}
+
+#[test]
+fn literal_column_processes_content_verbatim() {
+    // The `l` (literal) style processes a cell's content with the verbatim
+    // substitution group: inline markup like `*z*` is left intact and only the
+    // special characters are escaped, in contrast to the default style's normal
+    // substitutions.
+    let table = parse_table("[cols=\"l\"]\n|===\n|lit *z* and <x>\n|===");
+
+    assert_eq!(table.columns()[0].style(), ColumnStyle::Literal);
+
+    match table.body_rows()[0].cells()[0].content() {
+        TableCellContent::Simple(content) => {
+            assert_eq!(content.rendered(), "lit *z* and &lt;x&gt;");
+        }
+        TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
+    }
+}
+
+#[test]
+fn malformed_style_operator_falls_back_to_default() {
+    // The style operator is the entire remainder after the width, so trailing
+    // junk (here `em`, perhaps a typo for the `e` style) is not a recognized
+    // single-letter operator and the column falls back to the default style
+    // rather than silently honoring the first letter.
+    let table = parse_table("[cols=\"1em\"]\n|===\n|a\n|===");
+
+    assert_eq!(table.columns()[0].style(), ColumnStyle::Default);
+}
+
+#[test]
+fn asciidoc_cell_resolves_references_in_nested_blocks() {
+    // Cross-references inside an AsciiDoc cell are resolved during the document's
+    // reference-resolution pass, which descends into the cell's nested blocks.
+    let doc = Parser::default()
+        .parse("[#target]\nTarget paragraph.\n\n[cols=\"a\"]\n|===\n|See xref:target[].\n|===");
+
+    let table = doc
+        .nested_blocks()
+        .find_map(|block| match block {
+            Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .unwrap();
+
+    let blocks = match table.body_rows()[0].cells()[0].content() {
+        TableCellContent::AsciiDoc(blocks) => blocks,
+        TableCellContent::Simple(_) => panic!("expected AsciiDoc cell content"),
+    };
+
+    let rendered = blocks[0].rendered_content().unwrap();
+    assert!(
+        rendered.contains("href=\"#target\""),
+        "xref was not resolved: {rendered}"
+    );
+}
+
+#[test]
+fn asciidoc_cell_attributes_are_scoped_to_the_cell() {
+    // An AsciiDoc cell inherits the parent document's attributes, but an
+    // attribute it defines is scoped to the cell and does not leak back into the
+    // parent document (matching Asciidoctor).
+    let mut parser = Parser::default();
+    let doc = parser.parse(
+        ":parent-attr: inherited\n\n[cols=\"a\"]\n|===\n|\n:cell-attr: leaked\ncell sees: {parent-attr} {cell-attr}\n|===",
+    );
+
+    let table = doc
+        .nested_blocks()
+        .find_map(|block| match block {
+            Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .unwrap();
+
+    let blocks = match table.body_rows()[0].cells()[0].content() {
+        TableCellContent::AsciiDoc(blocks) => blocks,
+        TableCellContent::Simple(_) => panic!("expected AsciiDoc cell content"),
+    };
+
+    // Inside the cell, both the inherited parent attribute and the cell's own
+    // attribute resolve.
+    let rendered: String = blocks
+        .iter()
+        .filter_map(|block| block.rendered_content())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        rendered.contains("inherited"),
+        "cell did not inherit the parent attribute: {rendered}"
+    );
+    assert!(
+        rendered.contains("leaked"),
+        "cell did not see its own attribute: {rendered}"
+    );
+
+    // The attribute defined inside the cell did not leak into the parent, while
+    // the parent's own attribute is unaffected.
+    assert!(!parser.has_attribute("cell-attr"));
+    assert!(parser.has_attribute("parent-attr"));
 }

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -3,7 +3,10 @@
 
 use crate::{
     HasSpan, Parser, Span,
-    blocks::{Block, ContentModel, HorizontalAlignment, IsBlock, TableBlock, VerticalAlignment},
+    blocks::{
+        Block, ContentModel, HorizontalAlignment, IsBlock, TableBlock, TableCellContent,
+        VerticalAlignment,
+    },
     content::SubstitutionGroup,
     parser::ModificationContext,
 };
@@ -22,10 +25,16 @@ fn parse_table(source: &str) -> TableBlock<'_> {
 }
 
 /// Collect the rendered content of every cell in a row.
+///
+/// Every cell in these basic-table tests uses the default (inline) style, so a
+/// cell is expected to hold [`TableCellContent::Simple`].
 fn row_text(row: &crate::blocks::TableRow<'_>) -> Vec<String> {
     row.cells()
         .iter()
-        .map(|cell| cell.content().rendered().to_string())
+        .map(|cell| match cell.content() {
+            TableCellContent::Simple(content) => content.rendered().to_string(),
+            TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
+        })
         .collect()
 }
 

--- a/parser/src/tests/asciidoc_lang/tables/add_columns.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_columns.rs
@@ -120,27 +120,31 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                         width: 3,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 3,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 3,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 3,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 3,
@@ -148,10 +152,10 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                                     offset: 23,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 3,
@@ -159,10 +163,10 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                                     offset: 33,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 3,
@@ -170,10 +174,10 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                                     offset: 43,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 4",
                                     line: 3,
@@ -181,14 +185,14 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                                     offset: 53,
                                 },
                                 rendered: "Column 4",
-                            },
+                            }),
                         },
                     ],
                 }),
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 1",
                                     line: 5,
@@ -196,10 +200,10 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                                     offset: 64,
                                 },
                                 rendered: "Cell in column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 2",
                                     line: 6,
@@ -207,10 +211,10 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                                     offset: 82,
                                 },
                                 rendered: "Cell in column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 3",
                                     line: 7,
@@ -218,10 +222,10 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                                     offset: 100,
                                 },
                                 rendered: "Cell in column 3",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 4",
                                     line: 8,
@@ -229,7 +233,7 @@ Or, you could adjust the width of an individual column by xref:adjust-column-wid
                                     offset: 118,
                                 },
                                 rendered: "Cell in column 4",
-                            },
+                            }),
                         },
                     ],
                 }],
@@ -331,23 +335,26 @@ The integer `3`, combined with the `+*+` operator, indicates that the table will
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: None,
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 3,
@@ -355,10 +362,10 @@ The integer `3`, combined with the `+*+` operator, indicates that the table will
                                     offset: 18,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 3,
@@ -366,10 +373,10 @@ The integer `3`, combined with the `+*+` operator, indicates that the table will
                                     offset: 28,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 3,
@@ -377,7 +384,7 @@ The integer `3`, combined with the `+*+` operator, indicates that the table will
                                     offset: 38,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                     ],
                 }],
@@ -485,27 +492,31 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                         width: 5,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 3,
@@ -513,10 +524,10 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                                     offset: 20,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 3,
@@ -524,10 +535,10 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                                     offset: 30,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 3,
@@ -535,10 +546,10 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                                     offset: 40,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 4",
                                     line: 3,
@@ -546,14 +557,14 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                                     offset: 50,
                                 },
                                 rendered: "Column 4",
-                            },
+                            }),
                         },
                     ],
                 }),
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 1",
                                     line: 5,
@@ -561,10 +572,10 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                                     offset: 61,
                                 },
                                 rendered: "Cell in column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 2",
                                     line: 6,
@@ -572,10 +583,10 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                                     offset: 79,
                                 },
                                 rendered: "Cell in column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 3",
                                     line: 7,
@@ -583,10 +594,10 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                                     offset: 97,
                                 },
                                 rendered: "Cell in column 3",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 4",
                                     line: 8,
@@ -594,7 +605,7 @@ As shown below, <<ex-spec-and-multiplier>> creates a table containing a xref:adj
                                     offset: 115,
                                 },
                                 rendered: "Cell in column 4",
-                            },
+                            }),
                         },
                     ],
                 }],
@@ -728,16 +739,19 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: None,
@@ -745,7 +759,7 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
                     TableRow {
                         cells: &[
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 1, row 1",
                                         line: 3,
@@ -753,10 +767,10 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
                                         offset: 7,
                                     },
                                     rendered: "Cell in column 1, row 1",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 2, row 1",
                                         line: 3,
@@ -764,10 +778,10 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
                                         offset: 32,
                                     },
                                     rendered: "Cell in column 2, row 1",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 3, row 1",
                                         line: 3,
@@ -775,14 +789,14 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
                                         offset: 57,
                                     },
                                     rendered: "Cell in column 3, row 1",
-                                },
+                                }),
                             },
                         ],
                     },
                     TableRow {
                         cells: &[
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 1, row 2",
                                         line: 5,
@@ -790,10 +804,10 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
                                         offset: 83,
                                     },
                                     rendered: "Cell in column 1, row 2",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 2, row 2",
                                         line: 5,
@@ -801,10 +815,10 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
                                         offset: 108,
                                     },
                                     rendered: "Cell in column 2, row 2",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 3, row 2",
                                         line: 5,
@@ -812,7 +826,7 @@ The table in <<ex-implicit>> has three columns since its first row contains thre
                                         offset: 133,
                                     },
                                     rendered: "Cell in column 3, row 2",
-                                },
+                                }),
                             },
                         ],
                     },

--- a/parser/src/tests/asciidoc_lang/tables/add_title.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_title.rs
@@ -63,17 +63,19 @@ fn add_a_title_to_a_table() {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     }
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1, header row",
                                     line: 4,
@@ -81,10 +83,10 @@ fn add_a_title_to_a_table() {
                                     offset: 41,
                                 },
                                 rendered: "Column 1, header row",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2, header row",
                                     line: 4,
@@ -92,14 +94,14 @@ fn add_a_title_to_a_table() {
                                     offset: 63,
                                 },
                                 rendered: "Column 2, header row",
-                            },
+                            }),
                         },
                     ],
                 }),
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 1, row 2",
                                     line: 6,
@@ -107,10 +109,10 @@ fn add_a_title_to_a_table() {
                                     offset: 86,
                                 },
                                 rendered: "Cell in column 1, row 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 2, row 2",
                                     line: 7,
@@ -118,7 +120,7 @@ fn add_a_title_to_a_table() {
                                     offset: 111,
                                 },
                                 rendered: "Cell in column 2, row 2",
-                            },
+                            }),
                         },
                     ],
                 }],

--- a/parser/src/tests/asciidoc_lang/tables/adjust_column_widths.rs
+++ b/parser/src/tests/asciidoc_lang/tables/adjust_column_widths.rs
@@ -56,23 +56,26 @@ When using the HTML5 backend with the default Asciidoctor stylesheet, tables str
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: None,
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 2,
@@ -80,10 +83,10 @@ When using the HTML5 backend with the default Asciidoctor stylesheet, tables str
                                     offset: 6,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 2,
@@ -91,10 +94,10 @@ When using the HTML5 backend with the default Asciidoctor stylesheet, tables str
                                     offset: 16,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 2,
@@ -102,7 +105,7 @@ When using the HTML5 backend with the default Asciidoctor stylesheet, tables str
                                     offset: 26,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                     ],
                 },],
@@ -199,22 +202,25 @@ As seen below, the columns stretch across the width of the page according to the
                         width: 2,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 3,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 3,
@@ -222,10 +228,10 @@ As seen below, the columns stretch across the width of the page according to the
                                     offset: 21,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 3,
@@ -233,10 +239,10 @@ As seen below, the columns stretch across the width of the page according to the
                                     offset: 31,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 3,
@@ -244,14 +250,14 @@ As seen below, the columns stretch across the width of the page according to the
                                     offset: 41,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                     ],
                 },),
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 2",
                                     line: 5,
@@ -259,10 +265,10 @@ As seen below, the columns stretch across the width of the page according to the
                                     offset: 52,
                                 },
                                 rendered: "This column has a proportional width of 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 1",
                                     line: 6,
@@ -270,10 +276,10 @@ As seen below, the columns stretch across the width of the page according to the
                                     offset: 95,
                                 },
                                 rendered: "This column has a proportional width of 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 3",
                                     line: 7,
@@ -281,7 +287,7 @@ As seen below, the columns stretch across the width of the page according to the
                                     offset: 138,
                                 },
                                 rendered: "This column has a proportional width of 3",
-                            },
+                            }),
                         },
                     ],
                 },],
@@ -420,22 +426,25 @@ The columns, displayed in the table below, have adjusted across the width of the
                         width: 6,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 3,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 3,
@@ -443,10 +452,10 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 21,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 3,
@@ -454,10 +463,10 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 31,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 3,
@@ -465,14 +474,14 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 41,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                     ],
                 },),
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 6",
                                     line: 5,
@@ -480,10 +489,10 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 52,
                                 },
                                 rendered: "This column has a proportional width of 6",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 1",
                                     line: 6,
@@ -491,10 +500,10 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 95,
                                 },
                                 rendered: "This column has a proportional width of 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 3",
                                     line: 7,
@@ -502,7 +511,7 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 138,
                                 },
                                 rendered: "This column has a proportional width of 3",
-                            },
+                            }),
                         },
                     ],
                 },],
@@ -570,22 +579,25 @@ The columns, displayed in the table below, have adjusted across the width of the
                         width: 6,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 2,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 3,
@@ -593,10 +605,10 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 21,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 3,
@@ -604,10 +616,10 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 31,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 3,
@@ -615,14 +627,14 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 41,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                     ],
                 },),
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 6",
                                     line: 5,
@@ -630,10 +642,10 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 52,
                                 },
                                 rendered: "This column has a proportional width of 6",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 1",
                                     line: 6,
@@ -641,10 +653,10 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 95,
                                 },
                                 rendered: "This column has a proportional width of 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a proportional width of 2",
                                     line: 7,
@@ -652,7 +664,7 @@ The columns, displayed in the table below, have adjusted across the width of the
                                     offset: 138,
                                 },
                                 rendered: "This column has a proportional width of 2",
-                            },
+                            }),
                         },
                     ],
                 },],
@@ -765,22 +777,25 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                         width: 15,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 30,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 55,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 3,
@@ -788,10 +803,10 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 27,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 3,
@@ -799,10 +814,10 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 37,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 3,
@@ -810,14 +825,14 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 47,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                     ],
                 },),
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a width of 15%",
                                     line: 5,
@@ -825,10 +840,10 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 58,
                                 },
                                 rendered: "This column has a width of 15%",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a width of 30%",
                                     line: 6,
@@ -836,10 +851,10 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 90,
                                 },
                                 rendered: "This column has a width of 30%",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a width of 55%",
                                     line: 7,
@@ -847,7 +862,7 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 122,
                                 },
                                 rendered: "This column has a width of 55%",
-                            },
+                            }),
                         },
                     ],
                 },],
@@ -915,22 +930,25 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                         width: 15,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 30,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 55,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 1",
                                     line: 3,
@@ -938,10 +956,10 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 24,
                                 },
                                 rendered: "Column 1",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 2",
                                     line: 3,
@@ -949,10 +967,10 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 34,
                                 },
                                 rendered: "Column 2",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Column 3",
                                     line: 3,
@@ -960,14 +978,14 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 44,
                                 },
                                 rendered: "Column 3",
-                            },
+                            }),
                         },
                     ],
                 },),
                 body_rows: &[TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a width of 15%",
                                     line: 5,
@@ -975,10 +993,10 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 55,
                                 },
                                 rendered: "This column has a width of 15%",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a width of 30%",
                                     line: 6,
@@ -986,10 +1004,10 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 87,
                                 },
                                 rendered: "This column has a width of 30%",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "This column has a width of 55%",
                                     line: 7,
@@ -997,7 +1015,7 @@ For instance, both `[cols="15%,30%,55%"]` and `[cols="15,30,55"]` are valid.
                                     offset: 119,
                                 },
                                 rendered: "This column has a width of 55%",
-                            },
+                            }),
                         },
                     ],
                 },],

--- a/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
+++ b/parser/src/tests/asciidoc_lang/tables/build_a_basic_table.rs
@@ -130,11 +130,13 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     }
                 ],
                 header_row: None,
@@ -142,7 +144,7 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                     TableRow {
                         cells: &[
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 1, row 1",
                                         line: 3,
@@ -150,10 +152,10 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                                         offset: 19,
                                     },
                                     rendered: "Cell in column 1, row 1",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 2, row 1",
                                         line: 4,
@@ -161,14 +163,14 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                                         offset: 44,
                                     },
                                     rendered: "Cell in column 2, row 1",
-                                },
+                                }),
                             },
                         ],
                     },
                     TableRow {
                         cells: &[
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 1, row 2",
                                         line: 6,
@@ -176,10 +178,10 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                                         offset: 70,
                                     },
                                     rendered: "Cell in column 1, row 2",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 2, row 2",
                                         line: 6,
@@ -187,14 +189,14 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                                         offset: 95,
                                     },
                                     rendered: "Cell in column 2, row 2",
-                                },
+                                }),
                             },
                         ],
                     },
                     TableRow {
                         cells: &[
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 1, row 3",
                                         line: 7,
@@ -202,10 +204,10 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                                         offset: 120,
                                     },
                                     rendered: "Cell in column 1, row 3",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 2, row 3",
                                         line: 7,
@@ -213,7 +215,7 @@ However, the `cols` attribute is required to customize the xref:adjust-column-wi
                                         offset: 145,
                                     },
                                     rendered: "Cell in column 2, row 3",
-                                },
+                                }),
                             },
                         ],
                     },
@@ -339,17 +341,19 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     },
                     TableColumn {
                         width: 1,
                         h_align: HorizontalAlignment::Left,
                         v_align: VerticalAlignment::Top,
+                        style: ColumnStyle::Default,
                     }
                 ],
                 header_row: Some(TableRow {
                     cells: &[
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 1, header row",
                                     line: 3,
@@ -357,10 +361,10 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                                     offset: 19,
                                 },
                                 rendered: "Cell in column 1, header row",
-                            },
+                            }),
                         },
                         TableCell {
-                            content: Content {
+                            content: TableCellContent::Simple(Content {
                                 original: Span {
                                     data: "Cell in column 2, header row",
                                     line: 3,
@@ -368,7 +372,7 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                                     offset: 49,
                                 },
                                 rendered: "Cell in column 2, header row",
-                            },
+                            }),
                         },
                     ],
                 }),
@@ -376,7 +380,7 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                     TableRow {
                         cells: &[
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 1, row 2",
                                         line: 5,
@@ -384,10 +388,10 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                                         offset: 80,
                                     },
                                     rendered: "Cell in column 1, row 2",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 2, row 2",
                                         line: 6,
@@ -395,14 +399,14 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                                         offset: 105,
                                     },
                                     rendered: "Cell in column 2, row 2",
-                                },
+                                }),
                             },
                         ],
                     },
                     TableRow {
                         cells: &[
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 1, row 3",
                                         line: 8,
@@ -410,10 +414,10 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                                         offset: 131,
                                     },
                                     rendered: "Cell in column 1, row 3",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 2, row 3",
                                         line: 9,
@@ -421,14 +425,14 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                                         offset: 156,
                                     },
                                     rendered: "Cell in column 2, row 3",
-                                },
+                                }),
                             },
                         ],
                     },
                     TableRow {
                         cells: &[
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 1, row 4",
                                         line: 11,
@@ -436,10 +440,10 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                                         offset: 182,
                                     },
                                     rendered: "Cell in column 1, row 4",
-                                },
+                                }),
                             },
                             TableCell {
-                                content: Content {
+                                content: TableCellContent::Simple(Content {
                                     original: Span {
                                         data: "Cell in column 2, row 4",
                                         line: 12,
@@ -447,7 +451,7 @@ A header row can also be identified by assigning xref:add-header-row.adoc[header
                                         offset: 207,
                                     },
                                     rendered: "Cell in column 2, row 4",
-                                },
+                                }),
                             },
                         ],
                     },

--- a/parser/src/tests/asciidoc_lang/tables/format_column_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_column_content.rs
@@ -1,0 +1,492 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/format-column-content.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Collect each column's style.
+fn column_styles(table: &crate::blocks::TableBlock<'_>) -> Vec<ColumnStyle> {
+    table.columns().iter().map(|c| c.style()).collect()
+}
+
+/// Return the rendered text of a [`Simple`](crate::blocks::TableCellContent)
+/// cell, panicking if the cell holds AsciiDoc block content instead.
+fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
+    match cell.content() {
+        crate::blocks::TableCellContent::Simple(content) => content.rendered().to_string(),
+        crate::blocks::TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
+    }
+}
+
+non_normative!(
+    r#"
+= Format Content by Column
+
+"#
+);
+
+#[test]
+fn intro() {
+    verifies!(
+        r#"
+A column style operator is applied to a column specifier and xref:add-columns.adoc#cols-attribute[assigned to the cols attribute].
+"#
+    );
+
+    // A style operator on a column specifier in the `cols` attribute is applied
+    // to that column.
+    let table = parse_table("[cols=\"e\"]\n|===\n|content\n|===");
+    assert_eq!(column_styles(&table), vec![ColumnStyle::Emphasis]);
+}
+
+#[test]
+fn column_styles_and_their_operators() {
+    non_normative!(
+        r#"
+
+[#cols-style]
+== Column styles and their operators
+
+"#
+    );
+
+    verifies!(
+        r#"
+You can style all of the content in a column by adding a style operator to a column's specifier.
+
+"#
+    );
+
+    // The style operator governs the whole column: every body cell in the
+    // column is processed with the column's style. (The two adjacent rows are
+    // both body rows because no blank line follows the first, so neither
+    // becomes a header.)
+    let table = parse_table("[cols=\"s,m\"]\n|===\n|a |b\n|c |d\n|===");
+    assert_eq!(
+        column_styles(&table),
+        vec![ColumnStyle::Strong, ColumnStyle::Monospace]
+    );
+    assert_eq!(table.body_rows().len(), 2);
+
+    non_normative!(
+        r#"
+include::partial$style-operators.adoc[]
+
+"#
+    );
+
+    verifies!(
+        r#"
+When a style operator isn't explicitly applied to a column specifier, the `d` style is assigned automatically and the column is processed as paragraph text.
+"#
+    );
+
+    // With no style operator, a column is assigned the default (`d`) style.
+    let table = parse_table("[cols=\"1,1\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_styles(&table),
+        vec![ColumnStyle::Default, ColumnStyle::Default]
+    );
+
+    // The default style can also be requested explicitly with the `d` operator.
+    let table = parse_table("[cols=\"d,d\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_styles(&table),
+        vec![ColumnStyle::Default, ColumnStyle::Default]
+    );
+}
+
+#[test]
+fn apply_a_style_operator_to_a_column() {
+    non_normative!(
+        r#"
+
+== Apply a style operator to a column
+
+"#
+    );
+
+    verifies!(
+        r#"
+A style operator is always placed in the last position on a column's specifier or multiplier.
+
+* `[cols=">pass:q[#e#],.^3pass:q[#s#]"]` A style operator is placed directly after any other operators and the column width in the column's specifier.
+* `[cols="pass:q[#h#],pass:q[#e#]"]` When a column width isn't specified, the style operator can represent both the column and the column's content style.
+* `[cols="3*.>pass:q[#m#]"]` When a multiplier is present, the style operator is placed after any horizontal and vertical alignment operators.
+"#
+    );
+
+    // The style operator follows any alignment operators and the column width.
+    let table = parse_table("[cols=\">e,.^3s\"]\n|===\n|a |b\n|===");
+    let columns = table.columns();
+    assert_eq!(columns[0].h_align(), HorizontalAlignment::Right);
+    assert_eq!(columns[0].width(), 1);
+    assert_eq!(columns[0].style(), ColumnStyle::Emphasis);
+    assert_eq!(columns[1].v_align(), VerticalAlignment::Middle);
+    assert_eq!(columns[1].width(), 3);
+    assert_eq!(columns[1].style(), ColumnStyle::Strong);
+
+    // When a column width isn't specified, the style operator can represent both
+    // the column and its content style.
+    let table = parse_table("[cols=\"h,e\"]\n|===\n|a |b\n|===");
+    let columns = table.columns();
+    assert_eq!(
+        (columns[0].width(), columns[0].style()),
+        (1, ColumnStyle::Header)
+    );
+    assert_eq!(
+        (columns[1].width(), columns[1].style()),
+        (1, ColumnStyle::Emphasis)
+    );
+
+    // When a multiplier is present, the style operator follows the alignment
+    // operators on the (single) specifier that the multiplier repeats.
+    let table = parse_table("[cols=\"3*.>m\"]\n|===\n|a |b |c\n|===");
+    assert_eq!(
+        column_styles(&table),
+        vec![
+            ColumnStyle::Monospace,
+            ColumnStyle::Monospace,
+            ColumnStyle::Monospace
+        ]
+    );
+    for column in table.columns() {
+        assert_eq!(column.v_align(), VerticalAlignment::Bottom);
+    }
+
+    non_normative!(
+        r#"
+
+Let's apply a different style to each column in <<ex-style>>.
+
+.Add a style operator to each column
+[source#ex-style]
+----
+[cols="h,m,s,e"]
+|===
+|Column 1 |Column 2 |Column 3 |Column 4
+
+|This column's content and borders are rendered using the table header (`h`) styles.
+|This column's content is rendered using a monospace font (m).
+|This column's content is bold (`s`).
+|This column's content is italicized (`e`).
+
+|This column's content and borders are rendered using the table header (`h`) styles.
+|This column's content is rendered using a monospace font (m).
+|This column's content is bold (`s`).
+|This column's content is italicized (`e`).
+|===
+----
+
+The table from <<ex-style>> is displayed below.
+"#
+    );
+
+    verifies!(
+        r#"
+Note that the style applied to each column doesn't affect the xref:add-header-row.adoc[header row] or override any inline formatting.
+"#
+    );
+
+    // Each column carries its own style operator.
+    let table = parse_table(
+        "[cols=\"h,m,s,e\"]\n|===\n|Column 1 |Column 2 |Column 3 |Column 4\n\n|This column's content and borders are rendered using the table header (`h`) styles.\n|This column's content is rendered using a monospace font (m).\n|This column's content is bold (`s`).\n|This column's content is italicized (`e`).\n|===",
+    );
+    assert_eq!(
+        column_styles(&table),
+        vec![
+            ColumnStyle::Header,
+            ColumnStyle::Monospace,
+            ColumnStyle::Strong,
+            ColumnStyle::Emphasis,
+        ]
+    );
+
+    // The style doesn't affect the header row: each header cell holds plain
+    // inline content with no style applied, even though its column is styled.
+    let header = table.header_row().unwrap();
+    let header_text: Vec<String> = header.cells().iter().map(simple_text).collect();
+    assert_eq!(
+        header_text,
+        vec!["Column 1", "Column 2", "Column 3", "Column 4"]
+    );
+
+    // The style doesn't override inline formatting either: the body cell in the
+    // header-styled column still resolves its inline backtick markup to a
+    // monospace span.
+    let body = &table.body_rows()[0];
+    assert!(simple_text(&body.cells()[0]).contains("<code>h</code>"));
+}
+
+#[test]
+fn use_asciidoc_block_elements_in_a_column() {
+    non_normative!(
+        r#"
+
+.Result of <<ex-style>>
+[cols="h,m,s,e"]
+|===
+|Column 1 |Column 2 |Column 3 |Column 4
+
+|This column's content and borders are rendered using the table header (`h`) styles.
+|This column's content is rendered using a monospace font (m).
+|This column's content is bold (`s`).
+|This column's content is italicized (`e`).
+
+|This column's content and borders are rendered using the table header (`h`) styles.
+|This column's content is rendered using a monospace font (m).
+|This column's content is bold (`s`).
+|This column's content is italicized (`e`).
+|===
+
+Additionally, if a xref:format-cell-content.adoc#override-column-style[cell specifier contains a style operator], that style will override a column's style operator.
+
+== Use AsciiDoc block elements in a column
+
+"#
+    );
+
+    verifies!(
+        r#"
+To use AsciiDoc block elements, such as delimited source blocks and lists, in a column, place the lowercase letter `a` on the column specifier.
+"#
+    );
+
+    // The `a` operator marks a column as AsciiDoc; other columns keep the
+    // default style.
+    let table = parse_table("[cols=\"2a,2\"]\n|===\n|a |b\n|===");
+    assert_eq!(
+        column_styles(&table),
+        vec![ColumnStyle::AsciiDoc, ColumnStyle::Default]
+    );
+
+    non_normative!(
+        r#"
+
+.Apply the AsciiDoc block style operator to the first column
+[source#ex-asciidoc]
+....
+[cols="2a,2"]
+|===
+|Column with the `a` style operator applied to its specifier |Column using the default style
+
+|
+* List item 1
+* List item 2
+* List item 3
+|
+* List item 1
+* List item 2
+* List item 3
+
+|
+[source,python]
+----
+import os
+print "%s" %(os.uname())
+----
+|
+[source,python]
+----
+import os
+print ("%s" %(os.uname()))
+----
+|===
+....
+
+"#
+    );
+
+    verifies!(
+        r#"
+The AsciiDoc block style effectively creates a nested, standalone AsciiDoc document in each cell in the column.
+"#
+    );
+
+    // The AsciiDoc-styled column parses each of its cells as a nested sequence
+    // of blocks, while the default-styled column leaves the same markup as
+    // inline content.
+    let table = parse_table(
+        "[cols=\"2a,2\"]\n|===\n|Column with the `a` style operator applied to its specifier |Column using the default style\n\n|\n* List item 1\n* List item 2\n* List item 3\n|\n* List item 1\n* List item 2\n* List item 3\n\n|\n[source,python]\n----\nimport os\nprint \"%s\" %(os.uname())\n----\n|\n[source,python]\n----\nimport os\nprint (\"%s\" %(os.uname()))\n----\n|===",
+    );
+    assert_eq!(
+        column_styles(&table),
+        vec![ColumnStyle::AsciiDoc, ColumnStyle::Default]
+    );
+
+    // First body row: the AsciiDoc cell parses a list block; the default cell
+    // keeps the list markup as plain inline text.
+    let row = &table.body_rows()[0];
+    match row.cells()[0].content() {
+        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+            assert_eq!(blocks.len(), 1);
+            assert_eq!(blocks[0].raw_context().as_ref(), "list");
+        }
+        other => panic!("expected nested AsciiDoc blocks, got {other:?}"),
+    }
+    assert!(matches!(
+        row.cells()[1].content(),
+        crate::blocks::TableCellContent::Simple(_)
+    ));
+
+    // Second body row: the AsciiDoc cell parses the delimited source block.
+    let row = &table.body_rows()[1];
+    match row.cells()[0].content() {
+        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+            assert_eq!(blocks.len(), 1);
+            assert_eq!(blocks[0].raw_context().as_ref(), "listing");
+        }
+        other => panic!("expected nested AsciiDoc blocks, got {other:?}"),
+    }
+
+    // A full structural comparison of a minimal AsciiDoc cell: its content is a
+    // nested list block parsed as a standalone document fragment.
+    use crate::blocks::ListType;
+    assert_eq!(
+        TableBlock {
+            columns: &[TableColumn {
+                width: 1,
+                h_align: HorizontalAlignment::Left,
+                v_align: VerticalAlignment::Top,
+                style: ColumnStyle::AsciiDoc,
+            }],
+            header_row: None,
+            body_rows: &[TableRow {
+                cells: &[TableCell {
+                    content: TableCellContent::AsciiDoc(&[Block::List(ListBlock {
+                        type_: ListType::Unordered,
+                        items: &[Block::ListItem(ListItem {
+                            marker: ListItemMarker::Asterisks(Span {
+                                data: "*",
+                                line: 3,
+                                col: 3,
+                                offset: 18,
+                            }),
+                            blocks: &[Block::Simple(SimpleBlock {
+                                content: Content {
+                                    original: Span {
+                                        data: "item one",
+                                        line: 3,
+                                        col: 5,
+                                        offset: 20,
+                                    },
+                                    rendered: "item one",
+                                },
+                                source: Span {
+                                    data: "item one",
+                                    line: 3,
+                                    col: 5,
+                                    offset: 20,
+                                },
+                                style: SimpleBlockStyle::Paragraph,
+                                title_source: None,
+                                title: None,
+                                anchor: None,
+                                anchor_reftext: None,
+                                attrlist: None,
+                            })],
+                            source: Span {
+                                data: "* item one",
+                                line: 3,
+                                col: 3,
+                                offset: 18,
+                            },
+                            anchor: None,
+                            anchor_reftext: None,
+                            attrlist: None,
+                        })],
+                        source: Span {
+                            data: "* item one",
+                            line: 3,
+                            col: 3,
+                            offset: 18,
+                        },
+                        title_source: None,
+                        title: None,
+                        anchor: None,
+                        anchor_reftext: None,
+                        attrlist: None,
+                    })]),
+                }],
+            }],
+            footer_row: None,
+            source: Span {
+                data: "[cols=\"a\"]\n|===\n| * item one\n|===",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            title_source: None,
+            title: None,
+            caption: None,
+            anchor: None,
+            anchor_reftext: None,
+            attrlist: Some(Attrlist {
+                attributes: &[ElementAttribute {
+                    name: Some("cols"),
+                    shorthand_items: &[],
+                    value: "a",
+                }],
+                anchor: None,
+                source: Span {
+                    data: "cols=\"a\"",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+            }),
+        },
+        parse_table("[cols=\"a\"]\n|===\n| * item one\n|===")
+    );
+
+    non_normative!(
+        r#"
+The parent document's implicit attributes, such as `doctitle`, are shadowed and custom attributes are inherited.
+// what does "shadowed" actually mean???
+
+.Result of <<ex-asciidoc>>
+[cols="2a,2"]
+|===
+|Column with the `a` style operator applied to its specifier |Column using the default style
+
+|
+* List item 1
+* List item 2
+* List item 3
+|
+* List item 1
+* List item 2
+* List item 3
+
+|
+[source,python]
+----
+import os
+print "%s" %(os.uname())
+----
+
+|
+[source,python]
+----
+import os
+print ("%s" %(os.uname()))
+----
+|===
+
+You can also apply the xref:format-cell-content.adoc#a-operator[AsciiDoc block style operator to individual cells].
+"#
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/format_column_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_column_content.rs
@@ -43,6 +43,7 @@ fn intro() {
     verifies!(
         r#"
 A column style operator is applied to a column specifier and xref:add-columns.adoc#cols-attribute[assigned to the cols attribute].
+
 "#
     );
 
@@ -56,7 +57,6 @@ A column style operator is applied to a column specifier and xref:add-columns.ad
 fn column_styles_and_their_operators() {
     non_normative!(
         r#"
-
 [#cols-style]
 == Column styles and their operators
 
@@ -91,6 +91,7 @@ include::partial$style-operators.adoc[]
     verifies!(
         r#"
 When a style operator isn't explicitly applied to a column specifier, the `d` style is assigned automatically and the column is processed as paragraph text.
+
 "#
     );
 
@@ -113,7 +114,6 @@ When a style operator isn't explicitly applied to a column specifier, the `d` st
 fn apply_a_style_operator_to_a_column() {
     non_normative!(
         r#"
-
 == Apply a style operator to a column
 
 "#
@@ -126,6 +126,7 @@ A style operator is always placed in the last position on a column's specifier o
 * `[cols=">pass:q[#e#],.^3pass:q[#s#]"]` A style operator is placed directly after any other operators and the column width in the column's specifier.
 * `[cols="pass:q[#h#],pass:q[#e#]"]` When a column width isn't specified, the style operator can represent both the column and the column's content style.
 * `[cols="3*.>pass:q[#m#]"]` When a multiplier is present, the style operator is placed after any horizontal and vertical alignment operators.
+
 "#
     );
 
@@ -169,7 +170,6 @@ A style operator is always placed in the last position on a column's specifier o
 
     non_normative!(
         r#"
-
 Let's apply a different style to each column in <<ex-style>>.
 
 .Add a style operator to each column
@@ -198,6 +198,7 @@ The table from <<ex-style>> is displayed below.
     verifies!(
         r#"
 Note that the style applied to each column doesn't affect the xref:add-header-row.adoc[header row] or override any inline formatting.
+
 "#
     );
 
@@ -235,7 +236,6 @@ Note that the style applied to each column doesn't affect the xref:add-header-ro
 fn use_asciidoc_block_elements_in_a_column() {
     non_normative!(
         r#"
-
 .Result of <<ex-style>>
 [cols="h,m,s,e"]
 |===
@@ -262,6 +262,7 @@ Additionally, if a xref:format-cell-content.adoc#override-column-style[cell spec
     verifies!(
         r#"
 To use AsciiDoc block elements, such as delimited source blocks and lists, in a column, place the lowercase letter `a` on the column specifier.
+
 "#
     );
 
@@ -275,7 +276,6 @@ To use AsciiDoc block elements, such as delimited source blocks and lists, in a 
 
     non_normative!(
         r#"
-
 .Apply the AsciiDoc block style operator to the first column
 [source#ex-asciidoc]
 ....

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -4,4 +4,5 @@ mod adjust_column_widths;
 mod align_by_column;
 mod build_a_basic_table;
 mod customize_title_label;
+mod format_column_content;
 mod turn_off_title_label;

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -13,7 +13,7 @@ use crate::{
     blocks::{
         Block, Break, CompoundDelimitedBlock, IsBlock, ListBlock, ListItem, ListItemMarker,
         ListType, MediaBlock, Preamble, RawDelimitedBlock, SectionBlock, SimpleBlock,
-        SimpleBlockStyle, TableBlock, TableRow,
+        SimpleBlockStyle, TableBlock, TableCellContent, TableRow,
     },
 };
 
@@ -880,16 +880,29 @@ fn table_row_to_node(row: &TableRow<'_>, cell_tag: &str, wrap_in_paragraph: bool
         let mut cell_node =
             VirtualNode::new(cell_tag).with_classes(["tableblock", "halign-left", "valign-top"]);
 
-        let rendered = cell.content().rendered().to_string();
+        match cell.content() {
+            TableCellContent::Simple(content) => {
+                let rendered = content.rendered().to_string();
 
-        if wrap_in_paragraph {
-            cell_node.children.push(
-                VirtualNode::new("p")
-                    .with_class("tableblock")
-                    .with_text(rendered),
-            );
-        } else {
-            cell_node = cell_node.with_text(rendered);
+                if wrap_in_paragraph {
+                    cell_node.children.push(
+                        VirtualNode::new("p")
+                            .with_class("tableblock")
+                            .with_text(rendered),
+                    );
+                } else {
+                    cell_node = cell_node.with_text(rendered);
+                }
+            }
+
+            // An AsciiDoc-styled cell holds a nested sequence of blocks, which
+            // render directly into the cell rather than into a single
+            // paragraph.
+            TableCellContent::AsciiDoc(blocks) => {
+                for block in blocks {
+                    cell_node.children.push(block.to_virtual_dom());
+                }
+            }
         }
 
         tr.children.push(cell_node);

--- a/parser/src/tests/fixtures/blocks/mod.rs
+++ b/parser/src/tests/fixtures/blocks/mod.rs
@@ -35,4 +35,4 @@ mod simple;
 pub(crate) use simple::SimpleBlock;
 
 mod table;
-pub(crate) use table::{TableBlock, TableCell, TableColumn, TableRow};
+pub(crate) use table::{TableBlock, TableCell, TableCellContent, TableColumn, TableRow};

--- a/parser/src/tests/fixtures/blocks/table.rs
+++ b/parser/src/tests/fixtures/blocks/table.rs
@@ -2,8 +2,8 @@ use std::fmt;
 
 use crate::{
     HasSpan,
-    blocks::{HorizontalAlignment, IsBlock, VerticalAlignment},
-    tests::fixtures::{Span, attributes::Attrlist, content::Content},
+    blocks::{ColumnStyle, HorizontalAlignment, IsBlock, VerticalAlignment},
+    tests::fixtures::{Span, attributes::Attrlist, blocks::Block, content::Content},
 };
 
 #[derive(Eq, PartialEq)]
@@ -44,6 +44,7 @@ pub(crate) struct TableColumn {
     pub width: usize,
     pub h_align: HorizontalAlignment,
     pub v_align: VerticalAlignment,
+    pub style: ColumnStyle,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -53,7 +54,13 @@ pub(crate) struct TableRow {
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) struct TableCell {
-    pub content: Content,
+    pub content: TableCellContent,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum TableCellContent {
+    Simple(Content),
+    AsciiDoc(&'static [Block]),
 }
 
 impl<'src> PartialEq<crate::blocks::TableBlock<'src>> for TableBlock {
@@ -71,8 +78,21 @@ impl PartialEq<TableBlock> for crate::blocks::TableBlock<'_> {
 fn columns_eq(fixture: &[TableColumn], observed: &[crate::blocks::TableColumn]) -> bool {
     fixture.len() == observed.len()
         && fixture.iter().zip(observed.iter()).all(|(f, o)| {
-            f.width == o.width() && f.h_align == o.h_align() && f.v_align == o.v_align()
+            f.width == o.width()
+                && f.h_align == o.h_align()
+                && f.v_align == o.v_align()
+                && f.style == o.style()
         })
+}
+
+fn cell_content_eq(fixture: &TableCellContent, observed: &crate::blocks::TableCellContent) -> bool {
+    match (fixture, observed) {
+        (TableCellContent::Simple(f), crate::blocks::TableCellContent::Simple(o)) => f == o,
+        (TableCellContent::AsciiDoc(f), crate::blocks::TableCellContent::AsciiDoc(o)) => {
+            f.len() == o.len() && f.iter().zip(o.iter()).all(|(fb, ob)| fb == ob)
+        }
+        _ => false,
+    }
 }
 
 fn cells_eq(fixture: &[TableCell], observed: &[crate::blocks::TableCell]) -> bool {
@@ -80,7 +100,7 @@ fn cells_eq(fixture: &[TableCell], observed: &[crate::blocks::TableCell]) -> boo
         && fixture
             .iter()
             .zip(observed.iter())
-            .all(|(f, o)| f.content == *o.content())
+            .all(|(f, o)| cell_content_eq(&f.content, o.content()))
 }
 
 fn row_eq(fixture: &TableRow, observed: &crate::blocks::TableRow) -> bool {

--- a/parser/src/tests/prelude.rs
+++ b/parser/src/tests/prelude.rs
@@ -6,7 +6,9 @@ pub(crate) use std::collections::HashMap;
 
 pub(crate) use crate::{
     HasSpan, Parser,
-    blocks::{HorizontalAlignment, IsBlock, SectionType, SimpleBlockStyle, VerticalAlignment},
+    blocks::{
+        ColumnStyle, HorizontalAlignment, IsBlock, SectionType, SimpleBlockStyle, VerticalAlignment,
+    },
     content::SubstitutionGroup,
     parser::ModificationContext,
     tests::{


### PR DESCRIPTION
Implement the column style operators described in [docs/modules/tables/pages/format-column-content.adoc](docs/modules/tables/pages/format-column-content.adoc): `a` (AsciiDoc), `d` (default), `e` (emphasis), `h` (header), `l` (literal), `m` (monospace), and `s` (strong).

## What changed

- **`ColumnStyle` enum + `TableColumn::style`** — a new public enum models the seven style operators. `parse_col_spec` reads the style operator from the **last position** on a column specifier, after any `<n>*` multiplier, alignment operators, and width. When no operator is present, the default (`d`) style is assigned.
- **`TableCellContent` enum** — a cell's content is now either `Simple` inline content or `AsciiDoc` nested blocks:
  - `l` (literal) cells use **verbatim** substitutions; all other inline styles use the normal group (the `e`/`s`/`m`/`h` wrapping is render-time formatting, so the parsed inline content is unchanged).
  - `a` (AsciiDoc) cells parse their content as a **nested, standalone AsciiDoc document** (lists, delimited source blocks, etc.).
  - The header row is always processed as plain header content, so a column style operator never affects it.
- `TableBlock`/`Block` reference resolution recurses into the nested blocks of `a` cells.
- The test virtual DOM renders `a` cells' nested blocks; existing fixtures updated for the new `TableColumn.style` field and `TableCellContent` cell shape.

## Tests

- Full spec coverage for the page (132/132 lines) in `format_column_content.rs`, including the `ex-style` and `ex-asciidoc` worked examples.
- A structural fixture comparison exercises the nested-block (`AsciiDoc`) cell path end to end.
- `cargo test` (1958 passing), `cargo clippy --all-targets`, `cargo +nightly fmt --check`, and `cargo +nightly doc` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)