### PR TITLE
feat: Set table and column width (width attribute, autowidth option, ~ columns)

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -546,8 +546,11 @@ impl TableColumn {
     /// `table.columns().iter().any(TableColumn::is_autowidth)`.
     ///
     /// When this column itself is autowidth, this width is not used to size the
-    /// column (the column is sized to its content instead) and reports the
-    /// default value of `1`.
+    /// column (the column is sized to its content instead). A column made
+    /// autowidth by the `~` specifier reports the default width of `1`, but one
+    /// that inherits autowidth from the table's `autowidth` option retains
+    /// whatever width its specifier set (e.g. `2` for the first column of
+    /// `[%autowidth,cols="2,1"]`).
     pub fn width(&self) -> usize {
         self.width
     }

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -54,6 +54,11 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 /// block of both (`<n>.<n>+`). The per-cell duplication (`*`) operator is
 /// supported: a cell with a duplication factor (`<n>*`) clones its content and
 /// properties into `<n>` consecutive cells.
+///
+/// Table sizing is supported: the [`width`](Self::width) attribute sets a fixed
+/// table width, the `autowidth` option ([`is_autowidth`](Self::is_autowidth))
+/// sizes the table and its columns to their content, and an individual column
+/// can be made [autowidth](TableColumn::is_autowidth) with the `~` width value.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -140,11 +145,24 @@ impl<'src> TableBlock<'src> {
             columns.len()
         };
 
-        let columns = if columns.is_empty() {
+        let mut columns: Vec<TableColumn> = if columns.is_empty() {
             (0..ncols).map(|_| TableColumn::default()).collect()
         } else {
             columns
         };
+
+        // The `autowidth` option sizes the table to its content; the columns
+        // inherit the setting, so every column becomes autowidth regardless of
+        // any proportional width set on its specifier.
+        if metadata
+            .attrlist
+            .as_ref()
+            .is_some_and(|a| a.has_option("autowidth"))
+        {
+            for column in columns.iter_mut() {
+                column.autowidth = true;
+            }
+        }
 
         // The first row is an (implicit) header row when the line directly after
         // the opening delimiter is non-empty and is itself followed by an empty
@@ -387,6 +405,39 @@ impl<'src> TableBlock<'src> {
         &self.columns
     }
 
+    /// Returns the fixed width of this table, as a percentage of the content
+    /// area, when the `width` attribute is set.
+    ///
+    /// The `width` attribute is an integer percentage from 1 to 100; the
+    /// trailing `%` sign is optional (`[width=75%]` and `[width=75]` are
+    /// equivalent). A value outside that range, or one that is not an integer,
+    /// is ignored and reported as `None`. When the attribute is absent the
+    /// table spans the width of the content area and this returns `None`.
+    pub fn width(&self) -> Option<usize> {
+        let raw = self
+            .attrlist
+            .as_ref()
+            .and_then(|a| a.named_attribute("width"))?
+            .value();
+
+        let raw = raw.strip_suffix('%').unwrap_or(raw);
+        match raw.parse::<usize>() {
+            Ok(width) if (1..=100).contains(&width) => Some(width),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if this table carries the `autowidth` option.
+    ///
+    /// An autowidth table is sized to fit its content rather than spanning the
+    /// width of the content area, and each of its [columns](TableColumn) is
+    /// likewise [autowidth](TableColumn::is_autowidth).
+    pub fn is_autowidth(&self) -> bool {
+        self.attrlist
+            .as_ref()
+            .is_some_and(|a| a.has_option("autowidth"))
+    }
+
     /// Returns the header row of this table, if one was declared.
     pub fn header_row(&self) -> Option<&TableRow<'src>> {
         self.header_row.as_ref()
@@ -467,6 +518,7 @@ impl<'src> HasSpan<'src> for TableBlock<'src> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableColumn {
     width: usize,
+    autowidth: bool,
     h_align: HorizontalAlignment,
     v_align: VerticalAlignment,
     style: ColumnStyle,
@@ -475,8 +527,22 @@ pub struct TableColumn {
 impl TableColumn {
     /// Returns the proportional width of this column relative to the other
     /// columns in the table.
+    ///
+    /// When the column is [autowidth](Self::is_autowidth), this proportional
+    /// width is not used to size the column (the column is sized to its
+    /// content instead) and reports the default value of `1`.
     pub fn width(&self) -> usize {
         self.width
+    }
+
+    /// Returns `true` if this column is sized to fit its content rather than to
+    /// a proportional width.
+    ///
+    /// A column is autowidth when its column specifier uses the special width
+    /// value `~`, or when the table as a whole carries the `autowidth` option
+    /// (in which case every column inherits the setting).
+    pub fn is_autowidth(&self) -> bool {
+        self.autowidth
     }
 
     /// Returns the horizontal alignment applied to this column's content.
@@ -511,6 +577,7 @@ impl Default for TableColumn {
     fn default() -> Self {
         Self {
             width: 1,
+            autowidth: false,
             h_align: HorizontalAlignment::Left,
             v_align: VerticalAlignment::Top,
             style: ColumnStyle::Default,
@@ -870,8 +937,9 @@ fn parse_cols(value: &str) -> Vec<TableColumn> {
 /// present, the operators follow the multiplier, so the `spec` passed here is
 /// the portion after the `*`.
 ///
-/// The width is the first contiguous run of digits after any alignment
-/// operators; a spec with no digits falls back to the default width. The style
+/// The width is either the special autowidth value `~` (sizing the column to
+/// its content) or the first contiguous run of digits after any alignment
+/// operators; a spec with neither falls back to the default width. The style
 /// operator is the trailing letter (`a`, `d`, `e`, `h`, `l`, `m`, or `s`); an
 /// unrecognized trailing letter leaves the style at its default.
 fn parse_col_spec(spec: &str) -> TableColumn {
@@ -915,13 +983,24 @@ fn parse_col_spec(spec: &str) -> TableColumn {
         }
     }
 
-    // Width is the first run of digits after the alignment operators.
-    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-    let width = match digits.parse::<usize>() {
-        Ok(width) if width > 0 => width,
-        _ => TableColumn::default().width,
-    };
-    rest = &rest[digits.len()..];
+    // Width comes after the alignment operators. The special value `~` marks
+    // the column as autowidth (sized to its content); otherwise the width is
+    // the first run of digits. A spec with neither falls back to the default
+    // proportional width.
+    let mut autowidth = false;
+    let mut width = TableColumn::default().width;
+    if let Some(after_tilde) = rest.strip_prefix('~') {
+        autowidth = true;
+        rest = after_tilde;
+    } else {
+        let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if let Ok(parsed) = digits.parse::<usize>()
+            && parsed > 0
+        {
+            width = parsed;
+        }
+        rest = &rest[digits.len()..];
+    }
 
     // The style operator, if present, occupies the last position on the
     // specifier, so it is the entire remainder after the width. Matching the
@@ -941,6 +1020,7 @@ fn parse_col_spec(spec: &str) -> TableColumn {
 
     TableColumn {
         width,
+        autowidth,
         h_align,
         v_align,
         style,

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -525,12 +525,29 @@ pub struct TableColumn {
 }
 
 impl TableColumn {
-    /// Returns the proportional width of this column relative to the other
-    /// columns in the table.
+    /// Returns the width of this column relative to the other columns in the
+    /// table. The default width is `1`.
     ///
-    /// When the column is [autowidth](Self::is_autowidth), this proportional
-    /// width is not used to size the column (the column is sized to its
-    /// content instead) and reports the default value of `1`.
+    /// This value carries two different meanings depending on the table, and a
+    /// caller that resolves columns to final sizes must check which applies:
+    ///
+    /// * In an ordinary table (no column is [autowidth](Self::is_autowidth)),
+    ///   the width is a *proportional* ratio. Each column's share of the table
+    ///   is its width divided by the sum of all the column widths, so
+    ///   `[cols="1,2,3"]` yields shares of 1/6, 2/6, and 3/6.
+    /// * When at least one column in the table is autowidth (its specifier uses
+    ///   the special width value `~`), the AsciiDoc specification instead reads
+    ///   these widths as literal *percentages* (100-based): in
+    ///   `[cols="25,~,~"]` the first column is 25% wide and the `~` columns are
+    ///   sized to their content.
+    ///
+    /// The two cases are distinguished by whether any column in the table is
+    /// autowidth, which the caller can test with
+    /// `table.columns().iter().any(TableColumn::is_autowidth)`.
+    ///
+    /// When this column itself is autowidth, this width is not used to size the
+    /// column (the column is sized to its content instead) and reports the
+    /// default value of `1`.
     pub fn width(&self) -> usize {
         self.width
     }

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -168,10 +168,13 @@ fn autowidth_option_makes_columns_autowidth() {
         assert!(table.columns().iter().all(|c| c.is_autowidth()));
     }
 
-    // Even an explicit proportional width is overridden by the table's
-    // `autowidth` option.
+    // A column that inherits autowidth from the table's `autowidth` option
+    // still becomes autowidth, but retains the explicit width from its
+    // specifier (the width is simply not used to size an autowidth column).
     let table = parse_table("[%autowidth,cols=\"2,1\"]\n|===\n|a |b\n|===");
     assert!(table.columns().iter().all(|c| c.is_autowidth()));
+    let widths: Vec<usize> = table.columns().iter().map(|c| c.width()).collect();
+    assert_eq!(widths, vec![2, 1]);
 
     // Without the option, the table and its columns keep proportional widths.
     let table = parse_table("|===\n|a |b\n|===");

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -140,6 +140,61 @@ fn column_multiplier() {
 }
 
 #[test]
+fn table_width_attribute() {
+    // The `width` attribute reports an integer percentage; the trailing `%` is
+    // optional.
+    assert_eq!(parse_table("[width=75%]\n|===\n|a\n|===").width(), Some(75));
+    assert_eq!(parse_table("[width=75]\n|===\n|a\n|===").width(), Some(75));
+
+    // No `width` attribute means no fixed width.
+    assert_eq!(parse_table("|===\n|a\n|===").width(), None);
+
+    // Values outside the 1-to-100 range, or non-integer values, are ignored.
+    assert_eq!(parse_table("[width=0]\n|===\n|a\n|===").width(), None);
+    assert_eq!(parse_table("[width=101]\n|===\n|a\n|===").width(), None);
+    assert_eq!(parse_table("[width=half]\n|===\n|a\n|===").width(), None);
+}
+
+#[test]
+fn autowidth_option_makes_columns_autowidth() {
+    // The shorthand `%autowidth` and the formal `options="autowidth"` both set
+    // the table to autowidth, and every column inherits the setting.
+    for source in [
+        "[%autowidth]\n|===\n|a |b\n|===",
+        "[options=\"autowidth\"]\n|===\n|a |b\n|===",
+    ] {
+        let table = parse_table(source);
+        assert!(table.is_autowidth());
+        assert!(table.columns().iter().all(|c| c.is_autowidth()));
+    }
+
+    // Even an explicit proportional width is overridden by the table's
+    // `autowidth` option.
+    let table = parse_table("[%autowidth,cols=\"2,1\"]\n|===\n|a |b\n|===");
+    assert!(table.columns().iter().all(|c| c.is_autowidth()));
+
+    // Without the option, the table and its columns keep proportional widths.
+    let table = parse_table("|===\n|a |b\n|===");
+    assert!(!table.is_autowidth());
+    assert!(table.columns().iter().all(|c| !c.is_autowidth()));
+}
+
+#[test]
+fn autowidth_column_via_tilde() {
+    // The `~` width value marks only that column as autowidth, leaving the
+    // others at their explicit width; the table itself is not autowidth.
+    let table = parse_table("[cols=\"25h,~,~\"]\n|===\n|a |b |c\n|===");
+
+    let columns: Vec<(usize, bool)> = table
+        .columns()
+        .iter()
+        .map(|c| (c.width(), c.is_autowidth()))
+        .collect();
+    assert_eq!(columns, vec![(25, false), (1, true), (1, true)]);
+    assert!(!table.is_autowidth());
+}
+
+#[test]
 fn cell_content_is_substituted() {
     // Cell content flows through the normal substitution pipeline.
     let table = parse_table("|===\n|*bold* and _italic_\n|===");

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -13,3 +13,4 @@ mod format_cell_content;
 mod format_column_content;
 mod span_cells;
 mod turn_off_title_label;
+mod width;

--- a/parser/src/tests/asciidoc_lang/tables/width.rs
+++ b/parser/src/tests/asciidoc_lang/tables/width.rs
@@ -86,7 +86,7 @@ The `%` sign is optional.
     let src = format!("[width=wide]\n{BASE_H}");
     assert_eq!(parse_table(&src).width(), None);
 
-    non_normative!(
+    verifies!(
         r#"
 .Table with width set to 75%
 [source#ex-fixed]
@@ -140,7 +140,7 @@ The columns inherit this setting, so individual columns will also be sized accor
     assert_eq!(table.width(), None);
     assert_eq!(column_widths(&table), vec![(1, true), (1, true), (1, true)]);
 
-    non_normative!(
+    verifies!(
         r#"
 .Table using autowidth
 [source#ex-auto]
@@ -155,6 +155,16 @@ include::example$row.adoc[tag=base-h]
 
 "#
     );
+
+    // The autowidth table from <<ex-auto>> applied to the standard three-column
+    // table: the table is autowidth, every column is autowidth, and the header
+    // and body rows are otherwise unchanged.
+    let src = format!("[%autowidth]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert!(table.is_autowidth());
+    assert_eq!(column_widths(&table), vec![(1, true), (1, true), (1, true)]);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.body_rows().len(), 2);
 
     verifies!(
         r#"
@@ -178,7 +188,7 @@ If you want each column to have an automatic width, but want the table to span t
     let table = parse_table(&src);
     assert_eq!(table.width(), Some(100));
 
-    non_normative!(
+    verifies!(
         r#"
 .Full-width table with autowidth columns
 [source#ex-stretch]
@@ -194,6 +204,22 @@ The columns are sized to the content, but the table spans the width of the page.
 [%autowidth.stretch]
 include::example$row.adoc[tag=base-h]
 
+"#
+    );
+
+    // <<ex-stretch>>: the columns are sized to their content (each autowidth)
+    // while the `stretch` role records that the table spans the full page
+    // width.
+    let src = format!("[%autowidth.stretch]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert!(table.is_autowidth());
+    assert_eq!(column_widths(&table), vec![(1, true), (1, true), (1, true)]);
+    assert!(table.attrlist().unwrap().roles().contains(&"stretch"));
+
+    // The DocBook converter is out of scope for this parser, so the warning
+    // below describes downstream behavior we don't model.
+    non_normative!(
+        r#"
 WARNING: The `autowidth` option is not recognized by the DocBook converter.
 
 "#
@@ -217,23 +243,7 @@ In this case, width values are assumed to be a percentage value (i.e., 100-based
 "#
     );
 
-    // The `~` width value marks an individual column as autowidth; the other
-    // columns keep their explicit (percentage-based) width. Here the first
-    // column is a 25% header column and the remaining two are autowidth.
-    let table = parse_table(
-        "[cols=\"25h,~,~\"]\n|===\n|small |as big as the column needs to be |the rest\n|===",
-    );
-    assert_eq!(
-        column_widths(&table),
-        vec![(25, false), (1, true), (1, true)]
-    );
-    assert_eq!(table.columns()[0].style(), ColumnStyle::Header);
-
-    // Only the `~` columns are autowidth; the table itself carries no
-    // `autowidth` option.
-    assert!(!table.is_autowidth());
-
-    non_normative!(
+    verifies!(
         r#"
 .Table with fixed and autowidth columns
 [source#ex-mix]
@@ -251,4 +261,20 @@ In this case, width values are assumed to be a percentage value (i.e., 100-based
 |===
 "#
     );
+
+    // <<ex-mix>>: the `~` width value marks an individual column as autowidth;
+    // the other columns keep their explicit (percentage-based) width. Here the
+    // first column is a 25% header column and the remaining two are autowidth.
+    let table = parse_table(
+        "[cols=\"25h,~,~\"]\n|===\n|small |as big as the column needs to be |the rest\n|===",
+    );
+    assert_eq!(
+        column_widths(&table),
+        vec![(25, false), (1, true), (1, true)]
+    );
+    assert_eq!(table.columns()[0].style(), ColumnStyle::Header);
+
+    // Only the `~` columns are autowidth; the table itself carries no
+    // `autowidth` option.
+    assert!(!table.is_autowidth());
 }

--- a/parser/src/tests/asciidoc_lang/tables/width.rs
+++ b/parser/src/tests/asciidoc_lang/tables/width.rs
@@ -1,0 +1,254 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/width.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Collect each column's `(width, autowidth)` pair.
+fn column_widths(table: &crate::blocks::TableBlock<'_>) -> Vec<(usize, bool)> {
+    table
+        .columns()
+        .iter()
+        .map(|c| (c.width(), c.is_autowidth()))
+        .collect()
+}
+
+// Expansion of `include::example$row.adoc[tag=base-h]`: the standard
+// three-column table with a header row and two body rows used throughout the
+// table documentation.
+const BASE_H: &str = "|===\n|Column 1, header row |Column 2, header row |Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|Cell in column 3, row 3\n|===";
+
+non_normative!(
+    r#"
+= Table Width
+
+"#
+);
+
+#[test]
+fn fixed_width() {
+    verifies!(
+        r#"
+By default, a table will span the width of the content area.
+
+"#
+    );
+
+    // With no `width` attribute the table has no fixed width (it spans the
+    // content area) and is not autowidth.
+    let table = parse_table(BASE_H);
+    assert_eq!(table.width(), None);
+    assert!(!table.is_autowidth());
+
+    non_normative!(
+        r#"
+== Fixed width
+
+"#
+    );
+
+    verifies!(
+        r#"
+To constrain the width of the table to a fixed value, set the `width` attribute in the table's attribute list.
+The width is an integer percentage value ranging from 1 to 100.
+The `%` sign is optional.
+
+"#
+    );
+
+    // The `width` attribute constrains the table to a fixed percentage; the
+    // trailing `%` is optional, so `75%` and `75` are equivalent.
+    let src = format!("[width=75%]\n{BASE_H}");
+    assert_eq!(parse_table(&src).width(), Some(75));
+
+    let src = format!("[width=75]\n{BASE_H}");
+    assert_eq!(parse_table(&src).width(), Some(75));
+
+    // A value outside the 1-to-100 range (or one that isn't an integer) is
+    // ignored.
+    let src = format!("[width=0]\n{BASE_H}");
+    assert_eq!(parse_table(&src).width(), None);
+    let src = format!("[width=150]\n{BASE_H}");
+    assert_eq!(parse_table(&src).width(), None);
+    let src = format!("[width=wide]\n{BASE_H}");
+    assert_eq!(parse_table(&src).width(), None);
+
+    non_normative!(
+        r#"
+.Table with width set to 75%
+[source#ex-fixed]
+----
+[width=75%]
+include::example$row.adoc[tag=base-h]
+----
+
+.Result of <<ex-fixed>>
+[width=75%]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    // The fixed width applies to the standard three-column table; the columns
+    // themselves keep their default proportional width and are not autowidth.
+    let src = format!("[width=75%]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert_eq!(table.width(), Some(75));
+    assert_eq!(
+        column_widths(&table),
+        vec![(1, false), (1, false), (1, false)]
+    );
+    assert!(table.header_row().is_some());
+    assert_eq!(table.body_rows().len(), 2);
+}
+
+#[test]
+fn autowidth() {
+    non_normative!(
+        r#"
+== Autowidth
+
+"#
+    );
+
+    verifies!(
+        r#"
+Alternately, you can make the width fit the content by setting the `autowidth` option.
+The columns inherit this setting, so individual columns will also be sized according to the content.
+
+"#
+    );
+
+    // The `autowidth` option makes the table fit its content; it has no fixed
+    // width, and every column inherits the setting (each becomes autowidth).
+    let src = format!("[%autowidth]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert!(table.is_autowidth());
+    assert_eq!(table.width(), None);
+    assert_eq!(column_widths(&table), vec![(1, true), (1, true), (1, true)]);
+
+    non_normative!(
+        r#"
+.Table using autowidth
+[source#ex-auto]
+----
+[%autowidth]
+include::example$row.adoc[tag=base-h]
+----
+
+.Result of <<ex-auto>>
+[%autowidth]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    verifies!(
+        r#"
+If you want each column to have an automatic width, but want the table to span the width of the content area, add the `stretch` role to the table.
+(Alternatively, you can set the `width` attribute to `100%`.)
+
+"#
+    );
+
+    // Adding the `stretch` role keeps the columns autowidth while the role
+    // records the intent to span the content area.
+    let src = format!("[%autowidth.stretch]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert!(table.is_autowidth());
+    assert_eq!(column_widths(&table), vec![(1, true), (1, true), (1, true)]);
+    assert!(table.attrlist().unwrap().roles().contains(&"stretch"));
+
+    // Alternatively, setting the `width` attribute to `100%` spans the content
+    // area.
+    let src = format!("[width=100%]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert_eq!(table.width(), Some(100));
+
+    non_normative!(
+        r#"
+.Full-width table with autowidth columns
+[source#ex-stretch]
+----
+[%autowidth.stretch]
+include::example$row.adoc[tag=base-h]
+----
+
+The table from <<ex-stretch>> is rendered below.
+The columns are sized to the content, but the table spans the width of the page.
+
+.Result of <<ex-stretch>>
+[%autowidth.stretch]
+include::example$row.adoc[tag=base-h]
+
+WARNING: The `autowidth` option is not recognized by the DocBook converter.
+
+"#
+    );
+}
+
+#[test]
+fn mix_fixed_and_autowidth_columns() {
+    non_normative!(
+        r#"
+== Mix fixed and autowidth columns
+
+"#
+    );
+
+    verifies!(
+        r#"
+If you want to apply `autowidth` only to certain columns, use the special value `~` as the width of the column.
+In this case, width values are assumed to be a percentage value (i.e., 100-based).
+
+"#
+    );
+
+    // The `~` width value marks an individual column as autowidth; the other
+    // columns keep their explicit (percentage-based) width. Here the first
+    // column is a 25% header column and the remaining two are autowidth.
+    let table = parse_table(
+        "[cols=\"25h,~,~\"]\n|===\n|small |as big as the column needs to be |the rest\n|===",
+    );
+    assert_eq!(
+        column_widths(&table),
+        vec![(25, false), (1, true), (1, true)]
+    );
+    assert_eq!(table.columns()[0].style(), ColumnStyle::Header);
+
+    // Only the `~` columns are autowidth; the table itself carries no
+    // `autowidth` option.
+    assert!(!table.is_autowidth());
+
+    non_normative!(
+        r#"
+.Table with fixed and autowidth columns
+[source#ex-mix]
+----
+[cols="25h,~,~"]
+|===
+|small |as big as the column needs to be |the rest
+|===
+----
+
+.Result of <<ex-mix>>
+[cols="25h,~,~"]
+|===
+|small |as big as the column needs to be |the rest
+|===
+"#
+    );
+}


### PR DESCRIPTION
Implements all items on the tables [`width.adoc`](docs/modules/tables/pages/width.adoc) specification page.

## What's implemented

- **Fixed width** — the `width` attribute sets a fixed table width as an integer percentage (1–100, optional `%` sign). Exposed via `TableBlock::width() -> Option<usize>`. Out-of-range or non-integer values are ignored (`None`).
- **Autowidth** — the `autowidth` option sizes the table and its columns to their content. Exposed via `TableBlock::is_autowidth()`. Columns inherit the setting, so each becomes `TableColumn::is_autowidth()`.
- **Stretch** — the `stretch` role (and the equivalent `width=100%`) is already captured in the table's attribute list / `width()`; the spec test demonstrates this.
- **Mix fixed and autowidth columns** — the special `~` width value in a column specifier marks just that column autowidth (`TableColumn::is_autowidth()`), leaving the others at their explicit width. The table itself is not autowidth in this case.

## API additions

- `TableBlock::width() -> Option<usize>`
- `TableBlock::is_autowidth() -> bool`
- `TableColumn::is_autowidth() -> bool`

## Tests

- Verbatim, line-by-line spec coverage for `width.adoc` (`parser/src/tests/asciidoc_lang/tables/width.rs`) — `cd sdd && cargo run` reports the page fully covered.
- Focused unit tests in `parser/src/blocks/tests/table.rs`, including the formal `options="autowidth"` syntax and the width-attribute edge cases.

All parser tests pass; `cargo +nightly fmt`, `clippy`, and `cargo +nightly doc` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)