### PR TITLE
feat: Align table content by cell (per-cell alignment operators)

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -844,7 +844,10 @@ fn scan_cells(region: Span<'_>) -> Vec<RawCell<'_>> {
         if bytes.get(i).copied() == Some(b'|') {
             // Walk back to the start of the token directly preceding this `|`.
             // The token (a possible cell specifier) runs back to the previous
-            // whitespace, tab, or newline, or to the start of the region.
+            // whitespace, tab, or newline, or to the start of the region; either
+            // way the token is anchored at a line start or after whitespace, as a
+            // cell boundary requires. (When `tok_start == i` the token is empty
+            // and the separator is plain.)
             let mut tok_start = i;
             while tok_start > 0
                 && !matches!(
@@ -853,20 +856,6 @@ fn scan_cells(region: Span<'_>) -> Vec<RawCell<'_>> {
                 )
             {
                 tok_start -= 1;
-            }
-
-            // The token must be anchored at a line start or whitespace for the
-            // `|` to be a cell boundary. (When `tok_start == i` the token is
-            // empty and `tok_start - 1`, if any, is whitespace; either way the
-            // separator is plain.)
-            let anchored = tok_start == 0
-                || matches!(
-                    bytes.get(tok_start - 1).copied(),
-                    Some(b' ' | b'\t' | b'\n')
-                );
-            if !anchored {
-                i += 1;
-                continue;
             }
 
             let token = data.get(tok_start..i).unwrap_or_default();

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -33,13 +33,15 @@ use crate::{
 ///
 /// * The CSV, TSV, and DSV data formats (and the `,===` / `:===` shorthand
 ///   delimiters).
-/// * Cell specifiers (spans, duplication, per-cell alignment and style); the
-///   per-cell style operator that overrides a column's style operator is not
-///   yet recognized.
+/// * Cell specifier span (`+`) and duplication (`*`) operators and the per-cell
+///   style operator: these are recognized in a cell specifier (so the cell
+///   separator is still located correctly) but their layout and styling effects
+///   are not yet applied.
 ///
 /// Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, and `s`
 /// operators) are supported, along with proportional width and the horizontal
-/// and vertical alignment operators.
+/// and vertical alignment operators. Per-cell horizontal and vertical alignment
+/// operators are supported and override the column's alignment.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -205,17 +207,18 @@ impl<'src> TableBlock<'src> {
 
         let mut cells = Vec::with_capacity(raw_cells.len());
         for (idx, raw) in raw_cells.into_iter().enumerate() {
-            let style = if idx < header_len {
-                ColumnStyle::Default
-            } else {
-                // `idx % ncols` is in bounds whenever `ncols > 0`; an empty table
-                // (`ncols == 0`) has no columns, so the cell falls back to the
-                // default style.
-                columns
-                    .get(idx % ncols.max(1))
-                    .map_or(ColumnStyle::Default, |column| column.style)
-            };
-            cells.push(TableCell::parse(raw, style, parser, &mut warnings));
+            // `idx % ncols` is in bounds whenever `ncols > 0`; an empty table
+            // (`ncols == 0`) has no columns, so the cell falls back to the
+            // default column (default style and alignment).
+            let column = columns.get(idx % ncols.max(1)).cloned().unwrap_or_default();
+            let is_header = idx < header_len;
+            cells.push(TableCell::parse(
+                raw,
+                &column,
+                is_header,
+                parser,
+                &mut warnings,
+            ));
         }
         let mut cells = cells.into_iter();
 
@@ -532,12 +535,21 @@ impl<'src> TableRow<'src> {
 /// A single cell in a [`TableBlock`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableCell<'src> {
+    h_align: HorizontalAlignment,
+    v_align: VerticalAlignment,
     content: TableCellContent<'src>,
 }
 
 impl<'src> TableCell<'src> {
     /// Build a cell from the raw (untrimmed) span of its content, processing it
-    /// according to the [style](ColumnStyle) of the column the cell belongs to.
+    /// according to the [style](ColumnStyle) of the `column` the cell belongs
+    /// to.
+    ///
+    /// The cell's horizontal and vertical alignment come from the alignment
+    /// operators on its [specifier](RawCell::spec) when present; otherwise they
+    /// are inherited from the column. A header cell (`is_header`) is always
+    /// processed as plain header content, regardless of the column's style
+    /// operator.
     ///
     /// Leading and trailing whitespace is always stripped. For every style but
     /// [`AsciiDoc`](ColumnStyle::AsciiDoc) the cell holds inline
@@ -547,14 +559,28 @@ impl<'src> TableCell<'src> {
     /// [`AsciiDoc`](ColumnStyle::AsciiDoc) cell instead parses its content as a
     /// nested sequence of [blocks](TableCellContent::AsciiDoc).
     fn parse(
-        raw: Span<'src>,
-        style: ColumnStyle,
+        raw: RawCell<'src>,
+        column: &TableColumn,
+        is_header: bool,
         parser: &mut Parser,
         warnings: &mut Vec<Warning<'src>>,
     ) -> Self {
-        let trimmed = trim_surrounding_whitespace(raw);
+        // A cell's own alignment operator overrides the column's alignment; with
+        // no operator, the cell inherits the column's alignment.
+        let h_align = raw.spec.h_align.unwrap_or(column.h_align);
+        let v_align = raw.spec.v_align.unwrap_or(column.v_align);
 
-        if style == ColumnStyle::AsciiDoc {
+        // The header row is always processed as plain header content, so a
+        // column's style operator never affects a header cell.
+        let style = if is_header {
+            ColumnStyle::Default
+        } else {
+            column.style
+        };
+
+        let trimmed = trim_surrounding_whitespace(raw.content);
+
+        let content = if style == ColumnStyle::AsciiDoc {
             // The AsciiDoc style effectively creates a nested, standalone
             // AsciiDoc document in the cell. It inherits the parent document's
             // attributes, but any attribute it defines is scoped to the cell and
@@ -566,29 +592,51 @@ impl<'src> TableCell<'src> {
             let mut maw = parse_blocks_until(trimmed, |_| false, parser);
             parser.attribute_values = saved_attributes;
             warnings.append(&mut maw.warnings);
-            return Self {
-                content: TableCellContent::AsciiDoc(maw.item.item),
+            TableCellContent::AsciiDoc(maw.item.item)
+        } else {
+            let data = trimmed.data();
+
+            let mut content = if data.contains("\\|") {
+                Content::from_filtered(trimmed, data.replace("\\|", "|"))
+            } else {
+                Content::from(trimmed)
             };
-        }
 
-        let data = trimmed.data();
+            let substitutions = if style == ColumnStyle::Literal {
+                SubstitutionGroup::Verbatim
+            } else {
+                SubstitutionGroup::Normal
+            };
+            substitutions.apply(&mut content, parser, None);
 
-        let mut content = if data.contains("\\|") {
-            Content::from_filtered(trimmed, data.replace("\\|", "|"))
-        } else {
-            Content::from(trimmed)
+            TableCellContent::Simple(content)
         };
-
-        let substitutions = if style == ColumnStyle::Literal {
-            SubstitutionGroup::Verbatim
-        } else {
-            SubstitutionGroup::Normal
-        };
-        substitutions.apply(&mut content, parser, None);
 
         Self {
-            content: TableCellContent::Simple(content),
+            h_align,
+            v_align,
+            content,
         }
+    }
+
+    /// Returns the horizontal alignment of this cell's content.
+    ///
+    /// The alignment comes from a horizontal alignment operator (`<`, `>`, or
+    /// `^`) on the cell's specifier, which overrides the column's alignment. A
+    /// cell with no horizontal alignment operator inherits its column's
+    /// [`h_align`](TableColumn::h_align).
+    pub fn h_align(&self) -> HorizontalAlignment {
+        self.h_align
+    }
+
+    /// Returns the vertical alignment of this cell's content.
+    ///
+    /// The alignment comes from a vertical alignment operator (`.<`, `.>`, or
+    /// `.^`) on the cell's specifier, which overrides the column's alignment. A
+    /// cell with no vertical alignment operator inherits its column's
+    /// [`v_align`](TableColumn::v_align).
+    pub fn v_align(&self) -> VerticalAlignment {
+        self.v_align
     }
 
     /// Returns the interpreted content of this cell.
@@ -750,34 +798,95 @@ fn parse_col_spec(spec: &str) -> TableColumn {
     }
 }
 
-/// Scan a region for PSV cell boundaries, returning the raw (untrimmed) span of
-/// each cell's content.
+/// The alignment overrides parsed from a [cell specifier](RawCell::spec).
+///
+/// Each field is `None` when the corresponding alignment operator is absent
+/// from the specifier, in which case the cell inherits that alignment from its
+/// column.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct CellSpec {
+    h_align: Option<HorizontalAlignment>,
+    v_align: Option<VerticalAlignment>,
+}
+
+/// A single PSV cell as located by [`scan_cells`]: the alignment operators from
+/// its specifier together with the raw (untrimmed) span of its content.
+struct RawCell<'src> {
+    spec: CellSpec,
+    content: Span<'src>,
+}
+
+/// Scan a region for PSV cell boundaries, returning the [specifier](CellSpec)
+/// and raw (untrimmed) content span of each cell.
 ///
 /// A cell boundary is a vertical bar (`|`) that appears at the start of a line
-/// or is preceded by whitespace. Content before the first boundary is ignored.
+/// or is preceded by whitespace, optionally with a [cell specifier](CellSpec)
+/// (e.g. `^`, `2+`, `.>`) directly in front of the `|`. The token immediately
+/// preceding a `|` is taken to be a specifier when it parses as one (see
+/// [`parse_cell_spec`]); a token that doesn't parse as a specifier means the
+/// `|` is not a cell boundary. Content before the first boundary is ignored.
 ///
-/// An escaped separator (`\|`) is preceded by a backslash — neither a line
-/// start nor whitespace — so it already fails the boundary test and needs no
-/// special handling here; the backslash is stripped later in
-/// [`TableCell::parse`].
-fn scan_cells(region: Span<'_>) -> Vec<Span<'_>> {
-    let bytes = region.data().as_bytes();
+/// An escaped separator (`\|`) is preceded by a backslash, which is not a valid
+/// specifier, so the `|` already fails the boundary test and needs no special
+/// handling here; the backslash is stripped later in [`TableCell::parse`].
+fn scan_cells(region: Span<'_>) -> Vec<RawCell<'_>> {
+    let data = region.data();
+    let bytes = data.as_bytes();
     let len = bytes.len();
 
-    let mut cells: Vec<Span<'_>> = vec![];
+    let mut cells: Vec<RawCell<'_>> = vec![];
+    // The content start and specifier of the cell currently being accumulated.
     let mut content_start: Option<usize> = None;
+    let mut cur_spec = CellSpec::default();
     let mut i = 0;
 
     while i < len {
-        if bytes.get(i) == Some(&b'|') {
-            let prev = i.checked_sub(1).and_then(|p| bytes.get(p)).copied();
-            let at_line_start = prev.is_none() || prev == Some(b'\n');
-            let after_space = prev == Some(b' ') || prev == Some(b'\t');
+        if bytes.get(i).copied() == Some(b'|') {
+            // Walk back to the start of the token directly preceding this `|`.
+            // The token (a possible cell specifier) runs back to the previous
+            // whitespace, tab, or newline, or to the start of the region.
+            let mut tok_start = i;
+            while tok_start > 0
+                && !matches!(
+                    bytes.get(tok_start - 1).copied(),
+                    Some(b' ' | b'\t' | b'\n')
+                )
+            {
+                tok_start -= 1;
+            }
 
-            if at_line_start || after_space {
+            // The token must be anchored at a line start or whitespace for the
+            // `|` to be a cell boundary. (When `tok_start == i` the token is
+            // empty and `tok_start - 1`, if any, is whitespace; either way the
+            // separator is plain.)
+            let anchored = tok_start == 0
+                || matches!(
+                    bytes.get(tok_start - 1).copied(),
+                    Some(b' ' | b'\t' | b'\n')
+                );
+            if !anchored {
+                i += 1;
+                continue;
+            }
+
+            let token = data.get(tok_start..i).unwrap_or_default();
+            let spec = if token.is_empty() {
+                Some(CellSpec::default())
+            } else {
+                parse_cell_spec(token)
+            };
+
+            if let Some(spec) = spec {
                 if let Some(start) = content_start {
-                    cells.push(region.slice(start..i));
+                    // The previous cell's content ends at the start of this
+                    // cell's specifier; the separating whitespace, included in
+                    // the slice, is trimmed later in `TableCell::parse`.
+                    cells.push(RawCell {
+                        spec: cur_spec,
+                        content: region.slice(start..tok_start),
+                    });
                 }
+                cur_spec = spec;
                 content_start = Some(i + 1);
             }
         }
@@ -786,10 +895,103 @@ fn scan_cells(region: Span<'_>) -> Vec<Span<'_>> {
     }
 
     if let Some(start) = content_start {
-        cells.push(region.slice(start..len));
+        cells.push(RawCell {
+            spec: cur_spec,
+            content: region.slice(start..len),
+        });
     }
 
     cells
+}
+
+/// Parse a cell specifier, returning its [alignment overrides](CellSpec), or
+/// `None` if `token` is not a valid cell specifier.
+///
+/// A cell specifier is positional and every part is optional, but the whole
+/// token must be consumed for it to be valid:
+///
+/// ```text
+/// <factor><span or duplication operator><horizontal><vertical><style>
+/// ```
+///
+/// * The factor and span/duplication operator are an optional count (e.g. `2`,
+///   `2.3`, `.3`) that, when present, must be followed by `+` (span) or `*`
+///   (duplication). These operators are recognized so the cell separator is
+///   located correctly, but their layout effect is not yet applied.
+/// * The horizontal alignment operator is `<`, `>`, or `^`.
+/// * The vertical alignment operator is a dot followed by `<`, `>`, or `^`.
+/// * The style operator is a single lowercase letter. It is recognized (so the
+///   separator is located) but its styling effect is not yet applied.
+fn parse_cell_spec(token: &str) -> Option<CellSpec> {
+    let b = token.as_bytes();
+    let mut i = 0;
+
+    // Optional span/duplication: an optional count followed by `+` or `*`. The
+    // count is committed only when the operator that must follow it is present;
+    // otherwise leading digits remain and the token fails below.
+    let mut j = i;
+    while matches!(b.get(j).copied(), Some(c) if c.is_ascii_digit()) {
+        j += 1;
+    }
+    if b.get(j).copied() == Some(b'.') {
+        j += 1;
+        while matches!(b.get(j).copied(), Some(c) if c.is_ascii_digit()) {
+            j += 1;
+        }
+    }
+    if matches!(b.get(j).copied(), Some(b'+' | b'*')) {
+        i = j + 1;
+    }
+
+    // Optional horizontal alignment operator.
+    let mut h_align = None;
+    match b.get(i).copied() {
+        Some(b'<') => {
+            h_align = Some(HorizontalAlignment::Left);
+            i += 1;
+        }
+        Some(b'>') => {
+            h_align = Some(HorizontalAlignment::Right);
+            i += 1;
+        }
+        Some(b'^') => {
+            h_align = Some(HorizontalAlignment::Center);
+            i += 1;
+        }
+        _ => {}
+    }
+
+    // Optional vertical alignment operator, introduced by a dot.
+    let mut v_align = None;
+    if b.get(i).copied() == Some(b'.') {
+        match b.get(i + 1).copied() {
+            Some(b'<') => {
+                v_align = Some(VerticalAlignment::Top);
+                i += 2;
+            }
+            Some(b'>') => {
+                v_align = Some(VerticalAlignment::Bottom);
+                i += 2;
+            }
+            Some(b'^') => {
+                v_align = Some(VerticalAlignment::Middle);
+                i += 2;
+            }
+            _ => {}
+        }
+    }
+
+    // Optional style operator: a single lowercase letter in the last position.
+    if matches!(b.get(i).copied(), Some(c) if c.is_ascii_lowercase()) {
+        i += 1;
+    }
+
+    // The token is a cell specifier only if it was consumed in its entirety.
+    if i == b.len() {
+        Some(CellSpec { h_align, v_align })
+    } else {
+        None
+    }
 }
 
 /// Return the subspan of `s` with surrounding whitespace (including newlines)

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -597,3 +597,16 @@ fn non_specifier_token_is_not_a_cell_separator() {
     let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
     assert_eq!(rows, vec![vec!["a foo|b".to_string()]]);
 }
+
+#[test]
+fn dot_not_followed_by_vertical_operator_is_not_a_cell_separator() {
+    // A vertical alignment operator is a dot followed by `<`, `>`, or `^`. A dot
+    // followed by anything else (here `.x`) is not a valid cell specifier, so the
+    // `|` is not a cell separator: `a .x|b` is a single cell whose content
+    // includes the literal `.x|`.
+    let table = parse_table("|===\n|a .x|b\n|===");
+
+    assert_eq!(table.columns().len(), 1);
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(rows, vec![vec!["a .x|b".to_string()]]);
+}

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -558,3 +558,42 @@ fn asciidoc_cell_attributes_are_scoped_to_the_cell() {
     assert!(!parser.has_attribute("cell-attr"));
     assert!(parser.has_attribute("parent-attr"));
 }
+
+#[test]
+fn cell_specifier_style_operator_locates_separator() {
+    // A single lowercase letter directly in front of a `|` is a (style) cell
+    // specifier, so the `|` is a cell separator: `a s|b` is two cells, not one.
+    // The style operator is recognized only so the separator is located; its
+    // styling effect is not yet applied, so the cell renders as plain content.
+    let table = parse_table("|===\n|a s|b\n|===");
+
+    assert_eq!(table.columns().len(), 2);
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(rows, vec![vec!["a".to_string(), "b".to_string()]]);
+}
+
+#[test]
+fn cell_specifier_span_operator_without_factor_locates_separator() {
+    // The span (`+`) and duplication (`*`) operators may appear without a count.
+    // A bare `+` directly in front of a `|` is still a valid cell specifier, so
+    // `a +|b` is two cells. (The span operator's layout effect is not yet
+    // applied.)
+    let table = parse_table("|===\n|a +|b\n|===");
+
+    assert_eq!(table.columns().len(), 2);
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(rows, vec![vec!["a".to_string(), "b".to_string()]]);
+}
+
+#[test]
+fn non_specifier_token_is_not_a_cell_separator() {
+    // A token in front of a `|` that does not parse as a cell specifier (here the
+    // word `foo`, which is more than a single style letter) means the `|` is not
+    // a cell separator: `a foo|b` is a single cell whose content includes the
+    // literal `|`.
+    let table = parse_table("|===\n|a foo|b\n|===");
+
+    assert_eq!(table.columns().len(), 1);
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(rows, vec![vec!["a foo|b".to_string()]]);
+}

--- a/parser/src/tests/asciidoc_lang/tables/align_by_cell.rs
+++ b/parser/src/tests/asciidoc_lang/tables/align_by_cell.rs
@@ -1,0 +1,423 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/align-by-cell.adoc");
+
+non_normative!(
+    r#"
+= Align Content by Cell
+
+The alignment operators are applied to a xref:add-cells-and-rows.adoc#specifiers[cell's specifier] and allow you to horizontally and vertically align a cell's content.
+
+"#
+);
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Collect the `(horizontal, vertical)` alignment of each cell in each body
+/// row of `table`.
+fn body_alignments(
+    table: &crate::blocks::TableBlock<'_>,
+) -> Vec<Vec<(HorizontalAlignment, VerticalAlignment)>> {
+    table
+        .body_rows()
+        .iter()
+        .map(|row| {
+            row.cells()
+                .iter()
+                .map(|cell| (cell.h_align(), cell.v_align()))
+                .collect()
+        })
+        .collect()
+}
+
+#[test]
+fn horizontal_alignment_operators() {
+    non_normative!(
+        r#"
+[#horizontal-operators]
+== Horizontal alignment operators
+
+"#
+    );
+
+    verifies!(
+        r#"
+Content can be horizontally aligned to the left or right side of the cell as well as the center of the cell.
+
+Flush left operator (<):: The less-than sign (`<`) aligns the content to the left side of the cell.
+This is the default horizontal alignment.
+Flush right operator (>):: The greater-than sign (`>`) aligns the content to the right side of the cell.
+Center operator (^):: The caret (`+^+`) centers the content horizontally in the cell.
+
+A horizontal alignment operator is entered after a span or duplication operator (if present) and in front a <<vertical-operators,vertical alignment operator>> (if present).
+
+====
+<factor><span or duplication operator><**horizontal alignment operator**><vertical alignment operator><style operator>|<cell's content>
+====
+
+"#
+    );
+
+    // The three horizontal alignment operators on cell specifiers: `<` (left,
+    // the default), `>` (right), and `^` (center). Entered directly in front of
+    // the cell separator (`|`).
+    let table = parse_table("|===\n<|a >|b ^|c\n|===");
+    assert_eq!(
+        body_alignments(&table),
+        vec![vec![
+            (HorizontalAlignment::Left, VerticalAlignment::Top),
+            (HorizontalAlignment::Right, VerticalAlignment::Top),
+            (HorizontalAlignment::Center, VerticalAlignment::Top),
+        ]]
+    );
+}
+
+#[test]
+fn center_content_horizontally_in_a_cell() {
+    non_normative!(
+        r#"
+=== Center content horizontally in a cell
+
+"#
+    );
+
+    verifies!(
+        r#"
+To horizontally center the content in a cell, place the `+^+` operator in front of the xref:add-cells-and-rows.adoc#cell-separator[cell's separator] (`|`).
+Don't insert any spaces between the `|` and the operator.
+
+.Center the content of a cell horizontally
+[source#ex-hcenter]
+----
+include::example$align-cell.adoc[tag=hcenter]
+----
+
+The table from <<ex-hcenter>> is rendered below.
+
+.Result of <<ex-hcenter>>
+include::example$align-cell.adoc[tag=hcenter]
+
+"#
+    );
+
+    // Expansion of `example$align-cell.adoc[tag=hcenter]`. The first cell is
+    // centered (`^|`); the second falls back to the default (left).
+    let table = parse_table(
+        "|===\n|Column Name |Column Name\n\n^|This content is horizontally centered because the cell specifier includes the `+^+` operator.\n|There isn't a horizontal alignment operator on this cell specifier, so the cell falls back to the default horizontal alignment.\nContent is aligned to the left side of the cell by default.\n|===",
+    );
+    assert_eq!(
+        body_alignments(&table),
+        vec![vec![
+            (HorizontalAlignment::Center, VerticalAlignment::Top),
+            (HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]]
+    );
+
+    verifies!(
+        r#"
+If the cell specifier includes a span (`<n>+`) or duplication (`+<n>*+`), place the `+^+` directly after the span or duplication operator.
+
+.Center content horizontally in spanned columns and duplicated cells
+[source#ex-factor]
+----
+include::example$align-cell.adoc[tag=factor]
+----
+
+The table from <<ex-factor>> is rendered below.
+
+.Result of <<ex-factor>>
+include::example$align-cell.adoc[tag=factor]
+
+"#
+    );
+
+    // Expansion of `example$align-cell.adoc[tag=factor]`. The `+^+` operator is
+    // placed directly after the span (`2+`) and duplication (`2*`) operators;
+    // both cells are centered. (The span/duplication operators are recognized
+    // but their layout effect is not yet applied.)
+    let table = parse_table(
+        "|===\n|Column Name |Column Name\n\n2+^|This cell spans two columns, and its content is horizontally centered because the cell specifier includes the `+^+` operator.\n2*^|This content is duplicated in two adjacent columns.\nIts content is horizontally centered because the cell specifier\nincludes the `+^+` operator.\n|===",
+    );
+    assert_eq!(
+        body_alignments(&table),
+        vec![vec![
+            (HorizontalAlignment::Center, VerticalAlignment::Top),
+            (HorizontalAlignment::Center, VerticalAlignment::Top),
+        ]]
+    );
+}
+
+#[test]
+fn align_the_content_of_a_cell_to_the_right() {
+    non_normative!(
+        r#"
+== Align the content of a cell to the right
+
+"#
+    );
+
+    verifies!(
+        r#"
+To align the content in a cell to its right side, place the `>` operator in front of the xref:add-cells-and-rows.adoc#cell-separator[cell's separator] (`|`), but after a span (`<n>+`) or duplication (`+<n>*+`) operator (if present).
+Don't insert any spaces between the `|` and the operators.
+
+.Right align the content of a cell
+[source#ex-right]
+----
+include::example$align-cell.adoc[tag=right]
+----
+
+The table from <<ex-right>> is rendered below.
+
+.Result of <<ex-right>>
+include::example$align-cell.adoc[tag=right]
+
+"#
+    );
+
+    // Expansion of `example$align-cell.adoc[tag=right]`. The `>` operator
+    // right-aligns the first cell and the spanned cell (`2+>`); the cell with no
+    // operator falls back to the default (left).
+    let table = parse_table(
+        "|===\n|Column Name |Column Name\n\n>|This content is aligned to the right side of the cell because the cell specifier includes the `>` operator.\n|There isn't a horizontal alignment operator on this cell specifier, so the cell falls back to the default horizontal alignment.\nContent is aligned to the left side of the cell by default.\n\n2+>|This cell spans two columns.\n\nIts content is aligned to the right because the cell specifier includes the `>` operator.\nThe `>` operator must be placed directly after the span operator (`+`).\n|===",
+    );
+    assert_eq!(
+        body_alignments(&table),
+        vec![
+            vec![
+                (HorizontalAlignment::Right, VerticalAlignment::Top),
+                (HorizontalAlignment::Left, VerticalAlignment::Top),
+            ],
+            vec![(HorizontalAlignment::Right, VerticalAlignment::Top)],
+        ]
+    );
+}
+
+#[test]
+fn vertical_alignment_operators() {
+    non_normative!(
+        r#"
+[#vertical-operators]
+== Vertical alignment operators
+
+"#
+    );
+
+    verifies!(
+        r#"
+Content can be vertically aligned to the top or bottom of a cell as well as the center of a cell.
+Vertical alignment operators always begin with a dot (`.`).
+
+Flush top operator (.<):: The dot and less-than sign (`.<`) aligns the content to the top of the cell.
+This is the default vertical alignment.
+Flush bottom operator (.>):: The dot and greater-than sign (`.>`) aligns the content to the bottom of the cell.
+Center operator (.^):: The dot and caret (`+.^+`) centers the content vertically.
+
+A vertical alignment operator is entered after a <<horizontal-operators,horizontal alignment operator>> (if present) and in front of a style operator (if present).
+
+====
+<factor><span or duplication operator><horizontal alignment operator><**vertical alignment operator**><style operator>|<cell's content>
+====
+
+"#
+    );
+
+    // The three vertical alignment operators on cell specifiers: `.<` (top, the
+    // default), `.>` (bottom), and `.^` (center).
+    let table = parse_table("|===\n.<|a .>|b .^|c\n|===");
+    assert_eq!(
+        body_alignments(&table),
+        vec![vec![
+            (HorizontalAlignment::Left, VerticalAlignment::Top),
+            (HorizontalAlignment::Left, VerticalAlignment::Bottom),
+            (HorizontalAlignment::Left, VerticalAlignment::Middle),
+        ]]
+    );
+}
+
+#[test]
+fn align_content_to_the_bottom_of_a_cell() {
+    non_normative!(
+        r#"
+=== Align content to the bottom of a cell
+
+"#
+    );
+
+    verifies!(
+        r#"
+To align the content to the bottom of a cell, place the `+.>+` operator in front of the xref:add-cells-and-rows.adoc#cell-separator[cell's separator] (`|`).
+Don't insert any spaces between the `|` and the operator.
+
+.Align content to the bottom of a cell
+[source#ex-bottom]
+----
+include::example$align-cell.adoc[tag=bottom]
+----
+
+The table from <<ex-bottom>> is rendered below.
+
+.Result of <<ex-bottom>>
+include::example$align-cell.adoc[tag=bottom]
+
+"#
+    );
+
+    // Expansion of `example$align-cell.adoc[tag=bottom]`. The first cell is
+    // bottom-aligned (`.>|`); the second has no vertical alignment operator and
+    // falls back to the column's alignment (the `cols="2,1"` columns are
+    // top-aligned by default).
+    let table = parse_table(
+        "[cols=\"2,1\"]\n|===\n|Column Name |Column Name\n\n.>|This content is aligned to the bottom of the cell because the cell specifier includes the `.>` operator.\n|There isn't a vertical alignment operator on this cell specifier, so the cell falls back to the alignment assigned via the column specifier or the default vertical alignment.\nContent is aligned to the top of the cell by default.\n|===",
+    );
+    assert_eq!(
+        body_alignments(&table),
+        vec![vec![
+            (HorizontalAlignment::Left, VerticalAlignment::Bottom),
+            (HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]]
+    );
+
+    verifies!(
+        r#"
+If the cell specifier includes a span (`<n>+`) or duplication (`+<n>*+`), place the `.>` after the span or duplication operator.
+
+.Align content to the bottom of a cell that spans rows
+[source#ex-span-vertical]
+----
+include::example$align-cell.adoc[tag=vspan]
+----
+
+The table from <<ex-span-vertical>> is rendered below.
+
+.Result of <<ex-span-vertical>>
+include::example$align-cell.adoc[tag=vspan]
+
+"#
+    );
+
+    // Expansion of `example$align-cell.adoc[tag=vspan]`. The `.>` is placed
+    // after the row-span operator (`.2+`); that cell is bottom-aligned, while
+    // the cells with no vertical alignment operator stay top-aligned. (The
+    // row-span operator is recognized but its layout effect is not yet applied.)
+    let table = parse_table(
+        "|===\n|Column Name |Column Name\n\n|There isn't a vertical alignment operator on this cell specifier, so the content is aligned to the top of the cell by default.\n\n.2+.>|This cell spans two rows, and its content is aligned to the bottom because the cell specifier includes the `.>` operator.\n\n|This content is aligned to the top of the cell by default.\n|===",
+    );
+    assert_eq!(
+        body_alignments(&table),
+        vec![
+            vec![
+                (HorizontalAlignment::Left, VerticalAlignment::Top),
+                (HorizontalAlignment::Left, VerticalAlignment::Bottom),
+            ],
+            vec![(HorizontalAlignment::Left, VerticalAlignment::Top)],
+        ]
+    );
+}
+
+#[test]
+fn center_content_vertically_in_a_cell() {
+    non_normative!(
+        r#"
+=== Center content vertically in a cell
+
+"#
+    );
+
+    verifies!(
+        r#"
+To vertically center the content in a cell, place the `+.^+` operator in front of the xref:add-cells-and-rows.adoc#cell-separator[cell's separator] (`|`).
+Don't insert any spaces between the `|` and the operator.
+
+.Center the content of a cell vertically
+[source#ex-vcenter]
+----
+include::example$align-cell.adoc[tag=vcenter]
+----
+
+The table from <<ex-vcenter>> is rendered below.
+
+.Result of <<ex-vcenter>>
+include::example$align-cell.adoc[tag=vcenter]
+
+"#
+    );
+
+    // Expansion of `example$align-cell.adoc[tag=vcenter]`. The first cell is
+    // vertically centered (`.^|`); the second falls back to the default (top).
+    let table = parse_table(
+        "|===\n|Column Name |Column Name\n\n.^|This content is vertically centered because the cell specifier includes the `+.^+` operator.\n|There isn't a vertical alignment operator on this cell specifier, so the cell falls back to the default vertical alignment.\nContent is aligned to the top of the cell by default.\n|===",
+    );
+    assert_eq!(
+        body_alignments(&table),
+        vec![vec![
+            (HorizontalAlignment::Left, VerticalAlignment::Middle),
+            (HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]]
+    );
+}
+
+#[test]
+fn apply_horizontal_and_vertical_alignment_operators_to_the_same_cell() {
+    non_normative!(
+        r#"
+== Apply horizontal and vertical alignment operators to the same cell
+
+"#
+    );
+
+    verifies!(
+        r#"
+A cell can have a vertical and horizontal alignment operator included in its cell specifier.
+The <<horizontal-operators,horizontal operator>> always precedes the <<vertical-operators,vertical operator>>.
+
+.Align cells horizontally and vertically
+[source#ex-combine]
+----
+include::example$align-cell.adoc[tag=combine]
+----
+
+The table from <<ex-combine>> is rendered below.
+
+.Result <<ex-combine>>
+include::example$align-cell.adoc[tag=combine]
+"#
+    );
+
+    // Expansion of `example$align-cell.adoc[tag=combine]`. Each specifier
+    // applies both a horizontal and a vertical operator (the horizontal always
+    // first): `^.>` (center, bottom), `>.^` (right, middle), `2.3+^.^` (center,
+    // middle, after a span), and `3*.>` (bottom, after a duplication; the
+    // horizontal alignment falls back to the column default). The cell with no
+    // operators falls back to the default alignments (left, top).
+    let table = parse_table(
+        "|===\n|Column 1 |Column 2 |Column 3\n\n^.>|The specifier for this cell is `^.>`.\nThe content is centered horizontally and aligned to the bottom of the cell.\n|There aren't any alignment operators on this cell's specifier, so the cell falls back to the default alignments.\nThe default horizontal alignment is the left side of the cell.\nThe default vertical alignment is the top of the cell.\n>.^|The specifier for this cell is `>.^`.\nThe content is aligned to the right side of the cell and centered vertically.\n\n2.3+^.^|The specifier for this cell is `pass:[2.3+^.^]`.\nIt spans two columns and three rows.\n\nIts content is centered horizontally and vertically.\n3*.>|The specifier for this cell is `3*.>`.\nThe cell is duplicated in three consecutive rows in the same column.\nIt's content is aligned to the bottom of the cell.\n|===",
+    );
+    assert_eq!(
+        body_alignments(&table),
+        vec![
+            vec![
+                (HorizontalAlignment::Center, VerticalAlignment::Bottom),
+                (HorizontalAlignment::Left, VerticalAlignment::Top),
+                (HorizontalAlignment::Right, VerticalAlignment::Middle),
+            ],
+            vec![
+                (HorizontalAlignment::Center, VerticalAlignment::Middle),
+                (HorizontalAlignment::Left, VerticalAlignment::Bottom),
+            ],
+        ]
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/align_by_column.rs
+++ b/parser/src/tests/asciidoc_lang/tables/align_by_column.rs
@@ -635,12 +635,21 @@ centered vertically.
         ]
     );
 
-    // Cell specifiers (and thus their per-cell alignment operators) are not yet
-    // parsed, so the override of a column's alignment by a cell's alignment can't
-    // be verified yet.
-    to_do_verifies!(
+    verifies!(
         r#"
 IMPORTANT: If there is an xref:align-by-cell.adoc[alignment operator on a cell's specifier], it will override the column's alignment operator.
 "#
     );
+
+    // The column is centered horizontally and aligned to the bottom (`^.>`), but
+    // the cell's own specifier (`>.^`) overrides both: the cell is right-aligned
+    // and centered vertically.
+    let table = parse_table("[cols=\"^.>\"]\n|===\n>.^|overridden\n|===");
+    assert_eq!(
+        column_alignments(&table),
+        vec![(1, HorizontalAlignment::Center, VerticalAlignment::Bottom)]
+    );
+    let cell = &table.body_rows()[0].cells()[0];
+    assert_eq!(cell.h_align(), HorizontalAlignment::Right);
+    assert_eq!(cell.v_align(), VerticalAlignment::Middle);
 }

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -4,6 +4,7 @@ mod add_footer_row;
 mod add_header_row;
 mod add_title;
 mod adjust_column_widths;
+mod align_by_cell;
 mod align_by_column;
 mod build_a_basic_table;
 mod customize_title_label;


### PR DESCRIPTION
Implement the per-cell horizontal and vertical alignment operators from `docs/modules/tables/pages/align-by-cell.adoc`.

## The gap

Cell specifiers were not previously parsed. The cell scanner only treated a `|` preceded by whitespace or a line start as a separator, so a cell specifier (e.g. `^|`, `2+^|`, `.>|`) actually *prevented* the separator from being located at all.

## Changes

- **`scan_cells`** now inspects the token directly in front of each `|` and treats the `|` as a separator when that token parses as a cell specifier.
- **`parse_cell_spec`** parses the full positional grammar (`<factor><+|*><h-align><v-align><style>`), matching Asciidoctor's cell-spec rule. The whole token must be consumed, so non-specifier text (e.g. `foo|`) is *not* a separator and `\|` stays escaped.
- **`TableCell`** gained `h_align()` / `v_align()`. A cell's own alignment operator (`<`, `>`, `^`, `.<`, `.>`, `.^`) overrides the column's; with no operator the cell inherits the column's alignment, matching Asciidoctor.
- Span (`+`), duplication (`*`), and the per-cell style letter are *recognized* (so the separator is found) but their layout/styling effects are deferred to their own spec pages (`span-cells`, `duplicate-cells`, `format-cell-content`). Docs updated accordingly.

## Tests

- New `align_by_cell.rs` with full verbatim spec coverage (sdd: 87/87 normative lines, 0 gaps), asserting per-cell alignment for every example including the span/dup/combined ones.
- Upgraded the cell-overrides-column `to_do_verifies!` in `align_by_column.rs` to a real verified test.
- Added branch-coverage unit tests in `blocks/tests/table.rs` for the style-operator, bare-operator, and non-specifier (rejection) paths.

## Verification

Alignment semantics (including column fallback) cross-checked against real `asciidoctor` HTML output — they match exactly. Full suite (1983 tests), `clippy --all-targets`, nightly `fmt --check`, and `RUSTDOCFLAGS=-D warnings` doc build all pass.

## Scoping note

Because span/duplication *layout* isn't applied yet, a table like the `2+^` example parses each cell with the right alignment but doesn't yet collapse cells across columns/rows — intentionally left to the span/duplicate pages. Alignment assertions are written against per-parsed-cell behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)