### PR TITLE
feat: Control table borders (frame and grid attributes)

### DIFF
--- a/parser/src/blocks/mod.rs
+++ b/parser/src/blocks/mod.rs
@@ -66,8 +66,8 @@ pub use simple::{SimpleBlock, SimpleBlockStyle};
 
 mod table;
 pub use table::{
-    ColumnStyle, HorizontalAlignment, TableBlock, TableCell, TableCellContent, TableColumn,
-    TableRow, VerticalAlignment,
+    ColumnStyle, Frame, Grid, HorizontalAlignment, TableBlock, TableCell, TableCellContent,
+    TableColumn, TableRow, VerticalAlignment,
 };
 
 #[cfg(test)]

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -59,6 +59,11 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 /// table width, the `autowidth` option ([`is_autowidth`](Self::is_autowidth))
 /// sizes the table and its columns to their content, and an individual column
 /// can be made [autowidth](TableColumn::is_autowidth) with the `~` width value.
+///
+/// Table borders are supported: the [`frame`](Self::frame) attribute controls
+/// the border around the table and the [`grid`](Self::grid) attribute controls
+/// the borders between cells. Each falls back to a document-level default
+/// (`table-frame` / `table-grid`) and then to `all`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -69,6 +74,8 @@ pub struct TableBlock<'src> {
     title_source: Option<Span<'src>>,
     title: Option<String>,
     caption: Option<String>,
+    frame: Frame,
+    grid: Grid,
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
@@ -231,6 +238,15 @@ impl<'src> TableBlock<'src> {
             None
         };
 
+        // The `frame` and `grid` attributes control the table's borders. Each
+        // defaults to `all`; the default can be changed for the whole document
+        // with the `table-frame` / `table-grid` attribute, and an explicit
+        // attribute on the table overrides both. The value is resolved here
+        // (while `parser` is borrowed only immutably) and stored on the block so
+        // the accessors need no further document lookup.
+        let frame = resolve_border::<Frame>(metadata, parser, "frame", "table-frame");
+        let grid = resolve_border::<Grid>(metadata, parser, "grid", "table-grid");
+
         // Scan every cell in the table, in document order, then partition into
         // rows by walking the grid: a cell's span (colspan/rowspan) governs how
         // many column slots it occupies, so a column-spanning cell fills its row
@@ -376,6 +392,8 @@ impl<'src> TableBlock<'src> {
                     title_source: metadata.title_source,
                     title: metadata.title.clone(),
                     caption,
+                    frame,
+                    grid,
                     anchor: metadata.anchor,
                     anchor_reftext: metadata.anchor_reftext,
                     attrlist: metadata.attrlist.clone(),
@@ -436,6 +454,27 @@ impl<'src> TableBlock<'src> {
         self.attrlist
             .as_ref()
             .is_some_and(|a| a.has_option("autowidth"))
+    }
+
+    /// Returns the [`Frame`] that controls the border drawn around this table.
+    ///
+    /// The frame comes from the `frame` attribute on the table, which accepts
+    /// `all`, `ends`, `sides`, or `none`. When the attribute is absent the
+    /// value is taken from the `table-frame` document attribute, and when
+    /// that too is absent it defaults to [`Frame::All`].
+    pub fn frame(&self) -> Frame {
+        self.frame
+    }
+
+    /// Returns the [`Grid`] that controls the borders drawn between this
+    /// table's cells.
+    ///
+    /// The grid comes from the `grid` attribute on the table, which accepts
+    /// `all`, `rows`, `cols`, or `none`. When the attribute is absent the value
+    /// is taken from the `table-grid` document attribute, and when that too is
+    /// absent it defaults to [`Grid::All`].
+    pub fn grid(&self) -> Grid {
+        self.grid
     }
 
     /// Returns the header row of this table, if one was declared.
@@ -690,6 +729,118 @@ pub enum VerticalAlignment {
     /// Content is aligned to the bottom of the column's cells (the `.>`
     /// operator).
     Bottom,
+}
+
+/// The border drawn around a [`TableBlock`].
+///
+/// The frame is set with the `frame` attribute on the table (or, document-wide,
+/// the `table-frame` attribute). The default is [`All`](Self::All).
+///
+/// An unrecognized value falls back to [`All`](Self::All). (Asciidoctor instead
+/// passes an unrecognized value straight through to a CSS class, which the
+/// stylesheet ignores; this parser models only the four documented values.)
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum Frame {
+    /// A border is drawn on every side of the table (the `all` value). This is
+    /// the default frame.
+    #[default]
+    All,
+
+    /// A border is drawn on the top and bottom of the table (the `ends` value).
+    ///
+    /// The `topbot` value recognized by older versions of AsciiDoc is accepted
+    /// as a synonym.
+    Ends,
+
+    /// A border is drawn on the left and right sides of the table (the `sides`
+    /// value).
+    Sides,
+
+    /// No border is drawn around the table (the `none` value).
+    None,
+}
+
+/// The borders drawn between the cells of a [`TableBlock`].
+///
+/// The grid is set with the `grid` attribute on the table (or, document-wide,
+/// the `table-grid` attribute). The default is [`All`](Self::All).
+///
+/// An unrecognized value falls back to [`All`](Self::All). (Asciidoctor instead
+/// passes an unrecognized value straight through to a CSS class, which the
+/// stylesheet ignores; this parser models only the four documented values.)
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum Grid {
+    /// A border is drawn between all cells (the `all` value). This is the
+    /// default grid.
+    #[default]
+    All,
+
+    /// A border is drawn between the rows of the table (the `rows` value).
+    Rows,
+
+    /// A border is drawn between the columns of the table (the `cols` value).
+    Cols,
+
+    /// No border is drawn between the cells (the `none` value).
+    None,
+}
+
+/// A table border value ([`Frame`] or [`Grid`]) that can be parsed from an
+/// attribute value and has a default of `all`.
+trait BorderValue: Copy + Default {
+    /// Parse the value of a `frame` / `grid` attribute (or its document-level
+    /// `table-frame` / `table-grid` counterpart). An unrecognized value yields
+    /// the default.
+    fn from_attr_value(value: &str) -> Self;
+}
+
+impl BorderValue for Frame {
+    fn from_attr_value(value: &str) -> Self {
+        match value.trim() {
+            // `topbot` is the older synonym for `ends`.
+            "ends" | "topbot" => Frame::Ends,
+            "sides" => Frame::Sides,
+            "none" => Frame::None,
+            // `all` and any unrecognized value.
+            _ => Frame::All,
+        }
+    }
+}
+
+impl BorderValue for Grid {
+    fn from_attr_value(value: &str) -> Self {
+        match value.trim() {
+            "rows" => Grid::Rows,
+            "cols" => Grid::Cols,
+            "none" => Grid::None,
+            // `all` and any unrecognized value.
+            _ => Grid::All,
+        }
+    }
+}
+
+/// Resolve a table border attribute ([`Frame`] or [`Grid`]).
+///
+/// An explicit attribute on the table (`attr_name`) wins; otherwise the
+/// document-level default (`doc_attr_name`) is consulted; otherwise the value
+/// defaults to `all`.
+fn resolve_border<B: BorderValue>(
+    metadata: &BlockMetadata<'_>,
+    parser: &Parser,
+    attr_name: &str,
+    doc_attr_name: &str,
+) -> B {
+    if let Some(attr) = metadata
+        .attrlist
+        .as_ref()
+        .and_then(|a| a.named_attribute(attr_name))
+    {
+        B::from_attr_value(attr.value())
+    } else if let InterpretedValue::Value(value) = parser.attribute_value(doc_attr_name) {
+        B::from_attr_value(&value)
+    } else {
+        B::default()
+    }
 }
 
 /// A row of cells in a [`TableBlock`].

--- a/parser/src/tests/asciidoc_lang/tables/borders.rs
+++ b/parser/src/tests/asciidoc_lang/tables/borders.rs
@@ -1,0 +1,393 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/borders.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Return the first [`TableBlock`] in `doc`.
+///
+/// Used by the tests that exercise the `table-frame` / `table-grid` document
+/// attributes: those attributes must be set in the document header, so the
+/// whole document is parsed rather than a single block.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn first_table<'a>(doc: &'a crate::Document<'a>) -> &'a crate::blocks::TableBlock<'a> {
+    doc.nested_blocks()
+        .find_map(|block| match block {
+            crate::blocks::Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .expect("expected a table block")
+}
+
+// Expansion of `include::example$row.adoc[tag=base-h]`: the standard
+// three-column table with a header row and two body rows used throughout the
+// table documentation.
+const BASE_H: &str = "|===\n|Column 1, header row |Column 2, header row |Column 3, header row\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|Cell in column 3, row 2\n\n|Cell in column 1, row 3\n|Cell in column 2, row 3\n|Cell in column 3, row 3\n|===";
+
+non_normative!(
+    r#"
+= Table Borders
+:!table-frame:
+:!table-grid:
+
+"#
+);
+
+#[test]
+fn intro() {
+    verifies!(
+        r#"
+The borders on a table are controlled using the `frame` and `grid` block attributes.
+You can combine these two attributes to achieve a variety of border styles for your tables.
+
+"#
+    );
+
+    // With no `frame` or `grid` attribute, a table draws a border on every side
+    // and between every cell.
+    let table = parse_table(BASE_H);
+    assert_eq!(table.frame(), Frame::All);
+    assert_eq!(table.grid(), Grid::All);
+}
+
+#[test]
+fn frame() {
+    non_normative!(
+        r#"
+== Frame
+
+"#
+    );
+
+    verifies!(
+        r#"
+The border around a table is controlled using the `frame` attribute on the table.
+The frame attribute defaults to the value `all` (implied value), which draws a border on each side of the table.
+This default can be changed by setting the `table-frame` document attribute.
+You can override the default value by setting the frame attribute on the table to the value `all`, `ends`, `sides` or `none`.
+
+"#
+    );
+
+    // The frame defaults to `all`, and the implied (empty) value resolves the
+    // same way.
+    assert_eq!(parse_table(BASE_H).frame(), Frame::All);
+    let src = format!("[frame=all]\n{BASE_H}");
+    assert_eq!(parse_table(&src).frame(), Frame::All);
+
+    // The `table-frame` document attribute changes the default for tables that
+    // don't set their own `frame`.
+    let src = format!(":table-frame: sides\n\n{BASE_H}");
+    let doc = Parser::default().parse(&src);
+    assert_eq!(first_table(&doc).frame(), Frame::Sides);
+
+    // An explicit `frame` on the table overrides the document attribute.
+    let src = format!(":table-frame: sides\n\n[frame=ends]\n{BASE_H}");
+    let doc = Parser::default().parse(&src);
+    assert_eq!(first_table(&doc).frame(), Frame::Ends);
+
+    // An unrecognized value falls back to the default.
+    let src = format!("[frame=bogus]\n{BASE_H}");
+    assert_eq!(parse_table(&src).frame(), Frame::All);
+
+    verifies!(
+        r#"
+The `ends` value draws a border on the top and bottom of the table.
+
+"#
+    );
+
+    // `ends` draws a border on the top and bottom; `topbot` is accepted as the
+    // older synonym for the same value.
+    let src = format!("[frame=ends]\n{BASE_H}");
+    assert_eq!(parse_table(&src).frame(), Frame::Ends);
+    let src = format!("[frame=topbot]\n{BASE_H}");
+    assert_eq!(parse_table(&src).frame(), Frame::Ends);
+
+    verifies!(
+        r#"
+.Table with frame=ends
+[source#ex-ends]
+----
+[frame=ends]
+include::example$row.adoc[tag=base-h]
+----
+
+.Result of <<ex-ends>>
+[frame=ends]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    // <<ex-ends>>: the standard three-column table framed on its ends. The frame
+    // is the only thing that changes; the header and body rows are unaffected.
+    let src = format!("[frame=ends]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert_eq!(table.frame(), Frame::Ends);
+    assert_eq!(table.grid(), Grid::All);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.body_rows().len(), 2);
+
+    verifies!(
+        r#"
+The `sides` value draws a border on the right and left side of the table.
+
+"#
+    );
+
+    // `sides` draws a border on the left and right.
+    let src = format!("[frame=sides]\n{BASE_H}");
+    assert_eq!(parse_table(&src).frame(), Frame::Sides);
+
+    verifies!(
+        r#"
+.Table with frame=sides
+[source#ex-sides]
+----
+[frame=sides]
+include::example$row.adoc[tag=base-h]
+----
+
+.Result of <<ex-sides>>
+[frame=sides]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    // <<ex-sides>>: the standard three-column table framed on its sides.
+    let src = format!("[frame=sides]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert_eq!(table.frame(), Frame::Sides);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.body_rows().len(), 2);
+
+    verifies!(
+        r#"
+The `none` value removes the borders around the table.
+
+"#
+    );
+
+    // `none` removes the frame entirely.
+    let src = format!("[frame=none]\n{BASE_H}");
+    assert_eq!(parse_table(&src).frame(), Frame::None);
+
+    verifies!(
+        r#"
+.Table with frame=none
+[source#ex-noframe]
+----
+[frame=none]
+include::example$row.adoc[tag=base-h]
+----
+
+.Result of <<ex-noframe>>
+[frame=none]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    // <<ex-noframe>>: the standard three-column table with no frame.
+    let src = format!("[frame=none]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert_eq!(table.frame(), Frame::None);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.body_rows().len(), 2);
+}
+
+#[test]
+fn grid() {
+    non_normative!(
+        r#"
+== Grid
+
+"#
+    );
+
+    verifies!(
+        r#"
+The borders between the cells in a table are controlled using the `grid` attribute on the table.
+The grid attribute defaults to the value `all` (implied value), which draws a border between all cells.
+This default can be changed by setting the `table-grid` document attribute.
+You can override the default value by setting the grid attribute on the table to the value `all`, `rows`, `cols` or `none`.
+
+"#
+    );
+
+    // The grid defaults to `all`, and the implied (empty) value resolves the
+    // same way.
+    assert_eq!(parse_table(BASE_H).grid(), Grid::All);
+    let src = format!("[grid=all]\n{BASE_H}");
+    assert_eq!(parse_table(&src).grid(), Grid::All);
+
+    // The `table-grid` document attribute changes the default for tables that
+    // don't set their own `grid`.
+    let src = format!(":table-grid: cols\n\n{BASE_H}");
+    let doc = Parser::default().parse(&src);
+    assert_eq!(first_table(&doc).grid(), Grid::Cols);
+
+    // An explicit `grid` on the table overrides the document attribute.
+    let src = format!(":table-grid: cols\n\n[grid=rows]\n{BASE_H}");
+    let doc = Parser::default().parse(&src);
+    assert_eq!(first_table(&doc).grid(), Grid::Rows);
+
+    // An unrecognized value falls back to the default.
+    let src = format!("[grid=bogus]\n{BASE_H}");
+    assert_eq!(parse_table(&src).grid(), Grid::All);
+
+    verifies!(
+        r#"
+The `rows` value draws a border between the rows of the table.
+
+"#
+    );
+
+    // `rows` draws a border between the rows.
+    let src = format!("[grid=rows]\n{BASE_H}");
+    assert_eq!(parse_table(&src).grid(), Grid::Rows);
+
+    verifies!(
+        r#"
+.Table with grid=rows
+[source#ex-rows]
+----
+[grid=rows]
+include::example$row.adoc[tag=base-h]
+----
+
+.Result of <<ex-rows>>
+[grid=rows]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    // <<ex-rows>>: the standard three-column table with a border only between
+    // its rows. The grid is the only thing that changes.
+    let src = format!("[grid=rows]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert_eq!(table.grid(), Grid::Rows);
+    assert_eq!(table.frame(), Frame::All);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.body_rows().len(), 2);
+
+    verifies!(
+        r#"
+The `cols` value draws borders between the columns.
+
+"#
+    );
+
+    // `cols` draws a border between the columns.
+    let src = format!("[grid=cols]\n{BASE_H}");
+    assert_eq!(parse_table(&src).grid(), Grid::Cols);
+
+    verifies!(
+        r#"
+.Table with grid=cols
+[source#ex-cols]
+----
+[grid=cols]
+include::example$row.adoc[tag=base-h]
+----
+
+.Result of <<ex-cols>>
+[grid=cols]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    // <<ex-cols>>: the standard three-column table with a border only between
+    // its columns.
+    let src = format!("[grid=cols]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert_eq!(table.grid(), Grid::Cols);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.body_rows().len(), 2);
+
+    verifies!(
+        r#"
+The `none` value removes all borders between the cells.
+
+"#
+    );
+
+    // `none` removes the grid entirely.
+    let src = format!("[grid=none]\n{BASE_H}");
+    assert_eq!(parse_table(&src).grid(), Grid::None);
+
+    verifies!(
+        r#"
+.Table with grid=none
+[source#ex-nogrid]
+----
+[grid=none]
+include::example$row.adoc[tag=base-h]
+----
+
+.Result of <<ex-nogrid>>
+[grid=none]
+include::example$row.adoc[tag=base-h]
+
+"#
+    );
+
+    // <<ex-nogrid>>: the standard three-column table with no grid.
+    let src = format!("[grid=none]\n{BASE_H}");
+    let table = parse_table(&src);
+    assert_eq!(table.grid(), Grid::None);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.body_rows().len(), 2);
+}
+
+// The interaction between row/column spans and border placement is a rendering
+// limitation of styling HTML with CSS. It describes downstream converter
+// behavior rather than anything this parser models, so the whole section is
+// non-normative here.
+non_normative!(
+    r#"
+== Interaction with row and column spans
+
+Using row and column spans may interfere with the placement of borders on a table.
+This is a limitation of styling HTML using CSS.
+
+When a cell extends into other rows or columns, that cell is not represented in the HTML for the rows or columns it extends into.
+This is a problem if the cell reaches the boundary of the table.
+The CSS selector only matches the cell where it starts and thus does not detect when it is touching the table boundary.
+It therefore cannot add or remove the border as it would for a 1x1 cell (i.e., a cell confined to a single row and column).
+
+The interference with border placement caused by row and column spans does not always happen.
+Borders on a table with a rowspan or colspan that reaches the table boundary will always work correctly when the frame and grid are congruent.
+In this context, congruent means the frame and grid are contributing borders to the same edges.
+
+Here are those scenarios in which the frame and grid are congruent:
+
+* frame=all, grid=all
+* frame=all, grid=none
+* frame=all, grid=rows
+* frame=all, grid=cols
+* frame=ends, grid=rows
+* frame=sides, grid=cols
+* frame=none, grid=none
+
+If you use row and column spans in a table, you are strongly encouraged to use one of these frame and grid combinations.
+"#
+);

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -6,6 +6,7 @@ mod add_title;
 mod adjust_column_widths;
 mod align_by_cell;
 mod align_by_column;
+mod borders;
 mod build_a_basic_table;
 mod customize_title_label;
 mod duplicate_cells;

--- a/parser/src/tests/prelude.rs
+++ b/parser/src/tests/prelude.rs
@@ -7,7 +7,8 @@ pub(crate) use std::collections::HashMap;
 pub(crate) use crate::{
     HasSpan, Parser,
     blocks::{
-        ColumnStyle, HorizontalAlignment, IsBlock, SectionType, SimpleBlockStyle, VerticalAlignment,
+        ColumnStyle, Frame, Grid, HorizontalAlignment, IsBlock, SectionType, SimpleBlockStyle,
+        VerticalAlignment,
     },
     content::SubstitutionGroup,
     parser::ModificationContext,


### PR DESCRIPTION
Implements all items described on `docs/modules/tables/pages/borders.adoc`.

## What

Adds support for the two table-border block attributes:

- **`frame`** — `all` (default), `ends`, `sides`, `none`. Controls the border drawn *around* the table. Exposed as `TableBlock::frame() -> Frame`.
- **`grid`** — `all` (default), `rows`, `cols`, `none`. Controls the borders drawn *between* cells. Exposed as `TableBlock::grid() -> Grid`.

Resolution order for each (matching Asciidoctor): an explicit attribute on the table wins, then the document-level default (`table-frame` / `table-grid`), then `all`.

## Notes / Asciidoctor fidelity

- `topbot` is accepted as the older synonym for `ends` (verified against local `asciidoctor`).
- An unrecognized value falls back to `all`. (Asciidoctor instead passes an unrecognized value straight through as a CSS class, which the stylesheet ignores; this parser models only the four documented values — documented on the `Frame` / `Grid` enums.)
- The "Interaction with row and column spans" section describes a downstream HTML/CSS rendering limitation rather than parser behavior, so it is captured as non-normative spec coverage.

## Tests

- New `parser/src/tests/asciidoc_lang/tables/borders.rs` with line-by-line spec coverage (`track_file!` / `verifies!` / `non_normative!`); `cd sdd && cargo run` reports full coverage of `borders.adoc` (0 uncovered normative lines).
- Covers defaults, explicit values, document-attribute fallback, block-over-document override, the `topbot` synonym, and unrecognized-value fallback for both `frame` and `grid`.
- `cargo test`, `cargo clippy --all-targets`, `cargo +nightly fmt --check`, and `cargo +nightly doc` (deny warnings) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)