### PR TITLE
feat: Duplicate table cells across consecutive cells (duplication operator)

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -997,7 +997,7 @@ struct RawCell<'src> {
 /// realistic table — which never duplicates a cell more than a handful of times
 /// — untouched. (This is the one point where the implementation diverges from
 /// Asciidoctor, which expands the literal factor however large.)
-const MAX_DUPLICATION_FACTOR: usize = 100_000;
+const MAX_DUPLICATION_FACTOR: usize = 1_000;
 
 /// Expand each duplicated cell into the `<n>` independent cells it represents.
 ///

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -43,9 +43,6 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 ///
 /// * The CSV, TSV, and DSV data formats (and the `,===` / `:===` shorthand
 ///   delimiters).
-/// * The cell specifier duplication (`*`) operator: it is recognized in a cell
-///   specifier (so the cell separator is still located correctly) but its
-///   layout effect is not yet applied.
 ///
 /// Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, and `s`
 /// operators) are supported, along with proportional width and the horizontal
@@ -54,7 +51,9 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 /// style operator (in the last position of the cell specifier) is supported and
 /// overrides the column's style. The per-cell span (`+`) operator is supported:
 /// a cell can span multiple columns (`<n>+`), multiple rows (`.<n>+`), or a
-/// block of both (`<n>.<n>+`).
+/// block of both (`<n>.<n>+`). The per-cell duplication (`*`) operator is
+/// supported: a cell with a duplication factor (`<n>*`) clones its content and
+/// properties into `<n>` consecutive cells.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -128,10 +127,11 @@ impl<'src> TableBlock<'src> {
 
         // When the column count is implicit, it is the number of column slots in
         // the first non-empty line: a cell that spans columns (`<n>+`) counts as
-        // `<n>` slots, not one.
+        // `<n>` slots, not one, and a cell duplicated `<n>` times (`<n>*`) counts
+        // as `<n>` single-column slots (one per clone).
         let first_line_cells: usize = scan_cells(inside.discard_empty_lines().take_line().item)
             .iter()
-            .map(|c| c.spec.colspan.max(1))
+            .map(|c| c.spec.colspan.max(1) * c.spec.repeat.min(MAX_DUPLICATION_FACTOR))
             .sum();
 
         let ncols = if columns.is_empty() {
@@ -228,8 +228,12 @@ impl<'src> TableBlock<'src> {
         // matching Asciidoctor. A row whose columns are entirely pre-filled by
         // carried slots has no cells of its own to close it, so the next cell
         // overruns and is dropped together with that pre-filled row.
+        // A duplicated cell (`<n>*`) is expanded into `<n>` independent cells —
+        // each carrying the original's content, alignment, and style — before the
+        // grid walk, so each clone occupies its own column slot exactly like an
+        // ordinary cell. A duplication factor of zero drops the cell entirely.
         let mut warnings: Vec<Warning<'src>> = vec![];
-        let raw_cells = scan_cells(inside);
+        let raw_cells = expand_duplicates(scan_cells(inside));
 
         // A table can never have more rows than it has cells, so a row span is
         // clamped to the cell count for the `active_rowspans` bookkeeping below: a
@@ -949,7 +953,9 @@ fn parse_col_spec(spec: &str) -> TableColumn {
 /// Each alignment and style field is `None` when the corresponding operator is
 /// absent from the specifier, in which case the cell inherits that alignment
 /// (or style) from its column. `colspan` and `rowspan` are the number of
-/// columns and rows the cell spans; they default to `1` (no span).
+/// columns and rows the cell spans; they default to `1` (no span). `repeat` is
+/// the duplication factor — the number of consecutive cells the content is
+/// cloned into — and defaults to `1` (no duplication).
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct CellSpec {
     h_align: Option<HorizontalAlignment>,
@@ -957,6 +963,7 @@ struct CellSpec {
     style: Option<ColumnStyle>,
     colspan: usize,
     rowspan: usize,
+    repeat: usize,
 }
 
 impl Default for CellSpec {
@@ -967,15 +974,56 @@ impl Default for CellSpec {
             style: None,
             colspan: 1,
             rowspan: 1,
+            repeat: 1,
         }
     }
 }
 
 /// A single PSV cell as located by [`scan_cells`]: the alignment operators from
 /// its specifier together with the raw (untrimmed) span of its content.
+#[derive(Clone, Copy)]
 struct RawCell<'src> {
     spec: CellSpec,
     content: Span<'src>,
+}
+
+/// The largest number of cells a single duplication factor (`<n>*`) is allowed
+/// to expand into.
+///
+/// A duplicated cell is materialized as `<n>` independent cells, so the factor
+/// is an amplification: a dozen source bytes such as `1000000000*` would
+/// otherwise request a billion `RawCell`s (a multi-gigabyte allocation).
+/// Capping the per-specifier factor bounds that amplification while leaving any
+/// realistic table — which never duplicates a cell more than a handful of times
+/// — untouched. (This is the one point where the implementation diverges from
+/// Asciidoctor, which expands the literal factor however large.)
+const MAX_DUPLICATION_FACTOR: usize = 100_000;
+
+/// Expand each duplicated cell into the `<n>` independent cells it represents.
+///
+/// A cell specifier with a duplication factor (`<n>*`) clones the cell's
+/// content and properties into `<n>` consecutive cells. Each clone is an
+/// ordinary single-slot cell (colspan and rowspan of 1), so expanding here —
+/// before the grid is walked — lets the clones flow into rows exactly like
+/// cells the author typed out by hand. A duplication factor of zero produces no
+/// cells, dropping the original (matching Asciidoctor). A cell with no
+/// duplication factor has a `repeat` of 1 and so passes through unchanged. The
+/// factor is clamped to [`MAX_DUPLICATION_FACTOR`] so a hostile specifier can't
+/// trigger a runaway allocation.
+fn expand_duplicates(cells: Vec<RawCell<'_>>) -> Vec<RawCell<'_>> {
+    // The common case is no duplication at all, so only the clones beyond the
+    // first add to the count.
+    let extra: usize = cells
+        .iter()
+        .map(|c| c.spec.repeat.min(MAX_DUPLICATION_FACTOR).saturating_sub(1))
+        .sum();
+    let mut expanded = Vec::with_capacity(cells.len() + extra);
+    for cell in cells {
+        for _ in 0..cell.spec.repeat.min(MAX_DUPLICATION_FACTOR) {
+            expanded.push(cell);
+        }
+    }
+    expanded
 }
 
 /// Scan a region for PSV cell boundaries, returning the [specifier](CellSpec)
@@ -1068,9 +1116,10 @@ fn scan_cells(region: Span<'_>) -> Vec<RawCell<'_>> {
 /// * The factor and span/duplication operator are an optional count (e.g. `2`,
 ///   `2.3`, `.3`) that, when present, must be followed by `+` (span) or `*`
 ///   (duplication). For a span the factor is interpreted as the cell's colspan
-///   and rowspan (a missing column or row count defaults to 1). The duplication
-///   operator is recognized so the cell separator is located correctly, but its
-///   layout effect is not yet applied.
+///   and rowspan (a missing column or row count defaults to 1). For a
+///   duplication the column part of the factor is the duplication count — the
+///   number of consecutive cells the content is cloned into — and any row part
+///   is ignored; a duplicated cell keeps a colspan and rowspan of 1.
 /// * The horizontal alignment operator is `<`, `>`, or `^`.
 /// * The vertical alignment operator is a dot followed by `<`, `>`, or `^`.
 /// * The style operator is a single lowercase letter in the last position. A
@@ -1090,6 +1139,7 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
     // leading digits remain and the token fails the full-consumption check below.
     let mut colspan = 1;
     let mut rowspan = 1;
+    let mut repeat = 1;
     let col_start = i;
     let mut j = i;
     while matches!(b.get(j).copied(), Some(c) if c.is_ascii_digit()) {
@@ -1126,9 +1176,17 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
             }
             i = j + 1;
         }
-        // Duplication: recognized so the cell separator is still located, but its
-        // layout effect (and so its factor) is not yet applied.
+        // Duplication: the factor is interpreted as a duplication count, so the
+        // cell's content and properties are cloned into `<n>` consecutive cells.
+        // Only the column part of the factor is the count; any row part (`<n>.`)
+        // is ignored, matching Asciidoctor. A missing column count defaults to 1.
+        // Unlike a span, a duplication leaves `colspan` and `rowspan` at 1: each
+        // clone is an ordinary single-slot cell.
         Some(b'*') => {
+            let col_digits = token.get(col_start..col_end).unwrap_or_default();
+            if !col_digits.is_empty() {
+                repeat = col_digits.parse().unwrap_or(1);
+            }
             i = j + 1;
         }
         _ => {}
@@ -1201,6 +1259,7 @@ fn parse_cell_spec(token: &str) -> Option<CellSpec> {
             style,
             colspan,
             rowspan,
+            repeat,
         })
     } else {
         None

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -896,12 +896,12 @@ fn bare_duplication_operator_clones_once() {
 fn huge_duplication_factor_does_not_overallocate() {
     // A duplication factor is an amplifier — `1000000000*` would otherwise
     // materialize a billion cells (a multi-gigabyte allocation). The factor is
-    // clamped to `MAX_DUPLICATION_FACTOR` (100,000), so the expansion stays
+    // clamped to `MAX_DUPLICATION_FACTOR` (1,000), so the expansion stays
     // bounded. This is the one place the implementation diverges from Asciidoctor,
     // which would expand the literal factor. The table is built from the clamped
     // cells without hanging or exhausting memory.
     let table = parse_table("|===\n1000000000*|x\n|===");
     let total: usize = table.body_rows().iter().map(|r| r.cells().len()).sum();
-    assert_eq!(total, 100_000);
+    assert_eq!(total, 1_000);
     assert_eq!(row_text(&table.body_rows()[0])[0], "x".to_string());
 }

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -828,3 +828,80 @@ fn huge_row_span_factor_does_not_overallocate() {
     assert_eq!(cell.rowspan(), 1_000_000_000);
     assert_eq!(row_text(&table.body_rows()[0]), vec!["a".to_string()]);
 }
+
+#[test]
+fn duplication_clones_content_and_properties() {
+    // A duplication factor (`<n>*`) clones the cell into `<n>` independent cells,
+    // each an ordinary single-slot cell (colspan and rowspan of 1) that carries
+    // the original's content and style. Here `3*e|x` becomes three emphasized
+    // cells, each holding `x`.
+    let table = parse_table("[cols=\"3*\"]\n|===\n3*e|x\n|===");
+    let cells = table.body_rows()[0].cells();
+    assert_eq!(cells.len(), 3);
+    for cell in cells {
+        assert_eq!(cell.colspan(), 1);
+        assert_eq!(cell.rowspan(), 1);
+        assert_eq!(cell.style(), ColumnStyle::Emphasis);
+    }
+    assert_eq!(
+        row_text(&table.body_rows()[0]),
+        vec!["x".to_string(), "x".to_string(), "x".to_string()]
+    );
+}
+
+#[test]
+fn duplication_factor_ignores_row_part() {
+    // Only the column part of the factor is the duplication count; a row part
+    // (`<n>.<n>*`) is ignored, matching Asciidoctor. So `2.3*` duplicates the cell
+    // twice (not six times), and each clone keeps a rowspan of 1.
+    let table = parse_table("[cols=\"4*\"]\n|===\n2.3*|a |b |c\n|===");
+    let cells = table.body_rows()[0].cells();
+    assert_eq!(cells.len(), 4);
+    assert_eq!(cells[0].rowspan(), 1);
+    assert_eq!(
+        row_text(&table.body_rows()[0]),
+        vec![
+            "a".to_string(),
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string()
+        ]
+    );
+}
+
+#[test]
+fn duplication_factor_of_zero_drops_the_cell() {
+    // A duplication factor of zero (`0*`) clones the cell zero times, dropping it
+    // entirely; the following cells flow normally into the grid. Matching
+    // Asciidoctor, `0*|x |a |b |c` yields a single row of `a`, `b`, `c`.
+    let table = parse_table("[cols=\"3*\"]\n|===\n0*|x |a |b |c\n|===");
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(
+        rows,
+        vec![vec!["a".to_string(), "b".to_string(), "c".to_string()]]
+    );
+}
+
+#[test]
+fn bare_duplication_operator_clones_once() {
+    // A bare duplication operator (`*`) with no factor defaults to a count of 1,
+    // so `*|a` is a single cell and locates the separator just like a plain `|`.
+    let table = parse_table("|===\n|a *|b\n|===");
+    assert_eq!(table.columns().len(), 2);
+    let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
+    assert_eq!(rows, vec![vec!["a".to_string(), "b".to_string()]]);
+}
+
+#[test]
+fn huge_duplication_factor_does_not_overallocate() {
+    // A duplication factor is an amplifier — `1000000000*` would otherwise
+    // materialize a billion cells (a multi-gigabyte allocation). The factor is
+    // clamped to `MAX_DUPLICATION_FACTOR` (100,000), so the expansion stays
+    // bounded. This is the one place the implementation diverges from Asciidoctor,
+    // which would expand the literal factor. The table is built from the clamped
+    // cells without hanging or exhausting memory.
+    let table = parse_table("|===\n1000000000*|x\n|===");
+    let total: usize = table.body_rows().iter().map(|r| r.cells().len()).sum();
+    assert_eq!(total, 100_000);
+    assert_eq!(row_text(&table.body_rows()[0])[0], "x".to_string());
+}

--- a/parser/src/tests/asciidoc_lang/tables/add_cells_and_rows.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_cells_and_rows.rs
@@ -166,10 +166,9 @@ Taking into account any xref:span-cells.adoc[spans], which are applied via a <<s
 
     // Cell specifiers introduce per-cell spans, duplication, alignment, and
     // style operators, each specified in detail on a dedicated page (span-cells,
-    // duplicate-cells, align-by-cell, format-cell-content). The span, alignment,
-    // and style operators (and the override behavior) are implemented and
-    // verified here; the duplication operator is recognized so the separator is
-    // located, but its layout effect is not yet applied.
+    // duplicate-cells, align-by-cell, format-cell-content). The span,
+    // duplication, alignment, and style operators (and the override behavior)
+    // are all implemented and verified here.
     verifies!(
         r#"
 [#specifiers]

--- a/parser/src/tests/asciidoc_lang/tables/align_by_cell.rs
+++ b/parser/src/tests/asciidoc_lang/tables/align_by_cell.rs
@@ -147,8 +147,8 @@ include::example$align-cell.adoc[tag=factor]
     // Expansion of `example$align-cell.adoc[tag=factor]`. The `+^+` operator is
     // placed directly after the span (`2+`) and duplication (`2*`) operators;
     // both cells are centered. The `2+` span fills the two-column row on its own,
-    // so it lands in its own row; the duplication operator's layout effect is not
-    // yet applied, so the `2*^` cell becomes a single cell in the next row.
+    // so it lands in its own row; the `2*^` duplication clones its centered
+    // content into the two cells of the next row.
     let table = parse_table(
         "|===\n|Column Name |Column Name\n\n2+^|This cell spans two columns, and its content is horizontally centered because the cell specifier includes the `+^+` operator.\n2*^|This content is duplicated in two adjacent columns.\nIts content is horizontally centered because the cell specifier\nincludes the `+^+` operator.\n|===",
     );
@@ -156,7 +156,10 @@ include::example$align-cell.adoc[tag=factor]
         body_alignments(&table),
         vec![
             vec![(HorizontalAlignment::Center, VerticalAlignment::Top)],
-            vec![(HorizontalAlignment::Center, VerticalAlignment::Top)],
+            vec![
+                (HorizontalAlignment::Center, VerticalAlignment::Top),
+                (HorizontalAlignment::Center, VerticalAlignment::Top),
+            ],
         ]
     );
 }
@@ -404,7 +407,10 @@ include::example$align-cell.adoc[tag=combine]
     // first): `^.>` (center, bottom), `>.^` (right, middle), `2.3+^.^` (center,
     // middle, after a span), and `3*.>` (bottom, after a duplication; the
     // horizontal alignment falls back to the column default). The cell with no
-    // operators falls back to the default alignments (left, top).
+    // operators falls back to the default alignments (left, top). The `3*.>`
+    // duplication clones its bottom-aligned content into three cells: the first
+    // fills the row alongside the `2.3+` block span, and the next two each land
+    // in a row of their own (alongside the columns the block span carries down).
     let table = parse_table(
         "|===\n|Column 1 |Column 2 |Column 3\n\n^.>|The specifier for this cell is `^.>`.\nThe content is centered horizontally and aligned to the bottom of the cell.\n|There aren't any alignment operators on this cell's specifier, so the cell falls back to the default alignments.\nThe default horizontal alignment is the left side of the cell.\nThe default vertical alignment is the top of the cell.\n>.^|The specifier for this cell is `>.^`.\nThe content is aligned to the right side of the cell and centered vertically.\n\n2.3+^.^|The specifier for this cell is `pass:[2.3+^.^]`.\nIt spans two columns and three rows.\n\nIts content is centered horizontally and vertically.\n3*.>|The specifier for this cell is `3*.>`.\nThe cell is duplicated in three consecutive rows in the same column.\nIt's content is aligned to the bottom of the cell.\n|===",
     );
@@ -420,6 +426,8 @@ include::example$align-cell.adoc[tag=combine]
                 (HorizontalAlignment::Center, VerticalAlignment::Middle),
                 (HorizontalAlignment::Left, VerticalAlignment::Bottom),
             ],
+            vec![(HorizontalAlignment::Left, VerticalAlignment::Bottom)],
+            vec![(HorizontalAlignment::Left, VerticalAlignment::Bottom)],
         ]
     );
 }

--- a/parser/src/tests/asciidoc_lang/tables/duplicate_cells.rs
+++ b/parser/src/tests/asciidoc_lang/tables/duplicate_cells.rs
@@ -1,0 +1,214 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/duplicate-cells.adoc");
+
+non_normative!(
+    r#"
+= Duplicate Cells
+// clone, copy, replicate, duplicate
+
+The contents of a cell can be duplicated in consecutive cells.
+
+"#
+);
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Collect the rendered text of each cell in each body row of `table`.
+fn body_texts(table: &crate::blocks::TableBlock<'_>) -> Vec<Vec<String>> {
+    table
+        .body_rows()
+        .iter()
+        .map(|row| {
+            row.cells()
+                .iter()
+                .map(|cell| match cell.content() {
+                    crate::blocks::TableCellContent::Simple(content) => {
+                        content.rendered().to_string()
+                    }
+                    crate::blocks::TableCellContent::AsciiDoc(_) => {
+                        panic!("expected simple cell content")
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Collect the [`ColumnStyle`] of each cell in each body row of `table`.
+fn body_styles(table: &crate::blocks::TableBlock<'_>) -> Vec<Vec<crate::blocks::ColumnStyle>> {
+    table
+        .body_rows()
+        .iter()
+        .map(|row| row.cells().iter().map(|cell| cell.style()).collect())
+        .collect()
+}
+
+#[test]
+fn duplication_factor_and_operator() {
+    non_normative!(
+        r#"
+== Duplication factor and operator
+
+"#
+    );
+
+    verifies!(
+        r#"
+The duplication factor and operator are applied to a xref:add-cells-and-rows.adoc#specifiers[cell's specifier] and allow you to clone a cell's content and properties across consecutive cells.
+A duplication is the first operator in a cell specifier.
+
+====
+<**duplication factor**><**duplication operator**><horizontal alignment operator><vertical alignment operator><style operator>|<cell's content>
+====
+
+The [.term]*duplication factor* is a single integer (`<n>`) that indicates how many times the cell's content should be duplicated.
+
+The [.term]*duplication operator* is an asterisk (`+*+`) placed directly after the duplication factor (`+<n>*+`).
+The duplication operator tells the converter to interpret the duplication factor as part of a duplication instead of a span.
+
+"#
+    );
+
+    // The duplication factor is a single integer (`<n>`): a `<n>*` specifier
+    // clones the cell's content into `<n>` consecutive cells. Here `2*` produces
+    // two identical cells, leaving the trailing `|c` cell to complete the row.
+    // (The implicit column count is three, because each clone is counted as a
+    // separate column slot.)
+    let table = parse_table("|===\n2*|dup |c\n|===");
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(
+        body_texts(&table),
+        vec![vec!["dup".to_string(), "dup".to_string(), "c".to_string()]]
+    );
+
+    // The duplication factor is interpreted as a duplication, not a span, so each
+    // clone is an independent single-column cell (colspan 1) rather than one cell
+    // stretched across two columns. Contrast the span operator (`+`), which makes
+    // a single cell span the columns.
+    let dup = parse_table("|===\n2*|x\n|===");
+    assert_eq!(dup.body_rows()[0].cells().len(), 2);
+    assert_eq!(dup.body_rows()[0].cells()[0].colspan(), 1);
+    assert_eq!(dup.body_rows()[0].cells()[1].colspan(), 1);
+
+    let span = parse_table("|===\n2+|x\n|===");
+    assert_eq!(span.body_rows()[0].cells().len(), 1);
+    assert_eq!(span.body_rows()[0].cells()[0].colspan(), 2);
+
+    // A duplication is the first operator in the cell specifier: the duplication
+    // factor and operator come before any alignment or style operator. Here `3*e`
+    // is the duplication `3*` followed by the style operator `e`, so all three
+    // clones are emphasized.
+    let table = parse_table("|===\n3*e|x\n|===");
+    assert_eq!(
+        body_styles(&table),
+        vec![vec![
+            crate::blocks::ColumnStyle::Emphasis,
+            crate::blocks::ColumnStyle::Emphasis,
+            crate::blocks::ColumnStyle::Emphasis,
+        ]]
+    );
+}
+
+#[test]
+fn duplicate_a_cell_and_its_properties() {
+    non_normative!(
+        r#"
+== Duplicate a cell and its properties
+
+"#
+    );
+
+    verifies!(
+        r#"
+To duplicate a cell, enter the duplication factor and duplication operator (`+<n>*+`) in the cell specifier.
+Don't insert any spaces between the duplication, any alignment or style operators (if present), and the xref:add-cells-and-rows.adoc#cell-separator[cell's separator] (`|`).
+
+.Duplicate the contents of two cells
+[source#ex-clone]
+----
+include::example$cell.adoc[tag=clone]
+----
+
+The table from <<ex-clone>> is displayed below.
+
+.Result of <<ex-clone>>
+include::example$cell.adoc[tag=clone]
+"#
+    );
+
+    // Expansion of `example$cell.adoc[tag=clone]`. The `2*` cell clones its
+    // content into the first two columns of row 2, leaving the trailing `|Cell in
+    // column 3, row 2` cell to finish that row. The `3*e` cell clones its
+    // emphasized content into three cells: the first finishes row 3 (after the
+    // two plain cells) and the next two open row 4, which is then completed by the
+    // trailing `|Cell in column 3, row 4` cell.
+    let table = parse_table(
+        "|===\n|Column 1, header row |Column 2, header row |Column 3, header row\n\n2*|This cell is duplicated in columns 1 and 2 because its specifier contains a duplication of `2*`\n|Cell in column 3, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n3*e|This cell specifier contains the duplication `3*` and style operator `e`.\n\nThe cell's text is italicized and duplicated in column 3, row 3 and columns 1 and 2 on row 4.\n\n|Cell in column 3, row 4\n|===",
+    );
+
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(table.header_row().unwrap().cells().len(), 3);
+
+    // The `2*` cell's content is cloned verbatim into both of the first two
+    // columns; the `3*e` cell's content is cloned into three cells.
+    let dup_text = "This cell is duplicated in columns 1 and 2 because its specifier contains a duplication of <code>2*</code>";
+    let clone_text = "This cell specifier contains the duplication <code>3*</code> and style operator <code>e</code>.\n\nThe cell&#8217;s text is italicized and duplicated in column 3, row 3 and columns 1 and 2 on row 4.";
+    assert_eq!(
+        body_texts(&table),
+        vec![
+            vec![
+                dup_text.to_string(),
+                dup_text.to_string(),
+                "Cell in column 3, row 2".to_string(),
+            ],
+            vec![
+                "Cell in column 1, row 3".to_string(),
+                "Cell in column 2, row 3".to_string(),
+                clone_text.to_string(),
+            ],
+            vec![
+                clone_text.to_string(),
+                clone_text.to_string(),
+                "Cell in column 3, row 4".to_string(),
+            ],
+        ]
+    );
+
+    // The duplication clones the cell's properties as well as its content: the
+    // `3*e` style operator emphasizes every clone, while the cells with no style
+    // operator keep the default style.
+    assert_eq!(
+        body_styles(&table),
+        vec![
+            vec![
+                crate::blocks::ColumnStyle::Default,
+                crate::blocks::ColumnStyle::Default,
+                crate::blocks::ColumnStyle::Default,
+            ],
+            vec![
+                crate::blocks::ColumnStyle::Default,
+                crate::blocks::ColumnStyle::Default,
+                crate::blocks::ColumnStyle::Emphasis,
+            ],
+            vec![
+                crate::blocks::ColumnStyle::Emphasis,
+                crate::blocks::ColumnStyle::Emphasis,
+                crate::blocks::ColumnStyle::Default,
+            ],
+        ]
+    );
+}

--- a/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
@@ -143,16 +143,20 @@ Don't insert any spaces between the `|` and the operator.
     // The style operator occupies the last position of the specifier, after any
     // span/duplication operator and the horizontal and vertical alignment
     // operators: `2*>m` (duplication, right, monospace) and `.3+^.>s` (row span,
-    // center, bottom, strong).
+    // center, bottom, strong). The `2*` duplication clones its cell, so the first
+    // two cells both carry the right-aligned monospace specifier; the `.3+^.>s`
+    // cell follows.
     let table =
         parse_table("|===\n|h\n\n2*>m|dup right mono\n.3+^.>s|span center bottom strong\n|===");
     let cells: Vec<&crate::blocks::TableCell<'_>> =
         table.body_rows().iter().flat_map(|r| r.cells()).collect();
     assert_eq!(cells[0].style(), ColumnStyle::Monospace);
     assert_eq!(cells[0].h_align(), HorizontalAlignment::Right);
-    assert_eq!(cells[1].style(), ColumnStyle::Strong);
-    assert_eq!(cells[1].h_align(), HorizontalAlignment::Center);
-    assert_eq!(cells[1].v_align(), VerticalAlignment::Bottom);
+    assert_eq!(cells[1].style(), ColumnStyle::Monospace);
+    assert_eq!(cells[1].h_align(), HorizontalAlignment::Right);
+    assert_eq!(cells[2].style(), ColumnStyle::Strong);
+    assert_eq!(cells[2].h_align(), HorizontalAlignment::Center);
+    assert_eq!(cells[2].v_align(), VerticalAlignment::Bottom);
 
     verifies!(
         r#"
@@ -173,18 +177,18 @@ include::example$cell.adoc[tag=styles]
     );
 
     // Expansion of `example$cell.adoc[tag=styles]`. Each body cell carries its
-    // own style operator. The `.3+` row span on the second cell carries its
-    // column down through the next two rows, so each of those rows needs only one
-    // explicit cell to be complete. (The duplication operator's layout effect is
-    // not yet applied, so the `2*>m` cell is a single cell.)
+    // own style operator. The `2*>m` duplication clones its monospace content
+    // into the two cells of the first row. The `.3+` row span on the next cell
+    // carries its column down through the two rows below it, so each of those
+    // rows needs only one explicit cell to be complete.
     let table = parse_table(
         "|===\n|Column 1 |Column 2\n\n2*>m|This content is duplicated across two columns (2*) and aligned to the right side of the cell (>).\n\nIt's rendered using a monospace font (m).\n\n.3+^.>s|This cell spans 3 rows (`3+`).\nThe content is centered horizontally (`+^+`), vertically aligned to the bottom of the cell (`.>`), and styled as strong (`s`).\ne|This content is italicized (`e`).\n\nm|This content is rendered using a monospace font (m).\n\ns|This content is bold (`s`).\n|===",
     );
     assert_eq!(
         body_styles(&table),
         vec![
-            vec![ColumnStyle::Monospace, ColumnStyle::Strong],
-            vec![ColumnStyle::Emphasis],
+            vec![ColumnStyle::Monospace, ColumnStyle::Monospace],
+            vec![ColumnStyle::Strong, ColumnStyle::Emphasis],
             vec![ColumnStyle::Monospace],
             vec![ColumnStyle::Strong],
         ]

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -8,6 +8,7 @@ mod align_by_cell;
 mod align_by_column;
 mod build_a_basic_table;
 mod customize_title_label;
+mod duplicate_cells;
 mod format_cell_content;
 mod format_column_content;
 mod span_cells;


### PR DESCRIPTION
Implements all items on `docs/modules/tables/pages/duplicate-cells.adoc`: the per-cell duplication operator (`*`).

## What changed

A cell specifier's duplication factor (`<n>*`) now clones the cell's content **and** properties into `<n>` consecutive cells. Previously the factor and operator were recognized only well enough to locate the cell separator; their layout effect was discarded.

- Each duplicated cell is expanded into `<n>` independent single-slot cells (colspan/rowspan of 1) **before** the grid walk, so the clones flow into rows exactly like hand-typed cells, carrying their alignment and style operators.
- Only the column part of the factor is the count; any row part (`<n>.<n>*`) is ignored, and a factor of zero drops the cell — both matching Asciidoctor.
- The implicit column count sums each clone as its own column slot.
- The factor is clamped to `MAX_DUPLICATION_FACTOR` (1000) so a hostile specifier such as `1000000000*` can't trigger a runaway allocation. This is the one point where the implementation diverges from Asciidoctor, which expands the literal factor.

All behaviors were verified against the locally installed `asciidoctor` (including the `tag=clone` example, factor-with-dot, `0*`, and a complex span+duplication grid).

## Tests

- New spec-coverage file `duplicate_cells.rs` (full line-by-line coverage of the page, verified with `sdd`).
- New unit tests in `blocks/tests/table.rs` for cloning content/properties, the ignored row part, the zero factor, the bare `*`, and the allocation clamp.
- Updated the existing `align_by_cell` / `format_cell_content` / `add_cells_and_rows` tests and comments that previously asserted duplication layout was deferred.

`cargo test`, `cargo clippy --all-targets -D warnings`, and `cargo +nightly doc`/`fmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)