### PR TITLE
feat: Support CSV, TSV, and DSV table data formats

### DIFF
--- a/parser/src/blocks/mod.rs
+++ b/parser/src/blocks/mod.rs
@@ -66,7 +66,7 @@ pub use simple::{SimpleBlock, SimpleBlockStyle};
 
 mod table;
 pub use table::{
-    ColumnStyle, Frame, Grid, HorizontalAlignment, Stripes, TableBlock, TableCell,
+    ColumnStyle, DataFormat, Frame, Grid, HorizontalAlignment, Stripes, TableBlock, TableCell,
     TableCellContent, TableColumn, TableRow, VerticalAlignment,
 };
 

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1383,7 +1383,7 @@ fn squeeze_quotes(text: &str) -> String {
 /// Note: the escaped-pair collapse (`replace("\"\"", "")`) runs before the
 /// start/end check, so `"""` collapses to a single `"` and is reported
 /// *closed*. Strict RFC 4180 would read `"""` as an unclosed field (open quote
-/// + escaped `""` + missing close); this matches Asciidoctor's
+/// plus escaped `""` + missing close); this matches Asciidoctor's
 /// `buffer_has_unclosed_quotes?` instead, so the divergence is intentional.
 fn has_unclosed_quotes(buffer: &str) -> bool {
     let record = buffer.trim();

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1170,14 +1170,13 @@ fn build_data_table<'src>(
     } = body;
     let separator = separator.as_str();
 
-    let (fields, first_row_len) = match data_format {
-        // CSV and TSV share their parsing rules and differ only in the default
-        // separator (resolved by the caller).
-        DataFormat::Csv | DataFormat::Tsv => parse_csv_fields(inside, separator),
-        // DSV is parsed by its own, simpler rules.
-        DataFormat::Dsv => parse_dsv_fields(inside, separator),
-        // PSV never reaches this builder.
-        DataFormat::Psv => (vec![], 0),
+    // DSV is parsed by its own, simpler rules; CSV and TSV share their rules and
+    // differ only in the default separator (resolved by the caller). PSV never
+    // reaches this builder.
+    let (fields, first_row_len) = if data_format == DataFormat::Dsv {
+        parse_dsv_fields(inside, separator)
+    } else {
+        parse_csv_fields(inside, separator)
     };
 
     let ncols = if cols_attr.is_empty() {
@@ -1232,6 +1231,13 @@ struct DataField<'src> {
 /// quote is written by doubling it (`""`). A newline that is not inside a
 /// quoted value ends the row. The fields are returned flat; the caller flows
 /// them into rows.
+///
+/// This mirrors Asciidoctor's `Table::ParserContext`: a separator or newline is
+/// a cell boundary only when the text accumulated since the previous boundary
+/// has no [unclosed quote](has_unclosed_quotes); otherwise it is part of the
+/// value. As a result a value whose opening quote is never properly closed (or
+/// that has trailing characters after its closing quote) keeps its quotes and
+/// absorbs the following separators, rather than being treated as enclosed.
 fn parse_csv_fields<'src>(region: Span<'src>, separator: &str) -> (Vec<DataField<'src>>, usize) {
     let data = region.data();
     let n = data.len();
@@ -1241,143 +1247,150 @@ fn parse_csv_fields<'src>(region: Span<'src>, separator: &str) -> (Vec<DataField
 
     let mut fields: Vec<DataField<'src>> = vec![];
     let mut first_row_len = 0usize;
-    let mut row_count = 0usize;
+    let mut first_row_done = false;
+    let mut fields_in_row = 0usize;
+
+    // The raw text of the cell currently being accumulated runs from `cell_start`
+    // to the next boundary.
+    let mut cell_start = 0usize;
     let mut i = 0usize;
 
-    while i < n {
-        // Skip a blank (whitespace-only) physical line at a row boundary.
-        let mut line_end = i;
-        while line_end < n && at(line_end) != Some(b'\n') {
-            line_end += 1;
-        }
-        if data.get(i..line_end).unwrap_or("").trim().is_empty() {
-            i = if line_end < n { line_end + 1 } else { line_end };
+    while i <= n {
+        let at_eof = i == n;
+        let at_sep = !at_eof && starts_with_sep(i);
+        let at_nl = !at_eof && at(i) == Some(b'\n');
+
+        if !(at_eof || at_sep || at_nl) {
+            i += 1;
             continue;
         }
 
-        // Parse one row, field by field, until an unquoted newline (or EOF).
-        let mut fields_in_row = 0usize;
-        loop {
-            // Skip leading whitespace to detect a quoted value, but never skip a
-            // separator (so a leading tab in a TSV table starts an empty field).
-            let mut start = i;
-            while matches!(at(start), Some(b' ' | b'\t')) && !starts_with_sep(start) {
-                start += 1;
-            }
+        let raw = data.get(cell_start..i).unwrap_or_default();
 
-            let (field, after, ended_row) = if at(start) == Some(b'"') {
-                parse_csv_quoted_field(region, start + 1, &starts_with_sep)
-            } else {
-                // An unquoted value runs to the next separator or newline.
-                let mut q = i;
-                while q < n && at(q) != Some(b'\n') && !starts_with_sep(q) {
-                    q += 1;
-                }
-                let trimmed = trim_surrounding_whitespace(region.slice(i..q));
-                let ended_row = q >= n || at(q) == Some(b'\n');
-                (
-                    DataField {
-                        content: trimmed,
-                        replacement: None,
-                    },
-                    q,
-                    ended_row,
-                )
-            };
+        // A separator or newline that falls inside an unclosed quoted value is
+        // part of the value, not a boundary; absorb it and keep scanning.
+        if !at_eof && has_unclosed_quotes(raw) {
+            i += if at_sep { sep_len } else { 1 };
+            continue;
+        }
 
-            fields.push(field);
+        // A wholly blank physical line (or trailing blank text at the end of the
+        // region) between rows is skipped rather than emitted as an empty cell. A
+        // blank cell that follows a separator on a populated line is kept.
+        let blank_skip = (at_nl || at_eof) && fields_in_row == 0 && raw.trim().is_empty();
+        if !blank_skip {
+            fields.push(make_csv_field(region, cell_start, i));
             fields_in_row += 1;
-
-            if ended_row {
-                i = if after < n { after + 1 } else { after };
-                break;
+            if !first_row_done {
+                first_row_len = fields_in_row;
             }
-            i = after + sep_len;
         }
 
-        if row_count == 0 {
-            first_row_len = fields_in_row;
+        if at_eof {
+            break;
         }
-        row_count += 1;
+
+        if at_nl {
+            // The newline ends the row. The first populated row fixes the implicit
+            // column count.
+            if fields_in_row > 0 {
+                first_row_done = true;
+            }
+            fields_in_row = 0;
+            cell_start = i + 1;
+            i += 1;
+        } else {
+            cell_start = i + sep_len;
+            i += sep_len;
+        }
     }
 
     (fields, first_row_len)
 }
 
-/// Parse a CSV/TSV quoted value beginning just after its opening quote
-/// (`value_start`), returning the field, the byte offset just past the closing
-/// quote and any trailing characters, and whether the value ends the row.
+/// Build a CSV/TSV [field](DataField) from the byte range `start..end`,
+/// applying Asciidoctor's `close_cell` value processing.
 ///
-/// A doubled quote (`""`) inside the value is an escaped literal quote. After
-/// the closing quote, any characters up to the next separator or newline are
-/// ignored. A value with no closing quote runs to the end of the region.
-fn parse_csv_quoted_field<'src>(
-    region: Span<'src>,
-    value_start: usize,
-    starts_with_sep: &impl Fn(usize) -> bool,
-) -> (DataField<'src>, usize, bool) {
-    let data = region.data();
-    let n = data.len();
-    let at = |k: usize| data.as_bytes().get(k).copied();
+/// The value is stripped of surrounding whitespace; then, if it is enclosed in
+/// double quotes, the quotes are removed and the inner value is stripped again;
+/// finally any run of consecutive double quotes is collapsed to one (so an
+/// escaped `""` becomes a single `"`). A value that is not enclosed (no leading
+/// quote, an unclosed quote, or trailing characters after the closing quote)
+/// keeps its quotes and is only collapsed.
+fn make_csv_field<'src>(region: Span<'src>, start: usize, end: usize) -> DataField<'src> {
+    let trimmed = trim_surrounding_whitespace(region.slice(start..end));
+    let value = csv_cell_value(trimmed.data());
+    let replacement = (value != trimmed.data()).then_some(value);
+    DataField {
+        content: trimmed,
+        replacement,
+    }
+}
 
-    let mut buf = String::new();
-    let mut has_escape = false;
-    let mut seg_start = value_start;
-    let mut q = value_start;
-    let inner_end;
-    loop {
-        if q >= n {
-            inner_end = n;
-            break;
+/// Apply Asciidoctor's CSV value processing to an already-stripped cell value:
+/// unquote an enclosed value and collapse escaped double quotes (`""` -> `"`).
+fn csv_cell_value(text: &str) -> String {
+    if text.is_empty() || !text.contains('"') {
+        return text.to_string();
+    }
+
+    // An enclosed value (leading and trailing quote) has its quotes removed and
+    // is stripped again; a lone `"` becomes empty. Anything else keeps its text.
+    if text.starts_with('"') && text.ends_with('"') {
+        match text.get(1..text.len() - 1) {
+            Some(inner) => squeeze_quotes(inner.trim()),
+            None => String::new(),
         }
-        if at(q) == Some(b'"') {
-            if at(q + 1) == Some(b'"') {
-                // A doubled quote collapses to a single literal quote: keep the
-                // first quote (part of the preceding segment) and skip the second.
-                has_escape = true;
-                buf.push_str(data.get(seg_start..=q).unwrap_or_default());
-                q += 2;
-                seg_start = q;
+    } else {
+        squeeze_quotes(text)
+    }
+}
+
+/// Collapse every run of consecutive double quotes to a single double quote,
+/// matching Ruby's `String#squeeze('"')`.
+fn squeeze_quotes(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut prev_quote = false;
+    for c in text.chars() {
+        if c == '"' {
+            if prev_quote {
                 continue;
             }
-            // A lone quote closes the value.
-            inner_end = q;
-            break;
+            prev_quote = true;
+        } else {
+            prev_quote = false;
         }
-        q += 1;
+        out.push(c);
     }
-    if has_escape {
-        buf.push_str(data.get(seg_start..inner_end).unwrap_or_default());
+    out
+}
+
+/// Determine whether `buffer` (the cell text accumulated so far) holds an
+/// unclosed double quote, a direct port of Asciidoctor's
+/// `Table::ParserContext#buffer_has_unclosed_quotes?`.
+///
+/// Only a value that begins with a double quote can be "quoted"; for any other
+/// value embedded quotes are literal and this returns `false`. A leading quote
+/// is unclosed until a matching trailing quote appears (accounting for escaped
+/// `""` pairs).
+fn has_unclosed_quotes(buffer: &str) -> bool {
+    let record = buffer.trim();
+
+    if record == "\"" {
+        return true;
     }
 
-    // Advance past the closing quote (if any), then ignore trailing characters
-    // up to the next separator or newline.
-    let mut after = if at(inner_end) == Some(b'"') {
-        inner_end + 1
+    if !record.starts_with('"') {
+        return false;
+    }
+
+    let trailing_quote = record.ends_with('"');
+    if (trailing_quote && record.ends_with("\"\"")) || record.starts_with("\"\"") {
+        let collapsed = record.replace("\"\"", "");
+        collapsed.starts_with('"') && !collapsed.ends_with('"')
     } else {
-        inner_end
-    };
-    while after < n && at(after) != Some(b'\n') && !starts_with_sep(after) {
-        after += 1;
+        !trailing_quote
     }
-    let ended_row = after >= n || at(after) == Some(b'\n');
-
-    let trimmed = trim_surrounding_whitespace(region.slice(value_start..inner_end));
-    let replacement = if has_escape {
-        let value = buf.trim().to_string();
-        (value != trimmed.data()).then_some(value)
-    } else {
-        None
-    };
-
-    (
-        DataField {
-            content: trimmed,
-            replacement,
-        },
-        after,
-        ended_row,
-    )
 }
 
 /// Parse a DSV region into its [fields](DataField), returning them in document

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1348,6 +1348,12 @@ fn csv_cell_value(text: &str) -> String {
 
 /// Collapse every run of consecutive double quotes to a single double quote,
 /// matching Ruby's `String#squeeze('"')`.
+///
+/// Note: the `continue` intentionally leaves `prev_quote` set, so a run of
+/// *N ≥ 2* consecutive `"` collapses to a single `"` (e.g. `""""` -> `"`), not
+/// to pairs. This deliberately matches Asciidoctor rather than strict RFC 4180,
+/// under which only `""` is a double-quote escape — don't "fix" it to a
+/// two-character collapse without also changing Asciidoctor.
 fn squeeze_quotes(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     let mut prev_quote = false;
@@ -1373,6 +1379,12 @@ fn squeeze_quotes(text: &str) -> String {
 /// value embedded quotes are literal and this returns `false`. A leading quote
 /// is unclosed until a matching trailing quote appears (accounting for escaped
 /// `""` pairs).
+///
+/// Note: the escaped-pair collapse (`replace("\"\"", "")`) runs before the
+/// start/end check, so `"""` collapses to a single `"` and is reported
+/// *closed*. Strict RFC 4180 would read `"""` as an unclosed field (open quote
+/// + escaped `""` + missing close); this matches Asciidoctor's
+/// `buffer_has_unclosed_quotes?` instead, so the divergence is intentional.
 fn has_unclosed_quotes(buffer: &str) -> bool {
     let record = buffer.trim();
 

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -26,26 +26,29 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 /// columns.
 ///
 /// A table is introduced by a table delimiter (`|===`, or `!===` for a nested
-/// table) and closed by a matching delimiter. Cells are separated using
-/// prefix-separated value (PSV) syntax: the table's cell separator — a vertical
-/// bar (`|`) by default — at the start of a line or preceded by whitespace
-/// begins a new cell. Cells flow, in document order, into rows whose length is
-/// fixed by the number of columns. (The separator defaults to `!` inside a
-/// nested table and can be overridden with the `separator` attribute; see
-/// below.)
+/// table) and closed by a matching delimiter. By default cells are separated
+/// using prefix-separated value (PSV) syntax: the table's cell separator — a
+/// vertical bar (`|`) by default — at the start of a line or preceded by
+/// whitespace begins a new cell. Cells flow, in document order, into rows whose
+/// length is fixed by the number of columns. (The separator defaults to `!`
+/// inside a nested table and can be overridden with the `separator` attribute;
+/// see below.)
 ///
 /// The number of columns is determined either by the `cols` attribute or,
 /// implicitly, by the number of cells found in the first non-empty line after
 /// the opening delimiter.
 ///
-/// # Not yet supported
+/// # Data formats
 ///
-/// This is an initial implementation covering the basic PSV table. The
-/// following table features are recognized by the wider AsciiDoc specification
-/// but are not yet implemented:
-///
-/// * The CSV, TSV, and DSV data formats (and the `,===` / `:===` shorthand
-///   delimiters).
+/// In addition to the default PSV format, a table can be populated from
+/// delimiter-separated data with the [`format`](Self::data_format) attribute:
+/// `csv` (comma-separated values), `tsv` (tab-separated values), or `dsv`
+/// (delimited values, colon-separated by default). The `,===` and `:===`
+/// shorthand delimiters select the CSV and DSV formats respectively without an
+/// explicit `format` attribute. In a data format the separator is placed
+/// *between* values (not in front of each cell) and a cell carries no
+/// formatting spec; cell formatting is instead applied per column with the
+/// `cols` attribute. See [`DataFormat`] for the parsing rules.
 ///
 /// Column specifier style operators (the `a`, `d`, `e`, `h`, `l`, `m`, and `s`
 /// operators) are supported, along with proportional width and the horizontal
@@ -81,6 +84,7 @@ const ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES: &[&str] =
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TableBlock<'src> {
     columns: Vec<TableColumn>,
+    data_format: DataFormat,
     header_row: Option<TableRow<'src>>,
     body_rows: Vec<TableRow<'src>>,
     footer_row: Option<TableRow<'src>>,
@@ -99,20 +103,23 @@ pub struct TableBlock<'src> {
 impl<'src> TableBlock<'src> {
     /// Returns `true` if `line` is a table delimiter.
     ///
-    /// A table delimiter is a vertical bar (`|`) or an exclamation mark (`!`)
-    /// followed by three or more equals signs (`===`). The `!===` form opens a
-    /// table whose default cell separator is the exclamation mark, which lets a
-    /// nested table be distinguished from the `|`-separated table that encloses
-    /// it.
+    /// A table delimiter is one of the lead characters `|`, `!`, `,`, or `:`
+    /// followed by three or more equals signs (`===`). The lead character also
+    /// selects the table's data format and default cell separator:
     ///
-    /// **NOTE:** The `,===` (CSV) and `:===` (DSV) shorthand delimiters are not
-    /// yet recognized.
+    /// * `|===` is the ordinary (PSV) table delimiter.
+    /// * `!===` opens a table whose default cell separator is the exclamation
+    ///   mark, which lets a nested table be distinguished from the
+    ///   `|`-separated table that encloses it.
+    /// * `,===` is the shorthand for a CSV table.
+    /// * `:===` is the shorthand for a DSV table.
     pub(crate) fn is_table_delimiter(line: &Span<'src>) -> bool {
         let data = line.data();
-        // `len() >= 4` plus the leading `|`/`!` guarantees `rest` holds at least
-        // three bytes, so the closure only needs to confirm they are all `=`.
+        // `len() >= 4` plus the leading delimiter character guarantees `rest`
+        // holds at least three bytes, so the closure only needs to confirm they
+        // are all `=`.
         data.len() >= 4
-            && (data.starts_with('|') || data.starts_with('!'))
+            && matches!(data.as_bytes().first(), Some(b'|' | b'!' | b',' | b':'))
             && data
                 .get(1..)
                 .is_some_and(|rest| rest.bytes().all(|b| b == b'='))
@@ -146,57 +153,40 @@ impl<'src> TableBlock<'src> {
 
         let inside = delimiter.after.trim_remainder(closing_delimiter);
 
-        // The cell separator partitions each row into cells. It defaults to the
-        // vertical bar (`|`), except inside an AsciiDoc table cell — a nested,
-        // standalone document — where it defaults to the exclamation mark (`!`)
-        // so a nested table is distinguished from the `|`-separated table that
-        // encloses it. The `separator` attribute overrides the default with an
-        // explicit character; an empty `separator` falls back to the default.
-        let separator = resolve_separator(metadata, parser);
+        // The data format governs how the table body is split into cells. It
+        // defaults to PSV, but the `format` attribute selects CSV, TSV, or DSV,
+        // and the `,===` / `:===` shorthand delimiters select CSV / DSV. The
+        // lead character of the delimiter (`delimiter_text`) is passed so the
+        // shorthand can be honored.
+        let data_format = resolve_data_format(metadata, delimiter_text);
 
-        // Determine the number of columns, either from the `cols` attribute or
-        // implicitly from the number of cells in the first non-empty line.
-        let columns: Vec<TableColumn> = metadata
+        // The cell separator partitions each row into cells. In PSV it defaults
+        // to the vertical bar (`|`), except inside an AsciiDoc table cell — a
+        // nested, standalone document — where it defaults to the exclamation
+        // mark (`!`) so a nested table is distinguished from the `|`-separated
+        // table that encloses it. Each data format has its own default (CSV =
+        // comma, TSV = tab, DSV = colon). The `separator` attribute overrides
+        // the default; an empty `separator` falls back to the default, and the
+        // two-character sequence `\t` is interpreted as a tab.
+        let separator = resolve_separator(metadata, parser, data_format);
+
+        // The `cols` attribute, when present, fixes the number of columns and
+        // carries the per-column formatting. When it is absent the column count
+        // is implicit (resolved per format below).
+        let cols_attr: Vec<TableColumn> = metadata
             .attrlist
             .as_ref()
             .and_then(|a| a.named_attribute("cols"))
             .map(|attr| parse_cols(attr.value()))
             .unwrap_or_default();
 
-        // When the column count is implicit, it is the number of column slots in
-        // the first non-empty line: a cell that spans columns (`<n>+`) counts as
-        // `<n>` slots, not one, and a cell duplicated `<n>` times (`<n>*`) counts
-        // as `<n>` single-column slots (one per clone).
-        let first_line_cells: usize =
-            scan_cells(inside.discard_empty_lines().take_line().item, separator)
-                .iter()
-                .map(|c| c.spec.colspan.max(1) * c.spec.repeat.min(MAX_DUPLICATION_FACTOR))
-                .sum();
-
-        let ncols = if columns.is_empty() {
-            first_line_cells
-        } else {
-            columns.len()
-        };
-
-        let mut columns: Vec<TableColumn> = if columns.is_empty() {
-            (0..ncols).map(|_| TableColumn::default()).collect()
-        } else {
-            columns
-        };
-
         // The `autowidth` option sizes the table to its content; the columns
         // inherit the setting, so every column becomes autowidth regardless of
         // any proportional width set on its specifier.
-        if metadata
+        let autowidth = metadata
             .attrlist
             .as_ref()
-            .is_some_and(|a| a.has_option("autowidth"))
-        {
-            for column in columns.iter_mut() {
-                column.autowidth = true;
-            }
-        }
+            .is_some_and(|a| a.has_option("autowidth"));
 
         // The first row is an (implicit) header row when the line directly after
         // the opening delimiter is non-empty and is itself followed by an empty
@@ -278,119 +268,24 @@ impl<'src> TableBlock<'src> {
         let stripes =
             resolve_table_attribute::<Stripes>(metadata, parser, "stripes", "table-stripes");
 
-        // Scan every cell in the table, in document order, then partition into
-        // rows by walking the grid: a cell's span (colspan/rowspan) governs how
-        // many column slots it occupies, so a column-spanning cell fills its row
-        // with fewer cells and a row-spanning cell carries its columns down into
-        // the rows below.
-        //
-        // This mirrors Asciidoctor's grid walk. `active_rowspans[k]` records the
-        // number of column slots that cells from earlier rows occupy in the row
-        // `k` steps ahead of the one being filled; a row closes once its own
-        // cells' colspans plus the slots carried into it (`active_rowspans[0]`)
-        // reach `ncols`. A cell whose span pushes the row *past* `ncols` overruns
-        // the grid: the whole overrunning row is dropped (with a warning), again
-        // matching Asciidoctor. A row whose columns are entirely pre-filled by
-        // carried slots has no cells of its own to close it, so the next cell
-        // overruns and is dropped together with that pre-filled row.
-        // A duplicated cell (`<n>*`) is expanded into `<n>` independent cells —
-        // each carrying the original's content, alignment, and style — before the
-        // grid walk, so each clone occupies its own column slot exactly like an
-        // ordinary cell. A duplication factor of zero drops the cell entirely.
+        // Split the body into columns and rows according to the data format.
+        // PSV walks a grid that honors cell spans and duplication; the data
+        // formats (CSV/TSV/DSV) split on a separator with no per-cell spec and
+        // flow the values into fixed-width rows.
         let mut warnings: Vec<Warning<'src>> = vec![];
-        let raw_cells = expand_duplicates(scan_cells(inside, separator));
-
-        // A table can never have more rows than it has cells, so a row span is
-        // clamped to the cell count for the `active_rowspans` bookkeeping below: a
-        // larger span carries into rows that can't exist and so has no additional
-        // layout effect. The clamp also bounds the `active_rowspans` allocation,
-        // so a hostile specifier such as `.1000000000+` can't trigger a
-        // multi-gigabyte allocation. (The cell's reported [`rowspan`] keeps the
-        // literal parsed value, matching Asciidoctor.)
-        //
-        // [`rowspan`]: TableCell::rowspan
-        let max_rowspan = raw_cells.len().saturating_add(1);
-
-        let mut raw_rows: Vec<Vec<RawCell<'src>>> = vec![];
-        if ncols > 0 {
-            let mut active_rowspans: Vec<usize> = vec![0];
-            let mut column_visits = 0usize;
-            let mut current_row: Vec<RawCell<'src>> = vec![];
-
-            for raw in raw_cells {
-                let colspan = raw.spec.colspan.max(1);
-                let rowspan = raw.spec.rowspan.max(1).min(max_rowspan);
-
-                // A cell that spans more than one row reserves `colspan` slots in
-                // each of the rows it extends into (but not its own row).
-                if rowspan > 1 {
-                    if active_rowspans.len() < rowspan {
-                        active_rowspans.resize(rowspan, 0);
-                    }
-                    for slot in active_rowspans.iter_mut().take(rowspan).skip(1) {
-                        *slot += colspan;
-                    }
-                }
-
-                column_visits += colspan;
-                let cell_source = raw.content;
-                current_row.push(raw);
-
-                // The slots carried into the current row are `active_rowspans[0]`;
-                // the vector is never empty here, so the fallback is unreachable.
-                let carried = active_rowspans.first().copied().unwrap_or(0);
-                let effective = column_visits + carried;
-                if effective >= ncols {
-                    if effective == ncols {
-                        raw_rows.push(std::mem::take(&mut current_row));
-                    } else {
-                        // Overrun: this cell's span pushes the row past `ncols`.
-                        // Discard the whole row so the remaining cells stay
-                        // aligned to the grid.
-                        current_row.clear();
-                        warnings.push(Warning {
-                            source: cell_source,
-                            warning: WarningType::TableCellExceedsColumnCount,
-                        });
-                    }
-                    column_visits = 0;
-                    active_rowspans.remove(0);
-                    if active_rowspans.is_empty() {
-                        active_rowspans.push(0);
-                    }
-                }
+        let body = TableBody {
+            inside,
+            separator,
+            cols_attr,
+            autowidth,
+            has_header,
+        };
+        let (columns, rows) = match data_format {
+            DataFormat::Psv => build_psv_table(body, parser, &mut warnings),
+            DataFormat::Csv | DataFormat::Tsv | DataFormat::Dsv => {
+                build_data_table(body, data_format, parser, &mut warnings)
             }
-
-            // A trailing incomplete row (one that never reached `ncols`) is still
-            // emitted, matching the existing handling of short final rows.
-            if !current_row.is_empty() {
-                raw_rows.push(current_row);
-            }
-        }
-
-        // Each cell is processed according to the style of the column it falls
-        // in. A cell's column is its ordinal position within its row (matching
-        // Asciidoctor, which assigns the column by cell count, not grid slot). The
-        // header row (when present) is the first row and is always processed as
-        // plain header content, regardless of the column styles, so that a style
-        // operator doesn't affect the header row.
-        let mut rows: Vec<TableRow<'src>> = Vec::with_capacity(raw_rows.len());
-        for (row_idx, raw_row) in raw_rows.into_iter().enumerate() {
-            let is_header = has_header && row_idx == 0;
-            let mut cells = Vec::with_capacity(raw_row.len());
-            for (col_idx, raw) in raw_row.into_iter().enumerate() {
-                let column = columns.get(col_idx).cloned().unwrap_or_default();
-                cells.push(TableCell::parse(
-                    raw,
-                    &column,
-                    is_header,
-                    separator,
-                    parser,
-                    &mut warnings,
-                ));
-            }
-            rows.push(TableRow { cells });
-        }
+        };
 
         let mut rows = rows.into_iter();
         let header_row = if has_header { rows.next() } else { None };
@@ -417,6 +312,7 @@ impl<'src> TableBlock<'src> {
             item: Some(MatchedItem {
                 item: Self {
                     columns,
+                    data_format,
                     header_row,
                     body_rows,
                     footer_row,
@@ -454,6 +350,16 @@ impl<'src> TableBlock<'src> {
     /// Returns the columns of this table.
     pub fn columns(&self) -> &[TableColumn] {
         &self.columns
+    }
+
+    /// Returns the [`DataFormat`] used to populate this table.
+    ///
+    /// The format comes from the `format` attribute on the table (`psv`, `csv`,
+    /// `tsv`, or `dsv`) or from a shorthand delimiter (`,===` selects CSV,
+    /// `:===` selects DSV). When neither is present the format defaults to
+    /// [`DataFormat::Psv`].
+    pub fn data_format(&self) -> DataFormat {
+        self.data_format
     }
 
     /// Returns the fixed width of this table, as a percentage of the content
@@ -693,6 +599,46 @@ impl Default for TableColumn {
             style: ColumnStyle::Default,
         }
     }
+}
+
+/// The data format that governs how a [`TableBlock`]'s body is split into
+/// cells.
+///
+/// The format is selected by the `format` attribute (`psv`, `csv`, `tsv`, or
+/// `dsv`) or by a shorthand delimiter (`,===` for CSV, `:===` for DSV). The
+/// default is [`Psv`](Self::Psv).
+///
+/// In the PSV format the separator is placed in front of each cell and a cell
+/// may carry a formatting spec. In the delimiter-separated formats (CSV, TSV,
+/// and DSV) the separator is placed *between* values and a cell carries no
+/// spec; cell formatting is applied per column with the `cols` attribute
+/// instead. In every delimiter-separated format empty lines are skipped,
+/// whitespace surrounding each value is stripped, and a "ragged" table (whose
+/// rows do not all have the same number of cells) has its cells flowed into
+/// fixed-width rows, dropping any cells left over at the end.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum DataFormat {
+    /// Prefix-separated values: the default format. The separator (a vertical
+    /// bar, `|`, by default) is placed in front of each cell.
+    #[default]
+    Psv,
+
+    /// Comma-separated values (the `csv` format). The default separator is a
+    /// comma (`,`). Values may be enclosed in double quotes (`"`), within which
+    /// the separator and newlines are literal and a double quote is written by
+    /// doubling it (`""`); a newline that is not inside a quoted value begins a
+    /// new row. Loosely based on RFC 4180.
+    Csv,
+
+    /// Tab-separated values (the `tsv` format). Parsed by the same rules as
+    /// [`Csv`](Self::Csv), but the default separator is a tab.
+    Tsv,
+
+    /// Delimited values (the `dsv` format). The default separator is a colon
+    /// (`:`). Unlike CSV and TSV, an enclosing character is not recognized;
+    /// instead the separator can be included in a value by escaping it with a
+    /// single backslash (`\:`).
+    Dsv,
 }
 
 /// The style applied to the content of a [column](TableColumn) (and, by
@@ -942,21 +888,63 @@ fn resolve_table_attribute<B: TableAttributeValue>(
     }
 }
 
-/// Resolve the cell separator byte for a table.
+/// Resolve the [`DataFormat`] of a table.
 ///
-/// The separator defaults to the vertical bar (`|`), except inside an AsciiDoc
-/// table cell — a nested, standalone document — where it defaults to the
-/// exclamation mark (`!`), so a nested table is distinguished from the
-/// `|`-separated table that encloses it. An explicit `separator` attribute on
-/// the table overrides the default with its first byte; an empty `separator`
-/// value (e.g. `[separator=]`) falls back to the default. A non-ASCII first
-/// character is ignored (the byte-oriented cell scanner only recognizes a
-/// single-byte separator), so it too falls back to the default.
-fn resolve_separator(metadata: &BlockMetadata<'_>, parser: &Parser) -> u8 {
-    let default = if parser.nested_document_depth > 0 {
-        b'!'
-    } else {
-        b'|'
+/// An explicit, recognized `format` attribute (`psv`, `csv`, `tsv`, or `dsv`)
+/// always wins. Otherwise the lead character of the delimiter selects the
+/// format via its shorthand — `,===` is CSV and `:===` is DSV — and any other
+/// delimiter (`|===`, `!===`) is PSV.
+fn resolve_data_format(metadata: &BlockMetadata<'_>, delimiter_text: &str) -> DataFormat {
+    if let Some(attr) = metadata
+        .attrlist
+        .as_ref()
+        .and_then(|a| a.named_attribute("format"))
+    {
+        match attr.value().trim() {
+            "psv" => return DataFormat::Psv,
+            "csv" => return DataFormat::Csv,
+            "tsv" => return DataFormat::Tsv,
+            "dsv" => return DataFormat::Dsv,
+            // An unrecognized format value falls through to the shorthand (or
+            // the PSV default).
+            _ => {}
+        }
+    }
+
+    match delimiter_text.as_bytes().first() {
+        Some(b',') => DataFormat::Csv,
+        Some(b':') => DataFormat::Dsv,
+        _ => DataFormat::Psv,
+    }
+}
+
+/// Resolve the cell separator for a table.
+///
+/// Each [`DataFormat`] supplies a default separator: PSV uses the vertical bar
+/// (`|`), except inside an AsciiDoc table cell — a nested, standalone document
+/// — where it defaults to the exclamation mark (`!`) so a nested table is
+/// distinguished from the `|`-separated table that encloses it; CSV defaults to
+/// a comma (`,`), TSV to a tab, and DSV to a colon (`:`). An explicit
+/// `separator` attribute on the table overrides the default; an empty
+/// `separator` value (e.g. `[separator=]`) falls back to the default. The
+/// two-character sequence `\t` in the attribute value is interpreted as a tab,
+/// so a tab-separated table can be written `[format=csv,separator=\t]`.
+fn resolve_separator(
+    metadata: &BlockMetadata<'_>,
+    parser: &Parser,
+    data_format: DataFormat,
+) -> String {
+    let default = match data_format {
+        DataFormat::Psv => {
+            if parser.nested_document_depth > 0 {
+                "!"
+            } else {
+                "|"
+            }
+        }
+        DataFormat::Csv => ",",
+        DataFormat::Tsv => "\t",
+        DataFormat::Dsv => ":",
     };
 
     metadata
@@ -965,9 +953,609 @@ fn resolve_separator(metadata: &BlockMetadata<'_>, parser: &Parser) -> u8 {
         .and_then(|a| a.named_attribute("separator"))
         .map(|attr| attr.value())
         .filter(|value| !value.is_empty())
-        .and_then(|value| value.chars().next())
-        .filter(char::is_ascii)
-        .map_or(default, |c| c as u8)
+        // The author writes a literal tab as the escape sequence `\t`.
+        .map(|value| value.replace("\\t", "\t"))
+        .unwrap_or_else(|| default.to_string())
+}
+
+/// Finalize a table's columns once the column count is known.
+///
+/// When the `cols` attribute supplied columns (`cols_attr` is non-empty) they
+/// are used as-is; otherwise `ncols` default columns are created. When the
+/// table carries the `autowidth` option, every column is made autowidth
+/// regardless of the proportional width set on its specifier.
+fn finalize_columns(
+    cols_attr: Vec<TableColumn>,
+    ncols: usize,
+    autowidth: bool,
+) -> Vec<TableColumn> {
+    let mut columns = if cols_attr.is_empty() {
+        (0..ncols).map(|_| TableColumn::default()).collect()
+    } else {
+        cols_attr
+    };
+
+    if autowidth {
+        for column in columns.iter_mut() {
+            column.autowidth = true;
+        }
+    }
+
+    columns
+}
+
+/// The inputs shared by the PSV and data-format table-body builders.
+struct TableBody<'src> {
+    /// The region between the opening and closing delimiters.
+    inside: Span<'src>,
+    /// The resolved cell separator.
+    separator: String,
+    /// Columns parsed from the `cols` attribute (empty when the attribute is
+    /// absent, in which case the column count is implicit).
+    cols_attr: Vec<TableColumn>,
+    /// Whether the table carries the `autowidth` option.
+    autowidth: bool,
+    /// Whether the first row is a header row.
+    has_header: bool,
+}
+
+/// Build the columns and rows of a PSV (prefix-separated values) table.
+///
+/// The column count comes from the `cols` attribute (`cols_attr`) or, when that
+/// is absent, from the number of column slots in the first non-empty line.
+/// Cells are then scanned in document order and partitioned into rows by
+/// walking the grid: a cell's span (colspan/rowspan) governs how many column
+/// slots it occupies, so a column-spanning cell fills its row with fewer cells
+/// and a row-spanning cell carries its columns down into the rows below.
+///
+/// This mirrors Asciidoctor's grid walk. `active_rowspans[k]` records the
+/// number of column slots that cells from earlier rows occupy in the row `k`
+/// steps ahead of the one being filled; a row closes once its own cells'
+/// colspans plus the slots carried into it (`active_rowspans[0]`) reach
+/// `ncols`. A cell whose span pushes the row *past* `ncols` overruns the grid:
+/// the whole overrunning row is dropped (with a warning), again matching
+/// Asciidoctor. A row whose columns are entirely pre-filled by carried slots
+/// has no cells of its own to close it, so the next cell overruns and is
+/// dropped together with that pre-filled row. A duplicated cell (`<n>*`) is
+/// expanded into `<n>` independent cells — each carrying the original's
+/// content, alignment, and style — before the grid walk, so each clone occupies
+/// its own column slot exactly like an ordinary cell. A duplication factor of
+/// zero drops the cell entirely.
+fn build_psv_table<'src>(
+    body: TableBody<'src>,
+    parser: &mut Parser,
+    warnings: &mut Vec<Warning<'src>>,
+) -> (Vec<TableColumn>, Vec<TableRow<'src>>) {
+    let TableBody {
+        inside,
+        separator,
+        cols_attr,
+        autowidth,
+        has_header,
+    } = body;
+    let separator = separator.as_str();
+
+    // When the column count is implicit, it is the number of column slots in the
+    // first non-empty line: a cell that spans columns (`<n>+`) counts as `<n>`
+    // slots, not one, and a cell duplicated `<n>` times (`<n>*`) counts as `<n>`
+    // single-column slots (one per clone).
+    let first_line_cells: usize =
+        scan_cells(inside.discard_empty_lines().take_line().item, separator)
+            .iter()
+            .map(|c| c.spec.colspan.max(1) * c.spec.repeat.min(MAX_DUPLICATION_FACTOR))
+            .sum();
+
+    let ncols = if cols_attr.is_empty() {
+        first_line_cells
+    } else {
+        cols_attr.len()
+    };
+
+    let columns = finalize_columns(cols_attr, ncols, autowidth);
+
+    let raw_cells = expand_duplicates(scan_cells(inside, separator));
+
+    // A table can never have more rows than it has cells, so a row span is
+    // clamped to the cell count for the `active_rowspans` bookkeeping below: a
+    // larger span carries into rows that can't exist and so has no additional
+    // layout effect. The clamp also bounds the `active_rowspans` allocation, so a
+    // hostile specifier such as `.1000000000+` can't trigger a multi-gigabyte
+    // allocation. (The cell's reported [`rowspan`] keeps the literal parsed
+    // value, matching Asciidoctor.)
+    //
+    // [`rowspan`]: TableCell::rowspan
+    let max_rowspan = raw_cells.len().saturating_add(1);
+
+    let mut raw_rows: Vec<Vec<RawCell<'src>>> = vec![];
+    if ncols > 0 {
+        let mut active_rowspans: Vec<usize> = vec![0];
+        let mut column_visits = 0usize;
+        let mut current_row: Vec<RawCell<'src>> = vec![];
+
+        for raw in raw_cells {
+            let colspan = raw.spec.colspan.max(1);
+            let rowspan = raw.spec.rowspan.max(1).min(max_rowspan);
+
+            // A cell that spans more than one row reserves `colspan` slots in
+            // each of the rows it extends into (but not its own row).
+            if rowspan > 1 {
+                if active_rowspans.len() < rowspan {
+                    active_rowspans.resize(rowspan, 0);
+                }
+                for slot in active_rowspans.iter_mut().take(rowspan).skip(1) {
+                    *slot += colspan;
+                }
+            }
+
+            column_visits += colspan;
+            let cell_source = raw.content;
+            current_row.push(raw);
+
+            // The slots carried into the current row are `active_rowspans[0]`; the
+            // vector is never empty here, so the fallback is unreachable.
+            let carried = active_rowspans.first().copied().unwrap_or(0);
+            let effective = column_visits + carried;
+            if effective >= ncols {
+                if effective == ncols {
+                    raw_rows.push(std::mem::take(&mut current_row));
+                } else {
+                    // Overrun: this cell's span pushes the row past `ncols`.
+                    // Discard the whole row so the remaining cells stay aligned to
+                    // the grid.
+                    current_row.clear();
+                    warnings.push(Warning {
+                        source: cell_source,
+                        warning: WarningType::TableCellExceedsColumnCount,
+                    });
+                }
+                column_visits = 0;
+                active_rowspans.remove(0);
+                if active_rowspans.is_empty() {
+                    active_rowspans.push(0);
+                }
+            }
+        }
+
+        // A trailing incomplete row (one that never reached `ncols`) is still
+        // emitted, matching the existing handling of short final rows.
+        if !current_row.is_empty() {
+            raw_rows.push(current_row);
+        }
+    }
+
+    // Each cell is processed according to the style of the column it falls in. A
+    // cell's column is its ordinal position within its row (matching Asciidoctor,
+    // which assigns the column by cell count, not grid slot). The header row
+    // (when present) is the first row and is always processed as plain header
+    // content, regardless of the column styles, so that a style operator doesn't
+    // affect the header row.
+    let mut rows: Vec<TableRow<'src>> = Vec::with_capacity(raw_rows.len());
+    for (row_idx, raw_row) in raw_rows.into_iter().enumerate() {
+        let is_header = has_header && row_idx == 0;
+        let mut cells = Vec::with_capacity(raw_row.len());
+        for (col_idx, raw) in raw_row.into_iter().enumerate() {
+            let column = columns.get(col_idx).cloned().unwrap_or_default();
+            cells.push(TableCell::parse(
+                raw, &column, is_header, separator, parser, warnings,
+            ));
+        }
+        rows.push(TableRow { cells });
+    }
+
+    (columns, rows)
+}
+
+/// Build the columns and rows of a delimiter-separated table (CSV, TSV, or
+/// DSV).
+///
+/// The body is split into a flat list of [fields](DataField) by the format's
+/// parser, then flowed into fixed-width rows. The column count comes from the
+/// `cols` attribute (`cols_attr`) or, when that is absent, from the number of
+/// fields in the first row. Because a data cell carries no span, the fields are
+/// simply chunked `ncols` at a time; any fields left over after the last
+/// complete row are dropped ("extra cells at the end of the last row get
+/// dropped"). The first row is the header when `has_header` is set.
+fn build_data_table<'src>(
+    body: TableBody<'src>,
+    data_format: DataFormat,
+    parser: &mut Parser,
+    warnings: &mut Vec<Warning<'src>>,
+) -> (Vec<TableColumn>, Vec<TableRow<'src>>) {
+    let TableBody {
+        inside,
+        separator,
+        cols_attr,
+        autowidth,
+        has_header,
+    } = body;
+    let separator = separator.as_str();
+
+    let (fields, first_row_len) = match data_format {
+        // CSV and TSV share their parsing rules and differ only in the default
+        // separator (resolved by the caller).
+        DataFormat::Csv | DataFormat::Tsv => parse_csv_fields(inside, separator),
+        // DSV is parsed by its own, simpler rules.
+        DataFormat::Dsv => parse_dsv_fields(inside, separator),
+        // PSV never reaches this builder.
+        DataFormat::Psv => (vec![], 0),
+    };
+
+    let ncols = if cols_attr.is_empty() {
+        first_row_len
+    } else {
+        cols_attr.len()
+    };
+
+    let columns = finalize_columns(cols_attr, ncols, autowidth);
+
+    // Integer division drops any partial trailing row; `checked_div` yields zero
+    // rows when there are no columns.
+    let nrows = fields.len().checked_div(ncols).unwrap_or(0);
+    let mut rows: Vec<TableRow<'src>> = Vec::with_capacity(nrows);
+    let mut fields = fields.into_iter();
+    for row_idx in 0..nrows {
+        let is_header = has_header && row_idx == 0;
+        let mut cells = Vec::with_capacity(ncols);
+        for col_idx in 0..ncols {
+            // `nrows * ncols <= fields.len()`, so the iterator always yields.
+            let Some(field) = fields.next() else { break };
+            let column = columns.get(col_idx).cloned().unwrap_or_default();
+            cells.push(TableCell::parse_data(
+                field, &column, is_header, parser, warnings,
+            ));
+        }
+        rows.push(TableRow { cells });
+    }
+
+    (columns, rows)
+}
+
+/// A single field of a delimiter-separated (CSV, TSV, or DSV) table, as located
+/// by [`parse_csv_fields`] or [`parse_dsv_fields`].
+///
+/// `content` is the field's value span with surrounding whitespace already
+/// stripped. `replacement` holds the value after quote or escape processing
+/// when it differs from `content` (a CSV value with a doubled-quote escape, or
+/// a DSV value with a backslash-escaped separator); it is `None` when the span
+/// is the verbatim value.
+struct DataField<'src> {
+    content: Span<'src>,
+    replacement: Option<String>,
+}
+
+/// Parse a CSV/TSV region into its [fields](DataField), returning them in
+/// document order together with the number of fields in the first row.
+///
+/// The rules, loosely based on RFC 4180: empty lines are skipped; whitespace
+/// surrounding each value is stripped; a value may be enclosed in double
+/// quotes, within which the separator and newlines are literal and a double
+/// quote is written by doubling it (`""`). A newline that is not inside a
+/// quoted value ends the row. The fields are returned flat; the caller flows
+/// them into rows.
+fn parse_csv_fields<'src>(region: Span<'src>, separator: &str) -> (Vec<DataField<'src>>, usize) {
+    let data = region.data();
+    let n = data.len();
+    let sep_len = separator.len().max(1);
+    let at = |k: usize| data.as_bytes().get(k).copied();
+    let starts_with_sep = |pos: usize| data.get(pos..).is_some_and(|s| s.starts_with(separator));
+
+    let mut fields: Vec<DataField<'src>> = vec![];
+    let mut first_row_len = 0usize;
+    let mut row_count = 0usize;
+    let mut i = 0usize;
+
+    while i < n {
+        // Skip a blank (whitespace-only) physical line at a row boundary.
+        let mut line_end = i;
+        while line_end < n && at(line_end) != Some(b'\n') {
+            line_end += 1;
+        }
+        if data.get(i..line_end).unwrap_or("").trim().is_empty() {
+            i = if line_end < n { line_end + 1 } else { line_end };
+            continue;
+        }
+
+        // Parse one row, field by field, until an unquoted newline (or EOF).
+        let mut fields_in_row = 0usize;
+        loop {
+            // Skip leading whitespace to detect a quoted value, but never skip a
+            // separator (so a leading tab in a TSV table starts an empty field).
+            let mut start = i;
+            while matches!(at(start), Some(b' ' | b'\t')) && !starts_with_sep(start) {
+                start += 1;
+            }
+
+            let (field, after, ended_row) = if at(start) == Some(b'"') {
+                parse_csv_quoted_field(region, start + 1, &starts_with_sep)
+            } else {
+                // An unquoted value runs to the next separator or newline.
+                let mut q = i;
+                while q < n && at(q) != Some(b'\n') && !starts_with_sep(q) {
+                    q += 1;
+                }
+                let trimmed = trim_surrounding_whitespace(region.slice(i..q));
+                let ended_row = q >= n || at(q) == Some(b'\n');
+                (
+                    DataField {
+                        content: trimmed,
+                        replacement: None,
+                    },
+                    q,
+                    ended_row,
+                )
+            };
+
+            fields.push(field);
+            fields_in_row += 1;
+
+            if ended_row {
+                i = if after < n { after + 1 } else { after };
+                break;
+            }
+            i = after + sep_len;
+        }
+
+        if row_count == 0 {
+            first_row_len = fields_in_row;
+        }
+        row_count += 1;
+    }
+
+    (fields, first_row_len)
+}
+
+/// Parse a CSV/TSV quoted value beginning just after its opening quote
+/// (`value_start`), returning the field, the byte offset just past the closing
+/// quote and any trailing characters, and whether the value ends the row.
+///
+/// A doubled quote (`""`) inside the value is an escaped literal quote. After
+/// the closing quote, any characters up to the next separator or newline are
+/// ignored. A value with no closing quote runs to the end of the region.
+fn parse_csv_quoted_field<'src>(
+    region: Span<'src>,
+    value_start: usize,
+    starts_with_sep: &impl Fn(usize) -> bool,
+) -> (DataField<'src>, usize, bool) {
+    let data = region.data();
+    let n = data.len();
+    let at = |k: usize| data.as_bytes().get(k).copied();
+
+    let mut buf = String::new();
+    let mut has_escape = false;
+    let mut seg_start = value_start;
+    let mut q = value_start;
+    let inner_end;
+    loop {
+        if q >= n {
+            inner_end = n;
+            break;
+        }
+        if at(q) == Some(b'"') {
+            if at(q + 1) == Some(b'"') {
+                // A doubled quote collapses to a single literal quote: keep the
+                // first quote (part of the preceding segment) and skip the second.
+                has_escape = true;
+                buf.push_str(data.get(seg_start..=q).unwrap_or_default());
+                q += 2;
+                seg_start = q;
+                continue;
+            }
+            // A lone quote closes the value.
+            inner_end = q;
+            break;
+        }
+        q += 1;
+    }
+    if has_escape {
+        buf.push_str(data.get(seg_start..inner_end).unwrap_or_default());
+    }
+
+    // Advance past the closing quote (if any), then ignore trailing characters
+    // up to the next separator or newline.
+    let mut after = if at(inner_end) == Some(b'"') {
+        inner_end + 1
+    } else {
+        inner_end
+    };
+    while after < n && at(after) != Some(b'\n') && !starts_with_sep(after) {
+        after += 1;
+    }
+    let ended_row = after >= n || at(after) == Some(b'\n');
+
+    let trimmed = trim_surrounding_whitespace(region.slice(value_start..inner_end));
+    let replacement = if has_escape {
+        let value = buf.trim().to_string();
+        (value != trimmed.data()).then_some(value)
+    } else {
+        None
+    };
+
+    (
+        DataField {
+            content: trimmed,
+            replacement,
+        },
+        after,
+        ended_row,
+    )
+}
+
+/// Parse a DSV region into its [fields](DataField), returning them in document
+/// order together with the number of fields in the first row.
+///
+/// Each non-empty line is a row. Whitespace surrounding each value is stripped,
+/// and the separator can be included in a value by escaping it with a single
+/// backslash (`\:`). An enclosing character is not recognized.
+fn parse_dsv_fields<'src>(region: Span<'src>, separator: &str) -> (Vec<DataField<'src>>, usize) {
+    let data = region.data();
+    let n = data.len();
+    let sep_len = separator.len().max(1);
+    let escaped = format!("\\{separator}");
+    let at = |k: usize| data.as_bytes().get(k).copied();
+
+    let mut fields: Vec<DataField<'src>> = vec![];
+    let mut first_row_len = 0usize;
+    let mut row_count = 0usize;
+    let mut i = 0usize;
+
+    while i < n {
+        let mut line_end = i;
+        while line_end < n && at(line_end) != Some(b'\n') {
+            line_end += 1;
+        }
+
+        if data.get(i..line_end).unwrap_or("").trim().is_empty() {
+            i = if line_end < n { line_end + 1 } else { line_end };
+            continue;
+        }
+
+        let in_line = |pos: usize| {
+            data.get(pos..line_end)
+                .is_some_and(|s| s.starts_with(separator))
+        };
+
+        let mut fields_in_row = 0usize;
+        let mut field_start = i;
+        let mut p = i;
+        while p < line_end {
+            // A backslash that escapes the separator (`\:`) is not a boundary;
+            // skip past both so the separator stays in the value.
+            if at(p) == Some(b'\\')
+                && data
+                    .get(p + 1..line_end)
+                    .is_some_and(|s| s.starts_with(separator))
+            {
+                p += 1 + sep_len;
+                continue;
+            }
+
+            if in_line(p) {
+                fields.push(make_dsv_field(region, field_start, p, &escaped, separator));
+                fields_in_row += 1;
+                p += sep_len;
+                field_start = p;
+                continue;
+            }
+
+            p += 1;
+        }
+
+        // The final field of the line runs to the line end.
+        fields.push(make_dsv_field(
+            region,
+            field_start,
+            line_end,
+            &escaped,
+            separator,
+        ));
+        fields_in_row += 1;
+
+        if row_count == 0 {
+            first_row_len = fields_in_row;
+        }
+        row_count += 1;
+
+        i = if line_end < n { line_end + 1 } else { line_end };
+    }
+
+    (fields, first_row_len)
+}
+
+/// Build a DSV [field](DataField) from the byte range `start..end`, unescaping
+/// any backslash-escaped separators (`escaped`, e.g. `\:`) into the bare
+/// separator.
+fn make_dsv_field<'src>(
+    region: Span<'src>,
+    start: usize,
+    end: usize,
+    escaped: &str,
+    separator: &str,
+) -> DataField<'src> {
+    let trimmed = trim_surrounding_whitespace(region.slice(start..end));
+    let replacement = if trimmed.data().contains(escaped) {
+        Some(trimmed.data().replace(escaped, separator))
+    } else {
+        None
+    };
+
+    DataField {
+        content: trimmed,
+        replacement,
+    }
+}
+
+/// Process a cell's content according to its [style](ColumnStyle), shared by
+/// the PSV and data-format cell builders.
+///
+/// `trimmed` is the cell's content span with surrounding whitespace already
+/// removed. `replacement` is the pre-filtered value (an escaped separator
+/// unescaped, or a CSV/DSV value after quote/escape processing) when it differs
+/// from `trimmed`; it is ignored for the [`AsciiDoc`](ColumnStyle::AsciiDoc)
+/// style, which parses `trimmed` verbatim as a nested document. Every other
+/// style produces inline [`Simple`](TableCellContent::Simple) content with the
+/// verbatim substitution group for [`Literal`](ColumnStyle::Literal) and the
+/// normal group otherwise.
+fn process_content<'src>(
+    trimmed: Span<'src>,
+    replacement: Option<String>,
+    style: ColumnStyle,
+    parser: &mut Parser,
+    warnings: &mut Vec<Warning<'src>>,
+) -> TableCellContent<'src> {
+    if style == ColumnStyle::AsciiDoc {
+        // The AsciiDoc style effectively creates a nested, standalone AsciiDoc
+        // document in the cell. It inherits the parent document's attributes, but
+        // any attribute it defines is scoped to the cell and must not leak back
+        // into the parent. Snapshot the attribute set before parsing and restore
+        // it afterward to enforce that boundary (matching Asciidoctor, where a
+        // `:foo:` set inside a cell is not visible after the table).
+        let saved_attributes = parser.attribute_values.clone();
+
+        // An attribute that is set in the parent document cannot be modified
+        // inside the cell. Lock every inherited attribute that currently holds a
+        // value for the duration of the cell (other than the handful of
+        // exceptions the spec carves out), so a body assignment to one of them is
+        // ignored. An attribute that is unset in the parent is not locked: the
+        // cell may assign it (matching Asciidoctor, which here diverges from the
+        // spec's "set or explicitly unset" wording). The lock set is saved and
+        // restored so it applies only within the cell and nests correctly.
+        let saved_locks = parser.locked_attribute_names.clone();
+        for (name, value) in saved_attributes.iter() {
+            if !matches!(value.value, InterpretedValue::Unset)
+                && !ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES.contains(&name.as_str())
+            {
+                parser.locked_attribute_names.insert(name.clone());
+            }
+        }
+
+        // Mark that we are inside an AsciiDoc cell (a nested document) for the
+        // duration of the cell, so a table found within defaults its cell
+        // separator to `!` rather than `|` (matching Asciidoctor's
+        // `Document#nested?`). The depth is restored afterward so the marker is
+        // scoped to the cell and nests correctly.
+        parser.nested_document_depth += 1;
+        let mut maw = parse_blocks_until(trimmed, |_| false, parser);
+        parser.nested_document_depth -= 1;
+
+        parser.locked_attribute_names = saved_locks;
+        parser.attribute_values = saved_attributes;
+        warnings.append(&mut maw.warnings);
+        TableCellContent::AsciiDoc(maw.item.item)
+    } else {
+        let mut content = match replacement {
+            Some(replacement) => Content::from_filtered(trimmed, replacement),
+            None => Content::from(trimmed),
+        };
+
+        let substitutions = if style == ColumnStyle::Literal {
+            SubstitutionGroup::Verbatim
+        } else {
+            SubstitutionGroup::Normal
+        };
+        substitutions.apply(&mut content, parser, None);
+
+        TableCellContent::Simple(content)
+    }
 }
 
 /// A row of cells in a [`TableBlock`].
@@ -1019,7 +1607,7 @@ impl<'src> TableCell<'src> {
         raw: RawCell<'src>,
         column: &TableColumn,
         is_header: bool,
-        separator: u8,
+        separator: &str,
         parser: &mut Parser,
         warnings: &mut Vec<Warning<'src>>,
     ) -> Self {
@@ -1040,73 +1628,20 @@ impl<'src> TableCell<'src> {
 
         let trimmed = trim_surrounding_whitespace(raw.content);
 
-        let content = if style == ColumnStyle::AsciiDoc {
-            // The AsciiDoc style effectively creates a nested, standalone
-            // AsciiDoc document in the cell. It inherits the parent document's
-            // attributes, but any attribute it defines is scoped to the cell and
-            // must not leak back into the parent. Snapshot the attribute set
-            // before parsing and restore it afterward to enforce that boundary
-            // (matching Asciidoctor, where a `:foo:` set inside a cell is not
-            // visible after the table).
-            let saved_attributes = parser.attribute_values.clone();
-
-            // An attribute that is set in the parent document cannot be modified
-            // inside the cell. Lock every inherited attribute that currently
-            // holds a value for the duration of the cell (other than the handful
-            // of exceptions the spec carves out), so a body assignment to one of
-            // them is ignored. An attribute that is unset in the parent is not
-            // locked: the cell may assign it (matching Asciidoctor, which here
-            // diverges from the spec's "set or explicitly unset" wording). The
-            // lock set is saved and restored so it applies only within the cell
-            // and nests correctly.
-            let saved_locks = parser.locked_attribute_names.clone();
-            for (name, value) in saved_attributes.iter() {
-                if !matches!(value.value, InterpretedValue::Unset)
-                    && !ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES.contains(&name.as_str())
-                {
-                    parser.locked_attribute_names.insert(name.clone());
-                }
-            }
-
-            // Mark that we are inside an AsciiDoc cell (a nested document) for the
-            // duration of the cell, so a table found within defaults its cell
-            // separator to `!` rather than `|` (matching Asciidoctor's
-            // `Document#nested?`). The depth is restored afterward so the marker
-            // is scoped to the cell and nests correctly.
-            parser.nested_document_depth += 1;
-            let mut maw = parse_blocks_until(trimmed, |_| false, parser);
-            parser.nested_document_depth -= 1;
-
-            parser.locked_attribute_names = saved_locks;
-            parser.attribute_values = saved_attributes;
-            warnings.append(&mut maw.warnings);
-            TableCellContent::AsciiDoc(maw.item.item)
+        // An escaped cell separator (a backslash in front of the table's
+        // separator, e.g. `\|` or `\!`) is unescaped to the bare separator. Only
+        // the active separator is unescaped, so a `\|` in a `!`-separated table
+        // is left untouched. The replacement is computed only for the inline
+        // styles; an AsciiDoc cell parses its content verbatim (see
+        // [`process_content`]).
+        let escaped = format!("\\{separator}");
+        let replacement = if style != ColumnStyle::AsciiDoc && trimmed.data().contains(&escaped) {
+            Some(trimmed.data().replace(&escaped, separator))
         } else {
-            let data = trimmed.data();
-
-            // An escaped cell separator (a backslash in front of the table's
-            // separator character, e.g. `\|` or `\!`) is unescaped to the bare
-            // separator. Only the active separator is unescaped, so a `\|` in a
-            // `!`-separated table is left untouched.
-            let escaped = format!("\\{}", separator as char);
-            let mut content = if data.contains(&escaped) {
-                Content::from_filtered(
-                    trimmed,
-                    data.replace(&escaped, &(separator as char).to_string()),
-                )
-            } else {
-                Content::from(trimmed)
-            };
-
-            let substitutions = if style == ColumnStyle::Literal {
-                SubstitutionGroup::Verbatim
-            } else {
-                SubstitutionGroup::Normal
-            };
-            substitutions.apply(&mut content, parser, None);
-
-            TableCellContent::Simple(content)
+            None
         };
+
+        let content = process_content(trimmed, replacement, style, parser, warnings);
 
         Self {
             h_align,
@@ -1114,6 +1649,41 @@ impl<'src> TableCell<'src> {
             style,
             colspan: raw.spec.colspan.max(1),
             rowspan: raw.spec.rowspan.max(1),
+            content,
+        }
+    }
+
+    /// Build a cell from a [data field](DataField) of a delimiter-separated
+    /// table (CSV, TSV, or DSV).
+    ///
+    /// Unlike a PSV cell, a data cell carries no per-cell specifier: its
+    /// alignment and [style](ColumnStyle) come entirely from the `column`, and
+    /// it always spans a single row and column. The separator escaping is
+    /// handled by the format parser before this point, so the field already
+    /// holds the extracted value (its [`replacement`](DataField::replacement),
+    /// when present, is the value after quote/escape processing). A header cell
+    /// (`is_header`) is processed as plain header content.
+    fn parse_data(
+        field: DataField<'src>,
+        column: &TableColumn,
+        is_header: bool,
+        parser: &mut Parser,
+        warnings: &mut Vec<Warning<'src>>,
+    ) -> Self {
+        let style = if is_header {
+            ColumnStyle::Default
+        } else {
+            column.style
+        };
+
+        let content = process_content(field.content, field.replacement, style, parser, warnings);
+
+        Self {
+            h_align: column.h_align,
+            v_align: column.v_align,
+            style,
+            colspan: 1,
+            rowspan: 1,
             content,
         }
     }
@@ -1424,9 +1994,10 @@ fn expand_duplicates(cells: Vec<RawCell<'_>>) -> Vec<RawCell<'_>> {
 /// Scan a region for PSV cell boundaries, returning the [specifier](CellSpec)
 /// and raw (untrimmed) content span of each cell.
 ///
-/// A cell boundary is the table's `separator` byte (the vertical bar (`|`) by
-/// default, or the exclamation mark (`!`) for a nested table) that appears at
-/// the start of a line or is preceded by whitespace, optionally with a
+/// A cell boundary is the table's `separator` (the vertical bar (`|`) by
+/// default, the exclamation mark (`!`) for a nested table, or any string set
+/// with the `separator` attribute, e.g. the broken bar `¦`) that appears at the
+/// start of a line or is preceded by whitespace, optionally with a
 /// [cell specifier](CellSpec) (e.g. `^`, `2+`, `.>`) directly in front of the
 /// separator. The token immediately preceding a separator is taken to be a
 /// specifier when it parses as one (see [`parse_cell_spec`]); a token that
@@ -1437,19 +2008,25 @@ fn expand_duplicates(cells: Vec<RawCell<'_>>) -> Vec<RawCell<'_>> {
 /// valid specifier, so the separator already fails the boundary test and needs
 /// no special handling here; the backslash is stripped later in
 /// [`TableCell::parse`].
-fn scan_cells(region: Span<'_>, separator: u8) -> Vec<RawCell<'_>> {
+fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
     let data = region.data();
     let bytes = data.as_bytes();
     let len = bytes.len();
+    // A zero-length separator would never advance; treat it as a single byte to
+    // stay safe. (The resolver never produces an empty separator.)
+    let sep_len = separator.len().max(1);
 
-    let mut cells: Vec<RawCell<'_>> = vec![];
+    let mut cells: Vec<RawCell<'src>> = vec![];
     // The content start and specifier of the cell currently being accumulated.
     let mut content_start: Option<usize> = None;
     let mut cur_spec = CellSpec::default();
     let mut i = 0;
 
     while i < len {
-        if bytes.get(i).copied() == Some(separator) {
+        if data
+            .get(i..)
+            .is_some_and(|rest| rest.starts_with(separator))
+        {
             // Walk back to the start of the token directly preceding this
             // separator. The token (a possible cell specifier) runs back to the
             // previous whitespace, tab, or newline, or to the start of the
@@ -1484,7 +2061,9 @@ fn scan_cells(region: Span<'_>, separator: u8) -> Vec<RawCell<'_>> {
                     });
                 }
                 cur_spec = spec;
-                content_start = Some(i + 1);
+                content_start = Some(i + sep_len);
+                i += sep_len;
+                continue;
             }
         }
 

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -4,7 +4,7 @@
 use crate::{
     HasSpan, Parser, Span,
     blocks::{
-        Block, ColumnStyle, ContentModel, HorizontalAlignment, IsBlock, TableBlock,
+        Block, ColumnStyle, ContentModel, DataFormat, HorizontalAlignment, IsBlock, TableBlock,
         TableCellContent, VerticalAlignment,
     },
     content::SubstitutionGroup,
@@ -962,4 +962,94 @@ fn huge_duplication_factor_does_not_overallocate() {
     let total: usize = table.body_rows().iter().map(|r| r.cells().len()).sum();
     assert_eq!(total, 1_000);
     assert_eq!(row_text(&table.body_rows()[0])[0], "x".to_string());
+}
+
+// The `format` attribute selects the data format, and an unrecognized value
+// falls back to PSV. (Exercises `resolve_data_format`, including its
+// unrecognized-value arm.)
+#[test]
+fn data_format_attribute_recognizes_each_value() {
+    assert_eq!(
+        parse_table("|===\n|a |b\n|===").data_format(),
+        DataFormat::Psv
+    );
+    assert_eq!(
+        parse_table("[format=psv]\n|===\n|a |b\n|===").data_format(),
+        DataFormat::Psv
+    );
+    assert_eq!(
+        parse_table("[format=csv]\n|===\na,b\n|===").data_format(),
+        DataFormat::Csv
+    );
+    assert_eq!(
+        parse_table("[format=tsv]\n|===\na\tb\n|===").data_format(),
+        DataFormat::Tsv
+    );
+    assert_eq!(
+        parse_table("[format=dsv]\n|===\na:b\n|===").data_format(),
+        DataFormat::Dsv
+    );
+
+    // An unrecognized format value falls back to PSV.
+    assert_eq!(
+        parse_table("[format=bogus]\n|===\n|a |b\n|===").data_format(),
+        DataFormat::Psv
+    );
+}
+
+// A CSV value whose opening double quote is never closed keeps the quote and is
+// treated as literal text, matching Asciidoctor
+// (`buffer_has_unclosed_quotes?`).
+#[test]
+fn csv_unclosed_quote_is_literal() {
+    let table = parse_table("[format=csv]\n|===\nx,\"unterminated\n|===");
+    assert_eq!(table.columns().len(), 2);
+    assert_eq!(row_text(&table.body_rows()[0]), ["x", "\"unterminated"]);
+
+    // A bare leading quote leaves the value unclosed, so the following separator
+    // is absorbed into the (single) cell rather than ending it.
+    let table = parse_table("[format=csv]\n|===\n\",a\n|===");
+    assert_eq!(table.columns().len(), 1);
+    assert_eq!(row_text(&table.body_rows()[0]), ["\",a"]);
+
+    // A cell that is a single bare quote is an unclosed, empty quoted value.
+    let table = parse_table("[format=csv]\n|===\n\"\n|===");
+    assert_eq!(table.columns().len(), 1);
+    assert_eq!(row_text(&table.body_rows()[0]), [""]);
+}
+
+// A CSV value with characters after its closing quote is not a properly
+// enclosed value, so it (and any separators it spans) are taken literally as
+// one cell.
+#[test]
+fn csv_text_after_closing_quote_is_literal() {
+    let table = parse_table("[format=csv]\n|===\n\"abc\"x,d\n|===");
+    assert_eq!(table.columns().len(), 1);
+    assert_eq!(row_text(&table.body_rows()[0]), ["\"abc\"x,d"]);
+}
+
+// An escaped double quote (`""`) collapses to a single `"`, whether the value
+// is enclosed in quotes or not.
+#[test]
+fn csv_escaped_quotes_collapse() {
+    let table = parse_table("[format=csv]\n|===\n\"a\"\"b\",a\"\"b\n|===");
+    assert_eq!(table.columns().len(), 2);
+    assert_eq!(row_text(&table.body_rows()[0]), ["a\"b", "a\"b"]);
+
+    // An odd run of trailing quotes still leaves the value unclosed, so the
+    // separator is absorbed and the quotes are only collapsed.
+    let table = parse_table("[format=csv]\n|===\n\"a\"\",b\n|===");
+    assert_eq!(table.columns().len(), 1);
+    assert_eq!(row_text(&table.body_rows()[0]), ["\"a\",b"]);
+}
+
+// A trailing separator produces an empty cell at the end of the row
+// (Asciidoctor preserves it), so the row's column count includes that empty
+// cell.
+#[test]
+fn csv_trailing_separator_keeps_empty_cell() {
+    let table = parse_table("[format=csv]\n|===\na,b,\nc,d,e\n|===");
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(row_text(&table.body_rows()[0]), ["a", "b", ""]);
+    assert_eq!(row_text(&table.body_rows()[1]), ["c", "d", "e"]);
 }

--- a/parser/src/tests/asciidoc_lang/tables/data_format.rs
+++ b/parser/src/tests/asciidoc_lang/tables/data_format.rs
@@ -111,8 +111,10 @@ AsciiDoc also supports comma-separated values (CSV), tab-separated values (TSV),
     );
 }
 
-non_normative!(
-    r#"
+#[test]
+fn escape_the_cell_separator() {
+    verifies!(
+        r#"
 == Escape the cell separator
 
 The parser scans for the cell separator to partition cells _before_ it processes the cell text.
@@ -147,7 +149,25 @@ This table will render as follows:
 |===
 
 "#
-);
+    );
+
+    // The backslash-escaped separator (`\|`) is unescaped to a bare `|`, and the
+    // leading backslash is removed from the rendered cell.
+    let table = parse_table(
+        "[cols=2*]\n|===\n|The default separator in PSV tables is the \\| character.\n|The \\| character is often referred to as a \"`pipe`\".\n|===",
+    );
+    assert_eq!(table.body_rows().len(), 1);
+    let cells: Vec<String> = table.body_rows()[0]
+        .cells()
+        .iter()
+        .map(simple_text)
+        .collect();
+    assert_eq!(
+        cells[0],
+        "The default separator in PSV tables is the | character."
+    );
+    assert!(cells[1].contains("The | character"), "got: {:?}", cells[1]);
+}
 
 #[test]
 fn escape_with_backslash() {
@@ -190,8 +210,10 @@ This approach produces the same result as the previous example.
     assert!(cell.contains("the | character"), "got: {cell:?}");
 }
 
-non_normative!(
-    r#"
+#[test]
+fn substitute_the_vbar_reference() {
+    verifies!(
+        r#"
 [source]
 ----
 [cols=2*]
@@ -206,7 +228,24 @@ There are also times when you can't or don't want to modify the cell content (pe
 To address these cases, AsciiDoc allows you to override the cell separator.
 
 "#
-);
+    );
+
+    // The `{vbar}` attribute reference renders as a bare `|`, producing the same
+    // result as the backslash escape.
+    let table = parse_table(
+        "[cols=2*]\n|===\n|The default separator in PSV tables is the {vbar} character.\n|The {vbar} character is often referred to as a \"`pipe`\".\n|===",
+    );
+    let cells: Vec<String> = table.body_rows()[0]
+        .cells()
+        .iter()
+        .map(simple_text)
+        .collect();
+    assert_eq!(
+        cells[0],
+        "The default separator in PSV tables is the | character."
+    );
+    assert!(cells[1].contains("The | character"), "got: {:?}", cells[1]);
+}
 
 #[test]
 fn override_the_cell_separator() {
@@ -233,8 +272,10 @@ A good candidate is the broken bar, or `¦`.
     );
 }
 
-non_normative!(
-    r#"
+#[test]
+fn custom_separator_example() {
+    verifies!(
+        r#"
 Here's the previous example rewritten using a custom separator.
 
 [source]
@@ -253,7 +294,25 @@ You can safely use the original cell separator in the cell content and not worry
 == Delimiter-separated values
 
 "#
-);
+    );
+
+    // With the separator overridden to the broken bar (`¦`), the vertical bars in
+    // the cell content are ordinary text and need no escaping.
+    let table = parse_table(
+        "[cols=2*,separator=¦]\n|===\n¦The default separator in PSV tables is the | character.\n¦The | character is often referred to as a \"`pipe`\".\n|===",
+    );
+    assert_eq!(table.body_rows().len(), 1);
+    let cells: Vec<String> = table.body_rows()[0]
+        .cells()
+        .iter()
+        .map(simple_text)
+        .collect();
+    assert_eq!(
+        cells[0],
+        "The default separator in PSV tables is the | character."
+    );
+    assert!(cells[1].contains("The | character"), "got: {:?}", cells[1]);
+}
 
 #[test]
 fn delimiter_between_values() {
@@ -332,8 +391,10 @@ When the `format` attribute is set to `csv`, the default data separator is a com
     assert_eq!(table.body_rows().len(), 2);
 }
 
-non_normative!(
-    r#"
+#[test]
+fn csv_example() {
+    verifies!(
+        r#"
 [source]
 ----
 include::example$data.adoc[tag=csv]
@@ -355,7 +416,36 @@ You can do so using the xref:directives:include.adoc[include directive] between 
 ----
 
 "#
-);
+    );
+
+    // `include::example$data.adoc[tag=csv]` expands to this CSV table.
+    let table = parse_table(
+        "[%header,format=csv]\n|===\nArtist,Track,Genre\nBaauer,Harlem Shake,Hip Hop\nThe Lumineers,Ho Hey,Folk Rock\n|===",
+    );
+    assert_eq!(table.data_format(), DataFormat::Csv);
+    let header: Vec<String> = table
+        .header_row()
+        .unwrap()
+        .cells()
+        .iter()
+        .map(simple_text)
+        .collect();
+    assert_eq!(header, ["Artist", "Track", "Genre"]);
+    assert_eq!(
+        all_texts(&table),
+        [
+            "Artist",
+            "Track",
+            "Genre",
+            "Baauer",
+            "Harlem Shake",
+            "Hip Hop",
+            "The Lumineers",
+            "Ho Hey",
+            "Folk Rock"
+        ]
+    );
+}
 
 #[test]
 fn tsv_format() {
@@ -393,8 +483,10 @@ When the `format` attribute is set to `dsv`, the default data separator is a col
     assert_eq!(table.body_rows().len(), 2);
 }
 
-non_normative!(
-    r#"
+#[test]
+fn dsv_example() {
+    verifies!(
+        r#"
 [source]
 ----
 include::example$data.adoc[tag=dsv]
@@ -405,7 +497,28 @@ include::example$data.adoc[tag=dsv]
 include::example$data.adoc[tag=dsv]
 
 "#
-);
+    );
+
+    // `include::example$data.adoc[tag=dsv]` expands to this DSV table.
+    let table = parse_table(
+        "[%header,format=dsv]\n|===\nArtist:Track:Genre\nRobyn:Indestructible:Dance\nThe Piano Guys:Code Name Vivaldi:Classical\n|===",
+    );
+    assert_eq!(table.data_format(), DataFormat::Dsv);
+    assert_eq!(
+        all_texts(&table),
+        [
+            "Artist",
+            "Track",
+            "Genre",
+            "Robyn",
+            "Indestructible",
+            "Dance",
+            "The Piano Guys",
+            "Code Name Vivaldi",
+            "Classical"
+        ]
+    );
+}
 
 non_normative!(
     r#"
@@ -656,8 +769,10 @@ To make a CSV table, you can use `,===` as the table block delimiter:
     assert_eq!(table.columns().len(), 3);
 }
 
-non_normative!(
-    r#"
+#[test]
+fn shorthand_csv_example() {
+    verifies!(
+        r#"
 [source]
 ----
 include::example$data.adoc[tag=s-csv]
@@ -668,7 +783,24 @@ include::example$data.adoc[tag=s-csv]
 include::example$data.adoc[tag=s-csv]
 
 "#
-);
+    );
+
+    // `include::example$data.adoc[tag=s-csv]` expands to this shorthand CSV table.
+    let table = parse_table(",===\nArtist,Track,Genre\n\nBaauer,Harlem Shake,Hip Hop\n,===");
+    assert_eq!(table.data_format(), DataFormat::Csv);
+    assert!(table.header_row().is_some());
+    assert_eq!(
+        all_texts(&table),
+        [
+            "Artist",
+            "Track",
+            "Genre",
+            "Baauer",
+            "Harlem Shake",
+            "Hip Hop"
+        ]
+    );
+}
 
 #[test]
 fn shorthand_dsv_delimiter() {
@@ -686,8 +818,10 @@ To make a DSV table, you can use `:===` as the table block delimiter:
     assert_eq!(table.columns().len(), 3);
 }
 
-non_normative!(
-    r#"
+#[test]
+fn shorthand_dsv_example() {
+    verifies!(
+        r#"
 [source]
 ----
 include::example$data.adoc[tag=s-dsv]
@@ -698,7 +832,24 @@ include::example$data.adoc[tag=s-dsv]
 include::example$data.adoc[tag=s-dsv]
 
 "#
-);
+    );
+
+    // `include::example$data.adoc[tag=s-dsv]` expands to this shorthand DSV table.
+    let table = parse_table(":===\nArtist:Track:Genre\n\nRobyn:Indestructible:Dance\n:===");
+    assert_eq!(table.data_format(), DataFormat::Dsv);
+    assert!(table.header_row().is_some());
+    assert_eq!(
+        all_texts(&table),
+        [
+            "Artist",
+            "Track",
+            "Genre",
+            "Robyn",
+            "Indestructible",
+            "Dance"
+        ]
+    );
+}
 
 #[test]
 fn shorthand_implies_format() {
@@ -774,8 +925,10 @@ Instead, you can apply cell formatting to all cells in a given column using the 
     ));
 }
 
-non_normative!(
-    r#"
+#[test]
+fn data_formatting_example() {
+    verifies!(
+        r#"
 [source]
 ----
 [format=csv,cols="1h,1a"]
@@ -786,7 +939,20 @@ Forest,image::forest.jpg[]
 ----
 
 "#
-);
+    );
+
+    // The `cols="1h,1a"` example applies a header style to the first column and
+    // the AsciiDoc style to the second.
+    let table = parse_table(
+        "[format=csv,cols=\"1h,1a\"]\n|===\nSky,image::sky.jpg[]\nForest,image::forest.jpg[]\n|===",
+    );
+    assert_eq!(table.columns()[0].style(), ColumnStyle::Header);
+    assert_eq!(table.columns()[1].style(), ColumnStyle::AsciiDoc);
+    assert!(matches!(
+        table.body_rows()[0].cells()[1].content(),
+        TableCellContent::AsciiDoc(_)
+    ));
+}
 
 #[test]
 fn data_tables_do_not_support_spans() {

--- a/parser/src/tests/asciidoc_lang/tables/data_format.rs
+++ b/parser/src/tests/asciidoc_lang/tables/data_format.rs
@@ -1,0 +1,808 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/tables/pages/data-format.adoc");
+
+use crate::blocks::{DataFormat, TableCellContent};
+
+/// Parse `source` as a single block and return the [`TableBlock`] it produced.
+///
+/// [`TableBlock`]: crate::blocks::TableBlock
+fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
+    let mut parser = Parser::default();
+    let mi = crate::blocks::Block::parse(crate::Span::new(source), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    match mi.item {
+        crate::blocks::Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    }
+}
+
+/// Return the rendered text of a [`Simple`](TableCellContent::Simple) cell,
+/// panicking if the cell holds AsciiDoc block content.
+fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
+    match cell.content() {
+        TableCellContent::Simple(content) => content.rendered().to_string(),
+        TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
+    }
+}
+
+/// Return the rendered text of every cell in the table, in document order
+/// (header row first, then body rows, then any footer row).
+fn all_texts(table: &crate::blocks::TableBlock<'_>) -> Vec<String> {
+    table
+        .header_row()
+        .into_iter()
+        .chain(table.body_rows())
+        .chain(table.footer_row())
+        .flat_map(|row| row.cells().iter().map(simple_text))
+        .collect()
+}
+
+non_normative!(
+    r#"
+= Table Data Formats
+:navtitle: CSV, TSV and DSV Data
+:url-dsv: https://en.wikipedia.org/wiki/Delimiter-separated_values
+:url-rfc-4180: https://tools.ietf.org/html/rfc4180
+
+== Default table syntax
+
+A table is delimited by a vertical bar and three equal signs (`|===`).
+It contains cells that are arranged into rows according to the number of columns the table is assigned.
+The number of columns a table contains can be specified implicitly using the number of cells in the table's first row or by setting the `cols` attribute.
+Each cell is specified by a vertical bar (`|`).
+
+If you're new to AsciiDoc tables, xref:build-a-basic-table.adoc[] provides step by step directions for creating your first table.
+
+== Style and layout options
+
+Table content can be:
+
+* styled and aligned by column or cell,
+* aligned by row,
+* duplicated across multiple rows, and
+* marked up by any AsciiDoc syntax.
+
+Table cells can span rows and columns.
+
+You can adjust a table's:
+
+* width,
+* orientation, and
+* border style.
+
+You can also specify each column's width and designate header and footer rows.
+
+== Supported data formats
+
+"#
+);
+
+#[test]
+fn supported_data_formats() {
+    verifies!(
+        r#"
+The default table data format is prefix-separated values (PSV); that means the processor creates a new cell each time it encounters a vertical bar (`|`).
+AsciiDoc also supports comma-separated values (CSV), tab-separated values (TSV), and delimited data values (DSV).
+
+"#
+    );
+
+    // PSV is the default data format.
+    assert_eq!(
+        parse_table("|===\n|a |b\n|===").data_format(),
+        DataFormat::Psv
+    );
+
+    // CSV, TSV, and DSV are also supported, selected with the `format` attribute.
+    assert_eq!(
+        parse_table("[format=csv]\n|===\na,b\n|===").data_format(),
+        DataFormat::Csv
+    );
+    assert_eq!(
+        parse_table("[format=tsv]\n|===\na\tb\n|===").data_format(),
+        DataFormat::Tsv
+    );
+    assert_eq!(
+        parse_table("[format=dsv]\n|===\na:b\n|===").data_format(),
+        DataFormat::Dsv
+    );
+}
+
+non_normative!(
+    r#"
+== Escape the cell separator
+
+The parser scans for the cell separator to partition cells _before_ it processes the cell text.
+So even if you try to hide the cell separator using an inline passthrough, the parser will see it.
+If the cell contain contains the cell separator, you must escape that character.
+There are three ways to escape it:
+
+* Prefix the character with a leading backslash (i.e., `\|`), which will be removed from the output.
+* Use the `\{vbar}` attribute reference in place of `|` in content.
+* Change the cell separator used by the table.
+
+Unless you do one of these things, the cell separator will be interpreted as a cell boundary.
+
+Consider the following example, which escapes the cell separator using a leading backslash:
+
+[source]
+----
+[cols=2*]
+|===
+|The default separator in PSV tables is the \| character.
+|The \| character is often referred to as a "`pipe`".
+|===
+----
+
+This table will render as follows:
+
+.Result: Converted PSV table that contains pipe characters
+[cols=2*]
+|===
+|The default separator in PSV tables is the \| character.
+|The \| character is often referred to as a "`pipe`".
+|===
+
+"#
+);
+
+#[test]
+fn escape_with_backslash() {
+    verifies!(
+        r#"
+Notice that the pipe character appears without the leading backslash (i.e., unescaped) in the rendered result.
+
+"#
+    );
+
+    // The escaped separator (`\|`) is unescaped to a bare `|` in the rendered
+    // cell, and the leading backslash is removed.
+    let table = parse_table(
+        "[cols=2*]\n|===\n|The default separator in PSV tables is the \\| character.\n|The \\| character is often referred to as a \"`pipe`\".\n|===",
+    );
+    let cell = simple_text(&table.body_rows()[0].cells()[0]);
+    assert!(cell.contains("the | character"), "got: {cell:?}");
+    assert!(
+        !cell.contains("\\|"),
+        "backslash should be removed: {cell:?}"
+    );
+}
+
+#[test]
+fn substitute_with_vbar() {
+    verifies!(
+        r#"
+An alternative is to use the `\{vbar}` attribute reference as a substitute.
+This approach produces the same result as the previous example.
+
+"#
+    );
+
+    // The `{vbar}` attribute reference produces the same result as the escaped
+    // separator: a bare `|` in the rendered cell.
+    let table = parse_table(
+        "[cols=2*]\n|===\n|The default separator in PSV tables is the {vbar} character.\n|The {vbar} character is often referred to as a \"`pipe`\".\n|===",
+    );
+    let cell = simple_text(&table.body_rows()[0].cells()[0]);
+    assert!(cell.contains("the | character"), "got: {cell:?}");
+}
+
+non_normative!(
+    r#"
+[source]
+----
+[cols=2*]
+|===
+|The default separator in PSV tables is the {vbar} character.
+|The {vbar} character is often referred to as a "`pipe`".
+|===
+----
+
+Escaping each cell separator character that appears in the content of a cell can be tedious.
+There are also times when you can't or don't want to modify the cell content (perhaps because it is being included from another file).
+To address these cases, AsciiDoc allows you to override the cell separator.
+
+"#
+);
+
+#[test]
+fn override_the_cell_separator() {
+    verifies!(
+        r#"
+The cell separator is controlled using the `separator` attribute on the table block.
+You'll want to select any single character that is not found in the content.
+A good candidate is the broken bar, or `¦`.
+
+"#
+    );
+
+    // With the separator overridden to the broken bar (`¦`), the vertical bar in
+    // the cell content is ordinary text rather than a cell boundary.
+    let table = parse_table(
+        "[cols=2*,separator=¦]\n|===\n¦The default separator in PSV tables is the | character.\n¦The | character is often referred to as a \"`pipe`\".\n|===",
+    );
+    assert_eq!(table.body_rows().len(), 1);
+    assert_eq!(table.body_rows()[0].cells().len(), 2);
+    let cell = simple_text(&table.body_rows()[0].cells()[0]);
+    assert_eq!(
+        cell,
+        "The default separator in PSV tables is the | character."
+    );
+}
+
+non_normative!(
+    r#"
+Here's the previous example rewritten using a custom separator.
+
+[source]
+----
+[cols=2*,separator=¦]
+|===
+¦The default separator in PSV tables is the | character.
+¦The | character is often referred to as a "`pipe`".
+|===
+----
+
+Notice that it's no longer necessary to escape the pipe character in the content of the table cells.
+You can safely use the original cell separator in the cell content and not worry about it being interpreted as the boundary of a cell.
+
+[#delimiter-separated-values]
+== Delimiter-separated values
+
+"#
+);
+
+#[test]
+fn delimiter_between_values() {
+    verifies!(
+        r#"
+Tables can also be populated from data formatted as delimiter-separated values (i.e., data tables).
+In contrast with the PSV format, in which the delimiter is placed in front of each cell value, the delimiter in a delimiter-separated format (CSV, TSV, DSV) is placed between the cell values (called a _separator_) and does not accept a cell formatting spec.
+Each line of data is assumed to represent a single row, though you'll learn that's not a strict rule.
+How the table data gets interpreted is controlled by the `format` and `separator` attributes on the table.
+
+"#
+    );
+
+    // The separator sits between the values, so three comma-separated values
+    // produce three cells (a three-column row).
+    let table = parse_table("[format=csv]\n|===\na,b,c\n|===");
+    assert_eq!(table.data_format(), DataFormat::Csv);
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(all_texts(&table), ["a", "b", "c"]);
+
+    // A data cell does not accept a cell formatting spec: what would be a colspan
+    // operator in PSV (`2+`) is taken literally as the cell's value.
+    let table = parse_table("[format=csv]\n|===\n2+,b,c\n|===");
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(table.body_rows()[0].cells()[0].colspan(), 1);
+    assert_eq!(simple_text(&table.body_rows()[0].cells()[0]), "2+");
+}
+
+non_normative!(
+    r#"
+.What the delimiter?
+****
+Aren't comma-separated values a subset of {url-dsv}[delimiter-separated values^]?
+It really depends on who you consult.
+
+The term "`delimiter-separated values`" in this text refers to the family of data formats that use a delimiter, including comma-separated values (CSV), tab-separated values (TSV) and delimited data (DSV), all of which are supported in AsciiDoc tables.
+CSV is the data format used most often.
+
+"`Comma-separated values`" is really a misleading term since CSV can use delimiters other than `,` as the field separator (which, in this context, separates cells).
+What we're really talking about is how the data is interpreted.
+
+CSV and TSV both use a delimiter and an optional enclosing character, loosely based on {url-rfc-4180}[RFC 4180^].
+DSV (i.e., delimited data) only uses a delimiter, which can be escaped using a backslash; an enclosing character is not recognized.
+These parsing rules are described in detail in <<data-table-formats>>.
+****
+
+"#
+);
+
+#[test]
+fn csv_format() {
+    verifies!(
+        r#"
+Let's consider an example of using comma-separated values (CSV) to populate an AsciiDoc table with data.
+To instruct the processor to read the data as CSV, set the value of the `format` attribute on the table to `csv`.
+When the `format` attribute is set to `csv`, the default data separator is a comma (`,`), as seen in the table below.
+
+"#
+    );
+
+    // With `format=csv`, the default separator is a comma.
+    let table = parse_table(
+        "[%header,format=csv]\n|===\nArtist,Track,Genre\nBaauer,Harlem Shake,Hip Hop\nThe Lumineers,Ho Hey,Folk Rock\n|===",
+    );
+    assert_eq!(table.data_format(), DataFormat::Csv);
+    assert_eq!(table.columns().len(), 3);
+
+    let header: Vec<String> = table
+        .header_row()
+        .unwrap()
+        .cells()
+        .iter()
+        .map(simple_text)
+        .collect();
+    assert_eq!(header, ["Artist", "Track", "Genre"]);
+    assert_eq!(table.body_rows().len(), 2);
+}
+
+non_normative!(
+    r#"
+[source]
+----
+include::example$data.adoc[tag=csv]
+----
+
+.Result: Rendered CSV table
+[width=90%]
+include::example$data.adoc[tag=csv]
+
+This feature is particularly useful when you want to populate a table in your manuscript from data stored in a separate file.
+You can do so using the xref:directives:include.adoc[include directive] between the table delimiters, as shown here:
+
+[source]
+----
+[%header,format=csv]
+|===
+\include::tracks.csv[]
+|===
+----
+
+"#
+);
+
+#[test]
+fn tsv_format() {
+    verifies!(
+        r#"
+If your data is separated by tabs instead of commas, set the `format` to `tsv` (tab-separated values) instead.
+
+"#
+    );
+
+    // With `format=tsv`, the default separator is a tab.
+    let table = parse_table("[format=tsv]\n|===\nArtist\tTrack\tGenre\n|===");
+    assert_eq!(table.data_format(), DataFormat::Tsv);
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(all_texts(&table), ["Artist", "Track", "Genre"]);
+}
+
+#[test]
+fn dsv_format() {
+    verifies!(
+        r#"
+Now let's consider an example of using delimited data (DSV) to populate an AsciiDoc table with data.
+To instruct the processor to read the data as DSV, set the value of the `format` attribute on the table to `dsv`.
+When the `format` attribute is set to `dsv`, the default data separator is a colon (`:`), as seen in the table below.
+
+"#
+    );
+
+    // With `format=dsv`, the default separator is a colon.
+    let table = parse_table(
+        "[%header,format=dsv]\n|===\nArtist:Track:Genre\nRobyn:Indestructible:Dance\nThe Piano Guys:Code Name Vivaldi:Classical\n|===",
+    );
+    assert_eq!(table.data_format(), DataFormat::Dsv);
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(table.body_rows().len(), 2);
+}
+
+non_normative!(
+    r#"
+[source]
+----
+include::example$data.adoc[tag=dsv]
+----
+
+.Result: Rendered DSV table
+[width=90%]
+include::example$data.adoc[tag=dsv]
+
+"#
+);
+
+non_normative!(
+    r#"
+== Data table formats
+
+The CSV and TSV data formats are parsed differently from the DSV data format.
+The following two sections outline those differences.
+
+=== CSV and TSV
+
+"#
+);
+
+#[test]
+fn csv_and_tsv_parsing_rules() {
+    verifies!(
+        r#"
+Table data in either CSV or TSV format is parsed according to the following rules, loosely based on {url-rfc-4180}[RFC 4180^]:
+
+* The default delimiter for CSV is a comma (`,`) while the default delimiter for TSV is a tab character.
+* Empty lines are skipped (unless enclosed in a quoted value).
+* Whitespace surrounding each value is stripped.
+* Values can be enclosed in double quotes (`"`).
+ ** A quoted value may contain zero or more separator or newline characters.
+ ** A newline begins a new row unless the newline is enclosed in double quotes.
+ ** A quoted value may include the double quote character if escaped using another double quote (`""`).
+ ** Newlines in quoted values are retained.
+* If rows do not have the same number of cells ("`ragged`" tables), cells are shuffled to fully fill the rows.
+ ** This is different behavior than Excel, which pads short rows with empty cells.
+ ** Extra cells at the end of the last row get dropped.
+ ** As a rule of thumb, data for a single row should be on the same line.
+
+"#
+    );
+
+    // The default delimiter is a comma for CSV and a tab for TSV.
+    assert_eq!(
+        parse_table("[format=csv]\n|===\na,b,c\n|===")
+            .columns()
+            .len(),
+        3
+    );
+    assert_eq!(
+        parse_table("[format=tsv]\n|===\na\tb\tc\n|===")
+            .columns()
+            .len(),
+        3
+    );
+
+    // Empty lines are skipped and the whitespace surrounding each value is
+    // stripped.
+    let table = parse_table("[format=csv]\n|===\na, b ,c\nd,e,f\n\ng,h,i\n|===");
+    assert!(table.header_row().is_none());
+    assert_eq!(
+        all_texts(&table),
+        ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
+    );
+
+    // A quoted value may contain the separator, which is then literal.
+    let table = parse_table("[format=csv]\n|===\na,\"b,c\",d\n|===");
+    assert_eq!(all_texts(&table), ["a", "b,c", "d"]);
+
+    // A quoted value may contain newlines, which are retained, and a newline
+    // inside the quotes does not begin a new row.
+    let table = parse_table("[format=csv,cols=2*]\n|===\n\"line1\nline2\",x\ny,z\n|===");
+    assert_eq!(table.body_rows().len(), 2);
+    assert_eq!(
+        simple_text(&table.body_rows()[0].cells()[0]),
+        "line1\nline2"
+    );
+    assert_eq!(simple_text(&table.body_rows()[0].cells()[1]), "x");
+    assert_eq!(simple_text(&table.body_rows()[1].cells()[0]), "y");
+
+    // A doubled double quote inside a quoted value is an escaped literal quote.
+    let table = parse_table("[format=csv]\n|===\n\"he said \"\"hi\"\"\",p,q\n|===");
+    assert_eq!(
+        simple_text(&table.body_rows()[0].cells()[0]),
+        "he said \"hi\""
+    );
+
+    // A ragged table flows its cells into complete rows (it is not padded like
+    // Excel); cells left over after the last complete row are dropped.
+    let table = parse_table("[format=csv,cols=3*]\n|===\na,b,c,d,e\n|===");
+    assert_eq!(all_texts(&table), ["a", "b", "c"]);
+
+    let table = parse_table("[format=csv]\n|===\na,b,c\nd,e\nf,g,h,i\n|===");
+    assert!(table.header_row().is_none());
+    assert_eq!(
+        all_texts(&table),
+        ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
+    );
+}
+
+non_normative!(
+    r#"
+=== DSV
+
+"#
+);
+
+#[test]
+fn dsv_parsing_rules() {
+    verifies!(
+        r#"
+Table data in DSV format is parsed according to the following rules:
+
+* The default delimiter for DSV is a colon (`:`).
+* Empty lines are skipped.
+* Whitespace surrounding each value is stripped.
+* The delimiter character can be included in the value if escaped using a single backslash (`\:`).
+* If rows do not have the same number of cells ("`ragged`" tables), cells are shuffled to fully fill the rows.
+
+"#
+    );
+
+    // The default delimiter for DSV is a colon, empty lines are skipped, and the
+    // whitespace surrounding each value is stripped.
+    let table = parse_table("[format=dsv]\n|===\na : b :c\nd:e:f\n|===");
+    assert!(table.header_row().is_none());
+    assert_eq!(all_texts(&table), ["a", "b", "c", "d", "e", "f"]);
+
+    let table = parse_table("[format=dsv]\n|===\na:b\n\nc:d\n|===");
+    assert!(table.header_row().is_some());
+    assert_eq!(all_texts(&table), ["a", "b", "c", "d"]);
+
+    // The delimiter can be included in a value by escaping it with a single
+    // backslash; an enclosing character is not recognized.
+    let table = parse_table("[format=dsv]\n|===\nd\\:e:f:g\n|===");
+    assert_eq!(all_texts(&table), ["d:e", "f", "g"]);
+
+    // A ragged DSV table also flows its cells into complete rows.
+    let table = parse_table("[format=dsv,cols=2*]\n|===\na:b:c\n|===");
+    assert_eq!(all_texts(&table), ["a", "b"]);
+}
+
+non_normative!(
+    r#"
+== Custom delimiters
+
+"#
+);
+
+#[test]
+fn custom_delimiters() {
+    verifies!(
+        r#"
+Each data format has a default separator associated with it (csv = comma, tsv = tab, dsv = colon), but the separator can be changed to any character (or even a string of characters) by setting the `separator` attribute on the table.
+
+"#
+    );
+
+    // The separator can be changed to any character...
+    let table = parse_table("[format=dsv,separator=;]\n|===\na;b;c\nd;e;f\n|===");
+    assert_eq!(all_texts(&table), ["a", "b", "c", "d", "e", "f"]);
+
+    // ...or even to a string of characters.
+    let table = parse_table("[format=csv,separator=::]\n|===\na::b::c\n|===");
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(all_texts(&table), ["a", "b", "c"]);
+}
+
+non_normative!(
+    r#"
+Here's an example of a DSV table that uses a custom separator character (i.e., delimiter):
+
+.A DSV table with a custom separator
+[source]
+----
+[format=dsv,separator=;]
+|===
+a;b;c
+d;e;f
+|===
+----
+
+"#
+);
+
+#[test]
+fn tsv_via_csv_and_tab_separator() {
+    verifies!(
+        r#"
+TIP: To make a TSV table, you can set the `format` attribute to `csv` and the separator to `\t`.
+Though the `tsv` format is preferred.
+
+"#
+    );
+
+    // A TSV table can be produced with `format=csv` and the separator set to a
+    // tab (written `\t`); the preferred `tsv` format yields the same result.
+    let via_csv = parse_table("[format=csv,separator=\\t]\n|===\na\tb\tc\n|===");
+    assert_eq!(via_csv.data_format(), DataFormat::Csv);
+    assert_eq!(all_texts(&via_csv), ["a", "b", "c"]);
+
+    let via_tsv = parse_table("[format=tsv]\n|===\na\tb\tc\n|===");
+    assert_eq!(all_texts(&via_tsv), all_texts(&via_csv));
+}
+
+#[test]
+fn separator_independent_of_format() {
+    verifies!(
+        r#"
+The separator is independent of the processing rules for the format.
+If you set `format=dsv` and `separator=,`, the data will be processed using the DSV rules, even though the data looks like CSV.
+
+"#
+    );
+
+    // The same separator is processed by whichever format's rules are in effect.
+    // Under DSV a double quote is not an enclosing character, so it stays in the
+    // value and the separator still splits around it.
+    let table = parse_table("[format=dsv,separator=;]\n|===\n\"a;b\";c\n|===");
+    assert_eq!(table.data_format(), DataFormat::Dsv);
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(all_texts(&table), ["\"a", "b\"", "c"]);
+
+    // With the very same separator but `format=csv`, the double quotes instead
+    // enclose the value, so the separator inside them is literal.
+    let table = parse_table("[format=csv,separator=;]\n|===\n\"a;b\";c\n|===");
+    assert_eq!(table.data_format(), DataFormat::Csv);
+    assert_eq!(table.columns().len(), 2);
+    assert_eq!(all_texts(&table), ["a;b", "c"]);
+}
+
+non_normative!(
+    r#"
+== Shorthand notation for data tables
+
+"#
+);
+
+#[test]
+fn shorthand_csv_delimiter() {
+    verifies!(
+        r#"
+AsciiDoc provides shorthand notation for specifying the data format of a table.
+The first position of the table block delimiter (i.e., `|===`) can be replaced by a built-in delimiter to set the table format (e.g., `,===` for CSV).
+
+To make a CSV table, you can use `,===` as the table block delimiter:
+
+"#
+    );
+
+    // The `,===` shorthand delimiter sets the CSV format.
+    let table = parse_table(",===\nArtist,Track,Genre\n\nBaauer,Harlem Shake,Hip Hop\n,===");
+    assert_eq!(table.data_format(), DataFormat::Csv);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.columns().len(), 3);
+}
+
+non_normative!(
+    r#"
+[source]
+----
+include::example$data.adoc[tag=s-csv]
+----
+
+.Result: Rendered CSV table using shorthand syntax
+[width=90%]
+include::example$data.adoc[tag=s-csv]
+
+"#
+);
+
+#[test]
+fn shorthand_dsv_delimiter() {
+    verifies!(
+        r#"
+To make a DSV table, you can use `:===` as the table block delimiter:
+
+"#
+    );
+
+    // The `:===` shorthand delimiter sets the DSV format.
+    let table = parse_table(":===\nArtist:Track:Genre\n\nRobyn:Indestructible:Dance\n:===");
+    assert_eq!(table.data_format(), DataFormat::Dsv);
+    assert!(table.header_row().is_some());
+    assert_eq!(table.columns().len(), 3);
+}
+
+non_normative!(
+    r#"
+[source]
+----
+include::example$data.adoc[tag=s-dsv]
+----
+
+.Result: Rendered DSV table using shorthand syntax
+[width=90%]
+include::example$data.adoc[tag=s-dsv]
+
+"#
+);
+
+#[test]
+fn shorthand_implies_format() {
+    verifies!(
+        r#"
+When using either the CSV or DSV shorthand, you do not need to set the `format` attribute as it's implied.
+
+"#
+    );
+
+    // The shorthand implies the format, so no `format` attribute is required.
+    assert_eq!(
+        parse_table(",===\na,b,c\n,===").data_format(),
+        DataFormat::Csv
+    );
+    assert_eq!(
+        parse_table(":===\na:b:c\n:===").data_format(),
+        DataFormat::Dsv
+    );
+}
+
+#[test]
+fn tsv_has_no_shorthand_delimiter() {
+    verifies!(
+        r#"
+To make a TSV table, you can set the `format` attribute to `tsv` instead of having to set the `format` to `csv` and the separator to `\t`.
+In this case, you can use either `|===` or `,===` as the table block delimiter.
+There is no special delimited block notation for a TSV table.
+
+"#
+    );
+
+    // TSV is selected with `format=tsv`; there is no shorthand delimiter for it.
+    let table = parse_table("[format=tsv]\n|===\na\tb\tc\n|===");
+    assert_eq!(table.data_format(), DataFormat::Tsv);
+
+    // Either `|===` or `,===` may be used as the block delimiter for a TSV table.
+    let table = parse_table("[format=tsv]\n,===\na\tb\tc\n,===");
+    assert_eq!(table.data_format(), DataFormat::Tsv);
+    assert_eq!(all_texts(&table), ["a", "b", "c"]);
+}
+
+non_normative!(
+    r#"
+== Formatting cells in a data table
+
+"#
+);
+
+#[test]
+fn formatting_cells_via_cols_spec() {
+    verifies!(
+        r#"
+The delimited formats do not provide a way to express formatting of individual table cells.
+Instead, you can apply cell formatting to all cells in a given column using the `cols` spec on the table:
+
+"#
+    );
+
+    // The delimited formats carry no per-cell spec, so cell formatting is applied
+    // per column with the `cols` spec: here column 1 is a header column and
+    // column 2 is an AsciiDoc column.
+    let table = parse_table(
+        "[format=csv,cols=\"1h,1a\"]\n|===\nSky,image::sky.jpg[]\nForest,image::forest.jpg[]\n|===",
+    );
+    assert_eq!(table.columns()[0].style(), ColumnStyle::Header);
+    assert_eq!(table.columns()[1].style(), ColumnStyle::AsciiDoc);
+
+    // The second column's cells are parsed as AsciiDoc block content.
+    assert!(matches!(
+        table.body_rows()[0].cells()[1].content(),
+        TableCellContent::AsciiDoc(_)
+    ));
+}
+
+non_normative!(
+    r#"
+[source]
+----
+[format=csv,cols="1h,1a"]
+|===
+Sky,image::sky.jpg[]
+Forest,image::forest.jpg[]
+|===
+----
+
+"#
+);
+
+#[test]
+fn data_tables_do_not_support_spans() {
+    verifies!(
+        r#"
+Data tables do not support cells that span multiple rows or columns, since that information can only be expressed at the cell level.
+You are advised to use the PSV format if you need that functionality.
+"#
+    );
+
+    // A data table cannot express a row or column span: a `2+` operator is
+    // ordinary cell data, spanning a single column.
+    let table = parse_table("[format=csv]\n|===\n2+,b,c\nd,e,f\n|===");
+    assert_eq!(table.columns().len(), 3);
+    let cell = &table.body_rows()[0].cells()[0];
+    assert_eq!(cell.colspan(), 1);
+    assert_eq!(cell.rowspan(), 1);
+    assert_eq!(simple_text(cell), "2+");
+}

--- a/parser/src/tests/asciidoc_lang/tables/data_format.rs
+++ b/parser/src/tests/asciidoc_lang/tables/data_format.rs
@@ -680,8 +680,10 @@ Each data format has a default separator associated with it (csv = comma, tsv = 
     assert_eq!(all_texts(&table), ["a", "b", "c"]);
 }
 
-non_normative!(
-    r#"
+#[test]
+fn custom_separator_dsv_example() {
+    verifies!(
+        r#"
 Here's an example of a DSV table that uses a custom separator character (i.e., delimiter):
 
 .A DSV table with a custom separator
@@ -695,7 +697,14 @@ d;e;f
 ----
 
 "#
-);
+    );
+
+    // The DSV example with a custom `;` separator parses into two three-cell rows.
+    let table = parse_table("[format=dsv,separator=;]\n|===\na;b;c\nd;e;f\n|===");
+    assert_eq!(table.data_format(), DataFormat::Dsv);
+    assert_eq!(table.columns().len(), 3);
+    assert_eq!(all_texts(&table), ["a", "b", "c", "d", "e", "f"]);
+}
 
 #[test]
 fn tsv_via_csv_and_tab_separator() {

--- a/parser/src/tests/asciidoc_lang/tables/mod.rs
+++ b/parser/src/tests/asciidoc_lang/tables/mod.rs
@@ -10,6 +10,7 @@ mod assign_a_role;
 mod borders;
 mod build_a_basic_table;
 mod customize_title_label;
+mod data_format;
 mod duplicate_cells;
 mod format_cell_content;
 mod format_column_content;


### PR DESCRIPTION
Implements all of the items described in `docs/modules/tables/pages/data-format.adoc`, targeting the `tables` feature branch.

## What's implemented

- **`format` attribute** — selects the table data format (`psv`, `csv`, `tsv`, `dsv`), exposed via a new `TableBlock::data_format() -> DataFormat`.
- **Shorthand delimiters** — `,===` (CSV) and `:===` (DSV) select the format without an explicit `format` attribute; `is_table_delimiter` now recognizes the `,` and `:` lead characters.
- **CSV / TSV parsing** (loosely RFC 4180):
  - default delimiter comma (CSV) / tab (TSV)
  - empty lines skipped, surrounding whitespace stripped
  - double-quote enclosure: separators and newlines literal inside quotes, `""` escapes a literal quote, newlines retained
  - ragged tables flowed into fixed-width rows, leftover cells at the end dropped
- **DSV parsing** — colon default separator, separators escapable with a single backslash (`\:`), no enclosing character.
- **Custom separators** via the `separator` attribute, including:
  - multi-byte characters (the broken bar `¦` now works for PSV — the cell scanner matches a string separator instead of a single byte)
  - multi-character string separators
  - the `\t` tab escape (`[format=csv,separator=\t]`)
- **Per-column cell formatting** for data tables via the `cols` spec (e.g. `cols="1h,1a"`).

## Verification

- All behaviors were validated against the locally-installed Ruby Asciidoctor.
- New verbatim, line-by-line spec coverage in `parser/src/tests/asciidoc_lang/tables/data_format.rs` — the SDD tool reports the page fully covered (0 uncovered lines).
- `cargo test -p asciidoc-parser`, `cargo clippy --all-targets`, `cargo +nightly fmt --check`, and `cargo +nightly doc` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)