### PR TITLE
feat: Nest tables inside AsciiDoc cells (`!===` delimiter and `separator` attribute)

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1447,12 +1447,12 @@ fn scan_cells(region: Span<'_>, separator: u8) -> Vec<RawCell<'_>> {
 
     while i < len {
         if bytes.get(i).copied() == Some(separator) {
-            // Walk back to the start of the token directly preceding this `|`.
-            // The token (a possible cell specifier) runs back to the previous
-            // whitespace, tab, or newline, or to the start of the region; either
-            // way the token is anchored at a line start or after whitespace, as a
-            // cell boundary requires. (When `tok_start == i` the token is empty
-            // and the separator is plain.)
+            // Walk back to the start of the token directly preceding this
+            // separator. The token (a possible cell specifier) runs back to the
+            // previous whitespace, tab, or newline, or to the start of the
+            // region; either way the token is anchored at a line start or after
+            // whitespace, as a cell boundary requires. (When `tok_start == i`
+            // the token is empty and the separator is plain.)
             let mut tok_start = i;
             while tok_start > 0
                 && !matches!(

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -25,11 +25,14 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 /// A table is a delimited block that arranges content into a grid of rows and
 /// columns.
 ///
-/// A table is introduced by a table delimiter (`|===`) and closed by a matching
-/// delimiter. Cells are separated using prefix-separated value (PSV) syntax: a
-/// vertical bar (`|`) at the start of a line or preceded by whitespace begins a
-/// new cell. Cells flow, in document order, into rows whose length is fixed by
-/// the number of columns.
+/// A table is introduced by a table delimiter (`|===`, or `!===` for a nested
+/// table) and closed by a matching delimiter. Cells are separated using
+/// prefix-separated value (PSV) syntax: the table's cell separator — a vertical
+/// bar (`|`) by default — at the start of a line or preceded by whitespace
+/// begins a new cell. Cells flow, in document order, into rows whose length is
+/// fixed by the number of columns. (The separator defaults to `!` inside a
+/// nested table and can be overridden with the `separator` attribute; see
+/// below.)
 ///
 /// The number of columns is determined either by the `cols` attribute or,
 /// implicitly, by the number of cells found in the first non-empty line after

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -68,6 +68,13 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 /// Zebra striping is supported via the [`stripes`](Self::stripes) attribute,
 /// which falls back to the `table-stripes` document attribute and then to
 /// `none`.
+///
+/// Nested tables are supported: an [`AsciiDoc`](ColumnStyle::AsciiDoc) cell may
+/// contain its own table. The cell separator defaults to the vertical bar (`|`)
+/// but switches to the exclamation mark (`!`) inside an AsciiDoc cell, so a
+/// nested table is opened with `!===` and separates its cells with `!`. The
+/// `separator` attribute overrides the default separator with an explicit
+/// character at any level.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
@@ -89,17 +96,20 @@ pub struct TableBlock<'src> {
 impl<'src> TableBlock<'src> {
     /// Returns `true` if `line` is a table delimiter.
     ///
-    /// A table delimiter is a vertical bar (`|`) followed by three or more
-    /// equals signs (`===`).
+    /// A table delimiter is a vertical bar (`|`) or an exclamation mark (`!`)
+    /// followed by three or more equals signs (`===`). The `!===` form opens a
+    /// table whose default cell separator is the exclamation mark, which lets a
+    /// nested table be distinguished from the `|`-separated table that encloses
+    /// it.
     ///
-    /// **NOTE:** The `,===` (CSV), `:===` (DSV), and `!===` (nested) shorthand
-    /// delimiters are not yet recognized.
+    /// **NOTE:** The `,===` (CSV) and `:===` (DSV) shorthand delimiters are not
+    /// yet recognized.
     pub(crate) fn is_table_delimiter(line: &Span<'src>) -> bool {
         let data = line.data();
-        // `len() >= 4` plus the leading `|` guarantees `rest` holds at least three
-        // bytes, so the closure only needs to confirm they are all `=`.
+        // `len() >= 4` plus the leading `|`/`!` guarantees `rest` holds at least
+        // three bytes, so the closure only needs to confirm they are all `=`.
         data.len() >= 4
-            && data.starts_with('|')
+            && (data.starts_with('|') || data.starts_with('!'))
             && data
                 .get(1..)
                 .is_some_and(|rest| rest.bytes().all(|b| b == b'='))
@@ -133,6 +143,14 @@ impl<'src> TableBlock<'src> {
 
         let inside = delimiter.after.trim_remainder(closing_delimiter);
 
+        // The cell separator partitions each row into cells. It defaults to the
+        // vertical bar (`|`), except inside an AsciiDoc table cell — a nested,
+        // standalone document — where it defaults to the exclamation mark (`!`)
+        // so a nested table is distinguished from the `|`-separated table that
+        // encloses it. The `separator` attribute overrides the default with an
+        // explicit character; an empty `separator` falls back to the default.
+        let separator = resolve_separator(metadata, parser);
+
         // Determine the number of columns, either from the `cols` attribute or
         // implicitly from the number of cells in the first non-empty line.
         let columns: Vec<TableColumn> = metadata
@@ -146,10 +164,11 @@ impl<'src> TableBlock<'src> {
         // the first non-empty line: a cell that spans columns (`<n>+`) counts as
         // `<n>` slots, not one, and a cell duplicated `<n>` times (`<n>*`) counts
         // as `<n>` single-column slots (one per clone).
-        let first_line_cells: usize = scan_cells(inside.discard_empty_lines().take_line().item)
-            .iter()
-            .map(|c| c.spec.colspan.max(1) * c.spec.repeat.min(MAX_DUPLICATION_FACTOR))
-            .sum();
+        let first_line_cells: usize =
+            scan_cells(inside.discard_empty_lines().take_line().item, separator)
+                .iter()
+                .map(|c| c.spec.colspan.max(1) * c.spec.repeat.min(MAX_DUPLICATION_FACTOR))
+                .sum();
 
         let ncols = if columns.is_empty() {
             first_line_cells
@@ -276,7 +295,7 @@ impl<'src> TableBlock<'src> {
         // grid walk, so each clone occupies its own column slot exactly like an
         // ordinary cell. A duplication factor of zero drops the cell entirely.
         let mut warnings: Vec<Warning<'src>> = vec![];
-        let raw_cells = expand_duplicates(scan_cells(inside));
+        let raw_cells = expand_duplicates(scan_cells(inside, separator));
 
         // A table can never have more rows than it has cells, so a row span is
         // clamped to the cell count for the `active_rowspans` bookkeeping below: a
@@ -362,6 +381,7 @@ impl<'src> TableBlock<'src> {
                     raw,
                     &column,
                     is_header,
+                    separator,
                     parser,
                     &mut warnings,
                 ));
@@ -919,6 +939,34 @@ fn resolve_table_attribute<B: TableAttributeValue>(
     }
 }
 
+/// Resolve the cell separator byte for a table.
+///
+/// The separator defaults to the vertical bar (`|`), except inside an AsciiDoc
+/// table cell — a nested, standalone document — where it defaults to the
+/// exclamation mark (`!`), so a nested table is distinguished from the
+/// `|`-separated table that encloses it. An explicit `separator` attribute on
+/// the table overrides the default with its first byte; an empty `separator`
+/// value (e.g. `[separator=]`) falls back to the default. A non-ASCII first
+/// character is ignored (the byte-oriented cell scanner only recognizes a
+/// single-byte separator), so it too falls back to the default.
+fn resolve_separator(metadata: &BlockMetadata<'_>, parser: &Parser) -> u8 {
+    let default = if parser.nested_document_depth > 0 {
+        b'!'
+    } else {
+        b'|'
+    };
+
+    metadata
+        .attrlist
+        .as_ref()
+        .and_then(|a| a.named_attribute("separator"))
+        .map(|attr| attr.value())
+        .filter(|value| !value.is_empty())
+        .and_then(|value| value.chars().next())
+        .filter(char::is_ascii)
+        .map_or(default, |c| c as u8)
+}
+
 /// A row of cells in a [`TableBlock`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableRow<'src> {
@@ -958,8 +1006,9 @@ impl<'src> TableCell<'src> {
     ///
     /// Leading and trailing whitespace is always stripped. For every style but
     /// [`AsciiDoc`](ColumnStyle::AsciiDoc) the cell holds inline
-    /// [`Content`](TableCellContent::Simple): escaped cell separators (`\|`)
-    /// are unescaped and substitutions are applied — the verbatim group for
+    /// [`Content`](TableCellContent::Simple): escaped cell separators (the
+    /// table's `separator` character preceded by a backslash, e.g. `\|`) are
+    /// unescaped and substitutions are applied — the verbatim group for
     /// [`Literal`](ColumnStyle::Literal), the normal group otherwise. An
     /// [`AsciiDoc`](ColumnStyle::AsciiDoc) cell instead parses its content as a
     /// nested sequence of [blocks](TableCellContent::AsciiDoc).
@@ -967,6 +1016,7 @@ impl<'src> TableCell<'src> {
         raw: RawCell<'src>,
         column: &TableColumn,
         is_header: bool,
+        separator: u8,
         parser: &mut Parser,
         warnings: &mut Vec<Warning<'src>>,
     ) -> Self {
@@ -1015,7 +1065,14 @@ impl<'src> TableCell<'src> {
                 }
             }
 
+            // Mark that we are inside an AsciiDoc cell (a nested document) for the
+            // duration of the cell, so a table found within defaults its cell
+            // separator to `!` rather than `|` (matching Asciidoctor's
+            // `Document#nested?`). The depth is restored afterward so the marker
+            // is scoped to the cell and nests correctly.
+            parser.nested_document_depth += 1;
             let mut maw = parse_blocks_until(trimmed, |_| false, parser);
+            parser.nested_document_depth -= 1;
 
             parser.locked_attribute_names = saved_locks;
             parser.attribute_values = saved_attributes;
@@ -1024,8 +1081,16 @@ impl<'src> TableCell<'src> {
         } else {
             let data = trimmed.data();
 
-            let mut content = if data.contains("\\|") {
-                Content::from_filtered(trimmed, data.replace("\\|", "|"))
+            // An escaped cell separator (a backslash in front of the table's
+            // separator character, e.g. `\|` or `\!`) is unescaped to the bare
+            // separator. Only the active separator is unescaped, so a `\|` in a
+            // `!`-separated table is left untouched.
+            let escaped = format!("\\{}", separator as char);
+            let mut content = if data.contains(&escaped) {
+                Content::from_filtered(
+                    trimmed,
+                    data.replace(&escaped, &(separator as char).to_string()),
+                )
             } else {
                 Content::from(trimmed)
             };
@@ -1356,17 +1421,20 @@ fn expand_duplicates(cells: Vec<RawCell<'_>>) -> Vec<RawCell<'_>> {
 /// Scan a region for PSV cell boundaries, returning the [specifier](CellSpec)
 /// and raw (untrimmed) content span of each cell.
 ///
-/// A cell boundary is a vertical bar (`|`) that appears at the start of a line
-/// or is preceded by whitespace, optionally with a [cell specifier](CellSpec)
-/// (e.g. `^`, `2+`, `.>`) directly in front of the `|`. The token immediately
-/// preceding a `|` is taken to be a specifier when it parses as one (see
-/// [`parse_cell_spec`]); a token that doesn't parse as a specifier means the
-/// `|` is not a cell boundary. Content before the first boundary is ignored.
+/// A cell boundary is the table's `separator` byte (the vertical bar (`|`) by
+/// default, or the exclamation mark (`!`) for a nested table) that appears at
+/// the start of a line or is preceded by whitespace, optionally with a
+/// [cell specifier](CellSpec) (e.g. `^`, `2+`, `.>`) directly in front of the
+/// separator. The token immediately preceding a separator is taken to be a
+/// specifier when it parses as one (see [`parse_cell_spec`]); a token that
+/// doesn't parse as a specifier means the separator is not a cell boundary.
+/// Content before the first boundary is ignored.
 ///
-/// An escaped separator (`\|`) is preceded by a backslash, which is not a valid
-/// specifier, so the `|` already fails the boundary test and needs no special
-/// handling here; the backslash is stripped later in [`TableCell::parse`].
-fn scan_cells(region: Span<'_>) -> Vec<RawCell<'_>> {
+/// An escaped separator (e.g. `\|`) is preceded by a backslash, which is not a
+/// valid specifier, so the separator already fails the boundary test and needs
+/// no special handling here; the backslash is stripped later in
+/// [`TableCell::parse`].
+fn scan_cells(region: Span<'_>, separator: u8) -> Vec<RawCell<'_>> {
     let data = region.data();
     let bytes = data.as_bytes();
     let len = bytes.len();
@@ -1378,7 +1446,7 @@ fn scan_cells(region: Span<'_>) -> Vec<RawCell<'_>> {
     let mut i = 0;
 
     while i < len {
-        if bytes.get(i).copied() == Some(b'|') {
+        if bytes.get(i).copied() == Some(separator) {
             // Walk back to the start of the token directly preceding this `|`.
             // The token (a possible cell specifier) runs back to the previous
             // whitespace, tab, or newline, or to the start of the region; either

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -84,6 +84,17 @@ pub struct Parser {
     /// saved and restored around each cell, so the lock applies only within
     /// the cell (and nests correctly).
     pub(crate) locked_attribute_names: HashSet<String>,
+
+    /// Number of AsciiDoc table cells currently being parsed in the call stack.
+    ///
+    /// An AsciiDoc table cell creates a nested, standalone AsciiDoc document.
+    /// While that document is being parsed this counter is greater than zero,
+    /// which (matching Asciidoctor's `Document#nested?`) changes the default
+    /// cell separator of any table found inside from the vertical bar (`|`) to
+    /// the exclamation mark (`!`), so a nested table needs no explicit
+    /// `separator` attribute. The counter is incremented and decremented around
+    /// each AsciiDoc cell, so it nests correctly.
+    pub(crate) nested_document_depth: usize,
 }
 
 impl Default for Parser {
@@ -105,6 +116,7 @@ impl Default for Parser {
             topmost_section_type: SectionType::Normal,
             last_table_number: 0,
             locked_attribute_names: HashSet::new(),
+            nested_document_depth: 0,
         }
     }
 }

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -13,6 +13,7 @@ mod customize_title_label;
 mod duplicate_cells;
 mod format_cell_content;
 mod format_column_content;
+mod nested;
 mod orientation;
 mod span_cells;
 mod striping;

--- a/parser/src/tests/asciidoc_lang/tables/nested.rs
+++ b/parser/src/tests/asciidoc_lang/tables/nested.rs
@@ -110,11 +110,21 @@ To distinguish the inner table from the enclosing one, you need to use `!===` as
     assert_eq!(simple_text(&inner.body_rows()[0].cells()[1]), "C12");
 
     // A `!===` table at the top level (not inside an AsciiDoc cell) is still a
-    // table, but it separates on the default `|`, so a bare `!` there is literal
-    // text and does not begin a cell.
-    let top_level = parse_table("|===\n| a ! b\n|===");
+    // table — `parse_table` would panic if the `!===` delimiter were not
+    // recognized — but it separates on the default `|`, so the `|` begins the
+    // cell and a bare `!` is literal text that does not begin a cell.
+    let top_level = parse_table("!===\n| a ! b\n!===");
     assert_eq!(top_level.body_rows()[0].cells().len(), 1);
     assert_eq!(simple_text(&top_level.body_rows()[0].cells()[0]), "a ! b");
+
+    // The same top-level `!===` table behaves identically to its `|===`
+    // counterpart, confirming the leading delimiter character does not change
+    // the (top-level) default separator.
+    let pipe_level = parse_table("|===\n| a ! b\n|===");
+    assert_eq!(
+        simple_text(&top_level.body_rows()[0].cells()[0]),
+        simple_text(&pipe_level.body_rows()[0].cells()[0]),
+    );
 }
 
 #[test]

--- a/parser/src/tests/asciidoc_lang/tables/nested.rs
+++ b/parser/src/tests/asciidoc_lang/tables/nested.rs
@@ -1,0 +1,171 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/nested.adoc");
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Return the single nested [`TableBlock`] held by `cell`, panicking if the
+/// cell is not an [`AsciiDoc`](crate::blocks::TableCellContent::AsciiDoc) cell
+/// or does not contain exactly one table.
+fn nested_table<'a, 'src>(
+    cell: &'a crate::blocks::TableCell<'src>,
+) -> &'a crate::blocks::TableBlock<'src> {
+    match cell.content() {
+        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+            let tables: Vec<&crate::blocks::TableBlock<'src>> = blocks
+                .iter()
+                .filter_map(|block| match block {
+                    crate::blocks::Block::Table(table) => Some(table),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(tables.len(), 1, "expected exactly one nested table");
+            tables[0]
+        }
+        other => panic!("expected an AsciiDoc cell, got {other:?}"),
+    }
+}
+
+/// Return the rendered text of a [`Simple`](crate::blocks::TableCellContent)
+/// cell.
+fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
+    match cell.content() {
+        crate::blocks::TableCellContent::Simple(content) => content.rendered().to_string(),
+        crate::blocks::TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
+    }
+}
+
+// The `tag=nested` example from the page: an outer two-column table whose last
+// cell carries the AsciiDoc style (`a`) and holds a nested table. The nested
+// table has its own column spec, delimiter (`!===`), and cell separator (`!`).
+const NESTED_EXAMPLE: &str = "[cols=\"1,2a\"]\n|===\n| Col 1 | Col 2\n\n| Cell 1.1\n| Cell 1.2\n\n| Cell 2.1\n| Cell 2.2\n\n[cols=\"2,1\"]\n!===\n! Col1 ! Col2\n\n! C11\n! C12\n\n!===\n\n|===";
+
+non_normative!(
+    r#"
+= Nesting Tables
+
+"#
+);
+
+#[test]
+fn distinguish_inner_from_outer() {
+    verifies!(
+        r#"
+Table cells marked with the AsciiDoc table style (`a`) support nested tables in addition to normal block content.
+To distinguish the inner table from the enclosing one, you need to use `!===` as the table delimiter and a cell separator that differs from that used for the enclosing table.
+"#
+    );
+
+    // The outer table separates its cells with the default vertical bar (`|`).
+    // Its last column carries the AsciiDoc style (`a`), so the last body cell
+    // holds block content rather than inline content.
+    let outer = parse_table(NESTED_EXAMPLE);
+    assert_eq!(outer.body_rows().len(), 2);
+
+    let last_cell = &outer.body_rows()[1].cells()[1];
+    assert_eq!(last_cell.style(), ColumnStyle::AsciiDoc);
+
+    // The AsciiDoc cell holds a nested table in addition to its normal block
+    // content (the leading `Cell 2.2` paragraph).
+    match last_cell.content() {
+        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+            assert!(
+                blocks
+                    .iter()
+                    .any(|b| matches!(b, crate::blocks::Block::Table(_))),
+                "expected a nested table among the cell's blocks"
+            );
+            assert!(
+                blocks
+                    .iter()
+                    .any(|b| !matches!(b, crate::blocks::Block::Table(_))),
+                "expected normal block content alongside the nested table"
+            );
+        }
+        other => panic!("expected an AsciiDoc cell, got {other:?}"),
+    }
+
+    // The inner table is delimited by `!===` and separates its cells with `!`,
+    // which differs from the outer table's `|`. Because the separators differ,
+    // the outer table's `|` scan does not break the inner table apart: the inner
+    // `!`-separated cells are parsed as a complete two-column table.
+    let inner = nested_table(last_cell);
+    assert_eq!(inner.header_row().unwrap().cells().len(), 2);
+    assert_eq!(inner.body_rows().len(), 1);
+    assert_eq!(inner.body_rows()[0].cells().len(), 2);
+    assert_eq!(simple_text(&inner.body_rows()[0].cells()[0]), "C11");
+    assert_eq!(simple_text(&inner.body_rows()[0].cells()[1]), "C12");
+
+    // A `!===` table at the top level (not inside an AsciiDoc cell) is still a
+    // table, but it separates on the default `|`, so a bare `!` there is literal
+    // text and does not begin a cell.
+    let top_level = parse_table("|===\n| a ! b\n|===");
+    assert_eq!(top_level.body_rows()[0].cells().len(), 1);
+    assert_eq!(simple_text(&top_level.body_rows()[0].cells()[0]), "a ! b");
+}
+
+#[test]
+fn default_separator_and_override() {
+    verifies!(
+        r#"
+The default cell separator for a nested table is `!`, though you can choose another character by defining the `separator` attribute on the table.
+
+"#
+    );
+
+    // With no `separator` attribute, the nested table's cell separator defaults
+    // to `!`: the `!`-prefixed tokens begin cells and a `|` would be literal.
+    let outer = parse_table("|===\na|\n!===\n! one ! two\n!===\n|===");
+    let inner = nested_table(&outer.body_rows()[0].cells()[0]);
+    assert_eq!(inner.body_rows()[0].cells().len(), 2);
+    assert_eq!(simple_text(&inner.body_rows()[0].cells()[0]), "one");
+    assert_eq!(simple_text(&inner.body_rows()[0].cells()[1]), "two");
+
+    // The `separator` attribute overrides the default: here the nested table
+    // separates on `:` instead, so the `:`-prefixed tokens begin cells.
+    let outer = parse_table("|===\na|\n[separator=:]\n!===\n:one :two\n!===\n|===");
+    let inner = nested_table(&outer.body_rows()[0].cells()[0]);
+    assert_eq!(inner.body_rows()[0].cells().len(), 2);
+    assert_eq!(simple_text(&inner.body_rows()[0].cells()[0]), "one");
+    assert_eq!(simple_text(&inner.body_rows()[0].cells()[1]), "two");
+
+    // The `separator` attribute applies to an outer table as well, replacing the
+    // default `|` with the chosen character.
+    let outer = parse_table("[separator=;]\n|===\n;one ;two\n|===");
+    assert_eq!(outer.body_rows()[0].cells().len(), 2);
+    assert_eq!(simple_text(&outer.body_rows()[0].cells()[0]), "one");
+    assert_eq!(simple_text(&outer.body_rows()[0].cells()[1]), "two");
+}
+
+non_normative!(
+    r#"
+NOTE: Although nested tables are not technically valid in DocBook 5.0, the DocBook toolchain processes them anyway.
+
+The following example contains a nested table in the last cell.
+Notice the nested table has its own format, independent of that of the outer table:
+
+[source]
+----
+include::example$table.adoc[tag=nested]
+----
+
+.Result: A nested table
+include::example$table.adoc[tag=nested]
+
+We recommend using nested tables sparingly.
+There's usually a better way to present the information.
+"#
+);


### PR DESCRIPTION
Implements the **Nesting Tables** spec page (`docs/modules/tables/pages/nested.adoc`).

## What this adds

An AsciiDoc (`a`) table cell can now contain its own table:

- **`!===` delimiter** is recognized alongside `|===`.
- **Default separator switches to `!` inside an AsciiDoc cell.** A nested table is parsed inside a nested, standalone document; in that context the default cell separator becomes `!` (rather than `|`), so the inner table is distinguished from the enclosing `|`-separated table without the outer `|` scan tearing it apart. This mirrors Asciidoctor's `Document#nested?` behavior.
- **`separator` attribute** overrides the default separator with an explicit character at any nesting level (e.g. `[separator=:]`).
- **Escaping is separator-relative**: the active separator is unescaped (`\!` → `!` in a `!`-separated table), and a non-active separator is left untouched.

## Implementation notes

- `Parser` gains a `nested_document_depth` counter, incremented/decremented around the parse of an AsciiDoc cell's blocks, so any table found within picks the `!` default.
- The resolved separator byte is threaded through `scan_cells` and the cell-escape handling.
- At the top level, `!===` is still a valid table but separates on the default `|` (so a bare `!` is literal), matching Asciidoctor.

## Spec coverage

`docs/modules/tables/pages/nested.adoc` is fully covered (the three normative sentences are verified; the remainder is non-normative). Verified with the `sdd` tool — no uncovered lines.

## Testing

- `cargo test -p asciidoc-parser` — all pass (2025 tests).
- `cargo +nightly fmt --check`, `cargo clippy --all-targets`, and `RUSTDOCFLAGS=-D warnings cargo +nightly doc` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)