### PR TITLE
chore: Cover the "Assign a Role to a Table" page

### DIFF
--- a/parser/src/tests/asciidoc_lang/tables/assign_a_role.rs
+++ b/parser/src/tests/asciidoc_lang/tables/assign_a_role.rs
@@ -1,0 +1,78 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/assign-a-role.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+// The `tag=base` table referenced by the example on the page: a minimal,
+// two-cell table. Roles are independent of the table's shape, so this stands in
+// for the included example.
+const BASE: &str = "|===\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n|===";
+
+non_normative!(
+    r#"
+= Assign a Role to a Table
+
+"#
+);
+
+#[test]
+fn role_attribute() {
+    verifies!(
+        r#"
+Like with all blocks, you can add a role to a table using the `role` attribute.
+"#
+    );
+
+    // The formal `role` named attribute assigns the role to the table.
+    let src = format!("[role=name-of-role]\n{BASE}");
+    let table = parse_table(&src);
+    assert_eq!(table.roles(), vec!["name-of-role"]);
+
+    // A role may also carry multiple, space-separated values.
+    let src = format!("[role=\"role-one role-two\"]\n{BASE}");
+    let table = parse_table(&src);
+    assert_eq!(table.roles(), vec!["role-one", "role-two"]);
+
+    // The mapping of a role to an HTML CSS class is a rendering concern; this
+    // crate does not convert to HTML.
+    non_normative!(
+        r#"
+The role attribute becomes a CSS class when converted to HTML.
+"#
+    );
+}
+
+#[test]
+fn role_shorthand() {
+    verifies!(
+        r#"
+The preferred shorthand for assigning the role attribute is to put the role name in the first position of the block attribute list prefixed with a `.` character, as shown here:
+
+[source]
+----
+[.name-of-role]
+include::example$table.adoc[tag=base]
+----
+"#
+    );
+
+    // The dot-prefixed shorthand in the first position assigns the role just
+    // like the formal `role` attribute does.
+    let src = format!("[.name-of-role]\n{BASE}");
+    let table = parse_table(&src);
+    assert_eq!(table.roles(), vec!["name-of-role"]);
+}

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -6,6 +6,7 @@ mod add_title;
 mod adjust_column_widths;
 mod align_by_cell;
 mod align_by_column;
+mod assign_a_role;
 mod borders;
 mod build_a_basic_table;
 mod customize_title_label;


### PR DESCRIPTION
## Summary

Implements all items described on `docs/modules/tables/pages/assign-a-role.adoc` as spec-coverage tests targeting the `tables` feature branch.

Assigning a role to a table is — as the page says — handled "like with all blocks" by the generic block-attribute machinery (`IsBlock::roles` → `Attrlist::roles`). No parser changes were required; this PR pins that behavior to the page with verbatim, line-by-line coverage.

## What's covered

- **`role` named attribute** — `[role=name-of-role]` assigns the role to the table, including multiple space-separated roles.
- **`.name-of-role` shorthand** — the preferred dot-prefixed form in the first attribute position assigns the role identically.
- The statement that the role "becomes a CSS class when converted to HTML" is marked **non-normative**, since this crate does not render to HTML.

The page is now fully covered (verified via the `sdd` coverage tool, which also confirms the verbatim text matches).

## Testing

- `cargo test -p asciidoc-parser tables::` — 67 passed
- `cargo +nightly fmt --check` — clean
- `cargo clippy -p asciidoc-parser --tests` — clean
- `cd sdd && cargo run` — exits 0, page reports no uncovered lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)