### PR TITLE
feat: Support noheader option and add spec coverage for add-header-row.adoc

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -128,11 +128,17 @@ impl<'src> TableBlock<'src> {
 
         // The first row is an (implicit) header row when the line directly after
         // the opening delimiter is non-empty and is itself followed by an empty
-        // line. The `header` option forces the same interpretation.
+        // line. The `header` option forces the same interpretation; the
+        // `noheader` option suppresses only the implicit detection, so an
+        // explicit `header` still wins when both are present.
         let opts_header = metadata
             .attrlist
             .as_ref()
             .is_some_and(|a| a.has_option("header"));
+        let opts_noheader = metadata
+            .attrlist
+            .as_ref()
+            .is_some_and(|a| a.has_option("noheader"));
 
         // The blank line must genuinely exist after the first row; the end of the
         // table (an empty remainder) does not count, so a single-row table is not
@@ -141,7 +147,7 @@ impl<'src> TableBlock<'src> {
         let line1_blank = line1.item.data().trim().is_empty();
         let line2_blank =
             !line1.after.is_empty() && line1.after.take_line().item.data().trim().is_empty();
-        let has_header = opts_header || (!line1_blank && line2_blank);
+        let has_header = opts_header || (!opts_noheader && !line1_blank && line2_blank);
 
         // A titled table is given a caption (e.g. "Table 1. ") that a processor
         // prepends to the title.

--- a/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
@@ -1,0 +1,374 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/add-header-row.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Return the rendered text of a [`Simple`](crate::blocks::TableCellContent)
+/// cell, panicking if the cell holds AsciiDoc block content instead.
+fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
+    match cell.content() {
+        crate::blocks::TableCellContent::Simple(content) => content.rendered().to_string(),
+        crate::blocks::TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
+    }
+}
+
+/// Return the rendered text of each cell in the table's header row, panicking
+/// if the table has no header row.
+fn header_texts(table: &crate::blocks::TableBlock<'_>) -> Vec<String> {
+    table
+        .header_row()
+        .expect("expected a header row")
+        .cells()
+        .iter()
+        .map(simple_text)
+        .collect()
+}
+
+non_normative!(
+    r#"
+= Create a Header Row
+
+"#
+);
+
+#[test]
+fn intro() {
+    verifies!(
+        r#"
+The first row of a table is promoted to a header row if the `header` value is assigned to the table's `options` attribute.
+You can assign `header` to a table's first row explicitly or implicitly.
+
+"#
+    );
+
+    // Assigning `header` to the `options` attribute promotes the first row,
+    // regardless of the table's layout.
+    let explicit =
+        parse_table("[options=\"header\"]\n|===\n|Column 1 |Column 2\n|Cell 1 |Cell 2\n|===");
+    assert!(explicit.header_row().is_some());
+
+    // The first row can also be promoted implicitly, based on the table's
+    // layout (a non-empty first line followed by an empty line).
+    let implicit = parse_table("|===\n|Column 1 |Column 2\n\n|Cell 1 |Cell 2\n|===");
+    assert!(implicit.header_row().is_some());
+}
+
+#[test]
+fn header_ignores_operators() {
+    verifies!(
+        r#"
+TIP: The header row ignores any style operators assigned via column and cell specifiers.
+"#
+    );
+
+    // A column style operator (here the AsciiDoc `a` operator) governs the body
+    // cells in its column but is ignored for the header row: the header cell is
+    // processed as plain, default content even though its column is styled.
+    let table = parse_table(
+        "[cols=\"a,1\",options=\"header\"]\n|===\n|Column 1 |Column 2\n\n|* item\n|Cell 2\n|===",
+    );
+    assert!(matches!(
+        table.header_row().unwrap().cells()[0].content(),
+        crate::blocks::TableCellContent::Simple(_)
+    ));
+
+    // The body cell in the same column *is* processed with the column's style,
+    // so its content is parsed as a nested AsciiDoc list block.
+    assert!(matches!(
+        table.body_rows()[0].cells()[0].content(),
+        crate::blocks::TableCellContent::AsciiDoc(_)
+    ));
+
+    to_do_verifies!(
+        r#"
+It also ignores alignment operators assigned to the table's column specifiers; however, any alignment operators assigned to a cell specifier in the header row are applied.
+
+"#
+    );
+
+    // The interaction between the header row and alignment operators on a cell
+    // specifier depends on cell specifiers, which are not yet implemented.
+    if false {
+        todo!("cell specifiers and cell-level alignment for the header row");
+    }
+}
+
+#[test]
+fn explicitly_assign_header() {
+    non_normative!(
+        r#"
+== Explicitly assign header to the first row
+
+"#
+    );
+
+    verifies!(
+        r#"
+The header row semantics and styles are explicitly assigned to the first row in a table by assigning `header` to the `options` attribute.
+The `options` attribute is set in the table's attribute list using the shorthand (`%value`) or formal syntax (`options="value"`).
+
+"#
+    );
+
+    // Shorthand `%header` (entered before `cols`) promotes the first row; this
+    // is the `ex-short` example from the page.
+    let shorthand = parse_table(
+        "[%header,cols=\"2,2,1\"]\n|===\n|Column 1, header row\n|Column 2, header row\n|Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n|===",
+    );
+    assert_eq!(
+        header_texts(&shorthand),
+        vec![
+            "Column 1, header row",
+            "Column 2, header row",
+            "Column 3, header row"
+        ]
+    );
+    assert_eq!(shorthand.body_rows().len(), 1);
+
+    // Formal `options="header"` promotes the first row too; this is the `opt-h`
+    // example (row.adoc) referenced by the page.
+    let formal = parse_table(
+        "[cols=\"2*\",options=\"header\"]\n|===\n|Column 1, header row\n|Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|===",
+    );
+    assert_eq!(
+        header_texts(&formal),
+        vec!["Column 1, header row", "Column 2, header row"]
+    );
+    assert_eq!(formal.body_rows().len(), 2);
+
+    verifies!(
+        r#"
+The `options` attribute is represented by the percent sign (`%`) when it's set using the shorthand syntax.
+"#
+    );
+
+    // The `%` shorthand sets the `options` attribute, so `%header` assigns the
+    // `header` option. (No blank line follows the first row here, so the header
+    // can only come from the option, not from implicit detection.)
+    let table = parse_table("[%header]\n|===\n|Column 1 |Column 2\n|Cell 1 |Cell 2\n|===");
+    assert!(table.header_row().is_some());
+
+    non_normative!(
+        r#"
+In <<ex-short>>, `header` is assigned to using the shorthand syntax for `options`.
+
+.Table with `header` assigned using the shorthand syntax
+[source#ex-short]
+----
+[%header,cols="2,2,1"] <.>
+|===
+|Column 1, header row
+|Column 2, header row
+|Column 3, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+|===
+----
+"#
+    );
+
+    verifies!(
+        r#"
+<.> Values assigned using the shorthand syntax must be entered before the `cols` attribute (or any other named attributes) in a table's attribute list, otherwise the processor will ignore them.
+
+"#
+    );
+
+    // Shorthand `%header` entered before `cols` is honored.
+    let before = parse_table(
+        "[%header,cols=\"2,2,1\"]\n|===\n|Column 1 |Column 2 |Column 3\n|Cell 1 |Cell 2 |Cell 3\n|===",
+    );
+    assert!(before.header_row().is_some());
+
+    // The same shorthand entered after the `cols` (named) attribute is ignored,
+    // so the first row is not promoted. (No blank line follows it, so implicit
+    // detection does not apply either.)
+    let after = parse_table(
+        "[cols=\"2,2,1\",%header]\n|===\n|Column 1 |Column 2 |Column 3\n|Cell 1 |Cell 2 |Cell 3\n|===",
+    );
+    assert!(after.header_row().is_none());
+
+    non_normative!(
+        r#"
+The table from <<ex-short>> is displayed below.
+
+.Result of <<ex-short>>
+[%header,cols="2,2,1"]
+|===
+|Column 1, header row
+|Column 2, header row
+|Column 3, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+|===
+
+In <<ex-formal>>, the `options` attribute is set and assigned the `header` value using the formal syntax.
+"#
+    );
+
+    verifies!(
+        r#"
+The `options` attribute accepts a comma-separated list of values.
+
+"#
+    );
+
+    // The formal `options` value is a comma-separated list; `header` is honored
+    // when it appears among other values.
+    let table = parse_table(
+        "[options=\"header,unbreakable\"]\n|===\n|Column 1 |Column 2\n|Cell 1 |Cell 2\n|===",
+    );
+    assert!(table.header_row().is_some());
+
+    non_normative!(
+        r#"
+.Table with header assigned to the options attribute
+[source#ex-formal]
+----
+include::example$row.adoc[tag=opt-h]
+----
+
+The first row of the table in <<ex-formal>> is rendered using the corresponding header styles and semantics.
+
+.Result of <<ex-formal>>
+include::example$row.adoc[tag=opt-h]
+
+"#
+    );
+}
+
+#[test]
+fn implicitly_assign_header() {
+    non_normative!(
+        r#"
+== Implicitly assign header to the first row
+
+"#
+    );
+
+    verifies!(
+        r#"
+You can implicitly define a header row based on how you layout the table.
+The following conventions determine when the first row automatically becomes the header row:
+
+. The first line of content inside the table delimiters is not empty.
+. The second line of content inside the table delimiters is empty.
+
+"#
+    );
+
+    // Both conventions hold: the first line of content is non-empty and the
+    // second line is empty, so the first row becomes the header (the `impl-h`
+    // example from row.adoc).
+    let table = parse_table(
+        "|===\n|Column 1, header row |Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|===",
+    );
+    assert_eq!(
+        header_texts(&table),
+        vec!["Column 1, header row", "Column 2, header row"]
+    );
+    assert_eq!(table.body_rows().len(), 2);
+
+    // When the second line of content is *not* empty, the convention fails and
+    // the first row is not promoted to a header row.
+    let no_header = parse_table("|===\n|Cell 1 |Cell 2\n|Cell 3 |Cell 4\n|===");
+    assert!(no_header.header_row().is_none());
+
+    non_normative!(
+        r#"
+.First row is implicitly assigned header
+[source#ex-implicit]
+----
+include::example$row.adoc[tag=impl-h]
+----
+
+As seen in the result below, if all of these rules hold true, then the first row of the table is treated as a header row.
+
+.Result of <<ex-implicit>>
+include::example$row.adoc[tag=impl-h]
+
+"#
+    );
+}
+
+#[test]
+fn deactivate_implicit_header() {
+    non_normative!(
+        r#"
+=== Deactivate the implicit assignment of header
+
+"#
+    );
+
+    verifies!(
+        r#"
+To suppress the implicit behavior of promoting the first row to a header row, assign the value `noheader` to the `options` attribute using the formal (`options=noheader`) or shorthand (`%noheader`) syntax.
+In <<ex-noheader>>, `noheader` is assigned using the shorthand syntax.
+
+"#
+    );
+
+    // Shorthand `%noheader` suppresses the implicit header (the `ex-noheader`
+    // example from the page): the first row stays in the body.
+    let table = parse_table(
+        "[%noheader]\n|===\n|Cell in column 1, row 1 |Cell in column 2, row 1\n\n|Cell in column 1, row 2 |Cell in column 2, row 2\n|===",
+    );
+    assert!(table.header_row().is_none());
+    assert_eq!(table.body_rows().len(), 2);
+
+    // Formal `options="noheader"` suppresses the implicit header as well.
+    let table =
+        parse_table("[options=\"noheader\"]\n|===\n|Cell 1 |Cell 2\n\n|Cell 3 |Cell 4\n|===");
+    assert!(table.header_row().is_none());
+
+    // `noheader` only suppresses the *implicit* assignment; an explicit `header`
+    // still wins when both options are present.
+    let table = parse_table("[%header%noheader]\n|===\n|Cell 1 |Cell 2\n\n|Cell 3 |Cell 4\n|===");
+    assert!(table.header_row().is_some());
+
+    non_normative!(
+        r#"
+.Deactivate implicit header row with noheader
+[source#ex-noheader]
+----
+[%noheader]
+|===
+|Cell in column 1, row 1 |Cell in column 2, row 1
+
+|Cell in column 1, row 2 |Cell in column 2, row 2
+|===
+----
+
+The table from <<ex-noheader>> is displayed below.
+
+.Result of <<ex-noheader>>
+[%noheader]
+|===
+|Cell in column 1, row 1 |Cell in column 2, row 1
+
+|Cell in column 1, row 2 |Cell in column 2, row 2
+|===
+
+//CAUTION: We're considering using a similar convention for enabling the footer in the future.
+//Thus, if you rely on this convention to enable the header row, it's advised that you not put all the cells in the last row on the same line unless you intend on making it the footer row.
+"#
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -1,5 +1,6 @@
 mod add_cells_and_rows;
 mod add_columns;
+mod add_header_row;
 mod add_title;
 mod adjust_column_widths;
 mod align_by_column;


### PR DESCRIPTION
## Summary

Implements the behavior described on `docs/modules/tables/pages/add-header-row.adoc` (*Create a Header Row*) and adds line-by-line spec coverage for the page.

Explicit (`%header` / `options="header"`) and implicit header-row promotion were already implemented on the `tables` branch. This PR adds the one missing piece — the **`noheader`** option — and the spec-coverage test file.

## Changes

- **`noheader` option** (`parser/src/blocks/table.rs`): suppresses the *implicit* promotion of the first row to a header row. Matching Asciidoctor, `noheader` only affects the implicit detection — an explicit `header` still wins when both options are present (verified against `asciidoctor` locally).
- **Spec coverage** (`parser/src/tests/asciidoc_lang/tables/add_header_row.rs`): reproduces the page verbatim via `verifies!` / `non_normative!`, exercising:
  - explicit header via shorthand `%header` and formal `options="header"` (the page's `ex-short` / `opt-h` examples),
  - implicit header from layout, plus a counter-example where the second content line is non-empty,
  - `noheader` deactivation (shorthand and formal) and the explicit-`header`-wins edge case,
  - the TIP rule that the header row ignores column style operators (shown via an AsciiDoc-styled column).
  - The cell-specifier alignment portion of the TIP is `to_do_verifies!`, pending cell-specifier support.

## Verification

- `cargo test -p asciidoc-parser` — all pass (5 new tests).
- `cd sdd && cargo run` — every normative line of the page reports as covered, no `0` lines.
- `cargo clippy --all-targets` and `cargo +nightly doc --no-deps` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)