### PR TITLE
test: declare table orientation page non-normative

### DIFF
--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -12,6 +12,7 @@ mod customize_title_label;
 mod duplicate_cells;
 mod format_cell_content;
 mod format_column_content;
+mod orientation;
 mod span_cells;
 mod striping;
 mod turn_off_title_label;

--- a/parser/src/tests/asciidoc_lang/tables/orientation.rs
+++ b/parser/src/tests/asciidoc_lang/tables/orientation.rs
@@ -1,0 +1,33 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/orientation.adoc");
+
+// This entire page is considered non-normative because table orientation
+// (the `rotate` option and `orientation` attribute) only affects rendering, and
+// as the page itself notes, it is implemented solely by the DocBook backend.
+// This crate doesn't do rendering.
+non_normative!(
+    r#"
+= Table Orientation
+
+== Landscape
+
+A table can be displayed in landscape (rotated 90 degrees counterclockwise) using the `rotate` option (preferred).
+
+[source]
+----
+[%rotate]
+include::example$table.adoc[tag=base]
+----
+
+A table can also be displayed in landscape using the `orientation` attribute.
+
+[source]
+----
+[orientation=landscape]
+include::example$table.adoc[tag=base]
+----
+
+Currently, this is only implemented by the DocBook backend (it sets the attribute `orient="land"`).
+"#
+);


### PR DESCRIPTION
Implements the spec coverage for `docs/modules/tables/pages/orientation.adoc`.

## Summary

The table orientation page describes displaying a table in landscape via the `rotate` option (preferred) or the `orientation` attribute. As the page itself states in its final line:

> Currently, this is only implemented by the DocBook backend (it sets the attribute `orient="land"`).

Both mechanisms only affect rendering, and this crate does not do rendering (and we are not planning to support the DocBook backend). There is therefore nothing for the parser to implement here. Following the established pattern for render-only pages (e.g. [`lists/horizontal.rs`](parser/src/tests/asciidoc_lang/lists/horizontal.rs)), the entire page is declared **non-normative**.

## Changes

- Add `parser/src/tests/asciidoc_lang/tables/orientation.rs` wrapping the full page in `non_normative!`.
- Register the module in `parser/src/tests/asciidoc_lang/tables/mod.rs`.

## Verification

- `cargo run` (sdd) reports the page fully accounted for (no uncovered normative lines).
- `cargo +nightly fmt --check` clean.
- `cargo test -p asciidoc-parser tables::` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)