### PR TITLE
feat: Stripe table rows (stripes attribute and table-stripes document attribute)

### DIFF
--- a/parser/src/blocks/mod.rs
+++ b/parser/src/blocks/mod.rs
@@ -66,8 +66,8 @@ pub use simple::{SimpleBlock, SimpleBlockStyle};
 
 mod table;
 pub use table::{
-    ColumnStyle, Frame, Grid, HorizontalAlignment, TableBlock, TableCell, TableCellContent,
-    TableColumn, TableRow, VerticalAlignment,
+    ColumnStyle, Frame, Grid, HorizontalAlignment, Stripes, TableBlock, TableCell,
+    TableCellContent, TableColumn, TableRow, VerticalAlignment,
 };
 
 #[cfg(test)]

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -64,6 +64,10 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 /// the border around the table and the [`grid`](Self::grid) attribute controls
 /// the borders between cells. Each falls back to a document-level default
 /// (`table-frame` / `table-grid`) and then to `all`.
+///
+/// Zebra striping is supported via the [`stripes`](Self::stripes) attribute,
+/// which falls back to the `table-stripes` document attribute and then to
+/// `none`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -76,6 +80,7 @@ pub struct TableBlock<'src> {
     caption: Option<String>,
     frame: Frame,
     grid: Grid,
+    stripes: Stripes,
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
@@ -238,14 +243,18 @@ impl<'src> TableBlock<'src> {
             None
         };
 
-        // The `frame` and `grid` attributes control the table's borders. Each
-        // defaults to `all`; the default can be changed for the whole document
-        // with the `table-frame` / `table-grid` attribute, and an explicit
-        // attribute on the table overrides both. The value is resolved here
-        // (while `parser` is borrowed only immutably) and stored on the block so
-        // the accessors need no further document lookup.
-        let frame = resolve_border::<Frame>(metadata, parser, "frame", "table-frame");
-        let grid = resolve_border::<Grid>(metadata, parser, "grid", "table-grid");
+        // The `frame` and `grid` attributes control the table's borders, and the
+        // `stripes` attribute controls zebra striping. The borders each default
+        // to `all` and stripes defaults to `none`; the default can be changed for
+        // the whole document with the `table-frame` / `table-grid` /
+        // `table-stripes` attribute, and an explicit attribute on the table
+        // overrides both. Each value is resolved here (while `parser` is borrowed
+        // only immutably) and stored on the block so the accessors need no further
+        // document lookup.
+        let frame = resolve_table_attribute::<Frame>(metadata, parser, "frame", "table-frame");
+        let grid = resolve_table_attribute::<Grid>(metadata, parser, "grid", "table-grid");
+        let stripes =
+            resolve_table_attribute::<Stripes>(metadata, parser, "stripes", "table-stripes");
 
         // Scan every cell in the table, in document order, then partition into
         // rows by walking the grid: a cell's span (colspan/rowspan) governs how
@@ -394,6 +403,7 @@ impl<'src> TableBlock<'src> {
                     caption,
                     frame,
                     grid,
+                    stripes,
                     anchor: metadata.anchor,
                     anchor_reftext: metadata.anchor_reftext,
                     attrlist: metadata.attrlist.clone(),
@@ -475,6 +485,24 @@ impl<'src> TableBlock<'src> {
     /// absent it defaults to [`Grid::All`].
     pub fn grid(&self) -> Grid {
         self.grid
+    }
+
+    /// Returns the [`Stripes`] that control which rows of this table are shaded
+    /// to create a zebra-striping effect.
+    ///
+    /// The stripes come from the `stripes` attribute on the table, which
+    /// accepts `none`, `even`, `odd`, `all`, or `hover`. When the attribute
+    /// is absent the value is taken from the `table-stripes` document
+    /// attribute, and when that too is absent it defaults to
+    /// [`Stripes::None`].
+    ///
+    /// As a shorthand, a `stripes-<value>` role on the table (e.g.
+    /// `[.stripes-even]`) applies the same CSS class directly without setting
+    /// the `stripes` attribute. That shorthand does not affect this value
+    /// (which remains [`Stripes::None`]); the role is instead reported
+    /// among the table's [roles](crate::attributes::Attrlist::roles).
+    pub fn stripes(&self) -> Stripes {
+        self.stripes
     }
 
     /// Returns the header row of this table, if one was declared.
@@ -785,16 +813,51 @@ pub enum Grid {
     None,
 }
 
-/// A table border value ([`Frame`] or [`Grid`]) that can be parsed from an
-/// attribute value and has a default of `all`.
-trait BorderValue: Copy + Default {
-    /// Parse the value of a `frame` / `grid` attribute (or its document-level
-    /// `table-frame` / `table-grid` counterpart). An unrecognized value yields
-    /// the default.
+/// The zebra striping applied to the rows of a [`TableBlock`].
+///
+/// Striping shades the specified rows with a background color to create a zebra
+/// effect. It is set with the `stripes` attribute on the table (or,
+/// document-wide, the `table-stripes` attribute). The default is
+/// [`None`](Self::None).
+///
+/// Under the covers, a converter applies the CSS class `stripes-<value>` to the
+/// table; the actual shading depends on the stylesheet. As a shorthand, the
+/// same class can be applied directly with a role (e.g. `[.stripes-even]`)
+/// rather than the `stripes` attribute. A role does not set this value (see
+/// [`TableBlock::stripes`]).
+///
+/// An unrecognized value falls back to [`None`](Self::None). (Asciidoctor
+/// instead passes an unrecognized value straight through to a CSS class, which
+/// the stylesheet ignores; this parser models only the five documented values.)
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum Stripes {
+    /// No rows are shaded (the `none` value). This is the default.
+    #[default]
+    None,
+
+    /// Even rows are shaded (the `even` value).
+    Even,
+
+    /// Odd rows are shaded (the `odd` value).
+    Odd,
+
+    /// All rows are shaded (the `all` value).
+    All,
+
+    /// The row under the mouse cursor is shaded (the `hover` value). This has
+    /// an effect only in HTML output.
+    Hover,
+}
+
+/// A table-level attribute value ([`Frame`], [`Grid`], or [`Stripes`]) that can
+/// be parsed from an attribute value and has a default.
+trait TableAttributeValue: Copy + Default {
+    /// Parse the value of the table attribute (or its document-level
+    /// `table-<name>` counterpart). An unrecognized value yields the default.
     fn from_attr_value(value: &str) -> Self;
 }
 
-impl BorderValue for Frame {
+impl TableAttributeValue for Frame {
     fn from_attr_value(value: &str) -> Self {
         match value.trim() {
             // `topbot` is the older synonym for `ends`.
@@ -807,7 +870,7 @@ impl BorderValue for Frame {
     }
 }
 
-impl BorderValue for Grid {
+impl TableAttributeValue for Grid {
     fn from_attr_value(value: &str) -> Self {
         match value.trim() {
             "rows" => Grid::Rows,
@@ -819,12 +882,25 @@ impl BorderValue for Grid {
     }
 }
 
-/// Resolve a table border attribute ([`Frame`] or [`Grid`]).
+impl TableAttributeValue for Stripes {
+    fn from_attr_value(value: &str) -> Self {
+        match value.trim() {
+            "even" => Stripes::Even,
+            "odd" => Stripes::Odd,
+            "all" => Stripes::All,
+            "hover" => Stripes::Hover,
+            // `none` and any unrecognized value.
+            _ => Stripes::None,
+        }
+    }
+}
+
+/// Resolve a table-level attribute ([`Frame`], [`Grid`], or [`Stripes`]).
 ///
 /// An explicit attribute on the table (`attr_name`) wins; otherwise the
 /// document-level default (`doc_attr_name`) is consulted; otherwise the value
-/// defaults to `all`.
-fn resolve_border<B: BorderValue>(
+/// falls back to the type's default.
+fn resolve_table_attribute<B: TableAttributeValue>(
     metadata: &BlockMetadata<'_>,
     parser: &Parser,
     attr_name: &str,

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -13,5 +13,6 @@ mod duplicate_cells;
 mod format_cell_content;
 mod format_column_content;
 mod span_cells;
+mod striping;
 mod turn_off_title_label;
 mod width;

--- a/parser/src/tests/asciidoc_lang/tables/striping.rs
+++ b/parser/src/tests/asciidoc_lang/tables/striping.rs
@@ -1,0 +1,248 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/striping.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Return the first [`TableBlock`] in `doc`.
+///
+/// Used by the tests that exercise the `table-stripes` document attribute: that
+/// attribute must be set in the document header, so the whole document is
+/// parsed rather than a single block.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn first_table<'a>(doc: &'a crate::Document<'a>) -> &'a crate::blocks::TableBlock<'a> {
+    doc.nested_blocks()
+        .find_map(|block| match block {
+            crate::blocks::Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .expect("expected a table block")
+}
+
+// A minimal table (no attribute line of its own) used as the base for the
+// `stripes` / `table-stripes` assertions, which care only about the table-level
+// value and not the table's shape.
+const BASE: &str = "|===\n|A1\n|B1\n|===";
+
+non_normative!(
+    r#"
+= Table Striping
+
+"#
+);
+
+#[test]
+fn intro() {
+    verifies!(
+        r#"
+You can add zebra-striping to rows of a table.
+When this feature is enabled, the specified rows are shaded using a background color to create a zebra striping effect.
+
+"#
+    );
+
+    // With no `stripes` attribute, a table is not striped.
+    assert_eq!(parse_table(BASE).stripes(), Stripes::None);
+
+    // The note below describes a rendering concern (CSS and the stylesheet), not
+    // anything this parser models.
+    non_normative!(
+        r#"
+NOTE: In the HTML output, table striping is done using CSS and thus depends on the stylesheet to supply the necessary styles.
+The default stylesheet for Asciidoctor includes the necessary styles for table striping.
+
+"#
+    );
+}
+
+#[test]
+fn striping_attributes() {
+    non_normative!(
+        r#"
+== Striping attributes
+
+"#
+    );
+
+    verifies!(
+        r#"
+Which rows are striped is controlled using the `stripes` attribute on the table.
+The stripes attribute defaults to the value `none` (implied value), which means rows are not striped by default.
+This default can be changed by setting the `table-stripes` document attribute.
+You can override the default value by setting the stripes attribute on the table.
+
+"#
+    );
+
+    // The stripes default to `none`, both when the attribute is absent and when
+    // it is given the implied value `none`.
+    assert_eq!(parse_table(BASE).stripes(), Stripes::None);
+    let src = format!("[stripes=none]\n{BASE}");
+    assert_eq!(parse_table(&src).stripes(), Stripes::None);
+
+    // The `table-stripes` document attribute changes the default for tables that
+    // don't set their own `stripes`.
+    let src = format!(":table-stripes: odd\n\n{BASE}");
+    let doc = Parser::default().parse(&src);
+    assert_eq!(first_table(&doc).stripes(), Stripes::Odd);
+
+    // An explicit `stripes` on the table overrides the document attribute.
+    let src = format!(":table-stripes: odd\n\n[stripes=even]\n{BASE}");
+    let doc = Parser::default().parse(&src);
+    assert_eq!(first_table(&doc).stripes(), Stripes::Even);
+
+    verifies!(
+        r#"
+The `stripes` attribute on a table and the `table-stripes` document attribute accept the following values:
+
+* `none` - no rows are shaded (default)
+* `even` - even rows are shaded
+* `odd` - odd rows are shaded
+* `all` - all rows are shaded
+* `hover` - the row under the mouse cursor is shaded (HTML only)
+
+"#
+    );
+
+    // Each documented value resolves to its corresponding variant.
+    let src = format!("[stripes=none]\n{BASE}");
+    assert_eq!(parse_table(&src).stripes(), Stripes::None);
+    let src = format!("[stripes=even]\n{BASE}");
+    assert_eq!(parse_table(&src).stripes(), Stripes::Even);
+    let src = format!("[stripes=odd]\n{BASE}");
+    assert_eq!(parse_table(&src).stripes(), Stripes::Odd);
+    let src = format!("[stripes=all]\n{BASE}");
+    assert_eq!(parse_table(&src).stripes(), Stripes::All);
+    let src = format!("[stripes=hover]\n{BASE}");
+    assert_eq!(parse_table(&src).stripes(), Stripes::Hover);
+
+    // An unrecognized value falls back to the default.
+    let src = format!("[stripes=bogus]\n{BASE}");
+    assert_eq!(parse_table(&src).stripes(), Stripes::None);
+}
+
+#[test]
+fn stripes_block_attribute() {
+    non_normative!(
+        r#"
+== stripes block attribute
+
+"#
+    );
+
+    verifies!(
+        r#"
+In the following example, the stripes are enabled for even rows in the table body (the row that contains A2 and B2).
+
+[source]
+----
+[cols=2*,stripes=even]
+|===
+|A1
+|B1
+|A2
+|B2
+|A3
+|B3
+|===
+----
+
+"#
+    );
+
+    // The example table: two columns, three body rows, with even-row striping.
+    let src = "[cols=2*,stripes=even]\n|===\n|A1\n|B1\n|A2\n|B2\n|A3\n|B3\n|===";
+    let table = parse_table(src);
+    assert_eq!(table.stripes(), Stripes::Even);
+    assert_eq!(table.columns().len(), 2);
+    assert!(table.header_row().is_none());
+    assert_eq!(table.body_rows().len(), 3);
+
+    verifies!(
+        r#"
+Under the covers, the stripes attribute applies the CSS class `stripes-<value>` (e.g., `stripes-none`) to the table tag.
+As a shorthand, you can simply apply the CSS class to the table directly using a role.
+
+[source]
+----
+[.stripes-even,cols=2*]
+|===
+|A1
+|B1
+|A2
+|B2
+|A3
+|B3
+|===
+----
+
+"#
+    );
+
+    // The role shorthand applies the `stripes-even` CSS class directly without
+    // setting the `stripes` attribute, so the parsed `stripes` value stays
+    // `none` and the class is reported among the table's roles instead.
+    let src = "[.stripes-even,cols=2*]\n|===\n|A1\n|B1\n|A2\n|B2\n|A3\n|B3\n|===";
+    let table = parse_table(src);
+    assert_eq!(table.stripes(), Stripes::None);
+    assert!(table.attrlist().unwrap().roles().contains(&"stripes-even"));
+}
+
+#[test]
+fn table_stripes_attribute() {
+    non_normative!(
+        r#"
+== table-stripes attribute
+
+"#
+    );
+
+    verifies!(
+        r#"
+If you want to apply stripes to all tables in the document, set the `table-stripes` attribute in the document header.
+You can still override this setting per table.
+
+[source]
+----
+= Document Title
+:table-stripes: even
+
+[cols=2*]
+|===
+|A1
+|B1
+|A2
+|B2
+|A3
+|B3
+|===
+----
+"#
+    );
+
+    // The document-header attribute stripes every table that doesn't set its
+    // own `stripes`.
+    let src = "= Document Title\n:table-stripes: even\n\n[cols=2*]\n|===\n|A1\n|B1\n|A2\n|B2\n|A3\n|B3\n|===";
+    let doc = Parser::default().parse(src);
+    assert_eq!(first_table(&doc).stripes(), Stripes::Even);
+
+    // A table can still override the document-wide setting.
+    let src =
+        "= Document Title\n:table-stripes: even\n\n[stripes=odd,cols=2*]\n|===\n|A1\n|B1\n|===";
+    let doc = Parser::default().parse(src);
+    assert_eq!(first_table(&doc).stripes(), Stripes::Odd);
+}

--- a/parser/src/tests/prelude.rs
+++ b/parser/src/tests/prelude.rs
@@ -8,7 +8,7 @@ pub(crate) use crate::{
     HasSpan, Parser,
     blocks::{
         ColumnStyle, Frame, Grid, HorizontalAlignment, IsBlock, SectionType, SimpleBlockStyle,
-        VerticalAlignment,
+        Stripes, VerticalAlignment,
     },
     content::SubstitutionGroup,
     parser::ModificationContext,


### PR DESCRIPTION
## Summary

Implements the table striping feature described in [`docs/modules/tables/pages/striping.adoc`](docs/modules/tables/pages/striping.adoc).

- Adds the `stripes` table attribute and the `table-stripes` document attribute, which control zebra striping of table rows.
- Resolution follows the same precedence as `frame` / `grid`: an explicit `stripes` attribute on the table wins, otherwise the `table-stripes` document attribute, otherwise the default `none`.
- `stripes` accepts `none`, `even`, `odd`, `all`, and `hover`; an unrecognized value falls back to `none`.
- New `Stripes` enum, exposed via `TableBlock::stripes()`.
- The role shorthand (e.g. `[.stripes-even]`) applies the CSS class directly without setting the `stripes` attribute, so `stripes()` stays `none` and the class surfaces as a role — matching Asciidoctor's behavior (verified against a local `asciidoctor` run).

## Implementation notes

- The internal `BorderValue` trait / `resolve_border` helper are generalized to `TableAttributeValue` / `resolve_table_attribute`, since they now serve three table attributes rather than just the two border attributes.

## Tests

- New `parser/src/tests/asciidoc_lang/tables/striping.rs` provides line-by-line spec coverage for `striping.adoc` (every normative line covered; verified with `cd sdd && cargo run`), exercising every `Stripes` variant, the unrecognized-value fallback, the document-attribute fallback and per-table override, and the role shorthand.
- Full suite green (`cargo test -p asciidoc-parser`), clippy clean, `cargo +nightly fmt --check` clean, and `RUSTDOCFLAGS="-D warnings" cargo +nightly doc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)