### PR TITLE
feat: Promote last row to footer row (footer option)

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -36,7 +36,6 @@ use crate::{
 /// * Cell specifiers (spans, duplication, per-cell alignment and style); the
 ///   per-cell style operator that overrides a column's style operator is not
 ///   yet recognized.
-/// * Footer rows.
 ///
 /// Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, and `s`
 /// operators) are supported, along with proportional width and the horizontal
@@ -140,6 +139,14 @@ impl<'src> TableBlock<'src> {
             .as_ref()
             .is_some_and(|a| a.has_option("noheader"));
 
+        // The last row is promoted to a footer row when the `footer` option is
+        // set. Unlike the header row, a footer cell is processed with its
+        // column's style (it is simply the last body row, relabeled).
+        let opts_footer = metadata
+            .attrlist
+            .as_ref()
+            .is_some_and(|a| a.has_option("footer"));
+
         // The blank line must genuinely exist after the first row; the end of the
         // table (an empty remainder) does not count, so a single-row table is not
         // mistaken for an all-header table.
@@ -234,6 +241,11 @@ impl<'src> TableBlock<'src> {
             }
         }
 
+        // The footer row, when requested, is the last row of the table. It is
+        // moved out of the body so the caller sees it as a distinct footer. When
+        // the table has no rows to spare, no footer is produced.
+        let footer_row = if opts_footer { body_rows.pop() } else { None };
+
         let source = metadata
             .source
             .trim_remainder(closing_delimiter.discard_all())
@@ -252,7 +264,7 @@ impl<'src> TableBlock<'src> {
                     columns,
                     header_row,
                     body_rows,
-                    footer_row: None,
+                    footer_row,
                     source,
                     title_source: metadata.title_source,
                     title: metadata.title.clone(),

--- a/parser/src/tests/asciidoc_lang/tables/add_footer_row.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_footer_row.rs
@@ -117,18 +117,6 @@ The `options` attribute is represented by the percent sign (`%`) when it's set u
         r#"
 In <<ex-short>>, `footer` is assigned using the shorthand syntax for `options`.
 
-"#
-    );
-
-    // The `ex-short` example assigns `footer` (alongside `header`) using the
-    // `%` shorthand syntax, so the last row is promoted to the footer.
-    let ex_short = parse_table(
-        "[%header%footer,cols=\"2,2,1\"]\n|===\n|Column 1, header row\n|Column 2, header row\n|Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n\n|Column 1, footer row\n|Column 2, footer row\n|Column 3, footer row\n|===",
-    );
-    assert!(ex_short.footer_row().is_some());
-
-    non_normative!(
-        r#"
 .Table with footer assigned using the shorthand syntax
 [source#ex-short]
 ----
@@ -149,6 +137,13 @@ In <<ex-short>>, `footer` is assigned using the shorthand syntax for `options`.
 ----
 "#
     );
+
+    // The `ex-short` example assigns `footer` (alongside `header`) using the
+    // `%` shorthand syntax, so the last row is promoted to the footer.
+    let ex_short = parse_table(
+        "[%header%footer,cols=\"2,2,1\"]\n|===\n|Column 1, header row\n|Column 2, header row\n|Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n\n|Column 1, footer row\n|Column 2, footer row\n|Column 3, footer row\n|===",
+    );
+    assert!(ex_short.footer_row().is_some());
 
     verifies!(
         r#"
@@ -181,7 +176,7 @@ In <<ex-short>>, `footer` is assigned using the shorthand syntax for `options`.
     );
     assert!(after.footer_row().is_none());
 
-    non_normative!(
+    verifies!(
         r#"
 The table from <<ex-short>> is displayed below.
 
@@ -204,10 +199,29 @@ The table from <<ex-short>> is displayed below.
 "#
     );
 
+    // The rendered result of <<ex-short>>: the last row renders as the footer.
+    let ex_short_result = parse_table(
+        "[%header%footer,cols=\"2,2,1\"]\n|===\n|Column 1, header row\n|Column 2, header row\n|Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n\n|Column 1, footer row\n|Column 2, footer row\n|Column 3, footer row\n|===",
+    );
+    assert_eq!(
+        footer_texts(&ex_short_result),
+        vec![
+            "Column 1, footer row",
+            "Column 2, footer row",
+            "Column 3, footer row"
+        ]
+    );
+
     verifies!(
         r#"
 In <<ex-formal>>, the `options` attribute is set and assigned the `footer` value using the formal syntax.
 The `options` attribute accepts a comma-separated list of values.
+
+.Table with footer assigned to the options attribute
+[source#ex-formal]
+----
+include::example$row.adoc[tag=opt-f]
+----
 
 "#
     );
@@ -225,21 +239,12 @@ The `options` attribute accepts a comma-separated list of values.
     );
     assert!(table.footer_row().is_some());
 
-    non_normative!(
-        r#"
-.Table with footer assigned to the options attribute
-[source#ex-formal]
-----
-include::example$row.adoc[tag=opt-f]
-----
-
-"#
-    );
-
     verifies!(
         r#"
 The last row of the table in <<ex-formal>> is rendered using the corresponding footer styles.
 
+.Result of <<ex-formal>>
+include::example$row.adoc[tag=opt-f]
 "#
     );
 
@@ -255,12 +260,5 @@ The last row of the table in <<ex-formal>> is rendered using the corresponding f
     assert_eq!(
         footer_texts(&formal),
         vec!["Column 1, footer row", "Column 2, footer row"]
-    );
-
-    non_normative!(
-        r#"
-.Result of <<ex-formal>>
-include::example$row.adoc[tag=opt-f]
-"#
     );
 }

--- a/parser/src/tests/asciidoc_lang/tables/add_footer_row.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_footer_row.rs
@@ -113,10 +113,22 @@ The `options` attribute is represented by the percent sign (`%`) when it's set u
     let table = parse_table("[%footer]\n|===\n|Cell 1 |Cell 2\n|Foot 1 |Foot 2\n|===");
     assert!(table.footer_row().is_some());
 
-    non_normative!(
+    verifies!(
         r#"
 In <<ex-short>>, `footer` is assigned using the shorthand syntax for `options`.
 
+"#
+    );
+
+    // The `ex-short` example assigns `footer` (alongside `header`) using the
+    // `%` shorthand syntax, so the last row is promoted to the footer.
+    let ex_short = parse_table(
+        "[%header%footer,cols=\"2,2,1\"]\n|===\n|Column 1, header row\n|Column 2, header row\n|Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n\n|Column 1, footer row\n|Column 2, footer row\n|Column 3, footer row\n|===",
+    );
+    assert!(ex_short.footer_row().is_some());
+
+    non_normative!(
+        r#"
 .Table with footer assigned using the shorthand syntax
 [source#ex-short]
 ----

--- a/parser/src/tests/asciidoc_lang/tables/add_footer_row.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_footer_row.rs
@@ -201,16 +201,22 @@ The table from <<ex-short>> is displayed below.
 |Column 3, footer row
 |===
 
-In <<ex-formal>>, the `options` attribute is set and assigned the `footer` value using the formal syntax.
 "#
     );
 
     verifies!(
         r#"
+In <<ex-formal>>, the `options` attribute is set and assigned the `footer` value using the formal syntax.
 The `options` attribute accepts a comma-separated list of values.
 
 "#
     );
+
+    // The `ex-formal` example sets the `options` attribute to `footer` using the
+    // formal syntax, promoting the last row to the footer.
+    let ex_formal =
+        parse_table("[options=\"footer\"]\n|===\n|Cell 1 |Cell 2\n|Foot 1 |Foot 2\n|===");
+    assert!(ex_formal.footer_row().is_some());
 
     // The formal `options` value is a comma-separated list; `footer` is honored
     // when it appears among other values.

--- a/parser/src/tests/asciidoc_lang/tables/add_footer_row.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_footer_row.rs
@@ -1,0 +1,248 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/add-footer-row.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Return the rendered text of a [`Simple`](crate::blocks::TableCellContent)
+/// cell, panicking if the cell holds AsciiDoc block content instead.
+fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
+    match cell.content() {
+        crate::blocks::TableCellContent::Simple(content) => content.rendered().to_string(),
+        crate::blocks::TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
+    }
+}
+
+/// Return the rendered text of each cell in the table's footer row, panicking
+/// if the table has no footer row.
+fn footer_texts(table: &crate::blocks::TableBlock<'_>) -> Vec<String> {
+    table
+        .footer_row()
+        .expect("expected a footer row")
+        .cells()
+        .iter()
+        .map(simple_text)
+        .collect()
+}
+
+non_normative!(
+    r#"
+= Create a Footer Row
+
+"#
+);
+
+#[test]
+fn intro() {
+    verifies!(
+        r#"
+The last row of a table is promoted to a footer row if the `footer` value is assigned to the table's `options` attribute.
+
+"#
+    );
+
+    // Assigning `footer` to the `options` attribute promotes the last row,
+    // moving it out of the body and into the footer. (The second line of
+    // content is non-empty, so no implicit header is detected and both rows
+    // start out in the body.)
+    let table = parse_table("[options=\"footer\"]\n|===\n|Cell 1 |Cell 2\n|Foot 1 |Foot 2\n|===");
+    assert_eq!(footer_texts(&table), vec!["Foot 1", "Foot 2"]);
+    assert_eq!(table.body_rows().len(), 1);
+
+    // Without the `footer` option, the last row stays in the body.
+    let no_footer = parse_table("|===\n|Cell 1 |Cell 2\n|Foot 1 |Foot 2\n|===");
+    assert!(no_footer.footer_row().is_none());
+}
+
+#[test]
+fn assign_footer_to_last_row() {
+    non_normative!(
+        r#"
+== Assign footer to the last row
+
+"#
+    );
+
+    verifies!(
+        r#"
+The footer row semantics and styles are applied to the last row in a table by assigning `footer` to the `options` attribute.
+The `options` attribute is set in the table's attribute list using the shorthand (`%value`) or formal syntax (`options="value"`).
+
+"#
+    );
+
+    // Shorthand `%footer` promotes the last row to the footer.
+    let shorthand = parse_table("[%footer]\n|===\n|Cell 1 |Cell 2\n|Foot 1 |Foot 2\n|===");
+    assert_eq!(footer_texts(&shorthand), vec!["Foot 1", "Foot 2"]);
+
+    // Formal `options="footer"` promotes the last row too.
+    let formal = parse_table("[options=\"footer\"]\n|===\n|Cell 1 |Cell 2\n|Foot 1 |Foot 2\n|===");
+    assert_eq!(footer_texts(&formal), vec!["Foot 1", "Foot 2"]);
+
+    // Unlike the header row (which ignores column style operators), a footer
+    // cell is processed with its column's style: here the `a` operator parses
+    // the footer cell's content as a nested AsciiDoc list block.
+    let styled =
+        parse_table("[%footer,cols=\"a,1\"]\n|===\n|Cell 1 |Cell 2\n|* item\n|Foot 2\n|===");
+    assert!(matches!(
+        styled.footer_row().unwrap().cells()[0].content(),
+        crate::blocks::TableCellContent::AsciiDoc(_)
+    ));
+
+    verifies!(
+        r#"
+The `options` attribute is represented by the percent sign (`%`) when it's set using the shorthand syntax.
+"#
+    );
+
+    // The `%` shorthand sets the `options` attribute, so `%footer` assigns the
+    // `footer` option and promotes the last row.
+    let table = parse_table("[%footer]\n|===\n|Cell 1 |Cell 2\n|Foot 1 |Foot 2\n|===");
+    assert!(table.footer_row().is_some());
+
+    non_normative!(
+        r#"
+In <<ex-short>>, `footer` is assigned using the shorthand syntax for `options`.
+
+.Table with footer assigned using the shorthand syntax
+[source#ex-short]
+----
+[%header%footer,cols="2,2,1"] <.>
+|===
+|Column 1, header row
+|Column 2, header row
+|Column 3, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+
+|Column 1, footer row
+|Column 2, footer row
+|Column 3, footer row
+|===
+----
+"#
+    );
+
+    verifies!(
+        r#"
+<.> Values assigned using the shorthand syntax must be entered before the `cols` attribute (or any other named attributes) in a table's attribute list, otherwise the processor will ignore them.
+
+"#
+    );
+
+    // Shorthand `%header%footer` entered before `cols` is honored: the first row
+    // is the header and the last row is the footer (this is the `ex-short`
+    // example from the page).
+    let before = parse_table(
+        "[%header%footer,cols=\"2,2,1\"]\n|===\n|Column 1, header row\n|Column 2, header row\n|Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n\n|Column 1, footer row\n|Column 2, footer row\n|Column 3, footer row\n|===",
+    );
+    assert!(before.header_row().is_some());
+    assert_eq!(
+        footer_texts(&before),
+        vec![
+            "Column 1, footer row",
+            "Column 2, footer row",
+            "Column 3, footer row"
+        ]
+    );
+    assert_eq!(before.body_rows().len(), 1);
+
+    // The same shorthand entered after the `cols` (named) attribute is ignored,
+    // so the last row is not promoted to a footer row.
+    let after = parse_table(
+        "[cols=\"2,2,1\",%footer]\n|===\n|Cell 1 |Cell 2 |Cell 3\n\n|Foot 1 |Foot 2 |Foot 3\n|===",
+    );
+    assert!(after.footer_row().is_none());
+
+    non_normative!(
+        r#"
+The table from <<ex-short>> is displayed below.
+
+.Result of <<ex-short>>
+[%header%footer,cols="2,2,1"]
+|===
+|Column 1, header row
+|Column 2, header row
+|Column 3, header row
+
+|Cell in column 1, row 2
+|Cell in column 2, row 2
+|Cell in column 3, row 2
+
+|Column 1, footer row
+|Column 2, footer row
+|Column 3, footer row
+|===
+
+In <<ex-formal>>, the `options` attribute is set and assigned the `footer` value using the formal syntax.
+"#
+    );
+
+    verifies!(
+        r#"
+The `options` attribute accepts a comma-separated list of values.
+
+"#
+    );
+
+    // The formal `options` value is a comma-separated list; `footer` is honored
+    // when it appears among other values.
+    let table = parse_table(
+        "[options=\"footer,unbreakable\"]\n|===\n|Cell 1 |Cell 2\n|Foot 1 |Foot 2\n|===",
+    );
+    assert!(table.footer_row().is_some());
+
+    non_normative!(
+        r#"
+.Table with footer assigned to the options attribute
+[source#ex-formal]
+----
+include::example$row.adoc[tag=opt-f]
+----
+
+"#
+    );
+
+    verifies!(
+        r#"
+The last row of the table in <<ex-formal>> is rendered using the corresponding footer styles.
+
+"#
+    );
+
+    // The `opt-f` example from row.adoc: an implicit header (first line
+    // non-empty, second line blank) plus the formal `footer` option, so the
+    // first row is the header, the middle row is the body, and the last row is
+    // the footer.
+    let formal = parse_table(
+        "[options=\"footer\"]\n|===\n|Column 1, header row |Column 2, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n\n|Column 1, footer row\n|Column 2, footer row\n|===",
+    );
+    assert!(formal.header_row().is_some());
+    assert_eq!(formal.body_rows().len(), 1);
+    assert_eq!(
+        footer_texts(&formal),
+        vec!["Column 1, footer row", "Column 2, footer row"]
+    );
+
+    non_normative!(
+        r#"
+.Result of <<ex-formal>>
+include::example$row.adoc[tag=opt-f]
+"#
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -1,5 +1,6 @@
 mod add_cells_and_rows;
 mod add_columns;
+mod add_footer_row;
 mod add_header_row;
 mod add_title;
 mod adjust_column_widths;


### PR DESCRIPTION
## Summary

Implements the [add-footer-row.adoc](docs/modules/tables/pages/add-footer-row.adoc) spec page: the last row of a table is promoted to a footer row when the `footer` value is assigned to the table's `options` attribute (via the `%footer` shorthand or `options="footer"` formal syntax).

Unlike the header row — which ignores column style operators — a footer cell is processed with its column's style operator. The footer is simply the last body row, relabeled. This matches Asciidoctor (verified locally: an `a`-styled column renders a nested list in `<tfoot>` just as it does in `<tbody>`).

## Changes

- `parser/src/blocks/table.rs`: detect the `footer` option and pop the last body row into `footer_row` (the `footer_row` field already existed but was always `None`). Removed "Footer rows" from the *Not yet supported* doc list.
- `parser/src/tests/asciidoc_lang/tables/add_footer_row.rs`: new line-by-line spec coverage for the page, covering:
  - explicit footer via `%footer` shorthand and `options="footer"`
  - the `%header%footer` combination (`ex-short` example)
  - the implicit-header + footer layout (`opt-f` example from `row.adoc`)
  - footer cells honoring column style operators
  - the placement callout (shorthand after a named attribute is ignored)
  - the comma-separated `options` list

## Verification

- `cargo test -p asciidoc-parser --lib` — 1973 passing
- `cargo clippy` clean, `cargo +nightly fmt --check` clean, `cargo +nightly doc` (deny warnings) clean
- `sdd` reports all normative lines of the page covered exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)