### PR TITLE
feat: Span table cells across columns and rows (span operator)

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -231,6 +231,17 @@ impl<'src> TableBlock<'src> {
         let mut warnings: Vec<Warning<'src>> = vec![];
         let raw_cells = scan_cells(inside);
 
+        // A table can never have more rows than it has cells, so a row span is
+        // clamped to the cell count for the `active_rowspans` bookkeeping below: a
+        // larger span carries into rows that can't exist and so has no additional
+        // layout effect. The clamp also bounds the `active_rowspans` allocation,
+        // so a hostile specifier such as `.1000000000+` can't trigger a
+        // multi-gigabyte allocation. (The cell's reported [`rowspan`] keeps the
+        // literal parsed value, matching Asciidoctor.)
+        //
+        // [`rowspan`]: TableCell::rowspan
+        let max_rowspan = raw_cells.len().saturating_add(1);
+
         let mut raw_rows: Vec<Vec<RawCell<'src>>> = vec![];
         if ncols > 0 {
             let mut active_rowspans: Vec<usize> = vec![0];
@@ -239,7 +250,7 @@ impl<'src> TableBlock<'src> {
 
             for raw in raw_cells {
                 let colspan = raw.spec.colspan.max(1);
-                let rowspan = raw.spec.rowspan.max(1);
+                let rowspan = raw.spec.rowspan.max(1).min(max_rowspan);
 
                 // A cell that spans more than one row reserves `colspan` slots in
                 // each of the rows it extends into (but not its own row).

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -43,16 +43,18 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 ///
 /// * The CSV, TSV, and DSV data formats (and the `,===` / `:===` shorthand
 ///   delimiters).
-/// * Cell specifier span (`+`) and duplication (`*`) operators: these are
-///   recognized in a cell specifier (so the cell separator is still located
-///   correctly) but their layout effect is not yet applied.
+/// * The cell specifier duplication (`*`) operator: it is recognized in a cell
+///   specifier (so the cell separator is still located correctly) but its
+///   layout effect is not yet applied.
 ///
 /// Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, and `s`
 /// operators) are supported, along with proportional width and the horizontal
 /// and vertical alignment operators. Per-cell horizontal and vertical alignment
 /// operators are supported and override the column's alignment, and a per-cell
 /// style operator (in the last position of the cell specifier) is supported and
-/// overrides the column's style.
+/// overrides the column's style. The per-cell span (`+`) operator is supported:
+/// a cell can span multiple columns (`<n>+`), multiple rows (`.<n>+`), or a
+/// block of both (`<n>.<n>+`).
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -124,7 +126,13 @@ impl<'src> TableBlock<'src> {
             .map(|attr| parse_cols(attr.value()))
             .unwrap_or_default();
 
-        let first_line_cells = scan_cells(inside.discard_empty_lines().take_line().item).len();
+        // When the column count is implicit, it is the number of column slots in
+        // the first non-empty line: a cell that spans columns (`<n>+`) counts as
+        // `<n>` slots, not one.
+        let first_line_cells: usize = scan_cells(inside.discard_empty_lines().take_line().item)
+            .iter()
+            .map(|c| c.spec.colspan.max(1))
+            .sum();
 
         let ncols = if columns.is_empty() {
             first_line_cells
@@ -206,54 +214,89 @@ impl<'src> TableBlock<'src> {
         };
 
         // Scan every cell in the table, in document order, then partition into
-        // rows of `ncols` cells each.
+        // rows by walking the grid: a cell's span (colspan/rowspan) governs how
+        // many column slots it occupies, so a column-spanning cell fills its row
+        // with fewer cells and a row-spanning cell carries its columns down into
+        // the rows below.
         //
-        // Each cell is processed according to the style of the column it falls
-        // in. The header row (when present) is the first `ncols` cells and is
-        // always processed as plain header content, regardless of the column
-        // styles, so that a style operator doesn't affect the header row.
+        // This mirrors Asciidoctor's grid walk. `active_rowspans[k]` records the
+        // number of column slots that cells from earlier rows occupy in the row
+        // `k` steps ahead of the one being filled; a row closes once its own
+        // cells' colspans plus the slots carried into it (`active_rowspans[0]`)
+        // reach `ncols`.
         let mut warnings: Vec<Warning<'src>> = vec![];
         let raw_cells = scan_cells(inside);
-        let header_len = if has_header { ncols } else { 0 };
 
-        let mut cells = Vec::with_capacity(raw_cells.len());
-        for (idx, raw) in raw_cells.into_iter().enumerate() {
-            // `idx % ncols` is in bounds whenever `ncols > 0`; an empty table
-            // (`ncols == 0`) has no columns, so the cell falls back to the
-            // default column (default style and alignment).
-            let column = columns.get(idx % ncols.max(1)).cloned().unwrap_or_default();
-            let is_header = idx < header_len;
-            cells.push(TableCell::parse(
-                raw,
-                &column,
-                is_header,
-                parser,
-                &mut warnings,
-            ));
-        }
-        let mut cells = cells.into_iter();
-
-        let header_row = if has_header && ncols > 0 {
-            let row: Vec<TableCell<'src>> = cells.by_ref().take(ncols).collect();
-            if row.is_empty() {
-                None
-            } else {
-                Some(TableRow { cells: row })
-            }
-        } else {
-            None
-        };
-
-        let mut body_rows: Vec<TableRow<'src>> = vec![];
+        let mut raw_rows: Vec<Vec<RawCell<'src>>> = vec![];
         if ncols > 0 {
-            loop {
-                let row: Vec<TableCell<'src>> = cells.by_ref().take(ncols).collect();
-                if row.is_empty() {
-                    break;
+            let mut active_rowspans: Vec<usize> = vec![0];
+            let mut column_visits = 0usize;
+            let mut current_row: Vec<RawCell<'src>> = vec![];
+
+            for raw in raw_cells {
+                let colspan = raw.spec.colspan.max(1);
+                let rowspan = raw.spec.rowspan.max(1);
+
+                // A cell that spans more than one row reserves `colspan` slots in
+                // each of the rows it extends into (but not its own row).
+                if rowspan > 1 {
+                    if active_rowspans.len() < rowspan {
+                        active_rowspans.resize(rowspan, 0);
+                    }
+                    for slot in active_rowspans.iter_mut().take(rowspan).skip(1) {
+                        *slot += colspan;
+                    }
                 }
-                body_rows.push(TableRow { cells: row });
+
+                column_visits += colspan;
+                current_row.push(raw);
+
+                // The slots carried into the current row are `active_rowspans[0]`;
+                // the vector is never empty here, so the fallback is unreachable.
+                let carried = active_rowspans.first().copied().unwrap_or(0);
+                if column_visits + carried >= ncols {
+                    raw_rows.push(std::mem::take(&mut current_row));
+                    column_visits = 0;
+                    active_rowspans.remove(0);
+                    if active_rowspans.is_empty() {
+                        active_rowspans.push(0);
+                    }
+                }
+            }
+
+            // A trailing incomplete row (one that never reached `ncols`) is still
+            // emitted, matching the existing handling of short final rows.
+            if !current_row.is_empty() {
+                raw_rows.push(current_row);
             }
         }
+
+        // Each cell is processed according to the style of the column it falls
+        // in. A cell's column is its ordinal position within its row (matching
+        // Asciidoctor, which assigns the column by cell count, not grid slot). The
+        // header row (when present) is the first row and is always processed as
+        // plain header content, regardless of the column styles, so that a style
+        // operator doesn't affect the header row.
+        let mut rows: Vec<TableRow<'src>> = Vec::with_capacity(raw_rows.len());
+        for (row_idx, raw_row) in raw_rows.into_iter().enumerate() {
+            let is_header = has_header && row_idx == 0;
+            let mut cells = Vec::with_capacity(raw_row.len());
+            for (col_idx, raw) in raw_row.into_iter().enumerate() {
+                let column = columns.get(col_idx).cloned().unwrap_or_default();
+                cells.push(TableCell::parse(
+                    raw,
+                    &column,
+                    is_header,
+                    parser,
+                    &mut warnings,
+                ));
+            }
+            rows.push(TableRow { cells });
+        }
+
+        let mut rows = rows.into_iter();
+        let header_row = if has_header { rows.next() } else { None };
+        let mut body_rows: Vec<TableRow<'src>> = rows.collect();
 
         // The footer row, when requested, is the last row of the table. It is
         // moved out of the body so the caller sees it as a distinct footer. When
@@ -549,6 +592,8 @@ pub struct TableCell<'src> {
     h_align: HorizontalAlignment,
     v_align: VerticalAlignment,
     style: ColumnStyle,
+    colspan: usize,
+    rowspan: usize,
     content: TableCellContent<'src>,
 }
 
@@ -653,6 +698,8 @@ impl<'src> TableCell<'src> {
             h_align,
             v_align,
             style,
+            colspan: raw.spec.colspan.max(1),
+            rowspan: raw.spec.rowspan.max(1),
             content,
         }
     }
@@ -687,6 +734,26 @@ impl<'src> TableCell<'src> {
     /// operators on both column and cell specifiers.
     pub fn style(&self) -> ColumnStyle {
         self.style
+    }
+
+    /// Returns the number of columns this cell spans.
+    ///
+    /// The span comes from a column span factor (`<n>`) or block span factor
+    /// (`<n>.<n>`) in front of the span operator (`+`) on the cell's specifier.
+    /// A cell with no column span factor spans a single column, so the default
+    /// is `1`.
+    pub fn colspan(&self) -> usize {
+        self.colspan
+    }
+
+    /// Returns the number of rows this cell spans.
+    ///
+    /// The span comes from a row span factor (`.<n>`) or block span factor
+    /// (`<n>.<n>`) in front of the span operator (`+`) on the cell's specifier.
+    /// A cell with no row span factor spans a single row, so the default is
+    /// `1`.
+    pub fn rowspan(&self) -> usize {
+        self.rowspan
     }
 
     /// Returns the interpreted content of this cell.
@@ -848,17 +915,32 @@ fn parse_col_spec(spec: &str) -> TableColumn {
     }
 }
 
-/// The alignment and style overrides parsed from a
+/// The span, alignment, and style overrides parsed from a
 /// [cell specifier](RawCell::spec).
 ///
-/// Each field is `None` when the corresponding operator is absent from the
-/// specifier, in which case the cell inherits that alignment (or style) from
-/// its column.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+/// Each alignment and style field is `None` when the corresponding operator is
+/// absent from the specifier, in which case the cell inherits that alignment
+/// (or style) from its column. `colspan` and `rowspan` are the number of
+/// columns and rows the cell spans; they default to `1` (no span).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct CellSpec {
     h_align: Option<HorizontalAlignment>,
     v_align: Option<VerticalAlignment>,
     style: Option<ColumnStyle>,
+    colspan: usize,
+    rowspan: usize,
+}
+
+impl Default for CellSpec {
+    fn default() -> Self {
+        Self {
+            h_align: None,
+            v_align: None,
+            style: None,
+            colspan: 1,
+            rowspan: 1,
+        }
+    }
 }
 
 /// A single PSV cell as located by [`scan_cells`]: the alignment operators from
@@ -945,7 +1027,7 @@ fn scan_cells(region: Span<'_>) -> Vec<RawCell<'_>> {
     cells
 }
 
-/// Parse a cell specifier, returning its [alignment overrides](CellSpec), or
+/// Parse a cell specifier, returning its [span and overrides](CellSpec), or
 /// `None` if `token` is not a valid cell specifier.
 ///
 /// A cell specifier is positional and every part is optional, but the whole
@@ -957,8 +1039,10 @@ fn scan_cells(region: Span<'_>) -> Vec<RawCell<'_>> {
 ///
 /// * The factor and span/duplication operator are an optional count (e.g. `2`,
 ///   `2.3`, `.3`) that, when present, must be followed by `+` (span) or `*`
-///   (duplication). These operators are recognized so the cell separator is
-///   located correctly, but their layout effect is not yet applied.
+///   (duplication). For a span the factor is interpreted as the cell's colspan
+///   and rowspan (a missing column or row count defaults to 1). The duplication
+///   operator is recognized so the cell separator is located correctly, but its
+///   layout effect is not yet applied.
 /// * The horizontal alignment operator is `<`, `>`, or `^`.
 /// * The vertical alignment operator is a dot followed by `<`, `>`, or `^`.
 /// * The style operator is a single lowercase letter in the last position. A
@@ -971,21 +1055,55 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
     let b = token.as_bytes();
     let mut i = 0;
 
-    // Optional span/duplication: an optional count followed by `+` or `*`. The
-    // count is committed only when the operator that must follow it is present;
-    // otherwise leading digits remain and the token fails below.
+    // Optional span/duplication: an optional span factor followed by `+` (span)
+    // or `*` (duplication). The factor is a column count, an optional dot, and an
+    // optional row count (`<n>`, `.<n>`, or `<n>.<n>`). The factor is committed
+    // only when the operator that must follow it is present; otherwise the
+    // leading digits remain and the token fails the full-consumption check below.
+    let mut colspan = 1;
+    let mut rowspan = 1;
+    let col_start = i;
     let mut j = i;
     while matches!(b.get(j).copied(), Some(c) if c.is_ascii_digit()) {
         j += 1;
     }
+    let col_end = j;
+    let mut has_dot = false;
+    let mut row_start = j;
     if b.get(j).copied() == Some(b'.') {
+        has_dot = true;
         j += 1;
+        row_start = j;
         while matches!(b.get(j).copied(), Some(c) if c.is_ascii_digit()) {
             j += 1;
         }
     }
-    if matches!(b.get(j).copied(), Some(b'+' | b'*')) {
-        i = j + 1;
+    let row_end = j;
+    match b.get(j).copied() {
+        // Span: the factor is interpreted as a colspan and rowspan. A missing
+        // column or row count defaults to 1, so `2+` spans two columns, `.3+`
+        // spans three rows, and `2.3+` spans a 2x3 block.
+        Some(b'+') => {
+            // The factor consists only of ASCII digits and dots, so these ranges
+            // are always valid `str` slices.
+            let col_digits = token.get(col_start..col_end).unwrap_or_default();
+            if !col_digits.is_empty() {
+                colspan = col_digits.parse().unwrap_or(1);
+            }
+            if has_dot {
+                let row_digits = token.get(row_start..row_end).unwrap_or_default();
+                if !row_digits.is_empty() {
+                    rowspan = row_digits.parse().unwrap_or(1);
+                }
+            }
+            i = j + 1;
+        }
+        // Duplication: recognized so the cell separator is still located, but its
+        // layout effect (and so its factor) is not yet applied.
+        Some(b'*') => {
+            i = j + 1;
+        }
+        _ => {}
     }
 
     // Optional horizontal alignment operator.
@@ -1053,6 +1171,8 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
             h_align,
             v_align,
             style,
+            colspan,
+            rowspan,
         })
     } else {
         None

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -223,7 +223,11 @@ impl<'src> TableBlock<'src> {
         // number of column slots that cells from earlier rows occupy in the row
         // `k` steps ahead of the one being filled; a row closes once its own
         // cells' colspans plus the slots carried into it (`active_rowspans[0]`)
-        // reach `ncols`.
+        // reach `ncols`. A cell whose span pushes the row *past* `ncols` overruns
+        // the grid: the whole overrunning row is dropped (with a warning), again
+        // matching Asciidoctor. A row whose columns are entirely pre-filled by
+        // carried slots has no cells of its own to close it, so the next cell
+        // overruns and is dropped together with that pre-filled row.
         let mut warnings: Vec<Warning<'src>> = vec![];
         let raw_cells = scan_cells(inside);
 
@@ -249,13 +253,26 @@ impl<'src> TableBlock<'src> {
                 }
 
                 column_visits += colspan;
+                let cell_source = raw.content;
                 current_row.push(raw);
 
                 // The slots carried into the current row are `active_rowspans[0]`;
                 // the vector is never empty here, so the fallback is unreachable.
                 let carried = active_rowspans.first().copied().unwrap_or(0);
-                if column_visits + carried >= ncols {
-                    raw_rows.push(std::mem::take(&mut current_row));
+                let effective = column_visits + carried;
+                if effective >= ncols {
+                    if effective == ncols {
+                        raw_rows.push(std::mem::take(&mut current_row));
+                    } else {
+                        // Overrun: this cell's span pushes the row past `ncols`.
+                        // Discard the whole row so the remaining cells stay
+                        // aligned to the grid.
+                        current_row.clear();
+                        warnings.push(Warning {
+                            source: cell_source,
+                            warning: WarningType::TableCellExceedsColumnCount,
+                        });
+                    }
                     column_visits = 0;
                     active_rowspans.remove(0);
                     if active_rowspans.is_empty() {

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -704,3 +704,67 @@ fn dot_not_followed_by_vertical_operator_is_not_a_cell_separator() {
     let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
     assert_eq!(rows, vec![vec!["a .x|b".to_string()]]);
 }
+
+#[test]
+fn cell_span_exceeding_columns_drops_overrunning_row() {
+    // A span wider than the table overruns the grid. Matching Asciidoctor, the
+    // whole overrunning row is dropped and a warning is emitted: here the leading
+    // `x` cell is discarded along with the `3+|y` cell that overshoots the two
+    // columns, and the following row (`z`, `w`) stays aligned to the grid.
+    let mut parser = Parser::default();
+    let maw = Block::parse(
+        Span::new("[cols=\"2*\"]\n|===\n|x 3+|y\n|z |w\n|==="),
+        &mut parser,
+    );
+
+    assert!(maw.warnings.iter().any(|w| matches!(
+        w.warning,
+        crate::warnings::WarningType::TableCellExceedsColumnCount
+    )));
+
+    let table = match maw.item.unwrap().item {
+        Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    };
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(rows, vec![vec!["z".to_string(), "w".to_string()]]);
+}
+
+#[test]
+fn row_fully_covered_by_rowspans_drops_following_cell() {
+    // Two row-spanning cells (`.2+`) together cover every column of the next row,
+    // so that row has no cells of its own to close it. The following cell (`c1`)
+    // therefore overruns the pre-filled row and is dropped with it (matching
+    // Asciidoctor), leaving the remaining cells aligned: `c2` and `d1` form the
+    // second body row and the short final row holds `d2`.
+    let mut parser = Parser::default();
+    let maw = Block::parse(
+        Span::new("[cols=\"2*\"]\n|===\n.2+|a .2+|b\n|c1 |c2\n|d1 |d2\n|==="),
+        &mut parser,
+    );
+
+    assert_eq!(
+        maw.warnings
+            .iter()
+            .filter(|w| matches!(
+                w.warning,
+                crate::warnings::WarningType::TableCellExceedsColumnCount
+            ))
+            .count(),
+        1
+    );
+
+    let table = match maw.item.unwrap().item {
+        Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    };
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(
+        rows,
+        vec![
+            vec!["a".to_string(), "b".to_string()],
+            vec!["c2".to_string(), "d1".to_string()],
+            vec!["d2".to_string()],
+        ]
+    );
+}

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -768,3 +768,63 @@ fn row_fully_covered_by_rowspans_drops_following_cell() {
         ]
     );
 }
+
+#[test]
+fn dropped_overrunning_cell_keeps_its_rowspan_carryover() {
+    // When a cell that carries a row span is itself part of an overrunning row,
+    // its already-reserved slots in the next rows are *not* rolled back when the
+    // row is dropped. Matching Asciidoctor, the `2.2+|b` cell (colspan 2, rowspan
+    // 2) overruns the two-column row and is dropped with `a`, but its rowspan
+    // still pre-fills the next row, so `c` overruns that pre-filled row and is
+    // dropped too. Only `d` and `e` survive.
+    let mut parser = Parser::default();
+    let maw = Block::parse(
+        Span::new("[cols=\"2*\"]\n|===\n|a 2.2+|b\n|c\n|d\n|e\n|==="),
+        &mut parser,
+    );
+
+    assert_eq!(
+        maw.warnings
+            .iter()
+            .filter(|w| matches!(
+                w.warning,
+                crate::warnings::WarningType::TableCellExceedsColumnCount
+            ))
+            .count(),
+        2
+    );
+
+    let table = match maw.item.unwrap().item {
+        Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    };
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(rows, vec![vec!["d".to_string(), "e".to_string()]]);
+}
+
+#[test]
+fn huge_row_span_factor_does_not_overallocate() {
+    // A row span factor far larger than the table can never carry into rows that
+    // don't exist, so it is clamped for the grid bookkeeping; without the clamp,
+    // `.1000000000+` would resize the `active_rowspans` vector to a billion
+    // entries (a multi-gigabyte allocation). The cell still reports its literal
+    // parsed `rowspan` (matching Asciidoctor), and the following cell, covered by
+    // the span, overruns and is dropped.
+    let mut parser = Parser::default();
+    let maw = Block::parse(Span::new("|===\n.1000000000+|a\n|b\n|==="), &mut parser);
+
+    assert!(maw.warnings.iter().any(|w| matches!(
+        w.warning,
+        crate::warnings::WarningType::TableCellExceedsColumnCount
+    )));
+
+    let table = match maw.item.unwrap().item {
+        Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    };
+    assert_eq!(table.body_rows().len(), 1);
+    let cell = &table.body_rows()[0].cells()[0];
+    assert_eq!(cell.colspan(), 1);
+    assert_eq!(cell.rowspan(), 1_000_000_000);
+    assert_eq!(row_text(&table.body_rows()[0]), vec!["a".to_string()]);
+}

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -670,8 +670,8 @@ fn unrecognized_cell_style_operator_inherits_column_style() {
 fn cell_specifier_span_operator_without_factor_locates_separator() {
     // The span (`+`) and duplication (`*`) operators may appear without a count.
     // A bare `+` directly in front of a `|` is still a valid cell specifier, so
-    // `a +|b` is two cells. (The span operator's layout effect is not yet
-    // applied.)
+    // `a +|b` is two cells. With no count the span factor defaults to 1, so the
+    // bare `+` cell spans a single column (no layout effect).
     let table = parse_table("|===\n|a +|b\n|===");
 
     assert_eq!(table.columns().len(), 2);

--- a/parser/src/tests/asciidoc_lang/tables/add_cells_and_rows.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_cells_and_rows.rs
@@ -166,10 +166,10 @@ Taking into account any xref:span-cells.adoc[spans], which are applied via a <<s
 
     // Cell specifiers introduce per-cell spans, duplication, alignment, and
     // style operators, each specified in detail on a dedicated page (span-cells,
-    // duplicate-cells, align-by-cell, format-cell-content). The alignment and
-    // style operators (and the override behavior) are implemented and verified
-    // here; the span and duplication operators are recognized so the separator
-    // is located, but their layout effect is not yet applied.
+    // duplicate-cells, align-by-cell, format-cell-content). The span, alignment,
+    // and style operators (and the override behavior) are implemented and
+    // verified here; the duplication operator is recognized so the separator is
+    // located, but its layout effect is not yet applied.
     verifies!(
         r#"
 [#specifiers]

--- a/parser/src/tests/asciidoc_lang/tables/align_by_cell.rs
+++ b/parser/src/tests/asciidoc_lang/tables/align_by_cell.rs
@@ -146,17 +146,18 @@ include::example$align-cell.adoc[tag=factor]
 
     // Expansion of `example$align-cell.adoc[tag=factor]`. The `+^+` operator is
     // placed directly after the span (`2+`) and duplication (`2*`) operators;
-    // both cells are centered. (The span/duplication operators are recognized
-    // but their layout effect is not yet applied.)
+    // both cells are centered. The `2+` span fills the two-column row on its own,
+    // so it lands in its own row; the duplication operator's layout effect is not
+    // yet applied, so the `2*^` cell becomes a single cell in the next row.
     let table = parse_table(
         "|===\n|Column Name |Column Name\n\n2+^|This cell spans two columns, and its content is horizontally centered because the cell specifier includes the `+^+` operator.\n2*^|This content is duplicated in two adjacent columns.\nIts content is horizontally centered because the cell specifier\nincludes the `+^+` operator.\n|===",
     );
     assert_eq!(
         body_alignments(&table),
-        vec![vec![
-            (HorizontalAlignment::Center, VerticalAlignment::Top),
-            (HorizontalAlignment::Center, VerticalAlignment::Top),
-        ]]
+        vec![
+            vec![(HorizontalAlignment::Center, VerticalAlignment::Top)],
+            vec![(HorizontalAlignment::Center, VerticalAlignment::Top)],
+        ]
     );
 }
 
@@ -311,8 +312,9 @@ include::example$align-cell.adoc[tag=vspan]
 
     // Expansion of `example$align-cell.adoc[tag=vspan]`. The `.>` is placed
     // after the row-span operator (`.2+`); that cell is bottom-aligned, while
-    // the cells with no vertical alignment operator stay top-aligned. (The
-    // row-span operator is recognized but its layout effect is not yet applied.)
+    // the cells with no vertical alignment operator stay top-aligned. The `.2+`
+    // cell spans two rows, so it carries its column down into the next row, which
+    // then needs only the one remaining cell.
     let table = parse_table(
         "|===\n|Column Name |Column Name\n\n|There isn't a vertical alignment operator on this cell specifier, so the content is aligned to the top of the cell by default.\n\n.2+.>|This cell spans two rows, and its content is aligned to the bottom because the cell specifier includes the `.>` operator.\n\n|This content is aligned to the top of the cell by default.\n|===",
     );

--- a/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
@@ -173,9 +173,10 @@ include::example$cell.adoc[tag=styles]
     );
 
     // Expansion of `example$cell.adoc[tag=styles]`. Each body cell carries its
-    // own style operator (the span/duplication operators are recognized but
-    // their layout effect is not yet applied, so the cells flow into rows of
-    // two).
+    // own style operator. The `.3+` row span on the second cell carries its
+    // column down through the next two rows, so each of those rows needs only one
+    // explicit cell to be complete. (The duplication operator's layout effect is
+    // not yet applied, so the `2*>m` cell is a single cell.)
     let table = parse_table(
         "|===\n|Column 1 |Column 2\n\n2*>m|This content is duplicated across two columns (2*) and aligned to the right side of the cell (>).\n\nIt's rendered using a monospace font (m).\n\n.3+^.>s|This cell spans 3 rows (`3+`).\nThe content is centered horizontally (`+^+`), vertically aligned to the bottom of the cell (`.>`), and styled as strong (`s`).\ne|This content is italicized (`e`).\n\nm|This content is rendered using a monospace font (m).\n\ns|This content is bold (`s`).\n|===",
     );
@@ -183,7 +184,8 @@ include::example$cell.adoc[tag=styles]
         body_styles(&table),
         vec![
             vec![ColumnStyle::Monospace, ColumnStyle::Strong],
-            vec![ColumnStyle::Emphasis, ColumnStyle::Monospace],
+            vec![ColumnStyle::Emphasis],
+            vec![ColumnStyle::Monospace],
             vec![ColumnStyle::Strong],
         ]
     );

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -10,4 +10,5 @@ mod build_a_basic_table;
 mod customize_title_label;
 mod format_cell_content;
 mod format_column_content;
+mod span_cells;
 mod turn_off_title_label;

--- a/parser/src/tests/asciidoc_lang/tables/span_cells.rs
+++ b/parser/src/tests/asciidoc_lang/tables/span_cells.rs
@@ -1,0 +1,225 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/span-cells.adoc");
+
+non_normative!(
+    r#"
+= Span Columns and Rows
+
+A table cell can span more than one column and row.
+
+"#
+);
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Collect the `(colspan, rowspan)` of each cell in each body row of `table`.
+fn body_spans(table: &crate::blocks::TableBlock<'_>) -> Vec<Vec<(usize, usize)>> {
+    table
+        .body_rows()
+        .iter()
+        .map(|row| {
+            row.cells()
+                .iter()
+                .map(|cell| (cell.colspan(), cell.rowspan()))
+                .collect()
+        })
+        .collect()
+}
+
+#[test]
+fn span_factor_and_operator() {
+    non_normative!(
+        r#"
+== Span factor and operator
+
+"#
+    );
+
+    verifies!(
+        r#"
+With a [.term]*span* a table cell can stretch across adjacent columns, rows, or a block of adjacent columns and rows.
+A span consists of a span factor and a span operator.
+
+The [.term]*span factor* indicates the number columns, rows, or columns and rows a cell should span.
+
+[[col-factor]]Column span factor:: A single integer (`<n>`) that represents the number of consecutive columns a cell should span.
+[[row-factor]]Row span factor:: A single integer prefixed with a dot (`.<n>`) that represents the number of consecutive rows a cell should span.
+[[block-factor]]Block span factor:: Two integers (`<n>.<n>`) that represent a block of adjacent columns and rows a cell should span.
+The first integer, `<n>`, is the column span factor.
+The second integer, which is prefixed with a dot, `.<n>`, is the row span factor.
+
+The [.term]*span operator* is a plus sign (`\+`) placed directly after the span factor (`<n>.<n>+`).
+The span operator tells the converter to interpret the span factor as part of a span instead of a duplication.
+
+A span is the first operator in a xref:add-cells-and-rows.adoc#specifiers[cell specifier].
+
+====
+<**span factor**><**span operator**><horizontal alignment operator><vertical alignment operator><style operator>|<cell's content>
+====
+
+"#
+    );
+
+    // A column span factor (`<n>`) followed by the span operator (`+`) makes the
+    // cell span `<n>` consecutive columns (and a single row).
+    let table = parse_table("|===\n3+|x\n|===");
+    assert_eq!(body_spans(&table), vec![vec![(3, 1)]]);
+
+    // A row span factor (`.<n>`) followed by the span operator makes the cell
+    // span `<n>` consecutive rows (and a single column).
+    let table = parse_table("|===\n.2+|x\n|===");
+    assert_eq!(body_spans(&table), vec![vec![(1, 2)]]);
+
+    // A block span factor (`<n>.<n>`): the first integer is the column span and
+    // the second (dot-prefixed) integer is the row span.
+    let table = parse_table("|===\n2.3+|x\n|===");
+    assert_eq!(body_spans(&table), vec![vec![(2, 3)]]);
+}
+
+#[test]
+fn span_multiple_columns() {
+    non_normative!(
+        r#"
+== Span multiple columns
+
+"#
+    );
+
+    verifies!(
+        r#"
+To have a cell span consecutive columns, enter the <<col-factor,column span factor>> and span operator (`<n>+`) in the cell specifier.
+Don't insert any spaces between the span, any alignment or style operators (if present), and the xref:add-cells-and-rows.adoc#cell-separator[cell's separator] (`|`).
+
+.Span three columns with a cell
+[source#ex-span-columns]
+----
+include::example$cell.adoc[tag=span-cols]
+----
+
+The table from <<ex-span-columns>> is displayed below.
+
+.Result of <<ex-span-columns>>
+include::example$cell.adoc[tag=span-cols]
+
+"#
+    );
+
+    // Expansion of `example$cell.adoc[tag=span-cols]`. The `3+` cell spans the
+    // first three columns of its row, leaving room for a single trailing cell;
+    // the rows above and below it are ordinary four-cell rows.
+    let table = parse_table(
+        "|===\n|Column 1, header row |Column 2, header row |Column 3, header row |Column 4, header row\n\n3+|This cell spans columns 1, 2, and 3 because its specifier contains a span of `3+`\n|Cell in column 4, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|Cell in column 3, row 3\n|Cell in column 4, row 3\n|===",
+    );
+
+    assert_eq!(table.columns().len(), 4);
+    assert_eq!(table.header_row().unwrap().cells().len(), 4);
+    assert_eq!(
+        body_spans(&table),
+        vec![vec![(3, 1), (1, 1)], vec![(1, 1), (1, 1), (1, 1), (1, 1)],]
+    );
+}
+
+#[test]
+fn span_multiple_rows() {
+    non_normative!(
+        r#"
+== Span multiple rows
+
+"#
+    );
+
+    verifies!(
+        r#"
+To have a cell span consecutive rows, enter the <<row-factor,row span factor>> and span operator (`.<n>+`) in the cell specifier.
+Remember to prefix the span factor with a dot (`.`).
+Don't insert any spaces between the span, any alignment or style operators (if present), and the xref:add-cells-and-rows.adoc#cell-separator[cell's separator] (`|`).
+
+.Span two rows with a cell
+[source#ex-span-rows]
+----
+include::example$cell.adoc[tag=span-rows]
+----
+
+The table from <<ex-span-rows>> is displayed below.
+
+.Result of <<ex-span-rows>>
+include::example$cell.adoc[tag=span-rows]
+
+"#
+    );
+
+    // Expansion of `example$cell.adoc[tag=span-rows]`. The `.2+` cell spans rows
+    // 2 and 3 in the first column, so it carries that column down into row 3,
+    // which then needs only its single remaining cell.
+    let table = parse_table(
+        "|===\n|Column 1, header row |Column 2, header row\n\n.2+|This cell spans rows 2 and 3 because its specifier contains a span of `.2+`\n|Cell in column 2, row 2\n\n|Cell in column 2, row 3\n\n|Cell in column 1, row 4\n|Cell in column 2, row 4\n|===",
+    );
+
+    assert_eq!(table.columns().len(), 2);
+    assert_eq!(table.header_row().unwrap().cells().len(), 2);
+    assert_eq!(
+        body_spans(&table),
+        vec![vec![(1, 2), (1, 1)], vec![(1, 1)], vec![(1, 1), (1, 1)],]
+    );
+}
+
+#[test]
+fn span_columns_and_rows() {
+    non_normative!(
+        r#"
+== Span columns and rows
+
+"#
+    );
+
+    verifies!(
+        r#"
+A single cell can span a block of adjacent columns and rows.
+Enter the column span factor (`<n>`), followed by the row span factor (`.<n>`), and then the span operator (`+`).
+
+.Span two columns and three rows with a single cell
+[source#ex-block]
+----
+include::example$cell.adoc[tag=span-block]
+----
+
+The table from <<ex-block>> is displayed below.
+
+.Result of <<ex-block>>
+include::example$cell.adoc[tag=span-block]
+"#
+    );
+
+    // Expansion of `example$cell.adoc[tag=span-block]`. The `2.3+` cell spans
+    // columns 2 and 3 across rows 2, 3, and 4, so it carries two columns down
+    // into the two rows below it; each of those rows then needs only its two
+    // remaining (first- and last-column) cells.
+    let table = parse_table(
+        "|===\n|Column 1, header row |Column 2, header row |Column 3, header row |Column 4, header row\n\n|Cell in column 1, row 2\n2.3+|This cell spans columns 2 and 3 and rows 2, 3, and 4 because its specifier contains a span of `2.3+`\n|Cell in column 4, row 2\n\n|Cell in column 1, row 3\n|Cell in column 4, row 3\n\n|Cell in column 1, row 4\n|Cell in column 4, row 4\n|===",
+    );
+
+    assert_eq!(table.columns().len(), 4);
+    assert_eq!(table.header_row().unwrap().cells().len(), 4);
+    assert_eq!(
+        body_spans(&table),
+        vec![
+            vec![(1, 1), (2, 3), (1, 1)],
+            vec![(1, 1), (1, 1)],
+            vec![(1, 1), (1, 1)],
+        ]
+    );
+}

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -79,6 +79,9 @@ pub enum WarningType {
 
     #[error("List item index: expected {0}, got {1}")]
     ListItemOutOfSequence(String, String),
+
+    #[error("Dropping table cell because it exceeds the specified number of columns")]
+    TableCellExceedsColumnCount,
 }
 
 impl std::fmt::Debug for WarningType {
@@ -152,6 +155,10 @@ impl std::fmt::Debug for WarningType {
                 .field(expected)
                 .field(actual)
                 .finish(),
+
+            WarningType::TableCellExceedsColumnCount => {
+                write!(f, "WarningType::TableCellExceedsColumnCount")
+            }
         }
     }
 }
@@ -402,6 +409,13 @@ mod tests {
                     debug_output,
                     "WarningType::ListItemOutOfSequence(\"y\", \"z\")"
                 );
+            }
+
+            #[test]
+            fn table_cell_exceeds_column_count() {
+                let warning = WarningType::TableCellExceedsColumnCount;
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(debug_output, "WarningType::TableCellExceedsColumnCount");
             }
         }
     }


### PR DESCRIPTION
Implements all items on `docs/modules/tables/pages/span-cells.adoc`: the per-cell **span operator** (`+`).

## What changed

A cell specifier's span factor is now interpreted and applied to table layout. A cell can span:

- **multiple columns** — `<n>+` (e.g. `3+|...`)
- **multiple rows** — `.<n>+` (e.g. `.2+|...`)
- **a block of both** — `<n>.<n>+` (e.g. `2.3+|...`)

Previously the span factor/operator were recognized only enough to locate the cell separator, then discarded. Now cells are partitioned into rows by walking the grid, mirroring Asciidoctor's algorithm:

- a cell's `colspan`/`rowspan` governs how many column slots it occupies in its row;
- a row-spanning cell carries its columns down into the rows below (`active_rowspans` carryover), so those rows need fewer explicit cells;
- the implicit column count now sums the colspans of the first line rather than counting cells.

## API

`TableCell` gains `colspan()` and `rowspan()` accessors (both default to `1`).

## Tests / docs

- New spec-coverage module `span_cells.rs` covering `span-cells.adoc` line-by-line (verified with `sdd`).
- Existing `align_by_cell`, `format_cell_content`, and `add_cells_and_rows` tests (and their comments) updated to reflect that span layout is now applied. Duplication (`*`) layout remains deferred to its own page (`duplicate-cells.adoc`).
- `cargo +nightly fmt`, `cargo clippy --all-targets`, `cargo +nightly doc`, and the full test suite (1996 passing) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)