### PR TITLE
fix: Only honor attrlist shorthand in the first attribute position

### DIFF
--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -85,9 +85,13 @@ impl<'src> Attrlist<'src> {
                 });
             }
 
-            if attr.name().is_none() {
-                parse_shorthand_items = false;
-            }
+            // Shorthand items (the `#id`, `.role`, and `%option` entries) are
+            // only recognized in the first attribute position. Once the first
+            // attribute has been parsed — whether it was positional or named —
+            // disable shorthand parsing so that, for example, a `%header`
+            // entered after a named `cols` attribute is not mistaken for an
+            // option (the processor ignores it).
+            parse_shorthand_items = false;
 
             let mut after = Span::new(source_cow.as_ref()).discard(new_index);
 

--- a/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
@@ -1537,7 +1537,7 @@ Any space or tab characters at the boundaries of the value are ignored.
                             ElementAttribute {
                                 name: None,
                                 value: "zip",
-                                shorthand_items: &["zip"],
+                                shorthand_items: &[],
                             },
                             ElementAttribute {
                                 name: Some("target",),
@@ -1627,7 +1627,7 @@ Any space or tab characters at the boundaries of the value are ignored.
                             ElementAttribute {
                                 name: None,
                                 value: "zip",
-                                shorthand_items: &["zip"],
+                                shorthand_items: &[],
                             },
                             ElementAttribute {
                                 name: Some("target",),
@@ -1725,7 +1725,7 @@ If there is a closing double quote, the enclosing double quote characters are re
                             ElementAttribute {
                                 name: None,
                                 value: "zip",
-                                shorthand_items: &["zip"],
+                                shorthand_items: &[],
                             },
                             ElementAttribute {
                                 name: Some("target",),
@@ -1815,7 +1815,7 @@ If there is a closing double quote, the enclosing double quote characters are re
                             ElementAttribute {
                                 name: None,
                                 value: "zip",
-                                shorthand_items: &["zip"],
+                                shorthand_items: &[],
                             },
                             ElementAttribute {
                                 name: Some("target",),
@@ -1913,7 +1913,7 @@ If there is a closing single quote, the enclosing single quote characters are re
                             ElementAttribute {
                                 name: None,
                                 value: "zip",
-                                shorthand_items: &["zip"],
+                                shorthand_items: &[],
                             },
                             ElementAttribute {
                                 name: Some("target",),


### PR DESCRIPTION
## Summary

Fixes an `Attrlist` parsing bug: shorthand items (`#id`, `.role`, `%option`, and the bare block style) were honored in **later** attribute positions whenever the **first** attribute was *named*.

The parser only disabled shorthand parsing after a *positional* first attribute. When the first attribute was named, shorthand stayed active, so:

- `[cols="2,2,1",%header]` was mistakenly treated as carrying a `header` option, and
- a bare positional value after a named attribute (e.g. `zip` in `[foo=bar, zip]`) was wrongly decomposed into a block style.

The fix disables shorthand parsing after the first attribute regardless of whether that attribute was positional or named — shorthand is only ever valid in the first attribute position.

## Conformance

Verified against Ruby Asciidoctor (installed locally):

| Input | Asciidoctor | Before fix | After fix |
|-------|-------------|------------|-----------|
| `[verse,attribution=X]` | verse applied | applied | applied |
| `[attribution=X,verse]` | **not** applied | applied ❌ | not applied ✅ |
| `[cols=2,#myid]` | id ignored | honored ❌ | ignored ✅ |
| `[cols=2,.myrole]` | role ignored | honored ❌ | ignored ✅ |

This also makes the named-first case consistent with the already-correct positional-first case: the existing `[_foo = bar , zip , target=url]` test already expected empty shorthand items for `zip`.

## Tests

Updated the five `attribute_list_parsing` fixtures whose `zip` value followed a named attribute to expect empty shorthand items (`&[]` instead of `&["zip"]`). Full suite passes (1903 tests); `clippy`, nightly `doc`, and `fmt` are clean.

## Context

This bug was surfaced while implementing the tables `add-header-row.adoc` page (#523), whose `%header` shorthand-placement callout depends on this behavior. Splitting the fix into its own PR against `main` so it can be reviewed and merged independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)