### PR TITLE
feat: Port Ruby Asciidoctor table tests (and fix the parser divergences they surfaced)

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1,3 +1,7 @@
+use std::sync::Arc;
+
+use self_cell::self_cell;
+
 use crate::{
     HasSpan, Parser, Span,
     attributes::Attrlist,
@@ -8,6 +12,7 @@ use crate::{
     document::InterpretedValue,
     parser::{
         InlineSubstitutionRenderer, ModificationContext, ReferenceResolver, ReferenceWarning,
+        preprocessor::preprocess,
     },
     span::MatchedItem,
     strings::CowStr,
@@ -1613,55 +1618,38 @@ fn process_content<'src>(
         // derived `backend-html5-doctype-*` attribute is refreshed to match.
         parser.force_doctype("article");
 
-        // A leading level-0 title line (`= Title`) is the nested document's
-        // title rather than a section, so capture it here (a level-0 heading is
-        // otherwise rejected in block parsing). The remaining lines form the
-        // cell's body.
-        let first_line = trimmed.take_line();
-        let (title_source, body) = if first_line.item.data().starts_with("= ") {
-            (
-                Some(first_line.item.discard(2).discard_whitespace()),
-                first_line.after,
-            )
+        // A cell whose content holds a preprocessor directive (an `include::`)
+        // is parsed from an owned, expanded source the cell carries; every other
+        // cell is parsed in place from the parent document's source, which keeps
+        // its spans (and line numbers) and avoids a copy.
+        let cell = if content_has_directive(trimmed.data()) {
+            let (expanded, _source_map) = preprocess(trimmed.data(), parser);
+            let owned = OwnedCell::new(expanded, |source| {
+                // Warnings from the owned parse borrow the owned source and so
+                // cannot escape it; the include path is rare and currently
+                // warning-free, so they are dropped here.
+                let mut owned_warnings: Vec<Warning<'_>> = vec![];
+                let (title, inline, blocks) =
+                    parse_asciidoc_cell_body(Span::new(source), parser, &mut owned_warnings);
+                OwnedCellInner {
+                    title,
+                    inline,
+                    blocks,
+                }
+            });
+            AsciiDocCell::Owned(Arc::new(owned))
         } else {
-            (None, trimmed)
-        };
-
-        // Mark that we are inside an AsciiDoc cell (a nested document) for the
-        // duration of the cell, so a table found within defaults its cell
-        // separator to `!` rather than `|` (matching Asciidoctor's
-        // `Document#nested?`). The depth is restored afterward so the marker is
-        // scoped to the cell and nests correctly.
-        parser.nested_document_depth += 1;
-        let mut maw = parse_blocks_until(body, |_| false, parser);
-        parser.nested_document_depth -= 1;
-
-        // The cell's render-time decisions depend on its now-mutated attribute
-        // state (its body may have changed `doctype`/`showtitle`/`notitle`), so
-        // resolve them before the snapshot is restored. A captured title is kept
-        // only when the cell's effective `showtitle` shows it.
-        let inline = matches!(
-            parser.attribute_value("doctype"),
-            InterpretedValue::Value(ref v) if v == "inline"
-        );
-        let title = if parser.resolve_show_title(true) {
-            title_source.map(|span| {
-                let mut content = Content::from(span);
-                SubstitutionGroup::Header.apply(&mut content, parser, None);
-                content.rendered().to_string()
+            let (title, inline, blocks) = parse_asciidoc_cell_body(trimmed, parser, warnings);
+            AsciiDocCell::Borrowed(BorrowedCell {
+                title,
+                inline,
+                blocks,
             })
-        } else {
-            None
         };
 
         parser.locked_attribute_names = saved_locks;
         parser.attribute_values = saved_attributes;
-        warnings.append(&mut maw.warnings);
-        TableCellContent::AsciiDoc(AsciiDocCell {
-            title,
-            inline,
-            blocks: maw.item.item,
-        })
+        TableCellContent::AsciiDoc(cell)
     } else {
         let mut content = match replacement {
             Some(replacement) => Content::from_filtered(trimmed, replacement),
@@ -1677,6 +1665,63 @@ fn process_content<'src>(
 
         TableCellContent::Simple(content)
     }
+}
+
+/// Parses the body of an AsciiDoc table cell — a nested, standalone AsciiDoc
+/// document — returning its (shown) title, whether its doctype is `inline`, and
+/// its blocks.
+///
+/// A leading level-0 title line (`= Title`) is the nested document's title
+/// rather than a section, so it is split off and rendered here (a level-0
+/// heading is otherwise rejected in block parsing). The render-time decisions
+/// (`inline`, and whether the title is shown) depend on the cell's now-mutated
+/// attribute state, so they are resolved before the caller restores the
+/// parent's attribute snapshot.
+fn parse_asciidoc_cell_body<'src>(
+    content: Span<'src>,
+    parser: &mut Parser,
+    warnings: &mut Vec<Warning<'src>>,
+) -> (Option<String>, bool, Vec<Block<'src>>) {
+    let first_line = content.take_line();
+    let (title_source, body) = if first_line.item.data().starts_with("= ") {
+        (
+            Some(first_line.item.discard(2).discard_whitespace()),
+            first_line.after,
+        )
+    } else {
+        (None, content)
+    };
+
+    // Mark that we are inside an AsciiDoc cell (a nested document) for the
+    // duration of the parse, so a table found within defaults its cell separator
+    // to `!` rather than `|` (matching Asciidoctor's `Document#nested?`).
+    parser.nested_document_depth += 1;
+    let mut maw = parse_blocks_until(body, |_| false, parser);
+    parser.nested_document_depth -= 1;
+    warnings.append(&mut maw.warnings);
+
+    let inline = matches!(
+        parser.attribute_value("doctype"),
+        InterpretedValue::Value(ref v) if v == "inline"
+    );
+    let title = if parser.resolve_show_title(true) {
+        title_source.map(|span| {
+            let mut content = Content::from(span);
+            SubstitutionGroup::Header.apply(&mut content, parser, None);
+            content.rendered().to_string()
+        })
+    } else {
+        None
+    };
+
+    (title, inline, maw.item.item)
+}
+
+/// Returns `true` when the cell content holds an `include::` preprocessor
+/// directive at the start of a line, which must be expanded before the cell is
+/// parsed.
+fn content_has_directive(content: &str) -> bool {
+    content.starts_with("include::") || content.contains("\ninclude::")
 }
 
 /// A row of cells in a [`TableBlock`].
@@ -1885,9 +1930,7 @@ impl<'src> TableCell<'src> {
                 content.resolve_references(resolver, renderer, warnings);
             }
             TableCellContent::AsciiDoc(cell) => {
-                for block in cell.blocks_mut() {
-                    block.resolve_references(resolver, renderer, warnings);
-                }
+                cell.resolve_references(resolver, renderer, warnings);
             }
         }
     }
@@ -1929,11 +1972,19 @@ pub enum TableCellContent<'src> {
 /// parsed and captured here: whether the cell's nested document title is shown
 /// (and its rendered text), and whether the cell's `doctype` is `inline` (in
 /// which case a lone paragraph renders without the usual block wrapper).
+///
+/// A cell whose content has no preprocessor directives is parsed in place from
+/// the parent document's source ([`Borrowed`](Self::Borrowed)). A cell that
+/// expands an `include::` directive owns its preprocessed source
+/// ([`Owned`](Self::Owned)); the owned store is shared behind an [`Arc`] so the
+/// cell stays cheaply cloneable.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AsciiDocCell<'src> {
-    title: Option<String>,
-    inline: bool,
-    blocks: Vec<Block<'src>>,
+pub enum AsciiDocCell<'src> {
+    /// Parsed in place from the parent document's source.
+    Borrowed(BorrowedCell<'src>),
+
+    /// Parsed from an owned, include-expanded source the cell carries.
+    Owned(Arc<OwnedCell>),
 }
 
 impl<'src> AsciiDocCell<'src> {
@@ -1943,7 +1994,10 @@ impl<'src> AsciiDocCell<'src> {
     /// (`= Title`) *and* the cell's effective `showtitle`/`notitle` state means
     /// that title is shown; otherwise it is `None`.
     pub fn title(&self) -> Option<&str> {
-        self.title.as_deref()
+        match self {
+            Self::Borrowed(cell) => cell.title.as_deref(),
+            Self::Owned(cell) => cell.borrow_dependent().title.as_deref(),
+        }
     }
 
     /// Returns `true` when the cell's `doctype` resolves to `inline`.
@@ -1951,19 +2005,77 @@ impl<'src> AsciiDocCell<'src> {
     /// An `inline` document renders a lone paragraph as bare inline content,
     /// without the enclosing block wrapper.
     pub fn is_inline(&self) -> bool {
-        self.inline
+        match self {
+            Self::Borrowed(cell) => cell.inline,
+            Self::Owned(cell) => cell.borrow_dependent().inline,
+        }
     }
 
     /// Returns the blocks parsed from the cell's content.
-    pub fn blocks(&self) -> &[Block<'src>] {
-        &self.blocks
+    pub fn blocks(&self) -> &[Block<'_>] {
+        match self {
+            Self::Borrowed(cell) => &cell.blocks,
+            Self::Owned(cell) => &cell.borrow_dependent().blocks,
+        }
     }
 
-    /// Returns a mutable iterator over the cell's blocks (used to resolve
-    /// deferred cross-references).
-    fn blocks_mut(&mut self) -> impl Iterator<Item = &mut Block<'src>> {
-        self.blocks.iter_mut()
+    /// Resolves any deferred cross-references in the cell's blocks.
+    fn resolve_references(
+        &mut self,
+        resolver: &dyn ReferenceResolver,
+        renderer: &dyn InlineSubstitutionRenderer,
+        warnings: &mut Vec<ReferenceWarning>,
+    ) {
+        match self {
+            Self::Borrowed(cell) => {
+                for block in &mut cell.blocks {
+                    block.resolve_references(resolver, renderer, warnings);
+                }
+            }
+            // The owned store is shared behind an `Arc`, but references are
+            // resolved immediately after parsing while the cell is still its sole
+            // owner, so `get_mut` succeeds.
+            Self::Owned(cell) => {
+                if let Some(cell) = Arc::get_mut(cell) {
+                    cell.with_dependent_mut(|_, dependent| {
+                        for block in &mut dependent.blocks {
+                            block.resolve_references(resolver, renderer, warnings);
+                        }
+                    });
+                }
+            }
+        }
     }
+}
+
+/// An [`AsciiDoc`](TableCellContent::AsciiDoc) cell parsed in place from the
+/// parent document's source.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BorrowedCell<'src> {
+    title: Option<String>,
+    inline: bool,
+    blocks: Vec<Block<'src>>,
+}
+
+self_cell! {
+    /// An [`AsciiDoc`](TableCellContent::AsciiDoc) cell that owns its
+    /// (include-expanded) source, with the parsed blocks borrowing from it.
+    pub struct OwnedCell {
+        owner: String,
+
+        #[covariant]
+        dependent: OwnedCellInner,
+    }
+
+    impl {Debug, Eq, PartialEq}
+}
+
+/// The parsed contents of an [`OwnedCell`], borrowing its owned source.
+#[derive(Debug, Eq, PartialEq)]
+struct OwnedCellInner<'src> {
+    title: Option<String>,
+    inline: bool,
+    blocks: Vec<Block<'src>>,
 }
 
 /// Parse the value of the `cols` attribute into a list of columns, mirroring

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -2688,3 +2688,51 @@ fn psv_line_starts_cell(line: &str, separator: &str) -> bool {
 fn line_has_unclosed_quote(line: &str) -> bool {
     line.bytes().filter(|&b| b == b'"').count() % 2 == 1
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::{AsciiDocCell, OwnedCell, OwnedCellInner};
+    use crate::parser::{
+        HtmlSubstitutionRenderer, ReferenceResolver, ResolutionContext, ResolvedReference,
+    };
+
+    /// A resolver that resolves nothing; the owned-cell resolution path under
+    /// test carries no references, so it is never actually consulted.
+    struct NoopResolver;
+
+    impl ReferenceResolver for NoopResolver {
+        fn resolve(&self, _context: &ResolutionContext<'_>) -> Option<ResolvedReference> {
+            None
+        }
+    }
+
+    /// When an owned (include-expanded) AsciiDoc cell is shared behind more
+    /// than one `Arc` reference, `resolve_references` cannot obtain a
+    /// mutable borrow of the store and leaves it untouched rather than
+    /// panicking. Production code resolves while the cell is its sole
+    /// owner, so this defensive branch is exercised here by deliberately
+    /// holding a second reference.
+    #[test]
+    fn resolve_references_skips_shared_owned_cell() {
+        let mut cell = AsciiDocCell::Owned(Arc::new(OwnedCell::new(String::new(), |_source| {
+            OwnedCellInner {
+                title: None,
+                inline: false,
+                blocks: vec![],
+            }
+        })));
+
+        // Hold a second reference to the same store so `Arc::get_mut` fails.
+        let shared = cell.clone();
+
+        let mut warnings = vec![];
+        cell.resolve_references(&NoopResolver, &HtmlSubstitutionRenderer {}, &mut warnings);
+
+        // Resolution was skipped silently: no warnings, and the two references
+        // still describe the same (unmodified) cell.
+        assert!(warnings.is_empty());
+        assert_eq!(cell, shared);
+    }
+}

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1139,10 +1139,15 @@ fn build_psv_table<'src>(
             }
         }
 
-        // A trailing incomplete row (one that never reached `ncols`) is still
-        // emitted, matching the existing handling of short final rows.
-        if !current_row.is_empty() {
-            raw_rows.push(current_row);
+        // If the table ends mid-row, the cells accumulated since the last
+        // complete row never filled `ncols`. Matching Asciidoctor's
+        // `close_table`, that incomplete row is dropped and an error is logged
+        // against its last cell.
+        if let Some(last) = current_row.last() {
+            warnings.push(Warning {
+                source: last.content,
+                warning: WarningType::TableDroppingIncompleteRowAtEndOfTable,
+            });
         }
     }
 

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1056,6 +1056,7 @@ fn build_psv_table<'src>(
     // single-column slots (one per clone).
     let first_line_cells: usize =
         scan_cells(inside.discard_empty_lines().take_line().item, separator)
+            .0
             .iter()
             .map(|c| c.spec.colspan.max(1) * c.spec.repeat.min(MAX_DUPLICATION_FACTOR))
             .sum();
@@ -1068,7 +1069,14 @@ fn build_psv_table<'src>(
 
     let columns = finalize_columns(cols_attr, ncols, autowidth);
 
-    let raw_cells = expand_duplicates(scan_cells(inside, separator));
+    let (raw_cells, recovered_first_cell) = scan_cells(inside, separator);
+    if let Some(source) = recovered_first_cell {
+        warnings.push(Warning {
+            source,
+            warning: WarningType::TableMissingLeadingSeparator,
+        });
+    }
+    let raw_cells = expand_duplicates(raw_cells);
 
     // A table can never have more rows than it has cells, so a row span is
     // clamped to the cell count for the `active_rowspans` bookkeeping below: a
@@ -2087,7 +2095,10 @@ fn expand_duplicates(cells: Vec<RawCell<'_>>) -> Vec<RawCell<'_>> {
 /// inspected, so `\\|` is also read as an escaped separator — matching
 /// Asciidoctor, whose check is likewise the single-character
 /// `pre_match.end_with? '\'`.
-fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
+fn scan_cells<'src>(
+    region: Span<'src>,
+    separator: &str,
+) -> (Vec<RawCell<'src>>, Option<Span<'src>>) {
     let data = region.data();
     let bytes = data.as_bytes();
     let len = bytes.len();
@@ -2099,6 +2110,9 @@ fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
     // The content start and specifier of the cell currently being accumulated.
     let mut content_start: Option<usize> = None;
     let mut cur_spec = CellSpec::default();
+    // The span of a cell recovered from content that precedes the first
+    // separator (see below); `Some` drives a missing-leading-separator warning.
+    let mut recovered: Option<Span<'src>> = None;
     let mut i = 0;
 
     while i < len {
@@ -2147,13 +2161,30 @@ fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
                 None => (i, CellSpec::default()),
             };
 
-            if let Some(start) = content_start {
-                // The separating whitespace, included in the slice, is trimmed
-                // later in `TableCell::parse`.
-                cells.push(RawCell {
-                    spec: cur_spec,
-                    content: region.slice(start..content_end),
-                });
+            match content_start {
+                Some(start) => {
+                    // The separating whitespace, included in the slice, is
+                    // trimmed later in `TableCell::parse`.
+                    cells.push(RawCell {
+                        spec: cur_spec,
+                        content: region.slice(start..content_end),
+                    });
+                }
+                None => {
+                    // No cell has been opened yet, so this is the table's first
+                    // separator. Non-blank content in front of it means the first
+                    // cell is missing its leading separator; recover that content
+                    // as the first cell (with the default specifier) and record
+                    // its span so the caller can warn, matching Asciidoctor.
+                    let leading = region.slice(0..content_end);
+                    if !leading.data().trim().is_empty() {
+                        cells.push(RawCell {
+                            spec: CellSpec::default(),
+                            content: leading,
+                        });
+                        recovered = Some(leading);
+                    }
+                }
             }
             cur_spec = next_spec;
             content_start = Some(i + sep_len);
@@ -2171,7 +2202,7 @@ fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
         });
     }
 
-    cells
+    (cells, recovered)
 }
 
 /// Parse a cell specifier, returning its [span and overrides](CellSpec), or

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -6,7 +6,9 @@ use crate::{
     },
     content::{Content, SubstitutionGroup},
     document::InterpretedValue,
-    parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning},
+    parser::{
+        InlineSubstitutionRenderer, ModificationContext, ReferenceResolver, ReferenceWarning,
+    },
     span::MatchedItem,
     strings::CowStr,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -1581,14 +1583,49 @@ fn process_content<'src>(
         // cell may assign it (matching Asciidoctor, which here diverges from the
         // spec's "set or explicitly unset" wording). The lock set is saved and
         // restored so it applies only within the cell and nests correctly.
+        // An attribute set in the parent is locked, as is one hard set or unset
+        // through the API (its modification context is `ApiOnly`) even though it
+        // is unset — matching Asciidoctor, where an API-controlled attribute can
+        // never be overridden in a cell. An attribute merely unset in the parent
+        // document is not locked, so the cell may assign it.
         let saved_locks = parser.locked_attribute_names.clone();
         for (name, value) in saved_attributes.iter() {
-            if !matches!(value.value, InterpretedValue::Unset)
+            let api_locked = value.modification_context == ModificationContext::ApiOnly;
+            if (!matches!(value.value, InterpretedValue::Unset) || api_locked)
                 && !ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES.contains(&name.as_str())
             {
                 parser.locked_attribute_names.insert(name.clone());
             }
         }
+
+        // The modifiable attributes may always be changed inside a cell, even
+        // when the parent or the API set them with a restrictive modification
+        // context. Relax their context for the duration of the cell so a body
+        // assignment is honored; the snapshot restore reverts it afterward.
+        for name in ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES {
+            if let Some(attr) = parser.attribute_values.get_mut(*name) {
+                attr.modification_context = ModificationContext::Anywhere;
+            }
+        }
+
+        // A cell does not inherit the parent's doctype; it resets to the default
+        // (`article`). The cell body may still set its own doctype, and the
+        // derived `backend-html5-doctype-*` attribute is refreshed to match.
+        parser.force_doctype("article");
+
+        // A leading level-0 title line (`= Title`) is the nested document's
+        // title rather than a section, so capture it here (a level-0 heading is
+        // otherwise rejected in block parsing). The remaining lines form the
+        // cell's body.
+        let first_line = trimmed.take_line();
+        let (title_source, body) = if first_line.item.data().starts_with("= ") {
+            (
+                Some(first_line.item.discard(2).discard_whitespace()),
+                first_line.after,
+            )
+        } else {
+            (None, trimmed)
+        };
 
         // Mark that we are inside an AsciiDoc cell (a nested document) for the
         // duration of the cell, so a table found within defaults its cell
@@ -1596,13 +1633,35 @@ fn process_content<'src>(
         // `Document#nested?`). The depth is restored afterward so the marker is
         // scoped to the cell and nests correctly.
         parser.nested_document_depth += 1;
-        let mut maw = parse_blocks_until(trimmed, |_| false, parser);
+        let mut maw = parse_blocks_until(body, |_| false, parser);
         parser.nested_document_depth -= 1;
+
+        // The cell's render-time decisions depend on its now-mutated attribute
+        // state (its body may have changed `doctype`/`showtitle`/`notitle`), so
+        // resolve them before the snapshot is restored. A captured title is kept
+        // only when the cell's effective `showtitle` shows it.
+        let inline = matches!(
+            parser.attribute_value("doctype"),
+            InterpretedValue::Value(ref v) if v == "inline"
+        );
+        let title = if parser.resolve_show_title(true) {
+            title_source.map(|span| {
+                let mut content = Content::from(span);
+                SubstitutionGroup::Header.apply(&mut content, parser, None);
+                content.rendered().to_string()
+            })
+        } else {
+            None
+        };
 
         parser.locked_attribute_names = saved_locks;
         parser.attribute_values = saved_attributes;
         warnings.append(&mut maw.warnings);
-        TableCellContent::AsciiDoc(maw.item.item)
+        TableCellContent::AsciiDoc(AsciiDocCell {
+            title,
+            inline,
+            blocks: maw.item.item,
+        })
     } else {
         let mut content = match replacement {
             Some(replacement) => Content::from_filtered(trimmed, replacement),
@@ -1818,8 +1877,8 @@ impl<'src> TableCell<'src> {
             TableCellContent::Simple(content) => {
                 content.resolve_references(resolver, renderer, warnings);
             }
-            TableCellContent::AsciiDoc(blocks) => {
-                for block in blocks.iter_mut() {
+            TableCellContent::AsciiDoc(cell) => {
+                for block in cell.blocks_mut() {
                     block.resolve_references(resolver, renderer, warnings);
                 }
             }
@@ -1842,7 +1901,53 @@ pub enum TableCellContent<'src> {
 
     /// Block content: the cell's text parsed as a nested, standalone AsciiDoc
     /// document. Produced by the [`AsciiDoc`](ColumnStyle::AsciiDoc) style.
-    AsciiDoc(Vec<Block<'src>>),
+    AsciiDoc(AsciiDocCell<'src>),
+}
+
+/// The content of an [`AsciiDoc`](TableCellContent::AsciiDoc) table cell: a
+/// nested, standalone AsciiDoc document.
+///
+/// Because the cell behaves like its own document, a few render-time decisions
+/// depend on attribute state that is scoped to the cell and gone by the time
+/// the document is rendered. They are therefore resolved while the cell is
+/// parsed and captured here: whether the cell's nested document title is shown
+/// (and its rendered text), and whether the cell's `doctype` is `inline` (in
+/// which case a lone paragraph renders without the usual block wrapper).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AsciiDocCell<'src> {
+    title: Option<String>,
+    inline: bool,
+    blocks: Vec<Block<'src>>,
+}
+
+impl<'src> AsciiDocCell<'src> {
+    /// Returns the cell's nested-document title, rendered to its display text.
+    ///
+    /// This is `Some` only when the cell began with a level-0 title line
+    /// (`= Title`) *and* the cell's effective `showtitle`/`notitle` state means
+    /// that title is shown; otherwise it is `None`.
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    /// Returns `true` when the cell's `doctype` resolves to `inline`.
+    ///
+    /// An `inline` document renders a lone paragraph as bare inline content,
+    /// without the enclosing block wrapper.
+    pub fn is_inline(&self) -> bool {
+        self.inline
+    }
+
+    /// Returns the blocks parsed from the cell's content.
+    pub fn blocks(&self) -> &[Block<'src>] {
+        &self.blocks
+    }
+
+    /// Returns a mutable iterator over the cell's blocks (used to resolve
+    /// deferred cross-references).
+    fn blocks_mut(&mut self) -> impl Iterator<Item = &mut Block<'src>> {
+        self.blocks.iter_mut()
+    }
 }
 
 /// Parse the value of the `cols` attribute into a list of columns, mirroring

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1701,6 +1701,7 @@ pub struct TableCell<'src> {
     colspan: usize,
     rowspan: usize,
     content: TableCellContent<'src>,
+    source: Span<'src>,
 }
 
 impl<'src> TableCell<'src> {
@@ -1771,6 +1772,10 @@ impl<'src> TableCell<'src> {
             colspan: raw.spec.colspan.max(1),
             rowspan: raw.spec.rowspan.max(1),
             content,
+            // The cell's source begins at its content, immediately after the
+            // separator (before any trimming), so the cell's reported line is
+            // the separator's line.
+            source: raw.content,
         }
     }
 
@@ -1797,6 +1802,7 @@ impl<'src> TableCell<'src> {
             column.style
         };
 
+        let source = field.content;
         let content = process_content(field.content, field.replacement, style, parser, warnings);
 
         Self {
@@ -1806,6 +1812,7 @@ impl<'src> TableCell<'src> {
             colspan: 1,
             rowspan: 1,
             content,
+            source,
         }
     }
 
@@ -1883,6 +1890,15 @@ impl<'src> TableCell<'src> {
                 }
             }
         }
+    }
+}
+
+impl<'src> HasSpan<'src> for TableCell<'src> {
+    /// Returns the cell's source span, which begins at the cell's content
+    /// immediately after its separator. Its [line](Span::line) is therefore the
+    /// line on which the cell starts.
+    fn span(&self) -> Span<'src> {
+        self.source
     }
 }
 

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -217,7 +217,22 @@ impl<'src> TableBlock<'src> {
         let line1_blank = line1.item.data().trim().is_empty();
         let line2_blank =
             !line1.after.is_empty() && line1.after.take_line().item.data().trim().is_empty();
-        let has_header = opts_header || (!opts_noheader && !line1_blank && line2_blank);
+
+        // An implicit header additionally requires that the first row be complete
+        // on the first line. If the first cell spans multiple lines — for PSV,
+        // the first non-blank line after the blank gap continues the cell instead
+        // of starting a new one; for CSV/TSV, the first line opens a quoted value
+        // that is not closed on that line — there is no implicit header (matching
+        // Asciidoctor, which cancels the implicit header in these cases).
+        let first_row_complete = match data_format {
+            DataFormat::Psv => first_nonblank_line(line1.after)
+                .is_none_or(|line| psv_line_starts_cell(line.data(), separator.as_str())),
+            DataFormat::Csv | DataFormat::Tsv => !line_has_unclosed_quote(line1.item.data()),
+            DataFormat::Dsv => true,
+        };
+
+        let has_header =
+            opts_header || (!opts_noheader && !line1_blank && line2_blank && first_row_complete);
 
         // A titled table is given a caption (e.g. "Table 1. ") that a processor
         // prepends to the title.
@@ -1176,7 +1191,7 @@ fn build_data_table<'src>(
     let (fields, first_row_len) = if data_format == DataFormat::Dsv {
         parse_dsv_fields(inside, separator)
     } else {
-        parse_csv_fields(inside, separator)
+        parse_csv_fields(inside, separator, warnings)
     };
 
     let ncols = if cols_attr.is_empty() {
@@ -1238,7 +1253,11 @@ struct DataField<'src> {
 /// value. As a result a value whose opening quote is never properly closed (or
 /// that has trailing characters after its closing quote) keeps its quotes and
 /// absorbs the following separators, rather than being treated as enclosed.
-fn parse_csv_fields<'src>(region: Span<'src>, separator: &str) -> (Vec<DataField<'src>>, usize) {
+fn parse_csv_fields<'src>(
+    region: Span<'src>,
+    separator: &str,
+    warnings: &mut Vec<Warning<'src>>,
+) -> (Vec<DataField<'src>>, usize) {
     let data = region.data();
     let n = data.len();
     let sep_len = separator.len().max(1);
@@ -1279,7 +1298,7 @@ fn parse_csv_fields<'src>(region: Span<'src>, separator: &str) -> (Vec<DataField
         // blank cell that follows a separator on a populated line is kept.
         let blank_skip = (at_nl || at_eof) && fields_in_row == 0 && raw.trim().is_empty();
         if !blank_skip {
-            fields.push(make_csv_field(region, cell_start, i));
+            fields.push(make_csv_field(region, cell_start, i, warnings));
             fields_in_row += 1;
             if !first_row_done {
                 first_row_len = fields_in_row;
@@ -1312,37 +1331,42 @@ fn parse_csv_fields<'src>(region: Span<'src>, separator: &str) -> (Vec<DataField
 /// applying Asciidoctor's `close_cell` value processing.
 ///
 /// The value is stripped of surrounding whitespace; then, if it is enclosed in
-/// double quotes, the quotes are removed and the inner value is stripped again;
-/// finally any run of consecutive double quotes is collapsed to one (so an
-/// escaped `""` becomes a single `"`). A value that is not enclosed (no leading
-/// quote, an unclosed quote, or trailing characters after the closing quote)
-/// keeps its quotes and is only collapsed.
-fn make_csv_field<'src>(region: Span<'src>, start: usize, end: usize) -> DataField<'src> {
+/// double quotes, the quotes are removed and the inner value is stripped again,
+/// so the field's [content](DataField::content) span points at the actual value
+/// (this matters for an AsciiDoc cell, which parses that span). Finally any run
+/// of consecutive double quotes is collapsed to one (so an escaped `""` becomes
+/// a single `"`). A value that is not enclosed (no leading quote, or trailing
+/// characters after the closing quote) keeps its quotes and is only collapsed.
+///
+/// A lone double quote is an unclosed quoted value: it logs an error and the
+/// cell is set to empty (matching Asciidoctor).
+fn make_csv_field<'src>(
+    region: Span<'src>,
+    start: usize,
+    end: usize,
+    warnings: &mut Vec<Warning<'src>>,
+) -> DataField<'src> {
     let trimmed = trim_surrounding_whitespace(region.slice(start..end));
-    let value = csv_cell_value(trimmed.data());
-    let replacement = (value != trimmed.data()).then_some(value);
-    DataField {
-        content: trimmed,
-        replacement,
-    }
-}
+    let data = trimmed.data();
 
-/// Apply Asciidoctor's CSV value processing to an already-stripped cell value:
-/// unquote an enclosed value and collapse escaped double quotes (`""` -> `"`).
-fn csv_cell_value(text: &str) -> String {
-    if text.is_empty() || !text.contains('"') {
-        return text.to_string();
-    }
-
-    // An enclosed value (leading and trailing quote) has its quotes removed and
-    // is stripped again; a lone `"` becomes empty. Anything else keeps its text.
-    if text.starts_with('"') && text.ends_with('"') {
-        match text.get(1..text.len() - 1) {
-            Some(inner) => squeeze_quotes(inner.trim()),
-            None => String::new(),
-        }
+    let content = if data == "\"" {
+        warnings.push(Warning {
+            source: trimmed,
+            warning: WarningType::TableCsvDataHasUnclosedQuote,
+        });
+        trimmed.slice(0..0)
+    } else if data.len() >= 2 && data.starts_with('"') && data.ends_with('"') {
+        trim_surrounding_whitespace(trimmed.slice(1..data.len() - 1))
     } else {
-        squeeze_quotes(text)
+        trimmed
+    };
+
+    let value = squeeze_quotes(content.data());
+    let replacement = (value != content.data()).then_some(value);
+
+    DataField {
+        content,
+        replacement,
     }
 }
 
@@ -1651,7 +1675,7 @@ impl<'src> TableCell<'src> {
             raw.spec.style.unwrap_or(column.style)
         };
 
-        let trimmed = trim_surrounding_whitespace(raw.content);
+        let trimmed = trim_cell_content(raw.content, style);
 
         // An escaped cell separator (a backslash in front of the table's
         // separator, e.g. `\|` or `\!`) is unescaped to the bare separator. Only
@@ -1808,23 +1832,50 @@ pub enum TableCellContent<'src> {
     AsciiDoc(Vec<Block<'src>>),
 }
 
-/// Parse the value of the `cols` attribute into a list of columns.
+/// Parse the value of the `cols` attribute into a list of columns, mirroring
+/// Asciidoctor's `parse_colspecs`.
 ///
-/// The value is a comma-separated list of column specifiers. A specifier may be
-/// preceded by a multiplier (`<n>*`) that repeats the column `n` times. The
-/// alignment operators and proportional width of a specifier are interpreted;
-/// the style operator is not yet.
+/// All spaces are first removed from the value. A wholly blank value yields no
+/// columns (the caller then takes the column count from the first row), and a
+/// lone integer (the deprecated `cols="3"` form) yields that many default
+/// columns. Otherwise the value is a list of column specifiers separated by
+/// commas, or by semicolons when no comma is present. An empty record (e.g. the
+/// trailing field of `cols="1,,1"`) contributes a default column, and a
+/// specifier may be preceded by a multiplier (`<n>*`) that repeats the column
+/// `n` times. Each specifier's alignment operators, proportional width, and
+/// [style operator](parse_col_spec) are interpreted.
 fn parse_cols(value: &str) -> Vec<TableColumn> {
+    // Asciidoctor strips every space from the cols value before parsing, so
+    // `cols=" 1, 1 "` is equivalent to `cols="1,1"`.
+    let records: String = value.chars().filter(|c| !c.is_whitespace()).collect();
+
+    // A wholly blank cols value is ignored: the caller falls back to the column
+    // count of the first row.
+    if records.is_empty() {
+        return vec![];
+    }
+
+    // Deprecated single-integer form: `cols=3` is equivalent to `cols="3*"` and
+    // produces that many equally sized columns.
+    if let Ok(count) = records.parse::<usize>() {
+        return vec![TableColumn::default(); count];
+    }
+
+    // Split on commas when present, otherwise on semicolons (Asciidoctor accepts
+    // either as the column-spec separator, but not a mix). Empty records are
+    // kept: each one contributes a default column.
+    let parts: Vec<&str> = if records.contains(',') {
+        records.split(',').collect()
+    } else {
+        records.split(';').collect()
+    };
+
     let mut columns: Vec<TableColumn> = vec![];
-
-    for part in value.split(',') {
-        let part = part.trim();
+    for part in parts {
         if part.is_empty() {
-            continue;
-        }
-
-        if let Some((count, spec)) = part.split_once('*') {
-            let repeat = count.trim().parse::<usize>().unwrap_or(1).max(1);
+            columns.push(TableColumn::default());
+        } else if let Some((count, spec)) = part.split_once('*') {
+            let repeat = count.parse::<usize>().unwrap_or(1).max(1);
             let column = parse_col_spec(spec);
             for _ in 0..repeat {
                 columns.push(column.clone());
@@ -2019,20 +2070,23 @@ fn expand_duplicates(cells: Vec<RawCell<'_>>) -> Vec<RawCell<'_>> {
 /// Scan a region for PSV cell boundaries, returning the [specifier](CellSpec)
 /// and raw (untrimmed) content span of each cell.
 ///
-/// A cell boundary is the table's `separator` (the vertical bar (`|`) by
-/// default, the exclamation mark (`!`) for a nested table, or any string set
-/// with the `separator` attribute, e.g. the broken bar `¦`) that appears at the
-/// start of a line or is preceded by whitespace, optionally with a
-/// [cell specifier](CellSpec) (e.g. `^`, `2+`, `.>`) directly in front of the
-/// separator. The token immediately preceding a separator is taken to be a
-/// specifier when it parses as one (see [`parse_cell_spec`]); a token that
-/// doesn't parse as a specifier means the separator is not a cell boundary.
-/// Content before the first boundary is ignored.
+/// Every unescaped occurrence of the table's `separator` (the vertical bar
+/// (`|`) by default, the exclamation mark (`!`) for a nested table, or any
+/// string set with the `separator` attribute, e.g. the broken bar `¦`) is a
+/// cell boundary, matching Asciidoctor. The token immediately preceding a
+/// separator is treated as that cell's [specifier](CellSpec) (e.g. `^`, `2+`,
+/// `.>`) only when it parses as one (see [`parse_cell_spec`]) *and* is anchored
+/// at the line start or preceded by whitespace; otherwise the token is ordinary
+/// content of the preceding cell and the separator is a plain boundary (so the
+/// `a` in `|a|b` is content, not a style operator). Content before the first
+/// boundary is ignored.
 ///
-/// An escaped separator (e.g. `\|`) is preceded by a backslash, which is not a
-/// valid specifier, so the separator already fails the boundary test and needs
-/// no special handling here; the backslash is stripped later in
-/// [`TableCell::parse`].
+/// A separator immediately preceded by a backslash (e.g. `\|`) is escaped: it
+/// is literal content rather than a boundary, and the backslash is stripped
+/// later in [`TableCell::parse`]. Only the single byte before the separator is
+/// inspected, so `\\|` is also read as an escaped separator — matching
+/// Asciidoctor, whose check is likewise the single-character
+/// `pre_match.end_with? '\'`.
 fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
     let data = region.data();
     let bytes = data.as_bytes();
@@ -2052,12 +2106,18 @@ fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
             .get(i..)
             .is_some_and(|rest| rest.starts_with(separator))
         {
+            // A separator immediately preceded by a backslash is escaped: it is
+            // literal content, not a cell boundary. The backslash is stripped
+            // from the rendered cell later (see `TableCell::parse`).
+            if i > 0 && bytes.get(i - 1).copied() == Some(b'\\') {
+                i += sep_len;
+                continue;
+            }
+
             // Walk back to the start of the token directly preceding this
             // separator. The token (a possible cell specifier) runs back to the
             // previous whitespace, tab, or newline, or to the start of the
-            // region; either way the token is anchored at a line start or after
-            // whitespace, as a cell boundary requires. (When `tok_start == i`
-            // the token is empty and the separator is plain.)
+            // region.
             let mut tok_start = i;
             while tok_start > 0
                 && !matches!(
@@ -2075,21 +2135,30 @@ fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
                 parse_cell_spec(token)
             };
 
-            if let Some(spec) = spec {
-                if let Some(start) = content_start {
-                    // The previous cell's content ends at the start of this
-                    // cell's specifier; the separating whitespace, included in
-                    // the slice, is trimmed later in `TableCell::parse`.
-                    cells.push(RawCell {
-                        spec: cur_spec,
-                        content: region.slice(start..tok_start),
-                    });
-                }
-                cur_spec = spec;
-                content_start = Some(i + sep_len);
-                i += sep_len;
-                continue;
+            // Every unescaped separator is a cell boundary (matching
+            // Asciidoctor). When the token is empty or a valid specifier it
+            // belongs to the *next* cell, so the previous cell's content ends
+            // before the token. Otherwise the token is ordinary content of the
+            // previous cell (e.g. the `a` in `|a|b`, where `a` is not preceded
+            // by whitespace and so is not a specifier), the separator is plain,
+            // and the next cell takes the default specifier.
+            let (content_end, next_spec) = match spec {
+                Some(spec) => (tok_start, spec),
+                None => (i, CellSpec::default()),
+            };
+
+            if let Some(start) = content_start {
+                // The separating whitespace, included in the slice, is trimmed
+                // later in `TableCell::parse`.
+                cells.push(RawCell {
+                    spec: cur_spec,
+                    content: region.slice(start..content_end),
+                });
             }
+            cur_spec = next_spec;
+            content_start = Some(i + sep_len);
+            i += sep_len;
+            continue;
         }
 
         i += 1;
@@ -2275,4 +2344,78 @@ fn trim_surrounding_whitespace(s: Span<'_>) -> Span<'_> {
     let start = data.len() - data.trim_start().len();
     let len = data.trim().len();
     s.slice(start..start + len)
+}
+
+/// Trim a PSV cell's content according to its [style](ColumnStyle), matching
+/// Asciidoctor's `Table::Cell` initializer:
+///
+/// * A [`Literal`](ColumnStyle::Literal) cell has its trailing whitespace
+///   removed and any leading blank lines stripped, but the leading indentation
+///   of its first content line is preserved (so an indented literal cell keeps
+///   its indentation).
+/// * An [`AsciiDoc`](ColumnStyle::AsciiDoc) cell likewise removes trailing
+///   whitespace; if the remaining content begins with a newline it strips the
+///   leading blank lines (preserving the first content line's indentation, so a
+///   leading-indented line is interpreted as a literal block), otherwise it
+///   strips the leading whitespace.
+/// * Every other style has all surrounding whitespace removed.
+fn trim_cell_content(s: Span<'_>, style: ColumnStyle) -> Span<'_> {
+    let data = s.data();
+    match style {
+        ColumnStyle::Literal => {
+            let end = data.trim_end().len();
+            let mut start = 0;
+            while data[start..end].starts_with('\n') {
+                start += 1;
+            }
+            s.slice(start..end)
+        }
+        ColumnStyle::AsciiDoc => {
+            let end = data.trim_end().len();
+            if data[..end].starts_with('\n') {
+                let mut start = 0;
+                while data[start..end].starts_with('\n') {
+                    start += 1;
+                }
+                s.slice(start..end)
+            } else {
+                let start = end - data[..end].trim_start().len();
+                s.slice(start..end)
+            }
+        }
+        _ => trim_surrounding_whitespace(s),
+    }
+}
+
+/// Returns the first non-blank line in `rest`, or `None` when every remaining
+/// line is blank (or `rest` is empty).
+fn first_nonblank_line(mut rest: Span<'_>) -> Option<Span<'_>> {
+    while !rest.is_empty() {
+        let line = rest.take_line();
+        if !line.item.data().trim().is_empty() {
+            return Some(line.item);
+        }
+        rest = line.after;
+    }
+    None
+}
+
+/// Returns `true` when `line` begins a new PSV cell, i.e. it contains the
+/// separator and the text before the first separator (after any leading
+/// whitespace) is either empty or a valid cell specifier. A line that continues
+/// the previous cell returns `false`.
+fn psv_line_starts_cell(line: &str, separator: &str) -> bool {
+    match line.find(separator) {
+        Some(pos) => {
+            let prefix = line[..pos].trim_start();
+            prefix.is_empty() || parse_cell_spec(prefix).is_some()
+        }
+        None => false,
+    }
+}
+
+/// Returns `true` when `line` contains an odd number of double quotes, i.e. it
+/// opens a quoted CSV/TSV value that is not closed on the same line.
+fn line_has_unclosed_quote(line: &str) -> bool {
+    line.bytes().filter(|&b| b == b'"').count() % 2 == 1
 }

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -576,7 +576,7 @@ fn asciidoc_cell_resolves_references_in_nested_blocks() {
         .unwrap();
 
     let blocks = match table.body_rows()[0].cells()[0].content() {
-        TableCellContent::AsciiDoc(blocks) => blocks,
+        TableCellContent::AsciiDoc(cell) => cell.blocks(),
         TableCellContent::Simple(_) => panic!("expected AsciiDoc cell content"),
     };
 
@@ -606,7 +606,7 @@ fn asciidoc_cell_attributes_are_scoped_to_the_cell() {
         .unwrap();
 
     let blocks = match table.body_rows()[0].cells()[0].content() {
-        TableCellContent::AsciiDoc(blocks) => blocks,
+        TableCellContent::AsciiDoc(cell) => cell.blocks(),
         TableCellContent::Simple(_) => panic!("expected AsciiDoc cell content"),
     };
 
@@ -635,7 +635,8 @@ fn asciidoc_cell_attributes_are_scoped_to_the_cell() {
 /// Collect the rendered text of every block in an AsciiDoc cell.
 fn asciidoc_cell_text(table: &TableBlock<'_>, row: usize, col: usize) -> String {
     match table.body_rows()[row].cells()[col].content() {
-        TableCellContent::AsciiDoc(blocks) => blocks
+        TableCellContent::AsciiDoc(cell) => cell
+            .blocks()
             .iter()
             .filter_map(|block| block.rendered_content())
             .collect::<Vec<_>>()

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -282,11 +282,26 @@ fn escaped_cell_separator() {
 }
 
 #[test]
-fn cols_with_empty_specifier() {
-    // Empty entries in the `cols` list (e.g. from a doubled comma) are skipped.
-    let table = parse_table("[cols=\"1,,1\"]\n|===\n|a |b\n|===");
+fn separator_after_backslash_is_escaped() {
+    // The escape check inspects only the single byte before the separator, so a
+    // separator preceded by a backslash is escaped even when that backslash is
+    // itself preceded by another one. `|a\\|b` is therefore one cell whose
+    // content is `a\|b` (the escaping backslash is stripped), matching
+    // Asciidoctor, whose check is likewise the single-character
+    // `pre_match.end_with? '\'`.
+    let table = parse_table("|===\n|a\\\\|b\n|===");
 
-    assert_eq!(table.columns().len(), 2);
+    assert_eq!(table.body_rows().len(), 1);
+    assert_eq!(row_text(&table.body_rows()[0]), vec!["a\\|b".to_string()]);
+}
+
+#[test]
+fn cols_with_empty_specifier() {
+    // An empty entry in the `cols` list (e.g. from a doubled comma) contributes a
+    // default column, matching Asciidoctor: `cols="1,,1"` yields three columns.
+    let table = parse_table("[cols=\"1,,1\"]\n|===\n|a |b |c\n|===");
+
+    assert_eq!(table.columns().len(), 3);
 }
 
 #[test]
@@ -738,29 +753,27 @@ fn cell_specifier_span_operator_without_factor_locates_separator() {
 }
 
 #[test]
-fn non_specifier_token_is_not_a_cell_separator() {
+fn non_specifier_token_is_a_plain_cell_separator() {
     // A token in front of a `|` that does not parse as a cell specifier (here the
-    // word `foo`, which is more than a single style letter) means the `|` is not
-    // a cell separator: `a foo|b` is a single cell whose content includes the
-    // literal `|`.
+    // word `foo`, which is more than a single style letter) is ordinary content:
+    // the `|` is still a plain cell separator, so `a foo|b` is two cells (matching
+    // Asciidoctor).
     let table = parse_table("|===\n|a foo|b\n|===");
 
-    assert_eq!(table.columns().len(), 1);
     let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
-    assert_eq!(rows, vec![vec!["a foo|b".to_string()]]);
+    assert_eq!(rows, vec![vec!["a foo".to_string(), "b".to_string()]]);
 }
 
 #[test]
-fn dot_not_followed_by_vertical_operator_is_not_a_cell_separator() {
+fn dot_not_followed_by_vertical_operator_is_a_plain_cell_separator() {
     // A vertical alignment operator is a dot followed by `<`, `>`, or `^`. A dot
     // followed by anything else (here `.x`) is not a valid cell specifier, so the
-    // `|` is not a cell separator: `a .x|b` is a single cell whose content
-    // includes the literal `.x|`.
+    // `.x` is content and the `|` is a plain cell separator: `a .x|b` is two cells
+    // (matching Asciidoctor).
     let table = parse_table("|===\n|a .x|b\n|===");
 
-    assert_eq!(table.columns().len(), 1);
     let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
-    assert_eq!(rows, vec![vec!["a .x|b".to_string()]]);
+    assert_eq!(rows, vec![vec!["a .x".to_string(), "b".to_string()]]);
 }
 
 #[test]
@@ -1011,9 +1024,24 @@ fn csv_unclosed_quote_is_literal() {
     let table = parse_table("[format=csv]\n|===\n\",a\n|===");
     assert_eq!(table.columns().len(), 1);
     assert_eq!(row_text(&table.body_rows()[0]), ["\",a"]);
+}
 
-    // A cell that is a single bare quote is an unclosed, empty quoted value.
-    let table = parse_table("[format=csv]\n|===\n\"\n|===");
+#[test]
+fn csv_lone_quote_is_unclosed_and_empty_with_warning() {
+    // A cell that is a single bare quote is an unclosed, empty quoted value: it is
+    // set to empty and an error is logged (matching Asciidoctor).
+    let mut parser = Parser::default();
+    let maw = Block::parse(Span::new("[format=csv]\n|===\n\"\n|==="), &mut parser);
+
+    assert!(maw.warnings.iter().any(|w| matches!(
+        w.warning,
+        crate::warnings::WarningType::TableCsvDataHasUnclosedQuote
+    )));
+
+    let table = match maw.item.unwrap().item {
+        Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    };
     assert_eq!(table.columns().len(), 1);
     assert_eq!(row_text(&table.body_rows()[0]), [""]);
 }

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -805,9 +805,11 @@ fn cell_span_exceeding_columns_drops_overrunning_row() {
 fn row_fully_covered_by_rowspans_drops_following_cell() {
     // Two row-spanning cells (`.2+`) together cover every column of the next row,
     // so that row has no cells of its own to close it. The following cell (`c1`)
-    // therefore overruns the pre-filled row and is dropped with it (matching
-    // Asciidoctor), leaving the remaining cells aligned: `c2` and `d1` form the
-    // second body row and the short final row holds `d2`.
+    // therefore overruns the pre-filled row and is dropped with it (a column-count
+    // overrun warning), leaving `c2` and `d1` aligned as the second body row. The
+    // trailing `d2` cell can't fill a row of its own, so the table ends on an
+    // incomplete row that is dropped with an end-of-table warning (matching
+    // Asciidoctor, which renders only two rows here).
     let mut parser = Parser::default();
     let maw = Block::parse(
         Span::new("[cols=\"2*\"]\n|===\n.2+|a .2+|b\n|c1 |c2\n|d1 |d2\n|==="),
@@ -824,6 +826,16 @@ fn row_fully_covered_by_rowspans_drops_following_cell() {
             .count(),
         1
     );
+    assert_eq!(
+        maw.warnings
+            .iter()
+            .filter(|w| matches!(
+                w.warning,
+                crate::warnings::WarningType::TableDroppingIncompleteRowAtEndOfTable
+            ))
+            .count(),
+        1
+    );
 
     let table = match maw.item.unwrap().item {
         Block::Table(table) => table,
@@ -835,7 +847,6 @@ fn row_fully_covered_by_rowspans_drops_following_cell() {
         vec![
             vec!["a".to_string(), "b".to_string()],
             vec!["c2".to_string(), "d1".to_string()],
-            vec!["d2".to_string()],
         ]
     );
 }

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -45,6 +45,7 @@ struct InternalDependent<'src> {
     warnings: Vec<Warning<'src>>,
     source_map: SourceMap,
     catalog: Catalog,
+    show_doctitle: bool,
 }
 
 self_cell! {
@@ -114,6 +115,11 @@ impl<'src> Document<'src> {
                 blocks = section_blocks;
             }
 
+            // Whether the document title renders as an `<h1>`. An embedded
+            // document shows its title only when `showtitle` is set (the
+            // default is hidden), so resolve it from the final attribute state.
+            let show_doctitle = parser.resolve_show_title(false);
+
             InternalDependent {
                 header,
                 blocks,
@@ -121,6 +127,7 @@ impl<'src> Document<'src> {
                 warnings,
                 source_map,
                 catalog: parser.take_catalog(),
+                show_doctitle,
             }
         });
 
@@ -133,6 +140,19 @@ impl<'src> Document<'src> {
     /// Return the document header.
     pub fn header(&self) -> &Header<'_> {
         &self.internal.borrow_dependent().header
+    }
+
+    /// Return the document title (the level-0 `= Title`), if there was one.
+    pub fn doctitle(&self) -> Option<&str> {
+        self.header().title()
+    }
+
+    /// Return whether the document title should be displayed (as an `<h1>`).
+    ///
+    /// This reflects the effective `showtitle`/`notitle` attribute state: an
+    /// embedded document shows its title only when `showtitle` is set.
+    pub fn show_doctitle(&self) -> bool {
+        self.internal.borrow_dependent().show_doctitle
     }
 
     /// Return an iterator over any warnings found during parsing.

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -144,6 +144,27 @@ pub(super) fn built_in_attrs() -> HashMap<String, AttributeValue> {
         },
     );
 
+    // The document type defaults to `article` and may be set in the header or
+    // via the API. The derived `backend-html5-doctype-{doctype}` attribute is
+    // defined (empty) only for the active doctype; it is kept in sync by
+    // `Parser::refresh_doctype_derived_attr` whenever `doctype` changes.
+    attrs.insert(
+        "doctype".to_owned(),
+        AttributeValue {
+            allowable_value: AllowableValue::Any,
+            modification_context: ModificationContext::ApiOrHeader,
+            value: InterpretedValue::Value("article".to_owned()),
+        },
+    );
+    attrs.insert(
+        "backend-html5-doctype-article".to_owned(),
+        AttributeValue {
+            allowable_value: AllowableValue::Any,
+            modification_context: ModificationContext::Anywhere,
+            value: InterpretedValue::Value(String::new()),
+        },
+    );
+
     attrs
 }
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -255,6 +255,63 @@ impl Parser {
             .unwrap_or(false)
     }
 
+    /// Resolves whether a document title should be displayed, from the
+    /// `showtitle`/`notitle` attribute pair (which are complements).
+    ///
+    /// `showtitle` takes precedence: if present, the title shows precisely when
+    /// it is set. Otherwise `notitle`, if present, hides the title when set.
+    /// When neither attribute is present, `default_shown` decides — a
+    /// standalone document (such as a nested AsciiDoc table cell) shows its
+    /// title, while an embedded document does not.
+    pub(crate) fn resolve_show_title(&self, default_shown: bool) -> bool {
+        if self.has_attribute("showtitle") {
+            self.is_attribute_set("showtitle")
+        } else if self.has_attribute("notitle") {
+            !self.is_attribute_set("notitle")
+        } else {
+            default_shown
+        }
+    }
+
+    /// Forces the `doctype` attribute to `value`, refreshing the derived
+    /// `backend-html5-doctype-*` attribute.
+    ///
+    /// Used when a nested AsciiDoc table cell resets its doctype to the default
+    /// (a cell does not inherit the parent's doctype). The value stays
+    /// modifiable from the document body so the cell may still set its own
+    /// doctype.
+    pub(crate) fn force_doctype(&mut self, value: &str) {
+        self.attribute_values.insert(
+            "doctype".to_string(),
+            AttributeValue {
+                allowable_value: AllowableValue::Any,
+                modification_context: ModificationContext::ApiOrDocumentBody,
+                value: InterpretedValue::Value(value.to_string()),
+            },
+        );
+        self.refresh_doctype_derived_attr();
+    }
+
+    /// Recomputes the `backend-html5-doctype-{doctype}` intrinsic attribute so
+    /// exactly one exists — for the active doctype — resolving to an empty
+    /// (defined) value. References to any other doctype stay undefined and so
+    /// render literally.
+    pub(crate) fn refresh_doctype_derived_attr(&mut self) {
+        self.attribute_values
+            .retain(|name, _| !name.starts_with("backend-html5-doctype-"));
+
+        if let InterpretedValue::Value(doctype) = self.attribute_value("doctype") {
+            self.attribute_values.insert(
+                format!("backend-html5-doctype-{doctype}"),
+                AttributeValue {
+                    allowable_value: AllowableValue::Any,
+                    modification_context: ModificationContext::Anywhere,
+                    value: InterpretedValue::Value(String::new()),
+                },
+            );
+        }
+    }
+
     /// Sets the value of an [intrinsic attribute].
     ///
     /// Intrinsic attributes are set automatically by the processor. These
@@ -483,7 +540,11 @@ impl Parser {
             value,
         };
 
+        let is_doctype = attr_name == "doctype";
         self.attribute_values.insert(attr_name, attribute_value);
+        if is_doctype {
+            self.refresh_doctype_derived_attr();
+        }
     }
 
     /// Called from [`Header::parse()`] for a value that is derived from parsing
@@ -542,7 +603,11 @@ impl Parser {
             value: attr.value().clone(),
         };
 
+        let is_doctype = attr_name == "doctype";
         self.attribute_values.insert(attr_name, attribute_value);
+        if is_doctype {
+            self.refresh_doctype_derived_attr();
+        }
     }
 
     /// Assign the next section number for a given level.
@@ -796,5 +861,69 @@ mod tests {
             simple_block.content().rendered(),
             "Hello [AMP] goodbye [LT] world [GT] test"
         );
+    }
+
+    mod resolve_show_title {
+        use crate::parser::{ModificationContext, Parser};
+
+        fn with(name: &str, set: bool) -> Parser {
+            Parser::default().with_intrinsic_attribute_bool(
+                name,
+                set,
+                ModificationContext::Anywhere,
+            )
+        }
+
+        #[test]
+        fn neither_present_uses_default() {
+            assert!(Parser::default().resolve_show_title(true));
+            assert!(!Parser::default().resolve_show_title(false));
+        }
+
+        #[test]
+        fn showtitle_takes_precedence_and_decides() {
+            // Present and set -> shown; present and unset -> hidden, regardless
+            // of the default.
+            assert!(with("showtitle", true).resolve_show_title(false));
+            assert!(!with("showtitle", false).resolve_show_title(true));
+        }
+
+        #[test]
+        fn notitle_is_the_complement_when_showtitle_absent() {
+            // notitle set -> hidden; notitle unset -> shown.
+            assert!(!with("notitle", true).resolve_show_title(true));
+            assert!(with("notitle", false).resolve_show_title(false));
+        }
+    }
+
+    mod refresh_doctype_derived_attr {
+        use crate::{document::InterpretedValue, parser::Parser};
+
+        #[test]
+        fn tracks_the_active_doctype() {
+            let mut parser = Parser::default();
+
+            // The default doctype is `article`, so only its derived attribute is
+            // defined (to an empty value).
+            assert_eq!(
+                parser.attribute_value("backend-html5-doctype-article"),
+                InterpretedValue::Value(String::new())
+            );
+            assert_eq!(
+                parser.attribute_value("backend-html5-doctype-book"),
+                InterpretedValue::Unset
+            );
+
+            // Forcing a new doctype moves the derived attribute with it.
+            parser.force_doctype("book");
+            assert_eq!(
+                parser.attribute_value("backend-html5-doctype-book"),
+                InterpretedValue::Value(String::new())
+            );
+            assert_eq!(
+                parser.attribute_value("backend-html5-doctype-article"),
+                InterpretedValue::Unset
+            );
+        }
     }
 }

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -925,5 +925,27 @@ mod tests {
                 InterpretedValue::Unset
             );
         }
+
+        #[test]
+        fn defines_no_derived_attr_when_doctype_is_not_a_value() {
+            let mut parser = Parser::default();
+
+            // The default article derived attribute starts out defined.
+            assert_eq!(
+                parser.attribute_value("backend-html5-doctype-article"),
+                InterpretedValue::Value(String::new())
+            );
+
+            // With `doctype` unset (no `Value`), a refresh clears any existing
+            // derived attribute and defines none.
+            parser.attribute_values.remove("doctype");
+            parser.refresh_doctype_derived_attr();
+
+            assert_eq!(parser.attribute_value("doctype"), InterpretedValue::Unset);
+            assert_eq!(
+                parser.attribute_value("backend-html5-doctype-article"),
+                InterpretedValue::Unset
+            );
+        }
     }
 }

--- a/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
@@ -47,7 +47,8 @@ fn asciidoc_cell_text(doc: &crate::Document<'_>) -> String {
         .expect("expected a table block");
 
     match table.body_rows()[0].cells()[0].content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => blocks
+        crate::blocks::TableCellContent::AsciiDoc(cell) => cell
+            .blocks()
             .iter()
             .filter_map(|block| block.rendered_content())
             .collect::<Vec<_>>()
@@ -325,7 +326,8 @@ The `a` can also be specified on the column in the `cols` attribute on the table
         crate::blocks::TableCellContent::Simple(_)
     ));
     match row.cells()[1].content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+        crate::blocks::TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
             assert_eq!(blocks.len(), 1);
             assert_eq!(blocks[0].raw_context().as_ref(), "list");
         }
@@ -378,7 +380,8 @@ include::example$cell.adoc[tag=adoc]
         crate::blocks::TableCellContent::Simple(_)
     ));
     match row.cells()[1].content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+        crate::blocks::TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
             assert_eq!(blocks.len(), 2);
             assert_eq!(blocks[0].raw_context().as_ref(), "paragraph");
             assert_eq!(blocks[1].raw_context().as_ref(), "list");
@@ -395,7 +398,8 @@ include::example$cell.adoc[tag=adoc]
         crate::blocks::TableCellContent::Simple(_)
     ));
     match row.cells()[1].content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+        crate::blocks::TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
             assert_eq!(blocks.len(), 2);
             assert_eq!(blocks[0].raw_context().as_ref(), "paragraph");
             assert_eq!(blocks[1].raw_context().as_ref(), "listing");
@@ -422,7 +426,8 @@ As such, it inherits attributes from the parent document.
         })
         .expect("expected a table block");
     match table.body_rows()[0].cells()[0].content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+        crate::blocks::TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
             assert_eq!(blocks.len(), 1);
             match &blocks[0] {
                 crate::blocks::Block::Simple(simple) => {

--- a/parser/src/tests/asciidoc_lang/tables/format_column_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_column_content.rs
@@ -331,7 +331,8 @@ The AsciiDoc block style effectively creates a nested, standalone AsciiDoc docum
     // keeps the list markup as plain inline text.
     let row = &table.body_rows()[0];
     match row.cells()[0].content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+        crate::blocks::TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
             assert_eq!(blocks.len(), 1);
             assert_eq!(blocks[0].raw_context().as_ref(), "list");
         }
@@ -345,7 +346,8 @@ The AsciiDoc block style effectively creates a nested, standalone AsciiDoc docum
     // Second body row: the AsciiDoc cell parses the delimited source block.
     let row = &table.body_rows()[1];
     match row.cells()[0].content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+        crate::blocks::TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
             assert_eq!(blocks.len(), 1);
             assert_eq!(blocks[0].raw_context().as_ref(), "listing");
         }

--- a/parser/src/tests/asciidoc_lang/tables/nested.rs
+++ b/parser/src/tests/asciidoc_lang/tables/nested.rs
@@ -20,13 +20,11 @@ fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
 /// Return the single nested [`TableBlock`] held by `cell`, panicking if the
 /// cell is not an [`AsciiDoc`](crate::blocks::TableCellContent::AsciiDoc) cell
 /// or does not contain exactly one table.
-fn nested_table<'a, 'src>(
-    cell: &'a crate::blocks::TableCell<'src>,
-) -> &'a crate::blocks::TableBlock<'src> {
+fn nested_table<'a>(cell: &'a crate::blocks::TableCell<'_>) -> &'a crate::blocks::TableBlock<'a> {
     match cell.content() {
         crate::blocks::TableCellContent::AsciiDoc(cell) => {
             let blocks = cell.blocks();
-            let tables: Vec<&crate::blocks::TableBlock<'src>> = blocks
+            let tables: Vec<&crate::blocks::TableBlock<'_>> = blocks
                 .iter()
                 .filter_map(|block| match block {
                     crate::blocks::Block::Table(table) => Some(table),

--- a/parser/src/tests/asciidoc_lang/tables/nested.rs
+++ b/parser/src/tests/asciidoc_lang/tables/nested.rs
@@ -24,7 +24,8 @@ fn nested_table<'a, 'src>(
     cell: &'a crate::blocks::TableCell<'src>,
 ) -> &'a crate::blocks::TableBlock<'src> {
     match cell.content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+        crate::blocks::TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
             let tables: Vec<&crate::blocks::TableBlock<'src>> = blocks
                 .iter()
                 .filter_map(|block| match block {
@@ -81,7 +82,8 @@ To distinguish the inner table from the enclosing one, you need to use `!===` as
     // The AsciiDoc cell holds a nested table in addition to its normal block
     // content (the leading `Cell 2.2` paragraph).
     match last_cell.content() {
-        crate::blocks::TableCellContent::AsciiDoc(blocks) => {
+        crate::blocks::TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
             assert!(
                 blocks
                     .iter()

--- a/parser/src/tests/asciidoc_lang/tables/table_ref.rs
+++ b/parser/src/tests/asciidoc_lang/tables/table_ref.rs
@@ -35,7 +35,8 @@ fn nested_table<'a, 'src>(
     cell: &'a crate::blocks::TableCell<'src>,
 ) -> &'a crate::blocks::TableBlock<'src> {
     match cell.content() {
-        TableCellContent::AsciiDoc(blocks) => {
+        TableCellContent::AsciiDoc(cell) => {
+            let blocks = cell.blocks();
             let tables: Vec<&crate::blocks::TableBlock<'src>> = blocks
                 .iter()
                 .filter_map(|block| match block {

--- a/parser/src/tests/asciidoc_lang/tables/table_ref.rs
+++ b/parser/src/tests/asciidoc_lang/tables/table_ref.rs
@@ -31,13 +31,11 @@ fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
 /// Return the single nested [`TableBlock`] held by an AsciiDoc `cell`.
 ///
 /// [`TableBlock`]: crate::blocks::TableBlock
-fn nested_table<'a, 'src>(
-    cell: &'a crate::blocks::TableCell<'src>,
-) -> &'a crate::blocks::TableBlock<'src> {
+fn nested_table<'a>(cell: &'a crate::blocks::TableCell<'_>) -> &'a crate::blocks::TableBlock<'a> {
     match cell.content() {
         TableCellContent::AsciiDoc(cell) => {
             let blocks = cell.blocks();
-            let tables: Vec<&crate::blocks::TableBlock<'src>> = blocks
+            let tables: Vec<&crate::blocks::TableBlock<'_>> = blocks
                 .iter()
                 .filter_map(|block| match block {
                     crate::blocks::Block::Table(table) => Some(table),

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -2471,9 +2471,13 @@ mod description_lists_dlist {
             assert_xpath(&doc, "//dl/dt/following-sibling::dd", 2);
             assert_xpath(&doc, "(//dl/dt)[1][normalize-space(text()) = \"term1\"]", 1);
 
+            // The `--` renders as a spaced em dash (thin space, em dash, thin
+            // space); the test DOM now decodes numeric character references the
+            // way a browser's `text()` does, so this asserts the decoded
+            // characters rather than the raw `&#8201;&#8212;&#8201;` entities.
             assert_xpath(
                 &doc,
-                "(//dl/dt)[1]/following-sibling::dd/p[text() = \"def1&#8201;&#8212;&#8201;and a note\"]",
+                "(//dl/dt)[1]/following-sibling::dd/p[text() = \"def1\u{2009}\u{2014}\u{2009}and a note\"]",
                 1,
             );
 

--- a/parser/src/tests/asciidoctor_rb/mod.rs
+++ b/parser/src/tests/asciidoctor_rb/mod.rs
@@ -1,3 +1,25 @@
+//! Behavioral tests ported 1:1 from Ruby Asciidoctor's `test/*_test.rb` suites.
+//!
+//! Porting conventions (see the existing modules for worked examples):
+//!
+//! * One Rust module per Ruby file (`<suite>_test.rs`); nested Ruby `context`
+//!   blocks become nested `mod`s, and each Ruby `test 'name'` becomes a
+//!   `#[test] fn name()`.
+//! * Ruby `assert_xpath` / `assert_css` / `assert_output_contains` /
+//!   `refute_output_contains` map to the same-named helpers in
+//!   [`crate::tests::assert_dom`], run against `doc.to_virtual_dom()`. Use a
+//!   full-AST `assert_eq!(doc, Document { .. })` where the Ruby test inspects
+//!   parser state (warnings, source spans, catalog) rather than HTML.
+//! * DocBook and other non-HTML backends are out of scope: such tests are
+//!   omitted with a `// Backend-specific test omitted: DocBook.` note. Compat
+//!   mode is likewise disregarded.
+//! * Tests blocked on an unimplemented (but planned) feature are kept as
+//!   `#[ignore]`d stubs whose body preserves the Ruby assertions in
+//!   `todo!("..")` calls, tagged with a tracking-issue `TODO`. Features that
+//!   are explicitly out of scope are omitted with a one-line `// NOTE:`.
+//! * Expected values track the crate's *actual* output, not the Ruby HTML
+//!   string, when the two differ.
+
 // The tests in this tree are adapted from the Ruby implementation of
 // Asciidoctor, which comes with the following license:
 
@@ -27,3 +49,4 @@
 mod lists_test;
 mod paragraphs_test;
 mod substitutions_test;
+mod tables_test;

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -963,11 +963,11 @@ mod psv {
 
     #[test]
     #[ignore]
-    // TODO (issue TBD): The crate mis-groups cells into rows when a leading row's
-    // colspans overflow the column count: for this input it produces seven
-    // single-cell rows instead of dropping the overflowing first row and forming
-    // one row of seven cells. Enable once row grouping accounts for the dropped
-    // colspan row.
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/548): The crate
+    // mis-groups cells into rows when a leading row's colspans overflow the
+    // column count: for this input it produces seven single-cell rows instead of
+    // dropping the overflowing first row and forming one row of seven cells.
+    // Enable once row grouping accounts for the dropped colspan row.
     fn should_take_colspan_into_account_when_taking_cells_for_row() {
         let doc = Parser::default()
             .parse("[cols=7]\n|===\n2+|a 2+|b 2+|c 2+|d\n|e |f |g |h |i |j |k\n|===");

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1113,87 +1113,151 @@ mod psv {
         );
     }
 
-    // The following AsciiDoc-table-cell tests depend on nested-document
-    // attribute inheritance/locking (doctype, icons, sectids, showtitle/notitle
-    // set or unset in the cell relative to the parent document or the API),
-    // which the crate does not yet model. They are kept as ignored stubs so the
-    // scenarios are not lost.
-
     #[test]
-    #[ignore]
-    // TODO (issue TBD): doctype set inside an AsciiDoc table cell.
-    fn doctype_can_be_set_in_asciidoc_table_cell() {}
+    fn doctype_can_be_set_in_asciidoc_table_cell() {
+        let doc = Parser::default().parse("|===\na|\n:doctype: inline\n\ncontent\n|===");
 
-    #[test]
-    #[ignore]
-    // TODO (issue TBD): doctype reset to default inside an AsciiDoc table cell.
-    fn should_reset_doctype_to_default_in_asciidoc_table_cell() {}
-
-    #[test]
-    #[ignore]
-    // TODO (issue TBD): doctype-related attributes updated when doctype is set
-    // in an AsciiDoc table cell.
-    fn should_update_doctype_related_attributes_in_asciidoc_table_cell_when_doctype_is_set() {}
-
-    #[test]
-    #[ignore]
-    // TODO (issue TBD): an AsciiDoc table cell must not override an attribute
-    // hard set by the API.
-    fn should_not_allow_asciidoc_table_cell_to_set_a_document_attribute_that_was_hard_set_by_the_api()
-     {
+        // An `inline` doctype renders the cell's lone paragraph as bare inline
+        // content, with no `.paragraph` wrapper.
+        assert_css(&doc, "table.tableblock", 1);
+        assert_css(&doc, "table.tableblock .paragraph", 0);
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): an AsciiDoc table cell must not override an attribute
-    // hard unset by the API.
-    fn should_not_allow_asciidoc_table_cell_to_set_a_document_attribute_that_was_hard_unset_by_the_api()
-     {
+    fn should_reset_doctype_to_default_in_asciidoc_table_cell() {
+        // The parent is a `book`, but a cell resets to the default `article`
+        // doctype, so `{doctype}` is `article` and only the
+        // `backend-html5-doctype-article` derived attribute is defined (an
+        // undefined reference is left literal).
+        let doc = Parser::default().parse(
+            "= Book Title\n:doctype: book\n\n== Chapter 1\n\n|===\na|\n= AsciiDoc Table Cell\n\ndoctype={doctype}\n{backend-html5-doctype-article}\n{backend-html5-doctype-book}\n|===",
+        );
+
+        assert_rendered_contains(&doc, "doctype=article");
+        refute_rendered_contains(&doc, "{backend-html5-doctype-article}");
+        assert_rendered_contains(&doc, "{backend-html5-doctype-book}");
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): an attribute unset in the parent document stays unset in
-    // an AsciiDoc table cell.
-    fn should_keep_attribute_unset_in_asciidoc_table_cell_if_unset_in_parent_document() {}
+    fn should_update_doctype_related_attributes_in_asciidoc_table_cell_when_doctype_is_set() {
+        // Setting `:doctype: book` in the cell updates `{doctype}` and the
+        // derived `backend-html5-doctype-*` attribute accordingly.
+        let doc = Parser::default().parse(
+            "= Document Title\n:doctype: article\n\n== Chapter 1\n\n|===\na|\n= AsciiDoc Table Cell\n:doctype: book\n\ndoctype={doctype}\n{backend-html5-doctype-book}\n{backend-html5-doctype-article}\n|===",
+        );
+
+        assert_rendered_contains(&doc, "doctype=book");
+        refute_rendered_contains(&doc, "{backend-html5-doctype-book}");
+        assert_rendered_contains(&doc, "{backend-html5-doctype-article}");
+    }
+
+    // Deferred: "should not allow AsciiDoc table cell to set a document
+    // attribute that was hard set by the API" (Ruby 1457) observes the lock via
+    // a NOTE admonition's icon, and admonitions are not implemented. The same
+    // API-lock path is covered by
+    // `should_not_allow_locked_attribute_unset_in_parent_document_to_be_set_in_asciidoc_table_cell`.
+
+    // Deferred: "should not allow AsciiDoc table cell to set a document
+    // attribute that was hard unset by the API" (Ruby 1472) — same admonition
+    // dependency as above.
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): an attribute unset in the parent document can be set in
-    // an AsciiDoc table cell.
-    fn should_allow_attribute_unset_in_parent_document_to_be_set_in_asciidoc_table_cell() {}
+    fn should_keep_attribute_unset_in_asciidoc_table_cell_if_unset_in_parent_document() {
+        // `sectids` and `table-caption` are unset in the parent and stay unset
+        // in the cell: the headings get no id, and both the outer table and the
+        // nested table render their title as a bare `<caption>`.
+        let doc = Parser::default().parse(
+            ":!sectids:\n:!table-caption:\n\n== Outer Heading\n\n.Outer Table\n|===\na|\n\n== Inner Heading\n\n.Inner Table\n!===\n! table cell\n!===\n|===",
+        );
+
+        assert_xpath(&doc, "//h2[@id]", 0);
+        assert_xpath(&doc, "//caption[text()=\"Outer Table\"]", 1);
+        assert_xpath(&doc, "//caption[text()=\"Inner Table\"]", 1);
+    }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): a locked-unset attribute cannot be set in an AsciiDoc
-    // table cell.
+    fn should_allow_attribute_unset_in_parent_document_to_be_set_in_asciidoc_table_cell() {
+        // `sectids` is unset in the parent header (not locked), so the cell may
+        // set it: the heading after `:sectids:` in the cell gets an id.
+        let doc = Parser::default().parse(
+            ":!sectids:\n\n== No ID\n\n|===\na|\n\n== No ID\n\n:sectids:\n\n== Has ID\n|===",
+        );
+
+        assert_css(&doc, "h2", 3);
+        assert_xpath(&doc, "(//h2)[1][@id]", 0);
+        assert_xpath(&doc, "(//h2)[2][@id]", 0);
+        assert_xpath(&doc, "(//h2)[3][@id=\"_has_id\"]", 1);
+    }
+
+    #[test]
     fn should_not_allow_locked_attribute_unset_in_parent_document_to_be_set_in_asciidoc_table_cell()
     {
+        // `sectids` is hard unset by the API, so the cell's `:sectids:` is
+        // ignored and no heading gets an id.
+        let doc = Parser::default()
+            .with_intrinsic_attribute_bool("sectids", false, ModificationContext::ApiOnly)
+            .parse("== No ID\n\n|===\na|\n\n== No ID\n\n:sectids:\n\n== Has ID\n|===");
+
+        assert_css(&doc, "h2", 3);
+        assert_xpath(&doc, "//h2[@id]", 0);
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): showtitle enabled in an AsciiDoc table cell if unset in
-    // the parent document.
-    fn showtitle_can_be_enabled_in_asciidoc_table_cell_if_unset_in_parent_document() {}
+    fn showtitle_can_be_enabled_in_asciidoc_table_cell_if_unset_in_parent_document() {
+        // The parent hides its title; the cell shows its own. (`showtitle` and
+        // `notitle` are complements, so both spellings are exercised.)
+        for (parent, cell) in [(":!showtitle:", ":showtitle:"), (":notitle:", ":!notitle:")] {
+            let doc = Parser::default().parse(&format!(
+                "= Document Title\n{parent}\n\n|===\na|\n= Nested Document Title\n{cell}\n\ncontent\n|==="
+            ));
+            assert_css(&doc, "h1", 1);
+            assert_css(&doc, ".tableblock h1", 1);
+        }
+    }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): showtitle enabled in an AsciiDoc table cell if unset by
-    // the API.
-    fn showtitle_can_be_enabled_in_asciidoc_table_cell_if_unset_by_api() {}
+    fn showtitle_can_be_enabled_in_asciidoc_table_cell_if_unset_by_api() {
+        for (name, value, cell) in [
+            ("showtitle", false, ":showtitle:"),
+            ("notitle", true, ":!notitle:"),
+        ] {
+            let doc = Parser::default()
+                .with_intrinsic_attribute_bool(name, value, ModificationContext::ApiOnly)
+                .parse(&format!(
+                    "= Document Title\n\n|===\na|\n= Nested Document Title\n{cell}\n\ncontent\n|==="
+                ));
+            assert_css(&doc, "h1", 1);
+            assert_css(&doc, ".tableblock h1", 1);
+        }
+    }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): showtitle disabled in an AsciiDoc table cell if set in
-    // the parent document.
-    fn showtitle_can_be_disabled_in_asciidoc_table_cell_if_set_in_parent_document() {}
+    fn showtitle_can_be_disabled_in_asciidoc_table_cell_if_set_in_parent_document() {
+        // The parent shows its title; the cell hides its own.
+        for (parent, cell) in [(":showtitle:", ":!showtitle:"), (":!notitle:", ":notitle:")] {
+            let doc = Parser::default().parse(&format!(
+                "= Document Title\n{parent}\n\n|===\na|\n= Nested Document Title\n{cell}\n\ncontent\n|==="
+            ));
+            assert_css(&doc, "h1", 1);
+            assert_css(&doc, ".tableblock h1", 0);
+        }
+    }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): showtitle disabled in an AsciiDoc table cell if set by
-    // the API.
-    fn showtitle_can_be_disabled_in_asciidoc_table_cell_if_set_by_api() {}
+    fn showtitle_can_be_disabled_in_asciidoc_table_cell_if_set_by_api() {
+        for (name, value, cell) in [
+            ("showtitle", true, ":!showtitle:"),
+            ("notitle", false, ":notitle:"),
+        ] {
+            let doc = Parser::default()
+                .with_intrinsic_attribute_bool(name, value, ModificationContext::ApiOnly)
+                .parse(&format!(
+                    "= Document Title\n\n|===\na|\n= Nested Document Title\n{cell}\n\ncontent\n|==="
+                ));
+            assert_css(&doc, "h1", 1);
+            assert_css(&doc, ".tableblock h1", 0);
+        }
+    }
 
     #[test]
     #[ignore]

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -287,10 +287,40 @@ mod psv {
         let doc = Parser::default()
             .parse("[cols=\"15%,3*~\"]\n|=======\n|A |B |C |D\n|a |b |c |d\n|1 |2 |3 |4\n|=======");
 
+        // The fixed first column keeps its computed percentage in `colpcwidth`
+        // and carries the HTML `width` attribute; it is not autowidth.
+        assert_xpath(&doc, "(/table/colgroup/col)[1][@colpcwidth=\"15\"]", 1);
+        assert_xpath(&doc, "(/table/colgroup/col)[1][@width=\"15%\"]", 1);
+        assert_xpath(&doc, "(/table/colgroup/col)[1][@autowidth-option]", 0);
+
+        // Each autowidth column still has a computed `colpcwidth` (the remaining
+        // space shared three ways, truncated to four places with the balance
+        // donated to the last column) and the `autowidth-option` marker, but no
+        // HTML `width` attribute.
+        for i in 2..=3 {
+            assert_xpath(
+                &doc,
+                &format!("(/table/colgroup/col)[{i}][@colpcwidth=\"28.3333\"]"),
+                1,
+            );
+        }
+        assert_xpath(&doc, "(/table/colgroup/col)[4][@colpcwidth=\"28.3334\"]", 1);
+        for i in 2..=4 {
+            assert_xpath(
+                &doc,
+                &format!("(/table/colgroup/col)[{i}][@autowidth-option]"),
+                1,
+            );
+            assert_xpath(&doc, &format!("(/table/colgroup/col)[{i}][@width]"), 0);
+        }
+
+        // The HTML-output expectations from the Ruby test: every column renders a
+        // `<col>`, but only the single fixed column carries a `width` attribute.
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table colgroup col", 4);
         assert_css(&doc, "table colgroup col[width]", 1);
         assert_css(&doc, "table colgroup col[width=\"15%\"]", 1);
+        assert_css(&doc, "table colgroup col[autowidth-option]", 3);
     }
 
     #[test]

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1283,6 +1283,25 @@ mod psv {
      {
         let doc = Parser::default().parse("|===\na|\n $ command\na| paragraph\n|===");
 
+        // Source-map line numbers: the table starts on line 1; cell 1's
+        // separator is on line 2 and its inner document begins on line 3 (the
+        // indented `$ command`); cell 2 is on line 4.
+        let table = match doc.nested_blocks().next() {
+            Some(crate::blocks::Block::Table(table)) => table,
+            other => panic!("expected a table block, got {other:?}"),
+        };
+        assert_eq!(table.span().line(), 1);
+
+        let cell1 = &table.body_rows()[0].cells()[0];
+        assert_eq!(cell1.span().line(), 2);
+        let crate::blocks::TableCellContent::AsciiDoc(inner) = cell1.content() else {
+            panic!("expected an AsciiDoc cell");
+        };
+        assert_eq!(inner.blocks()[0].span().line(), 3);
+
+        let cell2 = &table.body_rows()[1].cells()[0];
+        assert_eq!(cell2.span().line(), 4);
+
         assert_css(&doc, "td", 2);
         assert_xpath(&doc, "(//td)[1]//*[@class=\"literalblock\"]", 1);
         assert_xpath(&doc, "(//td)[2]//*[@class=\"paragraph\"]", 1);

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1371,10 +1371,9 @@ mod psv {
     fn footnotes_should_not_be_shared_between_an_asciidoc_table_cell_and_the_main_document() {}
 
     // Backend-specific test omitted: DocBook ("callout numbers should be
-    // globally unique, including AsciiDoc table cells").
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311): the
-    // underlying feature (callouts, including global numbering across AsciiDoc
-    // table cells) is unimplemented; revisit when callouts land.
+    // globally unique, including AsciiDoc table cells"). Out of scope: it
+    // asserts only against DocBook output (`backend: 'docbook'`, `//co` /
+    // `//callout` elements), which the crate does not target.
 
     // Out of scope (omitted): compatibility mode is a stated limitation of the
     // crate, so the three "compat mode ... in AsciiDoc table cell" tests are not

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1408,9 +1408,8 @@ mod psv {
     // Attribute/option inheritance into the nested AsciiDoc-cell document is
     // implemented; the following remain unported for narrower reasons. The
     // `to_dir` test needs the nested cell exposed as an introspectable document
-    // object carrying inherited options. The `toc` tests need TOC rendering (a
-    // separate unimplemented feature); the doctitle test is rendered-output
-    // based.
+    // object carrying inherited options; the `toc` tests need TOC rendering (a
+    // separate unimplemented feature).
 
     #[test]
     #[ignore]
@@ -1444,10 +1443,19 @@ mod psv {
     fn should_be_able_to_enable_toc_in_both_outer_document_and_in_an_asciidoc_table_cell() {}
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): a document in an AsciiDoc table cell must not see the
-    // parent's doctitle.
-    fn document_in_an_asciidoc_table_cell_should_not_see_doctitle_of_parent() {}
+    fn document_in_an_asciidoc_table_cell_should_not_see_doctitle_of_parent() {
+        let doc = Parser::default()
+            .parse("= Document Title\n\n[cols=\"1a\"]\n|===\n|AsciiDoc content\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > tbody > tr > td", 1);
+
+        // The cell is its own (nested) document and does not inherit the parent's
+        // doctitle, so its lone paragraph is not promoted into a preamble: the
+        // cell renders a bare `.paragraph`, never a `#preamble`.
+        assert_css(&doc, "table > tbody > tr > td #preamble", 0);
+        assert_css(&doc, "table > tbody > tr > td .paragraph", 1);
+    }
 
     #[test]
     #[ignore]

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -329,10 +329,30 @@ mod psv {
             "[cols=\"4*~\",width=50%]\n|=======\n|A |B |C |D\n|a |b |c |d\n|1 |2 |3 |4\n|=======",
         );
 
+        // Every column is autowidth, so each takes an equal 25% share in
+        // `colpcwidth` and carries the `autowidth-option` marker; none carries an
+        // HTML `width` attribute even though the table itself has a width.
+        for i in 1..=4 {
+            assert_xpath(
+                &doc,
+                &format!("(/table/colgroup/col)[{i}][@colpcwidth=\"25\"]"),
+                1,
+            );
+            assert_xpath(
+                &doc,
+                &format!("(/table/colgroup/col)[{i}][@autowidth-option]"),
+                1,
+            );
+            assert_xpath(&doc, &format!("(/table/colgroup/col)[{i}][@width]"), 0);
+        }
+
+        // The explicit table width is still rendered, and no column carries a
+        // width-bearing `style` (the Ruby HTML-output expectations).
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table[width=\"50%\"]", 1);
         assert_css(&doc, "table colgroup col", 4);
         assert_css(&doc, "table colgroup col[style]", 0);
+        assert_css(&doc, "table colgroup col[autowidth-option]", 4);
     }
 
     // Backend-specific test omitted: DocBook ("equally distributes remaining

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -197,6 +197,30 @@ mod psv {
     }
 
     #[test]
+    fn should_auto_recover_with_warning_if_missing_leading_separator_on_first_cell() {
+        let doc = Parser::default().parse("|===\nA | here| a | there\n| x\n| y\n| z\n| end\n|===");
+
+        // The content before the first separator (`A`) is recovered as the first
+        // cell, so the first row has four cells and the table four columns.
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_css(&doc, "table > tbody > tr > td", 8);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[1]/p[text()=\"A\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p[text()=\"here\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[3]/p[text()=\"a\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[4]/p[text()=\"there\"]", 1);
+
+        // The recovery logs an error pointing at the offending line (line 2).
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::TableMissingLeadingSeparator
+        );
+        assert_eq!(warnings[0].source.line(), 2);
+    }
+
+    #[test]
     fn performs_normal_substitutions_on_cell_content() {
         let doc = Parser::default()
             .parse(":show_title: Cool new show\n|===\n|{show_title} |Coming soon...\n|===");

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1372,6 +1372,9 @@ mod psv {
 
     // Backend-specific test omitted: DocBook ("callout numbers should be
     // globally unique, including AsciiDoc table cells").
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311): the
+    // underlying feature (callouts, including global numbering across AsciiDoc
+    // table cells) is unimplemented; revisit when callouts land.
 
     // Out of scope (omitted): compatibility mode is a stated limitation of the
     // crate, so the three "compat mode ... in AsciiDoc table cell" tests are not

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1,0 +1,230 @@
+// Adapted from Asciidoctor's tables test suite, found in
+// https://github.com/asciidoctor/asciidoctor/blob/main/test/tables_test.rb.
+//
+// IMPORTANT: In porting this, I've disregarded compatibility mode (stated
+// limitation of `asciidoc-parser` crate) and alternate (non-HTML) back ends.
+
+mod psv {
+    use crate::tests::prelude::*;
+
+    #[test]
+    fn converts_simple_psv_table() {
+        let doc = Parser::default().parse("|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table.tableblock.frame-all.grid-all.stretch", 1);
+        assert_css(&doc, "table > colgroup > col[width=\"33.3333%\"]", 2);
+        // Ruby uses `col:last-of-type`; the indexed XPath form is equivalent.
+        assert_xpath(
+            &doc,
+            "(/table/colgroup/col)[3][@width=\"33.3334%\"]",
+            1,
+        );
+        assert_css(&doc, "table tr", 3);
+        assert_css(&doc, "table > tbody > tr", 3);
+        assert_css(&doc, "table td", 9);
+        assert_css(
+            &doc,
+            "table > tbody > tr > td.tableblock.halign-left.valign-top > p.tableblock",
+            9,
+        );
+
+        let cells = [["A", "B", "C"], ["a", "b", "c"], ["1", "2", "3"]];
+        for (rowi, row) in cells.iter().enumerate() {
+            assert_xpath(&doc, &format!("(/table/tbody/tr)[{}]/td", rowi + 1), row.len());
+            assert_xpath(&doc, &format!("(/table/tbody/tr)[{}]/td/p", rowi + 1), row.len());
+            for (celli, cell) in row.iter().enumerate() {
+                assert_xpath(
+                    &doc,
+                    &format!("(//tr)[{}]/td[{}]/p[text()='{cell}']", rowi + 1, celli + 1),
+                    1,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn should_add_direction_css_class_if_float_attribute_is_set_on_table() {
+        let doc = Parser::default()
+            .parse("[float=left]\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======");
+
+        assert_css(&doc, "table.left", 1);
+    }
+
+    #[test]
+    fn should_set_stripes_class_if_stripes_option_is_set() {
+        let doc = Parser::default()
+            .parse("[stripes=odd]\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======");
+
+        assert_css(&doc, "table.stripes-odd", 1);
+    }
+
+    #[test]
+    fn outputs_a_caption_on_simple_psv_table() {
+        let doc = Parser::default()
+            .parse(".Simple psv table\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======");
+
+        assert_xpath(
+            &doc,
+            "/table/caption[@class=\"title\"][text()=\"Table 1. Simple psv table\"]",
+            1,
+        );
+        assert_xpath(&doc, "/table/caption/following-sibling::colgroup", 1);
+    }
+
+    #[test]
+    fn only_increments_table_counter_for_tables_that_have_a_title() {
+        let doc = Parser::default().parse(
+            ".First numbered table\n|=======\n|1 |2 |3\n|=======\n\n|=======\n|4 |5 |6\n|=======\n\n.Second numbered table\n|=======\n|7 |8 |9\n|=======",
+        );
+
+        assert_xpath(&doc, "/table", 3);
+        assert_xpath(&doc, "(/table)[1]/caption", 1);
+        assert_xpath(
+            &doc,
+            "(/table)[1]/caption[text()=\"Table 1. First numbered table\"]",
+            1,
+        );
+        assert_xpath(&doc, "(/table)[2]/caption", 0);
+        assert_xpath(&doc, "(/table)[3]/caption", 1);
+        assert_xpath(
+            &doc,
+            "(/table)[3]/caption[text()=\"Table 2. Second numbered table\"]",
+            1,
+        );
+    }
+
+    #[test]
+    fn uses_explicit_caption_in_front_of_title_in_place_of_default_caption_and_number() {
+        let doc = Parser::default().parse(
+            "[caption=\"All the Data. \"]\n.Simple psv table\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======",
+        );
+
+        assert_xpath(
+            &doc,
+            "/table/caption[@class=\"title\"][text()=\"All the Data. Simple psv table\"]",
+            1,
+        );
+        assert_xpath(&doc, "/table/caption/following-sibling::colgroup", 1);
+    }
+
+    #[test]
+    fn disables_caption_when_caption_attribute_on_table_is_empty() {
+        let doc = Parser::default().parse(
+            "[caption=]\n.Simple psv table\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======",
+        );
+
+        assert_xpath(
+            &doc,
+            "/table/caption[@class=\"title\"][text()=\"Simple psv table\"]",
+            1,
+        );
+        assert_xpath(&doc, "/table/caption/following-sibling::colgroup", 1);
+    }
+
+    #[test]
+    fn disables_caption_when_caption_attribute_on_table_is_empty_string() {
+        let doc = Parser::default().parse(
+            "[caption=\"\"]\n.Simple psv table\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======",
+        );
+
+        assert_xpath(
+            &doc,
+            "/table/caption[@class=\"title\"][text()=\"Simple psv table\"]",
+            1,
+        );
+        assert_xpath(&doc, "/table/caption/following-sibling::colgroup", 1);
+    }
+
+    #[test]
+    fn disables_caption_on_table_when_table_caption_document_attribute_is_unset() {
+        let doc = Parser::default().parse(
+            ":!table-caption:\n\n.Simple psv table\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======",
+        );
+
+        assert_xpath(
+            &doc,
+            "/table/caption[@class=\"title\"][text()=\"Simple psv table\"]",
+            1,
+        );
+        assert_xpath(&doc, "/table/caption/following-sibling::colgroup", 1);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): The crate diverges from Asciidoctor on PSV cell
+    // splitting: it treats a `|` as a cell separator only when preceded by a
+    // delimiter boundary (e.g. a space), so `|a|b` parses as a single cell
+    // whereas Asciidoctor (and this test) splits it into two. Enable once the
+    // parser splits on any unescaped `|`.
+    fn ignores_escaped_separators() {
+        let doc =
+            Parser::default().parse("|===\n|A \\| here| a \\| there\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > tbody > tr", 1);
+        assert_css(&doc, "table > tbody > tr > td", 2);
+        assert_xpath(&doc, "/table/tbody/tr/td[1]/p[text()=\"A | here\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr/td[2]/p[text()=\"a | there\"]", 1);
+    }
+
+    #[test]
+    fn preserves_escaped_delimiters_at_the_end_of_the_line() {
+        let doc = Parser::default().parse(
+            "[%header,cols=\"1,1\"]\n|===\n|A |B\\|\n|A1 |B1\\|\n|A2 |B2\\|\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead > tr", 1);
+        assert_xpath(&doc, "(/table/thead/tr)[1]/th", 2);
+        assert_xpath(&doc, "/table/thead/tr[1]/th[2][text()=\"B|\"]", 1);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 2);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p[text()=\"B1|\"]", 1);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 2);
+        assert_xpath(&doc, "/table/tbody/tr[2]/td[2]/p[text()=\"B2|\"]", 1);
+    }
+
+    #[test]
+    fn should_treat_trailing_pipe_as_an_empty_cell() {
+        let doc =
+            Parser::default().parse("|===\n|A1 |\n|B1 |B2\n|C1 |C2\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > tbody > tr", 3);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td", 2);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[1]/p[text()=\"A1\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p", 0);
+        assert_xpath(&doc, "/table/tbody/tr[2]/td[1]/p[text()=\"B1\"]", 1);
+    }
+
+    #[test]
+    fn performs_normal_substitutions_on_cell_content() {
+        let doc = Parser::default().parse(
+            ":show_title: Cool new show\n|===\n|{show_title} |Coming soon...\n|===",
+        );
+
+        assert_xpath(&doc, "//tbody/tr/td[1]/p[text()=\"Cool new show\"]", 1);
+        assert_xpath(
+            &doc,
+            "//tbody/tr/td[2]/p[text()='Coming soon\u{2026}\u{200b}']",
+            1,
+        );
+    }
+}
+
+mod dsv {
+    #[allow(unused_imports)]
+    use crate::tests::prelude::*;
+}
+
+mod csv {
+    #[allow(unused_imports)]
+    use crate::tests::prelude::*;
+}
+
+
+

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -15,11 +15,7 @@ mod psv {
         assert_css(&doc, "table.tableblock.frame-all.grid-all.stretch", 1);
         assert_css(&doc, "table > colgroup > col[width=\"33.3333%\"]", 2);
         // Ruby uses `col:last-of-type`; the indexed XPath form is equivalent.
-        assert_xpath(
-            &doc,
-            "(/table/colgroup/col)[3][@width=\"33.3334%\"]",
-            1,
-        );
+        assert_xpath(&doc, "(/table/colgroup/col)[3][@width=\"33.3334%\"]", 1);
         assert_css(&doc, "table tr", 3);
         assert_css(&doc, "table > tbody > tr", 3);
         assert_css(&doc, "table td", 9);
@@ -31,8 +27,16 @@ mod psv {
 
         let cells = [["A", "B", "C"], ["a", "b", "c"], ["1", "2", "3"]];
         for (rowi, row) in cells.iter().enumerate() {
-            assert_xpath(&doc, &format!("(/table/tbody/tr)[{}]/td", rowi + 1), row.len());
-            assert_xpath(&doc, &format!("(/table/tbody/tr)[{}]/td/p", rowi + 1), row.len());
+            assert_xpath(
+                &doc,
+                &format!("(/table/tbody/tr)[{}]/td", rowi + 1),
+                row.len(),
+            );
+            assert_xpath(
+                &doc,
+                &format!("(/table/tbody/tr)[{}]/td/p", rowi + 1),
+                row.len(),
+            );
             for (celli, cell) in row.iter().enumerate() {
                 assert_xpath(
                     &doc,
@@ -158,8 +162,7 @@ mod psv {
     // whereas Asciidoctor (and this test) splits it into two. Enable once the
     // parser splits on any unescaped `|`.
     fn ignores_escaped_separators() {
-        let doc =
-            Parser::default().parse("|===\n|A \\| here| a \\| there\n|===");
+        let doc = Parser::default().parse("|===\n|A \\| here| a \\| there\n|===");
 
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table > colgroup > col", 2);
@@ -171,9 +174,8 @@ mod psv {
 
     #[test]
     fn preserves_escaped_delimiters_at_the_end_of_the_line() {
-        let doc = Parser::default().parse(
-            "[%header,cols=\"1,1\"]\n|===\n|A |B\\|\n|A1 |B1\\|\n|A2 |B2\\|\n|===",
-        );
+        let doc = Parser::default()
+            .parse("[%header,cols=\"1,1\"]\n|===\n|A |B\\|\n|A1 |B1\\|\n|A2 |B2\\|\n|===");
 
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table > colgroup > col", 2);
@@ -189,8 +191,7 @@ mod psv {
 
     #[test]
     fn should_treat_trailing_pipe_as_an_empty_cell() {
-        let doc =
-            Parser::default().parse("|===\n|A1 |\n|B1 |B2\n|C1 |C2\n|===");
+        let doc = Parser::default().parse("|===\n|A1 |\n|B1 |B2\n|C1 |C2\n|===");
 
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table > colgroup > col", 2);
@@ -203,9 +204,8 @@ mod psv {
 
     #[test]
     fn performs_normal_substitutions_on_cell_content() {
-        let doc = Parser::default().parse(
-            ":show_title: Cool new show\n|===\n|{show_title} |Coming soon...\n|===",
-        );
+        let doc = Parser::default()
+            .parse(":show_title: Cool new show\n|===\n|{show_title} |Coming soon...\n|===");
 
         assert_xpath(&doc, "//tbody/tr/td[1]/p[text()=\"Cool new show\"]", 1);
         assert_xpath(
@@ -235,8 +235,8 @@ mod psv {
     // preserve leading spaces on every line. Enable once fixed.
     fn should_preserve_leading_spaces_but_not_leading_newlines_or_trailing_spaces_in_literal_table_cells()
      {
-        let doc = Parser::default()
-            .parse("[cols=2*]\n|===\nl|\n  one\n  two\nthree\n\n  | normal\n|===");
+        let doc =
+            Parser::default().parse("[cols=2*]\n|===\nl|\n  one\n  two\nthree\n\n  | normal\n|===");
 
         assert_css(&doc, "table pre", 1);
         assert_xpath(&doc, "/table//pre[text()=\"  one\n  two\nthree\"]", 1);
@@ -244,8 +244,8 @@ mod psv {
 
     #[test]
     fn should_ignore_v_table_cell_style() {
-        let doc = Parser::default()
-            .parse("[cols=2*]\n|===\nv|\n  one\n  two\nthree\n\n  | normal\n|===");
+        let doc =
+            Parser::default().parse("[cols=2*]\n|===\nv|\n  one\n  two\nthree\n\n  | normal\n|===");
 
         // The unrecognized `v` style is ignored, so the cell renders as a normal
         // paragraph (`p.tableblock`) with leading newlines and trailing spaces
@@ -259,9 +259,8 @@ mod psv {
 
     #[test]
     fn table_and_column_width_not_assigned_when_autowidth_option_is_specified() {
-        let doc = Parser::default().parse(
-            "[options=\"autowidth\"]\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======",
-        );
+        let doc = Parser::default()
+            .parse("[options=\"autowidth\"]\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======");
 
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table.fit-content", 1);
@@ -272,9 +271,8 @@ mod psv {
 
     #[test]
     fn does_not_assign_column_width_for_autowidth_columns_in_html_output() {
-        let doc = Parser::default().parse(
-            "[cols=\"15%,3*~\"]\n|=======\n|A |B |C |D\n|a |b |c |d\n|1 |2 |3 |4\n|=======",
-        );
+        let doc = Parser::default()
+            .parse("[cols=\"15%,3*~\"]\n|=======\n|A |B |C |D\n|a |b |c |d\n|1 |2 |3 |4\n|=======");
 
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table colgroup col", 4);
@@ -302,9 +300,8 @@ mod psv {
 
     #[test]
     fn explicit_table_width_is_used_even_when_autowidth_option_is_specified() {
-        let doc = Parser::default().parse(
-            "[%autowidth,width=75%]\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======",
-        );
+        let doc = Parser::default()
+            .parse("[%autowidth,width=75%]\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======");
 
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table[width]", 1);
@@ -314,8 +311,8 @@ mod psv {
 
     #[test]
     fn first_row_sets_number_of_columns_when_not_specified() {
-        let doc = Parser::default()
-            .parse("|===\n|first |second |third |fourth\n|1 |2 |3\n|4\n|===");
+        let doc =
+            Parser::default().parse("|===\n|first |second |third |fourth\n|1 |2 |3\n|4\n|===");
 
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table > colgroup > col", 4);
@@ -326,8 +323,7 @@ mod psv {
 
     #[test]
     fn colspec_attribute_using_asterisk_syntax_sets_number_of_columns() {
-        let doc = Parser::default()
-            .parse("[cols=\"3*\"]\n|===\n|A |B |C |a |b |c |1 |2 |3\n|===");
+        let doc = Parser::default().parse("[cols=\"3*\"]\n|===\n|A |B |C |a |b |c |1 |2 |3\n|===");
 
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table > tbody > tr", 3);
@@ -468,9 +464,8 @@ mod psv {
 
     #[test]
     fn table_with_implicit_header_row() {
-        let doc = Parser::default().parse(
-            "|===\n|Column 1 |Column 2\n\n|Data A1\n|Data B1\n\n|Data A2\n|Data B2\n|===",
-        );
+        let doc = Parser::default()
+            .parse("|===\n|Column 1 |Column 2\n\n|Data A1\n|Data B1\n\n|Data A2\n|Data B2\n|===");
 
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table > colgroup > col", 2);
@@ -510,9 +505,8 @@ mod psv {
 
     #[test]
     fn no_implicit_header_row_if_second_line_not_blank() {
-        let doc = Parser::default().parse(
-            "|===\n|Column 1 |Column 2\n|Data A1\n|Data B1\n\n|Data A2\n|Data B2\n|===",
-        );
+        let doc = Parser::default()
+            .parse("|===\n|Column 1 |Column 2\n|Data A1\n|Data B1\n\n|Data A2\n|Data B2\n|===");
 
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table > colgroup > col", 2);
@@ -529,9 +523,8 @@ mod psv {
     // drops cells from the multi-line `A1 continued|B1` row. Enable once both
     // are fixed.
     fn no_implicit_header_row_if_cell_in_first_line_spans_multiple_lines() {
-        let doc = Parser::default().parse(
-            "[cols=2*]\n|===\n|A1\n\n\nA1 continued|B1\n\n|A2\n|B2\n|===",
-        );
+        let doc =
+            Parser::default().parse("[cols=2*]\n|===\n|A1\n\n\nA1 continued|B1\n\n|A2\n|B2\n|===");
 
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table > colgroup > col", 2);
@@ -573,7 +566,8 @@ mod psv {
     }
 
     #[test]
-    fn should_format_first_cell_as_asciidoc_if_there_is_no_implicit_header_row_and_cell_has_a_style() {
+    fn should_format_first_cell_as_asciidoc_if_there_is_no_implicit_header_row_and_cell_has_a_style()
+     {
         let doc = Parser::default().parse("|===\na| * list\n| normal\n|===");
 
         assert_css(&doc, "tbody .ulist", 1);
@@ -668,9 +662,21 @@ mod psv {
         let doc = Parser::default()
             .parse("[cols=\"s,e\"]\n|===\n| _strong_ | *emphasis*\n| strong\n| emphasis\n|===");
 
-        assert_xpath(&doc, "((//tbody/tr)[1]/td)[1]//strong/em[text()=\"strong\"]", 1);
-        assert_xpath(&doc, "((//tbody/tr)[1]/td)[2]//em/strong[text()=\"emphasis\"]", 1);
-        assert_xpath(&doc, "((//tbody/tr)[2]/td)[1]//strong[text()=\"strong\"]", 1);
+        assert_xpath(
+            &doc,
+            "((//tbody/tr)[1]/td)[1]//strong/em[text()=\"strong\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((//tbody/tr)[1]/td)[2]//em/strong[text()=\"emphasis\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((//tbody/tr)[2]/td)[1]//strong[text()=\"strong\"]",
+            1,
+        );
         assert_xpath(&doc, "((//tbody/tr)[2]/td)[2]//em[text()=\"emphasis\"]", 1);
     }
 
@@ -735,7 +741,8 @@ mod psv {
 
     #[test]
     fn percentages_as_column_widths() {
-        let doc = Parser::default().parse("[cols=\"<.^10%,<90%\"]\n|===\n|column A |column B\n|===");
+        let doc =
+            Parser::default().parse("[cols=\"<.^10%,<90%\"]\n|===\n|column A |column B\n|===");
 
         assert_xpath(&doc, "/table/colgroup/col", 2);
         assert_xpath(&doc, "(/table/colgroup/col)[1][@width=\"10%\"]", 1);
@@ -827,8 +834,8 @@ mod psv {
 
     #[test]
     fn sets_up_columns_correctly_if_first_row_has_cell_that_spans_columns() {
-        let doc = Parser::default()
-            .parse("|===\n2+^|AAA |CCC\n|AAA |BBB |CCC\n|AAA |BBB |CCC\n|===");
+        let doc =
+            Parser::default().parse("|===\n2+^|AAA |CCC\n|AAA |BBB |CCC\n|AAA |BBB |CCC\n|===");
 
         assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 2);
         assert_xpath(&doc, "((/table/tbody/tr)[1]/td)[1][@colspan=\"2\"]", 1);
@@ -981,7 +988,11 @@ mod psv {
 
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table > colgroup > col", 2);
-        assert_css(&doc, "table > tbody > tr > td:nth-child(1).halign-left.valign-top > p.tableblock", 7);
+        assert_css(
+            &doc,
+            "table > tbody > tr > td:nth-child(1).halign-left.valign-top > p.tableblock",
+            7,
+        );
     }
 
     #[test]
@@ -1001,17 +1012,24 @@ mod psv {
 
     #[test]
     fn should_strip_trailing_newlines_when_splitting_paragraphs() {
-        let doc = Parser::default().parse(
-            "|===\n|first wrapped\nparagraph\n\nsecond paragraph\n\nthird paragraph\n|===",
-        );
+        let doc = Parser::default()
+            .parse("|===\n|first wrapped\nparagraph\n\nsecond paragraph\n\nthird paragraph\n|===");
 
         assert_xpath(
             &doc,
             "(//p[@class=\"tableblock\"])[1][text()=\"first wrapped\nparagraph\"]",
             1,
         );
-        assert_xpath(&doc, "(//p[@class=\"tableblock\"])[2][text()=\"second paragraph\"]", 1);
-        assert_xpath(&doc, "(//p[@class=\"tableblock\"])[3][text()=\"third paragraph\"]", 1);
+        assert_xpath(
+            &doc,
+            "(//p[@class=\"tableblock\"])[2][text()=\"second paragraph\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "(//p[@class=\"tableblock\"])[3][text()=\"third paragraph\"]",
+            1,
+        );
     }
 
     #[test]
@@ -1025,8 +1043,16 @@ mod psv {
         assert_css(&doc, "table.tableblock", 1);
         assert_css(&doc, "table.tableblock td.tableblock", 1);
         assert_css(&doc, "table.tableblock td.tableblock .openblock", 1);
-        assert_css(&doc, "table.tableblock td.tableblock .openblock .admonitionblock", 1);
-        assert_css(&doc, "table.tableblock td.tableblock .openblock .paragraph", 1);
+        assert_css(
+            &doc,
+            "table.tableblock td.tableblock .openblock .admonitionblock",
+            1,
+        );
+        assert_css(
+            &doc,
+            "table.tableblock td.tableblock .openblock .paragraph",
+            1,
+        );
     }
 
     #[test]
@@ -1034,7 +1060,11 @@ mod psv {
         let doc = Parser::default().parse("|===\na|AsciiDoc table cell\n|===");
 
         assert_css(&doc, "table.tableblock td.tableblock > div.content", 1);
-        assert_css(&doc, "table.tableblock td.tableblock > div.content > div.paragraph", 1);
+        assert_css(
+            &doc,
+            "table.tableblock td.tableblock > div.content > div.paragraph",
+            1,
+        );
     }
 
     // The following AsciiDoc-table-cell tests depend on nested-document
@@ -1091,7 +1121,8 @@ mod psv {
     #[ignore]
     // TODO (issue TBD): a locked-unset attribute cannot be set in an AsciiDoc
     // table cell.
-    fn should_not_allow_locked_attribute_unset_in_parent_document_to_be_set_in_asciidoc_table_cell() {
+    fn should_not_allow_locked_attribute_unset_in_parent_document_to_be_set_in_asciidoc_table_cell()
+    {
     }
 
     #[test]
@@ -1162,7 +1193,9 @@ mod psv {
     #[ignore]
     // TODO (issue TBD): Cross-reference resolution from inside an AsciiDoc table
     // cell to a reference in the main document.
-    fn cross_reference_link_in_an_asciidoc_table_cell_should_resolve_to_reference_in_main_document() {}
+    fn cross_reference_link_in_an_asciidoc_table_cell_should_resolve_to_reference_in_main_document()
+    {
+    }
 
     #[test]
     #[ignore]
@@ -1272,8 +1305,7 @@ mod psv {
 
     #[test]
     fn should_warn_if_table_block_is_not_terminated() {
-        let doc =
-            Parser::default().parse("outside\n\n|===\n|\ninside\n\nstill inside\n\neof");
+        let doc = Parser::default().parse("outside\n\n|===\n|\ninside\n\nstill inside\n\neof");
 
         assert_xpath(&doc, "/table", 1);
 
@@ -1301,7 +1333,8 @@ mod psv {
         assert!(
             warnings
                 .iter()
-                .any(|w| w.warning == WarningType::UnterminatedDelimitedBlock && w.source.line() == 9)
+                .any(|w| w.warning == WarningType::UnterminatedDelimitedBlock
+                    && w.source.line() == 9)
         );
     }
 
@@ -1338,8 +1371,8 @@ mod psv {
     // suppresses the implicit header, but the crate creates one (see
     // `no_implicit_header_row_if_cell_in_first_line_spans_multiple_lines`).
     fn no_implicit_header_row_if_cell_in_first_line_is_quoted_and_spans_multiple_lines() {
-        let doc = Parser::default()
-            .parse("[cols=2*l]\n,===\n\"A1\n\nA1 continued\",B1\nA2,B2\n,===");
+        let doc =
+            Parser::default().parse("[cols=2*l]\n,===\n\"A1\n\nA1 continued\",B1\nA2,B2\n,===");
 
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table > colgroup > col", 2);
@@ -1351,11 +1384,234 @@ mod psv {
 }
 
 mod dsv {
-    #[allow(unused_imports)]
     use crate::tests::prelude::*;
+
+    #[test]
+    fn converts_simple_dsv_table() {
+        let doc = Parser::default().parse(
+            "[width=\"75%\",format=\"dsv\"]\n|===\nroot:x:0:0:root:/root:/bin/bash\nbin:x:1:1:bin:/bin:/sbin/nologin\nmysql:x:27:27:MySQL\\:Server:/var/lib/mysql:/bin/bash\ngdm:x:42:42::/var/lib/gdm:/sbin/nologin\nsshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/sbin/nologin\nnobody:x:99:99:Nobody:/:/sbin/nologin\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col[width=\"14.2857%\"]", 6);
+        // Ruby uses `col:last-of-type`; the indexed XPath form is equivalent.
+        assert_xpath(&doc, "(/table/colgroup/col)[7][@width=\"14.2858%\"]", 1);
+        assert_css(&doc, "table > tbody > tr", 6);
+        assert_xpath(&doc, "//tr[4]/td[5]/p/text()", 0);
+        assert_xpath(&doc, "//tr[3]/td[5]/p[text()=\"MySQL:Server\"]", 1);
+    }
+
+    #[test]
+    fn dsv_format_shorthand() {
+        let doc = Parser::default().parse(":===\na:b:c\n1:2:3\n:===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
+    }
+
+    #[test]
+    fn single_cell_in_dsv_table_should_only_produce_single_row() {
+        let doc = Parser::default().parse(":===\nsingle cell\n:===");
+
+        assert_css(&doc, "table td", 1);
+    }
+
+    #[test]
+    fn should_treat_trailing_colon_as_an_empty_cell() {
+        let doc = Parser::default().parse(":===\nA1:\nB1:B2\nC1:C2\n:===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > tbody > tr", 3);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td", 2);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[1]/p[text()=\"A1\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p", 0);
+        assert_xpath(&doc, "/table/tbody/tr[2]/td[1]/p[text()=\"B1\"]", 1);
+    }
 }
 
 mod csv {
-    #[allow(unused_imports)]
     use crate::tests::prelude::*;
+
+    #[test]
+    fn should_treat_trailing_comma_as_an_empty_cell() {
+        let doc = Parser::default().parse(",===\nA1,\nB1,B2\nC1,C2\n,===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > tbody > tr", 3);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td", 2);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[1]/p[text()=\"A1\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p", 0);
+        assert_xpath(&doc, "/table/tbody/tr[2]/td[1]/p[text()=\"B1\"]", 1);
+    }
+
+    #[test]
+    fn should_log_error_but_not_crash_if_cell_data_has_unclosed_quote() {
+        let doc = Parser::default().parse(",===\na,b\nc,\"\n,===");
+
+        // The unclosed quote recovers to an empty cell without crashing.
+        // NOTE: Asciidoctor also logs an ERROR ("unclosed quote in CSV data");
+        // the crate recovers silently, so that warning assertion is not ported.
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table td", 4);
+        assert_xpath(&doc, "(//td)[4]/p", 0);
+    }
+
+    #[test]
+    fn should_preserve_newlines_in_quoted_csv_values() {
+        let doc = Parser::default().parse(
+            "[cols=\"1,1,1l\"]\n,===\n\"A\nB\nC\",\"one\n\ntwo\n\nthree\",\"do\n\nre\n\nme\"\n,===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td", 3);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[1]/p[text()=\"A\nB\nC\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p", 3);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p[1][text()=\"one\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p[2][text()=\"two\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p[3][text()=\"three\"]", 1);
+        assert_xpath(
+            &doc,
+            "/table/tbody/tr[1]/td[3]//pre[text()=\"do\n\nre\n\nme\"]",
+            1,
+        );
+    }
+
+    // Out of scope (omitted): include files are not supported, so "should not
+    // drop trailing empty cell in TSV data when loaded from an include file" is
+    // not ported.
+
+    #[test]
+    fn mixed_unquoted_records_and_quoted_records_with_escaped_quotes_commas_and_wrapped_lines() {
+        let doc = Parser::default().parse(
+            "[format=\"csv\",options=\"header\"]\n|===\nYear,Make,Model,Description,Price\n1997,Ford,E350,\"ac, abs, moon\",3000.00\n1999,Chevy,\"Venture \"\"Extended Edition\"\"\",\"\",4900.00\n1999,Chevy,\"Venture \"\"Extended Edition, Very Large\"\"\",,5000.00\n1996,Jeep,Grand Cherokee,\"MUST SELL!\nair, moon roof, loaded\",4799.00\n2000,Toyota,Tundra,\"\"\"This one's gonna to blow you're socks off,\"\" per the sticker\",10000.00\n2000,Toyota,Tundra,\"Check it, \"\"this one's gonna to blow you're socks off\"\", per the sticker\",10000.00\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col[width=\"20%\"]", 5);
+        assert_css(&doc, "table > thead > tr", 1);
+        assert_css(&doc, "table > tbody > tr", 6);
+        assert_xpath(
+            &doc,
+            "((//tbody/tr)[1]/td)[4]/p[text()=\"ac, abs, moon\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((//tbody/tr)[2]/td)[3]/p[text()='Venture \"Extended Edition\"']",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((//tbody/tr)[4]/td)[4]/p[text()=\"MUST SELL!\nair, moon roof, loaded\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((//tbody/tr)[5]/td)[4]/p[text()='\"This one\u{2019}s gonna to blow you\u{2019}re socks off,\" per the sticker']",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((//tbody/tr)[6]/td)[4]/p[text()='Check it, \"this one\u{2019}s gonna to blow you\u{2019}re socks off\", per the sticker']",
+            1,
+        );
+    }
+
+    #[test]
+    fn should_allow_quotes_around_a_csv_value_to_be_on_their_own_lines() {
+        let doc = Parser::default().parse("[cols=2*]\n,===\n\"\nA\n\",\"\nB\n\"\n,===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > tbody > tr", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td", 2);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[1]/p[text()=\"A\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p[text()=\"B\"]", 1);
+    }
+
+    #[test]
+    fn csv_format_shorthand() {
+        let doc = Parser::default().parse(",===\na,b,c\n1,2,3\n,===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
+    }
+
+    #[test]
+    fn tsv_as_format() {
+        let doc = Parser::default().parse("[format=tsv]\n,===\na\tb\tc\n1\t2\t3\n,===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
+    }
+
+    #[test]
+    fn custom_csv_separator() {
+        let doc = Parser::default().parse("[format=csv,separator=;]\n|===\na;b;c\n1;2;3\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
+    }
+
+    #[test]
+    fn tab_as_separator() {
+        let doc = Parser::default().parse("[separator=\\t]\n,===\na\tb\tc\n1\t2\t3\n,===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
+    }
+
+    #[test]
+    fn single_cell_in_csv_table_should_only_produce_single_row() {
+        let doc = Parser::default().parse(",===\nsingle cell\n,===");
+
+        assert_css(&doc, "table td", 1);
+    }
+
+    #[test]
+    fn cell_formatted_with_asciidoc_style() {
+        let doc = Parser::default().parse(
+            "[cols=\"1,1,1a\",separator=;]\n,===\nelement;description;example\n\nthematic break,a visible break; also known as a horizontal rule;---\n,===",
+        );
+
+        assert_css(&doc, "table tbody hr", 1);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): For a multi-line, whitespace-padded quoted CSV value
+    // feeding an AsciiDoc (`a`) column, the crate does not strip the surrounding
+    // quotes or whitespace — the cell renders `"\n  one sentence, one line\n  "`
+    // verbatim instead of the trimmed `one sentence, one line`. Enable once the
+    // CSV quote/whitespace stripping handles this case.
+    fn should_strip_whitespace_around_contents_of_asciidoc_cell() {
+        let doc = Parser::default().parse(
+            "[cols=\"1,1,1a\",separator=;]\n,===\nelement;description;example\n\nparagraph;contiguous lines of words and phrases;\"\n  one sentence, one line\n  \"\n,===",
+        );
+
+        assert_xpath(
+            &doc,
+            "/table/tbody//*[@class=\"paragraph\"]/p[text()=\"one sentence, one line\"]",
+            1,
+        );
+    }
 }

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1405,13 +1405,18 @@ mod psv {
         assert_xpath(&doc, "/table/tbody/tr/td[2]//table/tbody/tr/td", 1);
     }
 
-    // The following depend on document option/attribute inheritance into the
-    // nested AsciiDoc-cell document (to_dir, toc, doctitle), which the crate
-    // does not yet model.
+    // Attribute/option inheritance into the nested AsciiDoc-cell document is
+    // implemented; the following remain unported for narrower reasons. The
+    // `to_dir` test needs the nested cell exposed as an introspectable document
+    // object carrying inherited options. The `toc` tests need TOC rendering (a
+    // separate unimplemented feature); the doctitle test is rendered-output
+    // based.
 
     #[test]
     #[ignore]
-    // TODO (issue TBD): AsciiDoc table cell should inherit the to_dir option.
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/545): AsciiDoc
+    // table cell should expose the nested document for introspection of inherited
+    // options (here, `to_dir`).
     fn asciidoc_table_cell_should_inherit_to_dir_option_from_parent_document() {}
 
     #[test]

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1421,24 +1421,26 @@ mod psv {
 
     #[test]
     #[ignore]
-    // TODO (issue TBD): AsciiDoc table cell should not inherit the toc setting.
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/546): AsciiDoc
+    // table cell should not inherit the toc setting.
     fn asciidoc_table_cell_should_not_inherit_toc_setting_from_parent_document() {}
 
     #[test]
     #[ignore]
-    // TODO (issue TBD): enabling toc in an AsciiDoc table cell.
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/546): enabling
+    // toc in an AsciiDoc table cell.
     fn should_be_able_to_enable_toc_in_an_asciidoc_table_cell() {}
 
     #[test]
     #[ignore]
-    // TODO (issue TBD): enabling toc in an AsciiDoc table cell even if hard unset
-    // by the API.
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/546): enabling
+    // toc in an AsciiDoc table cell even if hard unset by the API.
     fn should_be_able_to_enable_toc_in_an_asciidoc_table_cell_even_if_hard_unset_by_api() {}
 
     #[test]
     #[ignore]
-    // TODO (issue TBD): enabling toc in both the outer document and an AsciiDoc
-    // table cell.
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/546): enabling
+    // toc in both the outer document and an AsciiDoc table cell.
     fn should_be_able_to_enable_toc_in_both_outer_document_and_in_an_asciidoc_table_cell() {}
 
     #[test]

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1588,7 +1588,7 @@ mod dsv {
 }
 
 mod csv {
-    use crate::tests::prelude::*;
+    use crate::tests::prelude::{inline_file_handler::InlineFileHandler, *};
 
     #[test]
     fn should_treat_trailing_comma_as_an_empty_cell() {
@@ -1644,9 +1644,28 @@ mod csv {
         );
     }
 
-    // Out of scope (omitted): include files are not supported, so "should not
-    // drop trailing empty cell in TSV data when loaded from an include file" is
-    // not ported.
+    #[test]
+    fn should_not_drop_trailing_empty_cell_in_tsv_data_when_loaded_from_an_include_file() {
+        // The `1\t2\t` record ends with a tab, so its third field is empty. The
+        // include is the delivery mechanism; the behavior under test is that the
+        // trailing empty cell survives.
+        let handler = InlineFileHandler::from_pairs([(
+            "fixtures/data.tsv",
+            "First\tSecond\tThird\na\tb\tc\n1\t2\t\nx\ty\tz\n",
+        )]);
+        let mut parser = Parser::default().with_include_file_handler(handler);
+        let doc = parser.parse("[%header,format=tsv]\n|===\ninclude::fixtures/data.tsv[]\n|===");
+
+        assert_css(&doc, "table > tbody > tr", 3);
+        assert_css(&doc, "table > tbody > tr:nth-child(1) > td", 3);
+        assert_css(&doc, "table > tbody > tr:nth-child(2) > td", 3);
+        assert_css(&doc, "table > tbody > tr:nth-child(3) > td", 3);
+        assert_css(
+            &doc,
+            "table > tbody > tr:nth-child(2) > td:nth-child(3):empty",
+            1,
+        );
+    }
 
     #[test]
     fn mixed_unquoted_records_and_quoted_records_with_escaped_quotes_commas_and_wrapped_lines() {

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -436,6 +436,302 @@ mod psv {
         assert_xpath(&doc, "/table/thead/following-sibling::tbody", 1);
         assert_xpath(&doc, "/table/tbody/following-sibling::tfoot", 1);
     }
+
+    // Backend-specific test omitted: DocBook ("table with header and footer
+    // docbook").
+
+    // Backend-specific test omitted: DocBook ("should set horizontal and
+    // vertical alignment when converting to DocBook").
+
+    #[test]
+    fn should_preserve_frame_value_ends_when_converting_to_html() {
+        let doc = Parser::default().parse("[frame=ends]\n|===\n|A |B |C\n|===");
+
+        assert_css(&doc, "table.frame-ends", 1);
+    }
+
+    #[test]
+    fn should_normalize_frame_value_topbot_as_ends_when_converting_to_html() {
+        let doc = Parser::default().parse("[frame=topbot]\n|===\n|A |B |C\n|===");
+
+        assert_css(&doc, "table.frame-ends", 1);
+    }
+
+    // Backend-specific test omitted: DocBook ("should preserve frame value
+    // topbot when converting to DocBook").
+
+    // Backend-specific test omitted: DocBook ("should convert frame value ends
+    // to topbot when converting to DocBook").
+
+    // Backend-specific test omitted: DocBook ("table with landscape orientation
+    // in DocBook").
+
+    #[test]
+    fn table_with_implicit_header_row() {
+        let doc = Parser::default().parse(
+            "|===\n|Column 1 |Column 2\n\n|Data A1\n|Data B1\n\n|Data A2\n|Data B2\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 1);
+        assert_css(&doc, "table > thead > tr", 1);
+        assert_css(&doc, "table > thead > tr > th", 2);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 2);
+    }
+
+    #[test]
+    fn table_with_implicit_header_row_only() {
+        let doc = Parser::default().parse("|===\n|Column 1 |Column 2\n\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 1);
+        assert_css(&doc, "table > thead > tr", 1);
+        assert_css(&doc, "table > thead > tr > th", 2);
+        assert_css(&doc, "table > tbody", 0);
+    }
+
+    #[test]
+    fn table_with_implicit_header_row_when_other_options_set() {
+        let doc = Parser::default()
+            .parse("[%autowidth]\n|===\n|Column 1 |Column 2\n\n|Data A1\n|Data B1\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table[style*=\"width\"]", 0);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 1);
+        assert_css(&doc, "table > thead > tr", 1);
+        assert_css(&doc, "table > thead > tr > th", 2);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 1);
+    }
+
+    #[test]
+    fn no_implicit_header_row_if_second_line_not_blank() {
+        let doc = Parser::default().parse(
+            "|===\n|Column 1 |Column 2\n|Data A1\n|Data B1\n\n|Data A2\n|Data B2\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 0);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 3);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): The crate mis-parses this table — it creates an implicit
+    // header row even though the first cell spans multiple lines, and (blocked
+    // by the PSV cell-splitting divergence, see `ignores_escaped_separators`)
+    // drops cells from the multi-line `A1 continued|B1` row. Enable once both
+    // are fixed.
+    fn no_implicit_header_row_if_cell_in_first_line_spans_multiple_lines() {
+        let doc = Parser::default().parse(
+            "[cols=2*]\n|===\n|A1\n\n\nA1 continued|B1\n\n|A2\n|B2\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 0);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(//td)[1]/p", 2);
+    }
+
+    #[test]
+    fn should_format_first_cell_as_literal_if_there_is_no_implicit_header_row_and_column_has_l_style()
+     {
+        let doc = Parser::default().parse("[cols=\"1l,1\"]\n|===\n|literal\n|normal\n|===");
+
+        assert_css(&doc, "tbody pre", 1);
+        assert_css(&doc, "tbody p.tableblock", 1);
+    }
+
+    #[test]
+    fn should_format_first_cell_as_asciidoc_if_there_is_no_implicit_header_row_and_column_has_a_style()
+     {
+        let doc = Parser::default().parse("[cols=\"1a,1\"]\n|===\n| * list\n| normal\n|===");
+
+        assert_css(&doc, "tbody .ulist", 1);
+        assert_css(&doc, "tbody p.tableblock", 1);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): The crate does not treat a leading-indented line in an
+    // AsciiDoc (`a`) cell as a literal block, so no `<pre>` is produced. Enable
+    // once leading indent is interpreted inside AsciiDoc cells.
+    fn should_interpret_leading_indent_if_first_cell_is_asciidoc_and_there_is_no_implicit_header_row()
+     {
+        let doc = Parser::default().parse("[cols=\"1a,1\"]\n|===\n|\n  literal\n| normal\n|===");
+
+        assert_css(&doc, "tbody pre", 1);
+        assert_css(&doc, "tbody p.tableblock", 1);
+    }
+
+    #[test]
+    fn should_format_first_cell_as_asciidoc_if_there_is_no_implicit_header_row_and_cell_has_a_style() {
+        let doc = Parser::default().parse("|===\na| * list\n| normal\n|===");
+
+        assert_css(&doc, "tbody .ulist", 1);
+        assert_css(&doc, "tbody p.tableblock", 1);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): The crate creates an implicit header row even though the
+    // first cell (an AsciiDoc cell) spans multiple lines; Asciidoctor suppresses
+    // the implicit header in that case. Enable once implicit-header detection
+    // accounts for multi-line first cells.
+    fn no_implicit_header_row_if_asciidoc_cell_in_first_line_spans_multiple_lines() {
+        let doc = Parser::default().parse(
+            "[cols=2*]\n|===\na|contains AsciiDoc content\n\n* a\n* b\n* c\na|contains no AsciiDoc content\n\njust text\n|A2\n|B2\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 0);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(//td)[1]//ul", 1);
+    }
+
+    #[test]
+    fn no_implicit_header_row_if_first_line_blank() {
+        let doc = Parser::default().parse(
+            "|===\n\n|Column 1 |Column 2\n\n|Data A1\n|Data B1\n\n|Data A2\n|Data B2\n\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 0);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 3);
+    }
+
+    #[test]
+    fn no_implicit_header_row_if_noheader_option_is_specified() {
+        let doc = Parser::default().parse(
+            "[%noheader]\n|===\n|Column 1 |Column 2\n\n|Data A1\n|Data B1\n\n|Data A2\n|Data B2\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 0);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 3);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): Blocked by the PSV cell-splitting divergence (see
+    // `ignores_escaped_separators`): `|Occupation| Website` is not split into
+    // two cells, so the header/footer rows are mis-parsed. Enable once the
+    // parser splits on any unescaped `|`.
+    fn styles_not_applied_to_header_cells() {
+        let doc = Parser::default().parse(
+            "[cols=\"1h,1s,1e\",options=\"header,footer\"]\n|===\n|Name |Occupation| Website\n|Octocat |Social coding| https://github.com\n|Name |Occupation| Website\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > thead > tr > th", 3);
+        assert_css(&doc, "table > thead > tr > th > *", 0);
+
+        assert_css(&doc, "table > tfoot > tr > th", 1);
+        assert_css(&doc, "table > tfoot > tr > td", 2);
+        assert_css(&doc, "table > tfoot > tr > td > p > strong", 1);
+        assert_css(&doc, "table > tfoot > tr > td > p > em", 1);
+
+        assert_css(&doc, "table > tbody > tr > th", 1);
+        assert_css(&doc, "table > tbody > tr > td", 2);
+        assert_css(&doc, "table > tbody > tr > td > p.header", 0);
+        assert_css(&doc, "table > tbody > tr > td > p > strong", 1);
+        assert_css(&doc, "table > tbody > tr > td > p > em > a", 1);
+    }
+
+    #[test]
+    fn should_apply_text_formatting_to_cells_in_implicit_header_row_when_column_has_a_style() {
+        let doc = Parser::default()
+            .parse("[cols=\"2*a\"]\n|===\n| _foo_ | *bar*\n\n| * list item\n| paragraph\n|===");
+
+        assert_xpath(&doc, "(//thead/tr/th)[1]/em[text()=\"foo\"]", 1);
+        assert_xpath(&doc, "(//thead/tr/th)[2]/strong[text()=\"bar\"]", 1);
+        assert_css(&doc, "tbody .ulist", 1);
+        assert_css(&doc, "tbody .paragraph", 1);
+    }
+
+    #[test]
+    fn should_apply_style_and_text_formatting_to_cells_in_first_row_if_no_implicit_header() {
+        let doc = Parser::default()
+            .parse("[cols=\"s,e\"]\n|===\n| _strong_ | *emphasis*\n| strong\n| emphasis\n|===");
+
+        assert_xpath(&doc, "((//tbody/tr)[1]/td)[1]//strong/em[text()=\"strong\"]", 1);
+        assert_xpath(&doc, "((//tbody/tr)[1]/td)[2]//em/strong[text()=\"emphasis\"]", 1);
+        assert_xpath(&doc, "((//tbody/tr)[2]/td)[1]//strong[text()=\"strong\"]", 1);
+        assert_xpath(&doc, "((//tbody/tr)[2]/td)[2]//em[text()=\"emphasis\"]", 1);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): Blocked by the PSV cell-splitting divergence (see
+    // `ignores_escaped_separators`): `|Occupation| Website` is not split into
+    // two cells, so the rows are mis-parsed. Enable once the parser splits on
+    // any unescaped `|`.
+    fn vertical_table_headers_use_th_element_instead_of_header_class() {
+        let doc = Parser::default().parse(
+            "[cols=\"1h,1s,1e\"]\n|===\n\n|Name |Occupation| Website\n\n|Octocat |Social coding| https://github.com\n\n|Name |Occupation| Website\n\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > tbody > tr > th", 3);
+        assert_css(&doc, "table > tbody > tr > td", 6);
+        assert_css(&doc, "table > tbody > tr .header", 0);
+        assert_css(&doc, "table > tbody > tr > td > p > strong", 3);
+        assert_css(&doc, "table > tbody > tr > td > p > em", 3);
+        assert_css(&doc, "table > tbody > tr > td > p > em > a", 1);
+    }
+
+    #[test]
+    fn supports_horizontal_and_vertical_source_data_with_blank_lines_and_table_header() {
+        let doc = Parser::default().parse(
+            ".Horizontal and vertical source data\n[width=\"80%\",cols=\"3,^2,^2,10\",options=\"header\"]\n|===\n|Date |Duration |Avg HR |Notes\n\n|22-Aug-08 |10:24 | 157 |\nWorked out MSHR (max sustainable heart rate) by going hard\nfor this interval.\n\n|22-Aug-08 |23:03 | 152 |\nBack-to-back with previous interval.\n\n|24-Aug-08 |40:00 | 145 |\nModerately hard interspersed with 3x 3min intervals (2 min\nhard + 1 min really hard taking the HR up to 160).\n\nI am getting in shape!\n\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table[width=\"80%\"]", 1);
+        assert_xpath(
+            &doc,
+            "/table/caption[@class=\"title\"][text()=\"Table 1. Horizontal and vertical source data\"]",
+            1,
+        );
+        assert_css(&doc, "table > colgroup > col", 4);
+        // Ruby uses `col:nth-child(N)`; the indexed XPath form is equivalent.
+        assert_xpath(&doc, "(/table/colgroup/col)[1][@width=\"17.647%\"]", 1);
+        assert_xpath(&doc, "(/table/colgroup/col)[2][@width=\"11.7647%\"]", 1);
+        assert_xpath(&doc, "(/table/colgroup/col)[3][@width=\"11.7647%\"]", 1);
+        assert_xpath(&doc, "(/table/colgroup/col)[4][@width=\"58.8236%\"]", 1);
+        assert_css(&doc, "table > thead", 1);
+        assert_css(&doc, "table > thead > tr", 1);
+        assert_css(&doc, "table > thead > tr > th", 4);
+        assert_css(&doc, "table > tbody > tr", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 4);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 4);
+        assert_xpath(&doc, "(/table/tbody/tr)[3]/td", 4);
+        assert_xpath(
+            &doc,
+            "/table/tbody/tr[1]/td[4]/p[text()='Worked out MSHR (max sustainable heart rate) by going hard\nfor this interval.']",
+            1,
+        );
+        assert_xpath(&doc, "(/table/tbody/tr)[3]/td[4]/p", 2);
+        assert_xpath(
+            &doc,
+            "/table/tbody/tr[3]/td[4]/p[2][text()=\"I am getting in shape!\"]",
+            1,
+        );
+    }
 }
 
 mod dsv {
@@ -447,6 +743,8 @@ mod csv {
     #[allow(unused_imports)]
     use crate::tests::prelude::*;
 }
+
+
 
 
 

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1013,6 +1013,341 @@ mod psv {
         assert_xpath(&doc, "(//p[@class=\"tableblock\"])[2][text()=\"second paragraph\"]", 1);
         assert_xpath(&doc, "(//p[@class=\"tableblock\"])[3][text()=\"third paragraph\"]", 1);
     }
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/456): The
+    // admonition inside the open block does not render as `.admonitionblock`.
+    // Enable when admonitions are implemented.
+    fn basic_asciidoc_cell() {
+        let doc = Parser::default().parse("|===\na|--\nNOTE: content\n\ncontent\n--\n|===");
+
+        assert_css(&doc, "table.tableblock", 1);
+        assert_css(&doc, "table.tableblock td.tableblock", 1);
+        assert_css(&doc, "table.tableblock td.tableblock .openblock", 1);
+        assert_css(&doc, "table.tableblock td.tableblock .openblock .admonitionblock", 1);
+        assert_css(&doc, "table.tableblock td.tableblock .openblock .paragraph", 1);
+    }
+
+    #[test]
+    fn asciidoc_table_cell_should_be_wrapped_in_div_with_class_content() {
+        let doc = Parser::default().parse("|===\na|AsciiDoc table cell\n|===");
+
+        assert_css(&doc, "table.tableblock td.tableblock > div.content", 1);
+        assert_css(&doc, "table.tableblock td.tableblock > div.content > div.paragraph", 1);
+    }
+
+    // The following AsciiDoc-table-cell tests depend on nested-document
+    // attribute inheritance/locking (doctype, icons, sectids, showtitle/notitle
+    // set or unset in the cell relative to the parent document or the API),
+    // which the crate does not yet model. They are kept as ignored stubs so the
+    // scenarios are not lost.
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): doctype set inside an AsciiDoc table cell.
+    fn doctype_can_be_set_in_asciidoc_table_cell() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): doctype reset to default inside an AsciiDoc table cell.
+    fn should_reset_doctype_to_default_in_asciidoc_table_cell() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): doctype-related attributes updated when doctype is set
+    // in an AsciiDoc table cell.
+    fn should_update_doctype_related_attributes_in_asciidoc_table_cell_when_doctype_is_set() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): an AsciiDoc table cell must not override an attribute
+    // hard set by the API.
+    fn should_not_allow_asciidoc_table_cell_to_set_a_document_attribute_that_was_hard_set_by_the_api()
+     {
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): an AsciiDoc table cell must not override an attribute
+    // hard unset by the API.
+    fn should_not_allow_asciidoc_table_cell_to_set_a_document_attribute_that_was_hard_unset_by_the_api()
+     {
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): an attribute unset in the parent document stays unset in
+    // an AsciiDoc table cell.
+    fn should_keep_attribute_unset_in_asciidoc_table_cell_if_unset_in_parent_document() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): an attribute unset in the parent document can be set in
+    // an AsciiDoc table cell.
+    fn should_allow_attribute_unset_in_parent_document_to_be_set_in_asciidoc_table_cell() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): a locked-unset attribute cannot be set in an AsciiDoc
+    // table cell.
+    fn should_not_allow_locked_attribute_unset_in_parent_document_to_be_set_in_asciidoc_table_cell() {
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): showtitle enabled in an AsciiDoc table cell if unset in
+    // the parent document.
+    fn showtitle_can_be_enabled_in_asciidoc_table_cell_if_unset_in_parent_document() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): showtitle enabled in an AsciiDoc table cell if unset by
+    // the API.
+    fn showtitle_can_be_enabled_in_asciidoc_table_cell_if_unset_by_api() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): showtitle disabled in an AsciiDoc table cell if set in
+    // the parent document.
+    fn showtitle_can_be_disabled_in_asciidoc_table_cell_if_set_in_parent_document() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): showtitle disabled in an AsciiDoc table cell if set by
+    // the API.
+    fn showtitle_can_be_disabled_in_asciidoc_table_cell_if_set_by_api() {}
+
+    #[test]
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/456): The
+    // NOTE admonition and nested blocks do not render as `.admonitionblock` /
+    // `.dlist` inside the cell. Enable when admonitions are implemented.
+    fn asciidoc_content() {
+        let doc = Parser::default().parse(
+            "[cols=\"1e,1,5a\"]\n|===\n|Name |Backends |Description\n\n|badges |xhtml11, html5 |\nLink badges.\n\n[NOTE]\n====\nThe path names are relative.\n====\n|docinfo |All backends |\nThese attributes control docinfo:\n\ndocinfo:: Include x\ndocinfo1:: Include y\n|===",
+        );
+
+        assert_css(&doc, "table.tableblock > tbody > tr", 2);
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[1]/td)[3]//*[@class=\"admonitionblock\"]",
+            1,
+        );
+        assert_xpath(&doc, "((/table/tbody/tr)[2]/td)[3]//*[@class=\"dlist\"]", 1);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): A leading-indented line inside an AsciiDoc cell is not
+    // rendered as a literal block (`<pre>`). Related to the `1a`-column leading
+    // indent gap. Enable once interpreted.
+    fn should_preserve_leading_indentation_in_contents_of_asciidoc_table_cell_if_contents_starts_with_newline()
+     {
+        let doc = Parser::default().parse("|===\na|\n $ command\na| paragraph\n|===");
+
+        assert_css(&doc, "td", 2);
+        assert_xpath(&doc, "(//td)[1]//*[@class=\"literalblock\"]", 1);
+        assert_xpath(&doc, "(//td)[2]//*[@class=\"paragraph\"]", 1);
+        assert_xpath(&doc, "(//pre)[1][text()=\"$ command\"]", 1);
+        assert_xpath(&doc, "(//p)[1][text()=\"paragraph\"]", 1);
+    }
+
+    // Out of scope (omitted): include files / preprocessor directives are not
+    // supported, so "preprocessor directive on first line of an AsciiDoc table
+    // cell should be processed" and "error about unresolved preprocessor
+    // directive ... should have correct cursor" are not ported.
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): Cross-reference resolution from inside an AsciiDoc table
+    // cell to a reference in the main document.
+    fn cross_reference_link_in_an_asciidoc_table_cell_should_resolve_to_reference_in_main_document() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): Cataloging an anchor at the start of an AsciiDoc table
+    // cell as a document reference.
+    fn should_discover_anchor_at_start_of_cell_and_register_it_as_a_reference() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): Cataloging an anchor at the start of a cell in an
+    // implicit header row when the column has a style.
+    fn should_catalog_anchor_at_start_of_cell_in_implicit_header_row_when_column_has_a_style() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): Cataloging an anchor at the start of a cell in an
+    // explicit header row when the column has a style.
+    fn should_catalog_anchor_at_start_of_cell_in_explicit_header_row_when_column_has_a_style() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): Cataloging an anchor at the start of a cell in the first
+    // row.
+    fn should_catalog_anchor_at_start_of_cell_in_first_row() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): Footnotes must not be shared between an AsciiDoc table
+    // cell and the main document.
+    fn footnotes_should_not_be_shared_between_an_asciidoc_table_cell_and_the_main_document() {}
+
+    // Backend-specific test omitted: DocBook ("callout numbers should be
+    // globally unique, including AsciiDoc table cells").
+
+    // Out of scope (omitted): compatibility mode is a stated limitation of the
+    // crate, so the three "compat mode ... in AsciiDoc table cell" tests are not
+    // ported.
+
+    #[test]
+    fn nested_table() {
+        let doc = Parser::default().parse(
+            "[cols=\"1,2a\"]\n|===\n|Normal cell\n|Cell with nested table\n[cols=\"2,1\"]\n!===\n!Nested table cell 1 !Nested table cell 2\n!===\n|===",
+        );
+
+        assert_css(&doc, "table", 2);
+        assert_css(&doc, "table table", 1);
+        // Ruby uses `td:nth-child(2) table`; the nested table sits in the second
+        // cell of the (single) outer row.
+        assert_xpath(&doc, "/table/tbody/tr/td[2]//table", 1);
+        assert_xpath(&doc, "/table/tbody/tr/td[2]//table/tbody/tr/td", 2);
+    }
+
+    #[test]
+    fn can_set_format_of_nested_table_to_psv() {
+        let doc = Parser::default().parse(
+            "[cols=\"2*\"]\n|===\n|normal cell\na|\n[format=psv]\n!===\n!nested cell\n!===\n|===",
+        );
+
+        assert_css(&doc, "table", 2);
+        assert_css(&doc, "table table", 1);
+        assert_xpath(&doc, "/table/tbody/tr/td[2]//table", 1);
+        assert_xpath(&doc, "/table/tbody/tr/td[2]//table/tbody/tr/td", 1);
+    }
+
+    // The following depend on document option/attribute inheritance into the
+    // nested AsciiDoc-cell document (to_dir, toc, doctitle), which the crate
+    // does not yet model.
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): AsciiDoc table cell should inherit the to_dir option.
+    fn asciidoc_table_cell_should_inherit_to_dir_option_from_parent_document() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): AsciiDoc table cell should not inherit the toc setting.
+    fn asciidoc_table_cell_should_not_inherit_toc_setting_from_parent_document() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): enabling toc in an AsciiDoc table cell.
+    fn should_be_able_to_enable_toc_in_an_asciidoc_table_cell() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): enabling toc in an AsciiDoc table cell even if hard unset
+    // by the API.
+    fn should_be_able_to_enable_toc_in_an_asciidoc_table_cell_even_if_hard_unset_by_api() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): enabling toc in both the outer document and an AsciiDoc
+    // table cell.
+    fn should_be_able_to_enable_toc_in_both_outer_document_and_in_an_asciidoc_table_cell() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): a document in an AsciiDoc table cell must not see the
+    // parent's doctitle.
+    fn document_in_an_asciidoc_table_cell_should_not_see_doctitle_of_parent() {}
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): the `{set:cellbgcolor:...}` counter attribute is not
+    // supported, so per-cell background colors are not applied.
+    fn cell_background_color() {}
+
+    #[test]
+    fn should_warn_if_table_block_is_not_terminated() {
+        let doc =
+            Parser::default().parse("outside\n\n|===\n|\ninside\n\nstill inside\n\neof");
+
+        assert_xpath(&doc, "/table", 1);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].warning, WarningType::UnterminatedDelimitedBlock);
+        assert_eq!(warnings[0].source.line(), 3);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): an unterminated example block inside an AsciiDoc table
+    // cell that is itself attached to a list item — Asciidoctor reports the
+    // warning at the inner block's line (9). Enable once the cursor/line of
+    // nested-cell warnings is tracked.
+    fn should_show_correct_line_number_in_warning_about_unterminated_block_inside_asciidoc_table_cell()
+     {
+        let doc = Parser::default().parse(
+            "outside\n\n* list item\n+\n|===\n|cell\na|inside\n\n====\nunterminated example block\n|===\n\neof",
+        );
+
+        assert_xpath(&doc, "//ul//table", 1);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.warning == WarningType::UnterminatedDelimitedBlock && w.source.line() == 9)
+        );
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): Blocked by the deprecated bare-integer colspec
+    // divergence — `cols=2` should yield two columns but the crate parses one
+    // (see `table_with_explicit_deprecated_colspec_syntax_can_have_multiple_rows_on_a_single_line`).
+    // Enable once `cols=2` is supported.
+    fn custom_separator_for_an_asciidoc_table_cell() {
+        let doc = Parser::default().parse(
+            "[cols=2,separator=!]\n|===\n!Pipe output to vim\na!\n----\nasciidoctor -o - -s test.adoc | view -\n----\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > tbody > tr", 1);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 2);
+        assert_xpath(&doc, "((/table/tbody/tr)[1]/td)[1]//p", 1);
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[1]/td)[2]//*[@class=\"listingblock\"]",
+            1,
+        );
+    }
+
+    // Backend-specific tests omitted: DocBook ("table with breakable option
+    // docbook 5", "table with unbreakable option docbook 5").
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): Blocked by the multi-line-first-cell implicit-header
+    // divergence — the quoted first cell spans multiple lines, so Asciidoctor
+    // suppresses the implicit header, but the crate creates one (see
+    // `no_implicit_header_row_if_cell_in_first_line_spans_multiple_lines`).
+    fn no_implicit_header_row_if_cell_in_first_line_is_quoted_and_spans_multiple_lines() {
+        let doc = Parser::default()
+            .parse("[cols=2*l]\n,===\n\"A1\n\nA1 continued\",B1\nA2,B2\n,===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 0);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(//td)[1]//pre[text()=\"A1\n\nA1 continued\"]", 1);
+    }
 }
 
 mod dsv {

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1309,10 +1309,24 @@ mod psv {
         assert_xpath(&doc, "(//p)[1][text()=\"paragraph\"]", 1);
     }
 
-    // Out of scope (omitted): include files / preprocessor directives are not
-    // supported, so "preprocessor directive on first line of an AsciiDoc table
-    // cell should be processed" and "error about unresolved preprocessor
-    // directive ... should have correct cursor" are not ported.
+    #[test]
+    fn preprocessor_directive_on_first_line_of_an_asciidoc_table_cell_should_be_processed() {
+        use crate::tests::prelude::inline_file_handler::InlineFileHandler;
+
+        let handler =
+            InlineFileHandler::from_pairs([("fixtures/include-file.adoc", "included content")]);
+        let mut parser = Parser::default().with_include_file_handler(handler);
+        let doc = parser.parse("|===\na|include::fixtures/include-file.adoc[]\n|===");
+
+        // The `include::` on the cell's first line is expanded, so the cell holds
+        // the included content rather than the literal directive.
+        assert_rendered_contains(&doc, "included content");
+    }
+
+    // Deferred: "error about unresolved preprocessor directive on first line of
+    // an AsciiDoc table cell should have correct cursor" (Ruby 1728) asserts the
+    // file/line cursor of the unresolved-directive error, which needs the cell's
+    // nested source map threaded back to the parent — not yet implemented.
 
     #[test]
     #[ignore]

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1458,10 +1458,36 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): the `{set:cellbgcolor:...}` counter attribute is not
-    // supported, so per-cell background colors are not applied.
-    fn cell_background_color() {}
+    fn cell_background_color() {
+        let doc = Parser::default().parse(
+            "[cols=\"1e,1\", options=\"header\"]\n|===\n|{set:cellbgcolor:green}green\n|{set:cellbgcolor!}\nplain\n|{set:cellbgcolor:red}red\n|{set:cellbgcolor!}\nplain\n|===",
+        );
+
+        // The first cell sets `cellbgcolor` to green, so its header cell carries
+        // the background color; the second cell unsets it, so the next header
+        // cell has none. The attribute persists across cells, so the body cell
+        // that sets red is red, and the final cell unsets it again.
+        assert_xpath(
+            &doc,
+            "(/table/thead/tr/th)[1][@style=\"background-color: green;\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "(/table/thead/tr/th)[2][@style=\"background-color: green;\"]",
+            0,
+        );
+        assert_xpath(
+            &doc,
+            "(/table/tbody/tr/td)[1][@style=\"background-color: red;\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "(/table/tbody/tr/td)[2][@style=\"background-color: green;\"]",
+            0,
+        );
+    }
 
     #[test]
     fn should_warn_if_table_block_is_not_terminated() {

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -214,6 +214,228 @@ mod psv {
             1,
         );
     }
+
+    #[test]
+    fn should_only_substitute_specialchars_for_literal_table_cells() {
+        let doc = Parser::default().parse("|===\nl|one\n*two*\nthree\n<four>\n|===");
+
+        // Ruby compares the serialized `<pre>one\n*two*\nthree\n&lt;four&gt;</pre>`;
+        // the test DOM decodes entities in `text()`, so this asserts the decoded
+        // content (formatting markup left literal, specialchars escaped then
+        // decoded back).
+        assert_css(&doc, "table pre", 1);
+        assert_xpath(&doc, "/table//pre[text()=\"one\n*two*\nthree\n<four>\"]", 1);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): The crate strips the leading indentation from the first
+    // content line of a literal (`l`) cell, producing "one\n  two\nthree"
+    // instead of Asciidoctor's "  one\n  two\nthree". A literal cell should
+    // preserve leading spaces on every line. Enable once fixed.
+    fn should_preserve_leading_spaces_but_not_leading_newlines_or_trailing_spaces_in_literal_table_cells()
+     {
+        let doc = Parser::default()
+            .parse("[cols=2*]\n|===\nl|\n  one\n  two\nthree\n\n  | normal\n|===");
+
+        assert_css(&doc, "table pre", 1);
+        assert_xpath(&doc, "/table//pre[text()=\"  one\n  two\nthree\"]", 1);
+    }
+
+    #[test]
+    fn should_ignore_v_table_cell_style() {
+        let doc = Parser::default()
+            .parse("[cols=2*]\n|===\nv|\n  one\n  two\nthree\n\n  | normal\n|===");
+
+        // The unrecognized `v` style is ignored, so the cell renders as a normal
+        // paragraph (`p.tableblock`) with leading newlines and trailing spaces
+        // stripped but interior indentation preserved.
+        assert_xpath(
+            &doc,
+            "(/table/tbody/tr/td)[1]/p[@class=\"tableblock\"][text()=\"one\n  two\nthree\"]",
+            1,
+        );
+    }
+
+    #[test]
+    fn table_and_column_width_not_assigned_when_autowidth_option_is_specified() {
+        let doc = Parser::default().parse(
+            "[options=\"autowidth\"]\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table.fit-content", 1);
+        assert_css(&doc, "table[style*=\"width\"]", 0);
+        assert_css(&doc, "table colgroup col", 3);
+        assert_css(&doc, "table colgroup col[style*=\"width\"]", 0);
+    }
+
+    #[test]
+    fn does_not_assign_column_width_for_autowidth_columns_in_html_output() {
+        let doc = Parser::default().parse(
+            "[cols=\"15%,3*~\"]\n|=======\n|A |B |C |D\n|a |b |c |d\n|1 |2 |3 |4\n|=======",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table colgroup col", 4);
+        assert_css(&doc, "table colgroup col[width]", 1);
+        assert_css(&doc, "table colgroup col[width=\"15%\"]", 1);
+    }
+
+    #[test]
+    fn can_assign_autowidth_to_all_columns_even_when_table_has_a_width() {
+        let doc = Parser::default().parse(
+            "[cols=\"4*~\",width=50%]\n|=======\n|A |B |C |D\n|a |b |c |d\n|1 |2 |3 |4\n|=======",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table[width=\"50%\"]", 1);
+        assert_css(&doc, "table colgroup col", 4);
+        assert_css(&doc, "table colgroup col[style]", 0);
+    }
+
+    // Backend-specific test omitted: DocBook ("equally distributes remaining
+    // column width to autowidth columns in DocBook output").
+
+    // Backend-specific test omitted: DocBook ("should compute column widths
+    // based on pagewidth when width is set on table in DocBook output").
+
+    #[test]
+    fn explicit_table_width_is_used_even_when_autowidth_option_is_specified() {
+        let doc = Parser::default().parse(
+            "[%autowidth,width=75%]\n|=======\n|A |B |C\n|a |b |c\n|1 |2 |3\n|=======",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table[width]", 1);
+        assert_css(&doc, "table colgroup col", 3);
+        assert_css(&doc, "table colgroup col[style*=\"width\"]", 0);
+    }
+
+    #[test]
+    fn first_row_sets_number_of_columns_when_not_specified() {
+        let doc = Parser::default()
+            .parse("|===\n|first |second |third |fourth\n|1 |2 |3\n|4\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 4);
+        assert_css(&doc, "table > tbody > tr", 2);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 4);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 4);
+    }
+
+    #[test]
+    fn colspec_attribute_using_asterisk_syntax_sets_number_of_columns() {
+        let doc = Parser::default()
+            .parse("[cols=\"3*\"]\n|===\n|A |B |C |a |b |c |1 |2 |3\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > tbody > tr", 3);
+    }
+
+    #[test]
+    fn table_with_explicit_column_count_can_have_multiple_rows_on_a_single_line() {
+        let doc = Parser::default().parse("[cols=\"3*\"]\n|===\n|one |two\n|1 |2 |a |b\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 2);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): The crate does not support the deprecated bare-integer
+    // colspec (`cols="3"` meaning three columns); it parses a single column of
+    // width 3. Enable once the deprecated syntax is supported.
+    fn table_with_explicit_deprecated_colspec_syntax_can_have_multiple_rows_on_a_single_line() {
+        let doc = Parser::default().parse("[cols=\"3\"]\n|===\n|one |two\n|1 |2 |a |b\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 2);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): The crate does not add a column for an empty trailing
+    // record in the colspec (`cols="<,"` should yield two columns); it parses a
+    // single column. Enable once empty colspec records are honored.
+    fn columns_are_added_for_empty_records_in_colspec_attribute() {
+        let doc = Parser::default().parse("[cols=\"<,\"]\n|===\n|one |two\n|1 |2 |a |b\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > tbody > tr", 3);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): The crate does not accept a semicolon as the colspec
+    // separator (`cols="1s;3m"` should yield two columns); it parses a single
+    // column. Enable once `;`-separated colspecs are supported.
+    fn cols_may_be_separated_by_semi_colon_instead_of_comma() {
+        let doc = Parser::default().parse("[cols=\"1s;3m\"]\n|===\n| strong\n| mono\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "col[width=\"25%\"]", 1);
+        assert_css(&doc, "col[width=\"75%\"]", 1);
+        assert_xpath(&doc, "(//td)[1]//strong", 1);
+        assert_xpath(&doc, "(//td)[2]//code", 1);
+    }
+
+    #[test]
+    fn cols_attribute_may_include_spaces() {
+        let doc = Parser::default().parse("[cols=\" 1, 1 \"]\n|===\n|one |two |1 |2 |a |b\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "col[width=\"50%\"]", 2);
+        assert_css(&doc, "table > tbody > tr", 3);
+    }
+
+    #[test]
+    fn blank_cols_attribute_should_be_ignored() {
+        let doc = Parser::default().parse("[cols=\" \"]\n|===\n|one |two\n|1 |2 |a |b\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "col[width=\"50%\"]", 2);
+        assert_css(&doc, "table > tbody > tr", 3);
+    }
+
+    #[test]
+    fn empty_cols_attribute_should_be_ignored() {
+        let doc = Parser::default().parse("[cols=\"\"]\n|===\n|one |two\n|1 |2 |a |b\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "col[width=\"50%\"]", 2);
+        assert_css(&doc, "table > tbody > tr", 3);
+    }
+
+    #[test]
+    fn table_with_header_and_footer() {
+        let doc = Parser::default().parse(
+            "[options=\"header,footer\"]\n|===\n|Item       |Quantity\n|Item 1     |1\n|Item 2     |2\n|Item 3     |3\n|Total      |6\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > thead", 1);
+        assert_css(&doc, "table > thead > tr", 1);
+        assert_css(&doc, "table > thead > tr > th", 2);
+        assert_css(&doc, "table > tfoot", 1);
+        assert_css(&doc, "table > tfoot > tr", 1);
+        assert_css(&doc, "table > tfoot > tr > td", 2);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 3);
+
+        // Ruby additionally asserts the section order is thead, tbody, tfoot;
+        // the renderer emits them in that order.
+        assert_xpath(&doc, "/table/thead/following-sibling::tbody", 1);
+        assert_xpath(&doc, "/table/tbody/following-sibling::tfoot", 1);
+    }
 }
 
 mod dsv {
@@ -225,6 +447,8 @@ mod csv {
     #[allow(unused_imports)]
     use crate::tests::prelude::*;
 }
+
+
 
 
 

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1458,36 +1458,13 @@ mod psv {
     }
 
     #[test]
-    fn cell_background_color() {
-        let doc = Parser::default().parse(
-            "[cols=\"1e,1\", options=\"header\"]\n|===\n|{set:cellbgcolor:green}green\n|{set:cellbgcolor!}\nplain\n|{set:cellbgcolor:red}red\n|{set:cellbgcolor!}\nplain\n|===",
-        );
-
-        // The first cell sets `cellbgcolor` to green, so its header cell carries
-        // the background color; the second cell unsets it, so the next header
-        // cell has none. The attribute persists across cells, so the body cell
-        // that sets red is red, and the final cell unsets it again.
-        assert_xpath(
-            &doc,
-            "(/table/thead/tr/th)[1][@style=\"background-color: green;\"]",
-            1,
-        );
-        assert_xpath(
-            &doc,
-            "(/table/thead/tr/th)[2][@style=\"background-color: green;\"]",
-            0,
-        );
-        assert_xpath(
-            &doc,
-            "(/table/tbody/tr/td)[1][@style=\"background-color: red;\"]",
-            1,
-        );
-        assert_xpath(
-            &doc,
-            "(/table/tbody/tr/td)[2][@style=\"background-color: green;\"]",
-            0,
-        );
-    }
+    #[ignore]
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/547):
+    // per-cell background colors depend on the `{set:cellbgcolor:...}` /
+    // `{set:cellbgcolor!}` attribute-assignment reference, which the
+    // substitution layer does not implement. `{set:...}` is of uncertain status
+    // in the AsciiDoc language, so this is deferred pending that decision.
+    fn cell_background_color() {}
 
     #[test]
     fn should_warn_if_table_block_is_not_terminated() {

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1329,34 +1329,38 @@ mod psv {
 
     #[test]
     #[ignore]
-    // TODO (issue TBD): Cross-reference resolution from inside an AsciiDoc table
-    // cell to a reference in the main document.
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/543):
+    // Cross-reference resolution from inside an AsciiDoc table cell to a
+    // reference in the main document.
     fn cross_reference_link_in_an_asciidoc_table_cell_should_resolve_to_reference_in_main_document()
     {
     }
 
     #[test]
     #[ignore]
-    // TODO (issue TBD): Cataloging an anchor at the start of an AsciiDoc table
-    // cell as a document reference.
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/543):
+    // Cataloging an anchor at the start of an AsciiDoc table cell as a document
+    // reference.
     fn should_discover_anchor_at_start_of_cell_and_register_it_as_a_reference() {}
 
     #[test]
     #[ignore]
-    // TODO (issue TBD): Cataloging an anchor at the start of a cell in an
-    // implicit header row when the column has a style.
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/543):
+    // Cataloging an anchor at the start of a cell in an implicit header row when
+    // the column has a style.
     fn should_catalog_anchor_at_start_of_cell_in_implicit_header_row_when_column_has_a_style() {}
 
     #[test]
     #[ignore]
-    // TODO (issue TBD): Cataloging an anchor at the start of a cell in an
-    // explicit header row when the column has a style.
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/543):
+    // Cataloging an anchor at the start of a cell in an explicit header row when
+    // the column has a style.
     fn should_catalog_anchor_at_start_of_cell_in_explicit_header_row_when_column_has_a_style() {}
 
     #[test]
     #[ignore]
-    // TODO (issue TBD): Cataloging an anchor at the start of a cell in the first
-    // row.
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/543):
+    // Cataloging an anchor at the start of a cell in the first row.
     fn should_catalog_anchor_at_start_of_cell_in_first_row() {}
 
     #[test]
@@ -1455,10 +1459,11 @@ mod psv {
 
     #[test]
     #[ignore]
-    // TODO (issue TBD): an unterminated example block inside an AsciiDoc table
-    // cell that is itself attached to a list item — Asciidoctor reports the
-    // warning at the inner block's line (9). Enable once the cursor/line of
-    // nested-cell warnings is tracked.
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/542): an
+    // unterminated example block inside an AsciiDoc table cell that is itself
+    // attached to a list item — Asciidoctor reports the warning at the inner
+    // block's line (9). Enable once the cursor/line of nested-cell warnings is
+    // tracked (same nested-cell source-map work as #542).
     fn should_show_correct_line_number_in_warning_about_unterminated_block_inside_asciidoc_table_cell()
      {
         let doc = Parser::default().parse(

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -155,12 +155,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate diverges from Asciidoctor on PSV cell
-    // splitting: it treats a `|` as a cell separator only when preceded by a
-    // delimiter boundary (e.g. a space), so `|a|b` parses as a single cell
-    // whereas Asciidoctor (and this test) splits it into two. Enable once the
-    // parser splits on any unescaped `|`.
     fn ignores_escaped_separators() {
         let doc = Parser::default().parse("|===\n|A \\| here| a \\| there\n|===");
 
@@ -228,11 +222,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate strips the leading indentation from the first
-    // content line of a literal (`l`) cell, producing "one\n  two\nthree"
-    // instead of Asciidoctor's "  one\n  two\nthree". A literal cell should
-    // preserve leading spaces on every line. Enable once fixed.
     fn should_preserve_leading_spaces_but_not_leading_newlines_or_trailing_spaces_in_literal_table_cells()
      {
         let doc =
@@ -339,10 +328,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate does not support the deprecated bare-integer
-    // colspec (`cols="3"` meaning three columns); it parses a single column of
-    // width 3. Enable once the deprecated syntax is supported.
     fn table_with_explicit_deprecated_colspec_syntax_can_have_multiple_rows_on_a_single_line() {
         let doc = Parser::default().parse("[cols=\"3\"]\n|===\n|one |two\n|1 |2 |a |b\n|===");
 
@@ -352,10 +337,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate does not add a column for an empty trailing
-    // record in the colspec (`cols="<,"` should yield two columns); it parses a
-    // single column. Enable once empty colspec records are honored.
     fn columns_are_added_for_empty_records_in_colspec_attribute() {
         let doc = Parser::default().parse("[cols=\"<,\"]\n|===\n|one |two\n|1 |2 |a |b\n|===");
 
@@ -365,10 +346,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate does not accept a semicolon as the colspec
-    // separator (`cols="1s;3m"` should yield two columns); it parses a single
-    // column. Enable once `;`-separated colspecs are supported.
     fn cols_may_be_separated_by_semi_colon_instead_of_comma() {
         let doc = Parser::default().parse("[cols=\"1s;3m\"]\n|===\n| strong\n| mono\n|===");
 
@@ -516,12 +493,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate mis-parses this table — it creates an implicit
-    // header row even though the first cell spans multiple lines, and (blocked
-    // by the PSV cell-splitting divergence, see `ignores_escaped_separators`)
-    // drops cells from the multi-line `A1 continued|B1` row. Enable once both
-    // are fixed.
     fn no_implicit_header_row_if_cell_in_first_line_spans_multiple_lines() {
         let doc =
             Parser::default().parse("[cols=2*]\n|===\n|A1\n\n\nA1 continued|B1\n\n|A2\n|B2\n|===");
@@ -553,10 +524,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate does not treat a leading-indented line in an
-    // AsciiDoc (`a`) cell as a literal block, so no `<pre>` is produced. Enable
-    // once leading indent is interpreted inside AsciiDoc cells.
     fn should_interpret_leading_indent_if_first_cell_is_asciidoc_and_there_is_no_implicit_header_row()
      {
         let doc = Parser::default().parse("[cols=\"1a,1\"]\n|===\n|\n  literal\n| normal\n|===");
@@ -575,11 +542,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate creates an implicit header row even though the
-    // first cell (an AsciiDoc cell) spans multiple lines; Asciidoctor suppresses
-    // the implicit header in that case. Enable once implicit-header detection
-    // accounts for multi-line first cells.
     fn no_implicit_header_row_if_asciidoc_cell_in_first_line_spans_multiple_lines() {
         let doc = Parser::default().parse(
             "[cols=2*]\n|===\na|contains AsciiDoc content\n\n* a\n* b\n* c\na|contains no AsciiDoc content\n\njust text\n|A2\n|B2\n|===",
@@ -620,11 +582,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): Blocked by the PSV cell-splitting divergence (see
-    // `ignores_escaped_separators`): `|Occupation| Website` is not split into
-    // two cells, so the header/footer rows are mis-parsed. Enable once the
-    // parser splits on any unescaped `|`.
     fn styles_not_applied_to_header_cells() {
         let doc = Parser::default().parse(
             "[cols=\"1h,1s,1e\",options=\"header,footer\"]\n|===\n|Name |Occupation| Website\n|Octocat |Social coding| https://github.com\n|Name |Occupation| Website\n|===",
@@ -681,11 +638,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): Blocked by the PSV cell-splitting divergence (see
-    // `ignores_escaped_separators`): `|Occupation| Website` is not split into
-    // two cells, so the rows are mis-parsed. Enable once the parser splits on
-    // any unescaped `|`.
     fn vertical_table_headers_use_th_element_instead_of_header_class() {
         let doc = Parser::default().parse(
             "[cols=\"1h,1s,1e\"]\n|===\n\n|Name |Occupation| Website\n\n|Octocat |Social coding| https://github.com\n\n|Name |Occupation| Website\n\n|===",
@@ -1169,10 +1121,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): A leading-indented line inside an AsciiDoc cell is not
-    // rendered as a literal block (`<pre>`). Related to the `1a`-column leading
-    // indent gap. Enable once interpreted.
     fn should_preserve_leading_indentation_in_contents_of_asciidoc_table_cell_if_contents_starts_with_newline()
      {
         let doc = Parser::default().parse("|===\na|\n $ command\na| paragraph\n|===");
@@ -1339,11 +1287,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): Blocked by the deprecated bare-integer colspec
-    // divergence — `cols=2` should yield two columns but the crate parses one
-    // (see `table_with_explicit_deprecated_colspec_syntax_can_have_multiple_rows_on_a_single_line`).
-    // Enable once `cols=2` is supported.
     fn custom_separator_for_an_asciidoc_table_cell() {
         let doc = Parser::default().parse(
             "[cols=2,separator=!]\n|===\n!Pipe output to vim\na!\n----\nasciidoctor -o - -s test.adoc | view -\n----\n|===",
@@ -1365,11 +1308,6 @@ mod psv {
     // docbook 5", "table with unbreakable option docbook 5").
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): Blocked by the multi-line-first-cell implicit-header
-    // divergence — the quoted first cell spans multiple lines, so Asciidoctor
-    // suppresses the implicit header, but the crate creates one (see
-    // `no_implicit_header_row_if_cell_in_first_line_spans_multiple_lines`).
     fn no_implicit_header_row_if_cell_in_first_line_is_quoted_and_spans_multiple_lines() {
         let doc =
             Parser::default().parse("[cols=2*l]\n,===\n\"A1\n\nA1 continued\",B1\nA2,B2\n,===");
@@ -1453,12 +1391,19 @@ mod csv {
     fn should_log_error_but_not_crash_if_cell_data_has_unclosed_quote() {
         let doc = Parser::default().parse(",===\na,b\nc,\"\n,===");
 
-        // The unclosed quote recovers to an empty cell without crashing.
-        // NOTE: Asciidoctor also logs an ERROR ("unclosed quote in CSV data");
-        // the crate recovers silently, so that warning assertion is not ported.
+        // The unclosed quote recovers to an empty cell without crashing, and an
+        // error is logged for line 3 (the `c,"` line).
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table td", 4);
         assert_xpath(&doc, "(//td)[4]/p", 0);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::TableCsvDataHasUnclosedQuote
+        );
+        assert_eq!(warnings[0].source.line(), 3);
     }
 
     #[test]
@@ -1597,12 +1542,6 @@ mod csv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): For a multi-line, whitespace-padded quoted CSV value
-    // feeding an AsciiDoc (`a`) column, the crate does not strip the surrounding
-    // quotes or whitespace — the cell renders `"\n  one sentence, one line\n  "`
-    // verbatim instead of the trimmed `one sentence, one line`. Enable once the
-    // CSV quote/whitespace stripping handles this case.
     fn should_strip_whitespace_around_contents_of_asciidoc_cell() {
         let doc = Parser::default().parse(
             "[cols=\"1,1,1a\",separator=;]\n,===\nelement;description;example\n\nparagraph;contiguous lines of words and phrases;\"\n  one sentence, one line\n  \"\n,===",

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1045,17 +1045,14 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): A line containing only `{blank}` adjacent to non-blank
-    // lines should not split the cell into multiple paragraphs; the crate renders
-    // it as a blank line, producing multiple paragraphs. Enable once `{blank}`
-    // is handled inside table cells.
     fn should_not_split_paragraph_at_line_containing_only_blank_that_is_directly_adjacent_to_non_blank_lines()
      {
         let doc = Parser::default().parse(
             "|===\n|paragraph\n{blank}\nstill one paragraph\n{blank}\nstill one paragraph\n|===",
         );
 
+        // Each `{blank}` line renders as an empty line but is not blank in the
+        // source, so the cell stays a single paragraph.
         assert_css(&doc, "p.tableblock", 1);
     }
 

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -732,6 +732,287 @@ mod psv {
             1,
         );
     }
+
+    #[test]
+    fn percentages_as_column_widths() {
+        let doc = Parser::default().parse("[cols=\"<.^10%,<90%\"]\n|===\n|column A |column B\n|===");
+
+        assert_xpath(&doc, "/table/colgroup/col", 2);
+        assert_xpath(&doc, "(/table/colgroup/col)[1][@width=\"10%\"]", 1);
+        assert_xpath(&doc, "(/table/colgroup/col)[2][@width=\"90%\"]", 1);
+    }
+
+    #[test]
+    fn spans_alignments_and_styles() {
+        let doc = Parser::default().parse(
+            "[cols=\"e,m,^,>s\",width=\"25%\"]\n|===\n|1 >s|2 |3 |4\n^|5 2.2+^.^|6 .3+<.>m|7\n^|8\nd|9 2+>|10\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col[width=\"25%\"]", 4);
+        assert_css(&doc, "table > tbody > tr", 4);
+        assert_css(&doc, "table > tbody > tr > td", 10);
+
+        // Ruby uses `tr:nth-child(N)` / `td:nth-child(N)`; the indexed XPath form
+        // is equivalent and supported by the test DOM.
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 4);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[3]/td", 1);
+        assert_xpath(&doc, "(/table/tbody/tr)[4]/td", 2);
+
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[1]/td)[1][@class=\"halign-left valign-top\"]/p/em",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[1]/td)[2][@class=\"halign-right valign-top\"]/p/strong",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[1]/td)[3][@class=\"halign-center valign-top\"]/p",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[1]/td)[3][@class=\"halign-center valign-top\"]/p/*",
+            0,
+        );
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[1]/td)[4][@class=\"halign-right valign-top\"]/p/strong",
+            1,
+        );
+
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[2]/td)[1][@class=\"halign-center valign-top\"]/p/em",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[2]/td)[2][@class=\"halign-center valign-middle\"][@colspan=\"2\"][@rowspan=\"2\"]/p/code",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[2]/td)[3][@class=\"halign-left valign-bottom\"][@rowspan=\"3\"]/p/code",
+            1,
+        );
+
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[3]/td)[1][@class=\"halign-center valign-top\"]/p/em",
+            1,
+        );
+
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[4]/td)[1][@class=\"halign-left valign-top\"]/p",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[4]/td)[1][@class=\"halign-left valign-top\"]/p/em",
+            0,
+        );
+        assert_xpath(
+            &doc,
+            "((/table/tbody/tr)[4]/td)[2][@class=\"halign-right valign-top\"][@colspan=\"2\"]/p/code",
+            1,
+        );
+    }
+
+    #[test]
+    fn sets_up_columns_correctly_if_first_row_has_cell_that_spans_columns() {
+        let doc = Parser::default()
+            .parse("|===\n2+^|AAA |CCC\n|AAA |BBB |CCC\n|AAA |BBB |CCC\n|===");
+
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 2);
+        assert_xpath(&doc, "((/table/tbody/tr)[1]/td)[1][@colspan=\"2\"]", 1);
+        // Ruby uses `td:nth-child(1)[colspan]` / `td:nth-child(2):not([colspan])`;
+        // since row 1 has exactly one cell carrying a colspan, asserting the row
+        // has a single colspanned cell is equivalent.
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td[@colspan]", 1);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td[@colspan]", 0);
+        assert_xpath(&doc, "(/table/tbody/tr)[3]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[3]/td[@colspan]", 0);
+    }
+
+    #[test]
+    fn supports_repeating_cells() {
+        let doc = Parser::default().parse("|===\n3*|A\n|1 3*|2\n|b |c\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 3);
+        assert_css(&doc, "table > tbody > tr", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[1]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[2]/td", 3);
+        assert_xpath(&doc, "(/table/tbody/tr)[3]/td", 3);
+
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[1]/p[text()=\"A\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[2]/p[text()=\"A\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[1]/td[3]/p[text()=\"A\"]", 1);
+
+        assert_xpath(&doc, "/table/tbody/tr[2]/td[1]/p[text()=\"1\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[2]/td[2]/p[text()=\"2\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[2]/td[3]/p[text()=\"2\"]", 1);
+
+        assert_xpath(&doc, "/table/tbody/tr[3]/td[1]/p[text()=\"2\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[3]/td[2]/p[text()=\"b\"]", 1);
+        assert_xpath(&doc, "/table/tbody/tr[3]/td[3]/p[text()=\"c\"]", 1);
+    }
+
+    // Backend-specific test omitted: DocBook ("calculates colnames correctly
+    // when using implicit column count and single cell with colspan").
+
+    // Backend-specific test omitted: DocBook ("calculates colnames correctly
+    // when using implicit column count and cells with mixed colspans").
+
+    // Backend-specific test omitted: DocBook ("assigns unique column names for
+    // table with implicit column count and colspans in first row").
+
+    #[test]
+    fn should_drop_row_but_preserve_remaining_rows_after_cell_with_colspan_exceeds_number_of_columns()
+     {
+        let doc = Parser::default().parse("[cols=2*]\n|===\n3+|A\n|B\na|C\n\nmore C\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table tr", 1);
+        assert_xpath(&doc, "/table/tbody/tr/td[1]/p[text()=\"B\"]", 1);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::TableCellExceedsColumnCount
+        );
+        assert_eq!(warnings[0].source.line(), 3);
+    }
+
+    #[test]
+    fn should_drop_last_row_if_last_cell_in_table_has_colspan_that_exceeds_specified_number_of_columns()
+     {
+        let doc = Parser::default().parse("[cols=2*]\n|===\n|a 2+|b\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table *", 0);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::TableCellExceedsColumnCount
+        );
+        assert_eq!(warnings[0].source.line(), 3);
+    }
+
+    #[test]
+    fn should_drop_last_row_if_last_cell_in_table_has_colspan_that_exceeds_implicit_number_of_columns()
+     {
+        let doc = Parser::default().parse("|===\n|a |b\n|c 2+|d\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table tr", 1);
+        assert_xpath(&doc, "/table/tbody/tr/td[1]/p[text()=\"a\"]", 1);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::TableCellExceedsColumnCount
+        );
+        assert_eq!(warnings[0].source.line(), 3);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): The crate mis-groups cells into rows when a leading row's
+    // colspans overflow the column count: for this input it produces seven
+    // single-cell rows instead of dropping the overflowing first row and forming
+    // one row of seven cells. Enable once row grouping accounts for the dropped
+    // colspan row.
+    fn should_take_colspan_into_account_when_taking_cells_for_row() {
+        let doc = Parser::default()
+            .parse("[cols=7]\n|===\n2+|a 2+|b 2+|c 2+|d\n|e |f |g |h |i |j |k\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table tr", 1);
+        assert_css(&doc, "table tr td", 7);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::TableCellExceedsColumnCount
+        );
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): The crate does not drop an incomplete final row nor warn
+    // about it; Asciidoctor drops the `|e` row and logs an error. Enable once
+    // incomplete trailing rows are detected.
+    fn should_drop_incomplete_row_at_end_of_table_and_log_an_error() {
+        let doc = Parser::default().parse("[cols=2*]\n|===\n|a |b\n|c |d\n|e\n|===");
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table tr", 2);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): Duplicating a cell across columns with different styles
+    // (`2*|` into a default column and an `^l` literal column) is mishandled —
+    // the crate produces single-cell rows that all take the literal style
+    // instead of one row whose first cell is paragraphs and second is a literal
+    // block. Enable once cross-column cell duplication applies each column's
+    // style.
+    fn should_apply_cell_style_for_column_to_repeated_content() {
+        let doc = Parser::default().parse(
+            "[cols=\",^l\"]\n|===\n|Paragraphs |Literal\n\n2*|The discussion about what is good,\nwhat is beautiful, what is noble,\nwhat is pure, and what is true\ncould always go on.\n\nWhy is that important?\nWhy would I like to do that?\n\nBecause that's the only conversation worth having.\n\nAnd whether it goes on or not after I die, I don't know.\nBut, I do know that it is the conversation I want to have while I am still alive.\n\nWhich means that to me the offer of certainty,\nthe offer of complete security,\nthe offer of an impermeable faith that can't give way\nis an offer of something not worth having.\n\nI want to live my life taking the risk all the time\nthat I don't know anything like enough yet...\nthat I haven't understood enough...\nthat I can't know enough...\nthat I am always hungrily operating on the margins\nof a potentially great harvest of future knowledge and wisdom.\n\nI wouldn't have it any other way.\n|===",
+        );
+
+        assert_css(&doc, "table", 1);
+        assert_css(&doc, "table > colgroup > col", 2);
+        assert_css(&doc, "table > tbody > tr > td:nth-child(1).halign-left.valign-top > p.tableblock", 7);
+    }
+
+    #[test]
+    #[ignore]
+    // TODO (issue TBD): A line containing only `{blank}` adjacent to non-blank
+    // lines should not split the cell into multiple paragraphs; the crate renders
+    // it as a blank line, producing multiple paragraphs. Enable once `{blank}`
+    // is handled inside table cells.
+    fn should_not_split_paragraph_at_line_containing_only_blank_that_is_directly_adjacent_to_non_blank_lines()
+     {
+        let doc = Parser::default().parse(
+            "|===\n|paragraph\n{blank}\nstill one paragraph\n{blank}\nstill one paragraph\n|===",
+        );
+
+        assert_css(&doc, "p.tableblock", 1);
+    }
+
+    #[test]
+    fn should_strip_trailing_newlines_when_splitting_paragraphs() {
+        let doc = Parser::default().parse(
+            "|===\n|first wrapped\nparagraph\n\nsecond paragraph\n\nthird paragraph\n|===",
+        );
+
+        assert_xpath(
+            &doc,
+            "(//p[@class=\"tableblock\"])[1][text()=\"first wrapped\nparagraph\"]",
+            1,
+        );
+        assert_xpath(&doc, "(//p[@class=\"tableblock\"])[2][text()=\"second paragraph\"]", 1);
+        assert_xpath(&doc, "(//p[@class=\"tableblock\"])[3][text()=\"third paragraph\"]", 1);
+    }
 }
 
 mod dsv {
@@ -743,10 +1024,3 @@ mod csv {
     #[allow(unused_imports)]
     use crate::tests::prelude::*;
 }
-
-
-
-
-
-
-

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -985,18 +985,21 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate does not drop an incomplete final row nor warn
-    // about it; Asciidoctor drops the `|e` row and logs an error. Enable once
-    // incomplete trailing rows are detected.
     fn should_drop_incomplete_row_at_end_of_table_and_log_an_error() {
         let doc = Parser::default().parse("[cols=2*]\n|===\n|a |b\n|c |d\n|e\n|===");
 
+        // The incomplete `|e` row is dropped, leaving two rows, and an error is
+        // logged against its line (line 5).
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table tr", 2);
 
         let warnings: Vec<_> = doc.warnings().collect();
         assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::TableDroppingIncompleteRowAtEndOfTable
+        );
+        assert_eq!(warnings[0].source.line(), 5);
     }
 
     #[test]

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1365,8 +1365,9 @@ mod psv {
 
     #[test]
     #[ignore]
-    // TODO (issue TBD): Footnotes must not be shared between an AsciiDoc table
-    // cell and the main document.
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/544):
+    // Footnotes must not be shared between an AsciiDoc table cell and the main
+    // document.
     fn footnotes_should_not_be_shared_between_an_asciidoc_table_cell_and_the_main_document() {}
 
     // Backend-specific test omitted: DocBook ("callout numbers should be

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -5,7 +5,7 @@
 // limitation of `asciidoc-parser` crate) and alternate (non-HTML) back ends.
 
 mod psv {
-    use crate::tests::prelude::*;
+    use crate::tests::prelude::{inline_file_handler::InlineFileHandler, *};
 
     #[test]
     fn converts_simple_psv_table() {
@@ -1311,8 +1311,6 @@ mod psv {
 
     #[test]
     fn preprocessor_directive_on_first_line_of_an_asciidoc_table_cell_should_be_processed() {
-        use crate::tests::prelude::inline_file_handler::InlineFileHandler;
-
         let handler =
             InlineFileHandler::from_pairs([("fixtures/include-file.adoc", "included content")]);
         let mut parser = Parser::default().with_include_file_handler(handler);
@@ -1323,10 +1321,11 @@ mod psv {
         assert_rendered_contains(&doc, "included content");
     }
 
-    // Deferred: "error about unresolved preprocessor directive on first line of
-    // an AsciiDoc table cell should have correct cursor" (Ruby 1728) asserts the
-    // file/line cursor of the unresolved-directive error, which needs the cell's
-    // nested source map threaded back to the parent — not yet implemented.
+    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/542): Deferred:
+    // "error about unresolved preprocessor directive on first line of an AsciiDoc
+    // table cell should have correct cursor" (Ruby 1728) asserts the file/line
+    // cursor of the unresolved-directive error, which needs the cell's nested
+    // source map threaded back to the parent — not yet implemented.
 
     #[test]
     #[ignore]

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1003,13 +1003,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): Duplicating a cell across columns with different styles
-    // (`2*|` into a default column and an `^l` literal column) is mishandled —
-    // the crate produces single-cell rows that all take the literal style
-    // instead of one row whose first cell is paragraphs and second is a literal
-    // block. Enable once cross-column cell duplication applies each column's
-    // style.
     fn should_apply_cell_style_for_column_to_repeated_content() {
         let doc = Parser::default().parse(
             "[cols=\",^l\"]\n|===\n|Paragraphs |Literal\n\n2*|The discussion about what is good,\nwhat is beautiful, what is noble,\nwhat is pure, and what is true\ncould always go on.\n\nWhy is that important?\nWhy would I like to do that?\n\nBecause that's the only conversation worth having.\n\nAnd whether it goes on or not after I die, I don't know.\nBut, I do know that it is the conversation I want to have while I am still alive.\n\nWhich means that to me the offer of certainty,\nthe offer of complete security,\nthe offer of an impermeable faith that can't give way\nis an offer of something not worth having.\n\nI want to live my life taking the risk all the time\nthat I don't know anything like enough yet...\nthat I haven't understood enough...\nthat I can't know enough...\nthat I am always hungrily operating on the margins\nof a potentially great harvest of future knowledge and wisdom.\n\nI wouldn't have it any other way.\n|===",
@@ -1017,10 +1010,37 @@ mod psv {
 
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table > colgroup > col", 2);
-        assert_css(
+        assert_css(&doc, "table > thead", 1);
+        assert_css(&doc, "table > thead > tr", 1);
+        assert_css(&doc, "table > thead > tr > th", 2);
+        assert_css(&doc, "table > tbody", 1);
+        assert_css(&doc, "table > tbody > tr", 1);
+        assert_css(&doc, "table > tbody > tr > td", 2);
+
+        // The duplicated cell (`2*|`) is cloned into both columns, and each clone
+        // takes its own column's style: the first (default) column renders the
+        // content as seven paragraphs, the second (`^l`) column as a single
+        // centered literal block. (Ruby uses `td:nth-child(N)`; the equivalent
+        // positional `td[N]` is expressed in XPath here.)
+        assert_xpath(
             &doc,
-            "table > tbody > tr > td:nth-child(1).halign-left.valign-top > p.tableblock",
+            "/table/tbody/tr/td[1][@class=\"halign-left valign-top\"]/p[@class=\"tableblock\"]",
             7,
+        );
+        assert_xpath(
+            &doc,
+            "/table/tbody/tr/td[2][@class=\"halign-center valign-top\"]/div[@class=\"literal\"]/pre",
+            1,
+        );
+
+        // The literal block preserves every line of the cell, including the blank
+        // lines between paragraphs (26 lines total).
+        let vdom = doc.to_virtual_dom();
+        let pre = query_xpath(&vdom, "/table/tbody/tr/td[2]//pre");
+        assert_eq!(pre.len(), 1);
+        assert_eq!(
+            pre[0].text.as_deref().unwrap_or_default().lines().count(),
+            26
         );
     }
 

--- a/parser/src/tests/assert_dom/css.rs
+++ b/parser/src/tests/assert_dom/css.rs
@@ -564,9 +564,47 @@ fn matches_single_predicate(node: &VirtualNode, predicate: &str) -> bool {
         }
     }
 
+    // CSS-style attribute substring selector: [attr*="value"].
+    if let Some((attr_name, value_part)) = predicate.split_once("*=") {
+        let attr_name = attr_name.trim();
+        let value = unquote_attr_value(value_part);
+        return node
+            .attributes
+            .get(attr_name)
+            .is_some_and(|v| v.contains(&value));
+    }
+
+    // CSS-style attribute value selector without the `@` prefix:
+    // [attr="value"]. (The `@`-prefixed form is handled above.)
+    if let Some((attr_name, value_part)) = predicate.split_once('=') {
+        let attr_name = attr_name.trim();
+        let value = unquote_attr_value(value_part);
+        match attr_name {
+            "class" => {
+                return value
+                    .split_whitespace()
+                    .all(|c| node.classes.iter().any(|nc| nc == c));
+            }
+            "id" => return node.id.as_deref() == Some(value.as_str()),
+            _ => return node.attributes.get(attr_name).map(|v| v.as_str()) == Some(value.as_str()),
+        }
+    }
+
     // Numeric predicate [N]: Would need to be handled by caller with context.
     // For now, just return `true` to pass through.
     true
+}
+
+/// Strips surrounding single or double quotes (and whitespace) from a CSS
+/// attribute selector value.
+fn unquote_attr_value(value_part: &str) -> String {
+    let trimmed = value_part.trim();
+    let unquoted = trimmed
+        .strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .or_else(|| trimmed.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')))
+        .unwrap_or(trimmed);
+    unescape_css_string(unquoted)
 }
 
 /// Unescapes CSS string literals.

--- a/parser/src/tests/assert_dom/css.rs
+++ b/parser/src/tests/assert_dom/css.rs
@@ -44,37 +44,39 @@ pub(crate) fn query_css<'a>(root: &'a VirtualNode, selector: &str) -> Vec<&'a Vi
         .collect()
 }
 
-/// Finds the position of a space that acts as a descendant combinator.
-/// Returns `None` if there are no descendant combinator spaces.
+/// Finds the position of the first space that acts as a descendant combinator,
+/// scanning the whole pattern. Returns `None` if there are none.
 ///
-/// This distinguishes between:
+/// A space is a descendant combinator only when it is not merely whitespace
+/// padding a `>` or `+` combinator. This distinguishes between:
 /// - `div p` - space is a descendant combinator
-/// - `div > p` - space is just whitespace around `>`
-/// - `div + p` - space is just whitespace around `+`
+/// - `div > p` - spaces are just whitespace around `>`
+/// - `div + p` - spaces are just whitespace around `+`
+/// - `a > b c` - the space before `c` is a descendant combinator even though it
+///   follows a `>` combinator earlier in the pattern
 fn find_descendant_combinator_space(pattern: &str) -> Option<usize> {
-    let gt_pos = pattern.find('>');
-    let plus_pos = pattern.find('+');
-
-    // Find first space.
     for (i, ch) in pattern.char_indices() {
-        if ch == ' ' {
-            // Check if this space is before any `>` or `+` combinator.
-            let before_gt = gt_pos.is_none_or(|gt| i < gt);
-            let before_plus = plus_pos.is_none_or(|plus| i < plus);
-
-            if before_gt && before_plus {
-                // This space comes before any other combinators.
-                // Check if the next non-whitespace character is a combinator.
-                let rest = pattern[i..].trim_start();
-                if rest.starts_with('>') || rest.starts_with('+') {
-                    // This is whitespace before a combinator, not a descendant combinator.
-                    continue;
-                }
-
-                // This is a descendant combinator.
-                return Some(i);
-            }
+        if ch != ' ' {
+            continue;
         }
+
+        // Whitespace immediately before a `>`/`+` combinator is not a descendant
+        // combinator (e.g. the space in `div >`).
+        let rest = pattern[i..].trim_start();
+        if rest.starts_with('>') || rest.starts_with('+') {
+            continue;
+        }
+
+        // Whitespace immediately after a `>`/`+` combinator (or leading the
+        // pattern) is not a descendant combinator either (e.g. the space in
+        // `div > p`).
+        let prev = pattern[..i].trim_end();
+        if prev.is_empty() || prev.ends_with('>') || prev.ends_with('+') {
+            continue;
+        }
+
+        // A simple selector on both sides: this is a descendant combinator.
+        return Some(i);
     }
 
     None
@@ -223,6 +225,32 @@ fn query_with_direct_child_constraint<'a>(
     // Find which combinator appears first to process them in order.
     let plus_pos = pattern.find('+');
     let gt_pos = pattern.find('>');
+    let space_pos = find_descendant_combinator_space(pattern);
+
+    // Process a descendant combinator first if it is the leftmost combinator
+    // (e.g. the ` ` in `td .paragraph`, reached after stripping the preceding
+    // `>` steps of `table > tbody > tr > td .paragraph`). The constrained child
+    // matches a direct child; the rest is an unconstrained descendant search.
+    if let Some(space) = space_pos
+        && gt_pos.is_none_or(|gt| space < gt)
+        && plus_pos.is_none_or(|plus| space < plus)
+    {
+        let (first, rest) = pattern.split_at(space);
+        let first = first.trim();
+        let rest = rest.trim();
+
+        let mut results = Vec::new();
+        for child in &node.children {
+            if matches_selector_with_context(child, first, Some(node)) {
+                // The descendant combinator excludes the matched child itself, so
+                // search its subtrees rather than the child node.
+                for grandchild in &child.children {
+                    results.extend(query_descendant_or_self(grandchild, rest));
+                }
+            }
+        }
+        return results;
+    }
 
     // Process `>` first if it appears before `+`.
     if let Some(gt) = gt_pos
@@ -751,6 +779,28 @@ mod tests {
             1,
             "Should find 1 .olist that is adjacent sibling of p inside li"
         );
+    }
+
+    #[test]
+    fn query_child_chain_then_descendant() {
+        // A chain of `>` child combinators followed by a trailing descendant
+        // combinator (`a > b > c d`). The descendant step is reached only after
+        // the preceding `>` steps are stripped, so it must be handled inside the
+        // direct-child traversal, not just at the top level.
+        let doc = Parser::default().parse("[cols=\"1a\"]\n|===\n|AsciiDoc content\n|===");
+        let vdom = doc.to_virtual_dom();
+
+        // The paragraph sits at td > div.content > div.paragraph, i.e. it is a
+        // descendant (not a direct child) of the `td`.
+        assert_eq!(query_css(&vdom, "table > tbody > tr > td").len(), 1);
+        assert_eq!(
+            query_css(&vdom, "table > tbody > tr > td .paragraph").len(),
+            1
+        );
+
+        // A descendant step that itself precedes a further child combinator
+        // (`td .content > .paragraph`) is also handled.
+        assert_eq!(query_css(&vdom, "td .content > .paragraph").len(), 1);
     }
 
     #[test]

--- a/parser/src/tests/assert_dom/css.rs
+++ b/parser/src/tests/assert_dom/css.rs
@@ -25,7 +25,23 @@ use crate::tests::assert_dom::virtual_dom::VirtualNode;
 pub(crate) fn query_css<'a>(root: &'a VirtualNode, selector: &str) -> Vec<&'a VirtualNode> {
     let selector = selector.trim();
 
+    // A descendant selector can reach the same node through more than one
+    // matching ancestor (e.g. `.tableblock h1` where both the `<table>` and the
+    // `<td>` carry the `tableblock` class). De-duplicate so each node is counted
+    // once, matching a real CSS engine.
+    let mut seen: Vec<*const VirtualNode> = Vec::new();
     query_descendant_or_self(root, selector)
+        .into_iter()
+        .filter(|node| {
+            let ptr = *node as *const VirtualNode;
+            if seen.contains(&ptr) {
+                false
+            } else {
+                seen.push(ptr);
+                true
+            }
+        })
+        .collect()
 }
 
 /// Finds the position of a space that acts as a descendant combinator.

--- a/parser/src/tests/assert_dom/css.rs
+++ b/parser/src/tests/assert_dom/css.rs
@@ -602,7 +602,11 @@ fn unquote_attr_value(value_part: &str) -> String {
     let unquoted = trimmed
         .strip_prefix('"')
         .and_then(|s| s.strip_suffix('"'))
-        .or_else(|| trimmed.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')))
+        .or_else(|| {
+            trimmed
+                .strip_prefix('\'')
+                .and_then(|s| s.strip_suffix('\''))
+        })
         .unwrap_or(trimmed);
     unescape_css_string(unquoted)
 }

--- a/parser/src/tests/assert_dom/css.rs
+++ b/parser/src/tests/assert_dom/css.rs
@@ -564,14 +564,24 @@ fn matches_single_predicate(node: &VirtualNode, predicate: &str) -> bool {
         }
     }
 
-    // CSS-style attribute substring selector: [attr*="value"].
+    // CSS-style attribute substring selector: [attr*="value"]. As with the
+    // exact-match form below, `class` and `id` live on their own node fields
+    // rather than in `attributes`; `class` is matched against the rendered
+    // (space-joined) class list so the substring may span class boundaries.
     if let Some((attr_name, value_part)) = predicate.split_once("*=") {
         let attr_name = attr_name.trim();
         let value = unquote_attr_value(value_part);
-        return node
-            .attributes
-            .get(attr_name)
-            .is_some_and(|v| v.contains(&value));
+        return match attr_name {
+            "class" => node.classes.join(" ").contains(value.as_str()),
+            "id" => node
+                .id
+                .as_deref()
+                .is_some_and(|id| id.contains(value.as_str())),
+            _ => node
+                .attributes
+                .get(attr_name)
+                .is_some_and(|v| v.contains(&value)),
+        };
     }
 
     // CSS-style attribute value selector without the `@` prefix:
@@ -749,6 +759,29 @@ mod tests {
 
         // Verify the attribute value.
         assert_eq!(result[0].attributes.get("start"), Some(&"2".to_string()));
+    }
+
+    #[test]
+    fn query_attribute_substring_selector() {
+        // The `[attr*="value"]` substring selector must consult the dedicated
+        // `class` and `id` node fields, not just `attributes`.
+        let node = VirtualNode::new("table")
+            .with_classes(["tableblock", "fit-content"])
+            .with_id("results")
+            .with_attribute("style", "width: 50%;");
+
+        // `class` matches against the space-joined class list.
+        assert_eq!(query_css(&node, "table[class*=\"fit\"]").len(), 1);
+        assert_eq!(query_css(&node, "table[class*=\"block\"]").len(), 1);
+        assert_eq!(query_css(&node, "table[class*=\"nope\"]").len(), 0);
+
+        // `id` matches against the id field.
+        assert_eq!(query_css(&node, "table[id*=\"sult\"]").len(), 1);
+        assert_eq!(query_css(&node, "table[id*=\"nope\"]").len(), 0);
+
+        // An ordinary attribute matches against its value.
+        assert_eq!(query_css(&node, "table[style*=\"width\"]").len(), 1);
+        assert_eq!(query_css(&node, "table[style*=\"height\"]").len(), 0);
     }
 
     #[test]

--- a/parser/src/tests/assert_dom/css.rs
+++ b/parser/src/tests/assert_dom/css.rs
@@ -13,6 +13,9 @@ use crate::tests::assert_dom::virtual_dom::VirtualNode;
 /// - `tag > child` - Find direct children only
 /// - `tag:first-of-type` - Find first occurrence of tag among siblings
 /// - `tag:not(selector)` - Find elements that do NOT match the inner selector
+/// - `tag:nth-child(N)` - Find the element that is the Nth child of its parent
+/// - `tag:empty` - Find elements with no children and no text
+/// - Pseudo-classes may be chained, e.g. `td:nth-child(3):empty`
 ///
 /// # Example
 ///
@@ -346,7 +349,8 @@ fn query_with_direct_child_constraint<'a>(
 /// - ID selector: `[@id="foo"]` or `#foo`
 /// - Text content: `[text()="value"]`
 /// - Index: `[1]`, `[2]`, etc. (handled by `apply_numeric_predicate`)
-/// - Pseudo-selectors: `:first-of-type`
+/// - Pseudo-selectors: `:first-of-type`, `:not(...)`, `:nth-child(N)`, `:empty`
+///   (and chains thereof, e.g. `:nth-child(3):empty`)
 fn matches_selector_with_context(
     node: &VirtualNode,
     selector: &str,
@@ -436,8 +440,39 @@ fn matches_selector_with_context(
     true
 }
 
-/// Checks if a node matches a pseudo-selector.
+/// Checks if a node matches a pseudo-selector, which may be a chain of several
+/// pseudo-classes (e.g. `nth-child(3):empty`). Every pseudo-class in the chain
+/// must match.
 fn matches_pseudo_selector(node: &VirtualNode, pseudo: &str, parent: Option<&VirtualNode>) -> bool {
+    split_pseudo_chain(pseudo.trim())
+        .iter()
+        .all(|part| matches_single_pseudo(node, part, parent))
+}
+
+/// Splits a pseudo-selector chain on top-level `:` separators, leaving colons
+/// inside parentheses (e.g. a nested `:not(...)`) untouched.
+/// `nth-child(3):empty` becomes `["nth-child(3)", "empty"]`.
+fn split_pseudo_chain(pseudo: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0;
+    for (i, ch) in pseudo.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => depth = depth.saturating_sub(1),
+            ':' if depth == 0 => {
+                parts.push(&pseudo[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    parts.push(&pseudo[start..]);
+    parts.into_iter().filter(|p| !p.is_empty()).collect()
+}
+
+/// Checks if a node matches a single pseudo-class.
+fn matches_single_pseudo(node: &VirtualNode, pseudo: &str, parent: Option<&VirtualNode>) -> bool {
     let pseudo = pseudo.trim();
 
     // Handle :not() pseudo-class.
@@ -447,6 +482,20 @@ fn matches_pseudo_selector(node: &VirtualNode, pseudo: &str, parent: Option<&Vir
             return !matches_inner_not_selector(node, inner.trim());
         }
         return false; // Malformed :not().
+    }
+
+    // Handle :nth-child(N) pseudo-class (1-indexed position among siblings).
+    if let Some(arg) = pseudo.strip_prefix("nth-child(") {
+        if let Some(arg) = arg.strip_suffix(')')
+            && let Ok(n) = arg.trim().parse::<usize>()
+            && let Some(parent) = parent
+        {
+            return parent
+                .children
+                .get(n.wrapping_sub(1))
+                .is_some_and(|child| std::ptr::eq(child as *const _, node as *const _));
+        }
+        return false; // Malformed or unsupported :nth-child() argument.
     }
 
     match pseudo {
@@ -779,6 +828,31 @@ mod tests {
             1,
             "Should find 1 .olist that is adjacent sibling of p inside li"
         );
+    }
+
+    #[test]
+    fn query_nth_child_and_pseudo_chain() {
+        // A two-row, three-column table whose middle row has an empty trailing
+        // cell. Exercises `:nth-child(N)` and a pseudo chain (`:nth-child(3):empty`).
+        let doc = Parser::default().parse("[format=csv]\n|===\na,b,c\n1,2,\n|===");
+        let vdom = doc.to_virtual_dom();
+
+        assert_eq!(query_css(&vdom, "tbody > tr").len(), 2);
+        assert_eq!(query_css(&vdom, "tbody > tr:nth-child(1) > td").len(), 3);
+        assert_eq!(query_css(&vdom, "tbody > tr:nth-child(2) > td").len(), 3);
+
+        // Only the second row's third cell is empty.
+        assert_eq!(
+            query_css(&vdom, "tbody > tr:nth-child(2) > td:nth-child(3):empty").len(),
+            1
+        );
+        assert_eq!(
+            query_css(&vdom, "tbody > tr:nth-child(1) > td:nth-child(3):empty").len(),
+            0
+        );
+
+        // A position that no sibling occupies matches nothing.
+        assert_eq!(query_css(&vdom, "tbody > tr:nth-child(3)").len(), 0);
     }
 
     #[test]

--- a/parser/src/tests/assert_dom/mod.rs
+++ b/parser/src/tests/assert_dom/mod.rs
@@ -123,6 +123,54 @@ fn refute_block_contains<'src, B: IsBlock<'src>>(block: &'src B, text: &str) {
     }
 }
 
+/// Asserts that the document's rendered output (its virtual DOM text) contains
+/// the given text. Unlike [`assert_output_contains`], this descends into table
+/// cells, so it can see content nested in an AsciiDoc cell.
+///
+/// # Panics
+///
+/// Panics if the rendered text does not contain `text`.
+#[track_caller]
+pub(crate) fn assert_rendered_contains(doc: &Document, text: &str) {
+    let rendered = rendered_text(doc);
+    assert!(
+        rendered.contains(text),
+        "rendered output should contain {text:?}, but did not:\n\n{rendered}"
+    );
+}
+
+/// Refutes that the document's rendered output (its virtual DOM text) contains
+/// the given text.
+///
+/// # Panics
+///
+/// Panics if the rendered text contains `text`.
+#[track_caller]
+pub(crate) fn refute_rendered_contains(doc: &Document, text: &str) {
+    let rendered = rendered_text(doc);
+    assert!(
+        !rendered.contains(text),
+        "rendered output should not contain {text:?}, but did:\n\n{rendered}"
+    );
+}
+
+/// Collects all text in the document's virtual DOM, in document order.
+fn rendered_text(doc: &Document) -> String {
+    fn collect(node: &virtual_dom::VirtualNode, out: &mut String) {
+        if let Some(text) = &node.text {
+            out.push_str(text);
+            out.push('\n');
+        }
+        for child in &node.children {
+            collect(child, out);
+        }
+    }
+
+    let mut out = String::new();
+    collect(&doc.to_virtual_dom(), &mut out);
+    out
+}
+
 mod css;
 use css::*;
 

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -172,6 +172,38 @@ static HTML_ATTR: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*"([^"]*)""#).unwrap()
 });
 
+/// Matches an inline `{set:cellbgcolor:VALUE}` / `{set:cellbgcolor!}` attribute
+/// directive in cell text. The capture group holds the value for the set form;
+/// the unset (`!`) form leaves it absent.
+static CELL_BGCOLOR_DIRECTIVE: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(r"\{set:cellbgcolor(?::([^}]*)|!)\}").unwrap()
+});
+
+/// Applies any `{set:cellbgcolor:…}` / `{set:cellbgcolor!}` directives found in
+/// a cell's rendered text, updating `current` to the resulting cell-background
+/// color (the document attribute persists across cells), and returns the text
+/// with the directives stripped.
+///
+/// The crate's substitution layer does not yet implement the `{set:NAME:VALUE}`
+/// attribute-assignment reference (a sibling of the counter references tracked
+/// in <https://github.com/asciidoc-rs/asciidoc-parser/issues/514>), so the
+/// directives survive into the cell's rendered string. This test-only helper
+/// interprets the `cellbgcolor` case so the table renderer can reproduce
+/// Asciidoctor's per-cell `background-color` style.
+fn apply_cellbgcolor_directives(rendered: &str, current: &mut Option<String>) -> String {
+    if !rendered.contains("{set:cellbgcolor") {
+        return rendered.to_string();
+    }
+
+    CELL_BGCOLOR_DIRECTIVE
+        .replace_all(rendered, |caps: &regex::Captures<'_>| {
+            *current = caps.get(1).map(|value| value.as_str().to_string());
+            String::new()
+        })
+        .into_owned()
+}
+
 /// Parses the attributes from an opening tag's content and applies them to
 /// `node`, routing `id` and `class` to their dedicated fields and everything
 /// else into the generic attribute map.
@@ -974,16 +1006,25 @@ fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
     }
     node.children.push(colgroup);
 
+    // The `cellbgcolor` document attribute set inside a cell persists to later
+    // cells, so the resolved background color is threaded through the rows in
+    // render order (header, body, footer).
+    let mut cell_bgcolor: Option<String> = None;
+
     if let Some(header) = table.header_row() {
         let mut thead = VirtualNode::new("thead");
-        thead.children.push(table_row_to_node(header, true, false));
+        thead
+            .children
+            .push(table_row_to_node(header, true, false, &mut cell_bgcolor));
         node.children.push(thead);
     }
 
     if !table.body_rows().is_empty() {
         let mut tbody = VirtualNode::new("tbody");
         for row in table.body_rows() {
-            tbody.children.push(table_row_to_node(row, false, true));
+            tbody
+                .children
+                .push(table_row_to_node(row, false, true, &mut cell_bgcolor));
         }
         node.children.push(tbody);
     }
@@ -992,7 +1033,9 @@ fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
     // thead, tbody, tfoot.
     if let Some(footer) = table.footer_row() {
         let mut tfoot = VirtualNode::new("tfoot");
-        tfoot.children.push(table_row_to_node(footer, false, true));
+        tfoot
+            .children
+            .push(table_row_to_node(footer, false, true, &mut cell_bgcolor));
         node.children.push(tfoot);
     }
 
@@ -1003,7 +1046,12 @@ fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
 /// cells become `<th>` and their content is not wrapped in a paragraph);
 /// otherwise cells are `<td>` and body content is wrapped in a
 /// `<p class="tableblock">` (`wrap_in_paragraph`).
-fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bool) -> VirtualNode {
+fn table_row_to_node(
+    row: &TableRow<'_>,
+    header_row: bool,
+    wrap_in_paragraph: bool,
+    cell_bgcolor: &mut Option<String>,
+) -> VirtualNode {
     let mut tr = VirtualNode::new("tr");
 
     for cell in row.cells() {
@@ -1031,7 +1079,10 @@ fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bo
 
         match cell.content() {
             TableCellContent::Simple(content) => {
-                let rendered = content.rendered().to_string();
+                // Interpret and strip any `{set:cellbgcolor:…}` directive before
+                // rendering the cell text; the resolved color is applied as an
+                // inline `style` below.
+                let rendered = apply_cellbgcolor_directives(content.rendered(), cell_bgcolor);
 
                 match cell.style() {
                     // A literal cell renders its content verbatim inside a
@@ -1124,6 +1175,12 @@ fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bo
 
                 cell_node.children.push(content);
             }
+        }
+
+        // Apply the currently-effective cell background color (set by this cell's
+        // own `{set:cellbgcolor:…}` directive or persisted from an earlier cell).
+        if let Some(color) = cell_bgcolor.as_deref() {
+            cell_node = cell_node.with_attribute("style", format!("background-color: {color};"));
         }
 
         tr.children.push(cell_node);

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -11,9 +11,10 @@ use regex::Regex;
 use crate::{
     Document, HasSpan,
     blocks::{
-        Block, Break, CompoundDelimitedBlock, IsBlock, ListBlock, ListItem, ListItemMarker,
-        ListType, MediaBlock, Preamble, RawDelimitedBlock, SectionBlock, SimpleBlock,
-        SimpleBlockStyle, TableBlock, TableCellContent, TableRow,
+        Block, Break, ColumnStyle, CompoundDelimitedBlock, Frame, Grid, HorizontalAlignment,
+        IsBlock, ListBlock, ListItem, ListItemMarker, ListType, MediaBlock, Preamble,
+        RawDelimitedBlock, SectionBlock, SimpleBlock, SimpleBlockStyle, Stripes, TableBlock,
+        TableCellContent, TableColumn, TableRow, VerticalAlignment,
     },
 };
 
@@ -22,11 +23,53 @@ use crate::{
 /// This simulates what a browser would do when parsing HTML and accessing
 /// text content via JavaScript's `textContent` or XPath's `text()`.
 fn decode_html_entities(s: &str) -> String {
+    let s = decode_numeric_entities(s);
     s.replace("&lt;", "<")
         .replace("&gt;", ">")
         .replace("&amp;", "&")
         .replace("&quot;", "\"")
         .replace("&apos;", "'")
+}
+
+/// Decodes numeric character references (`&#8230;` and `&#x2026;`) to their
+/// character equivalents, mirroring what a browser does when reading `text()`.
+/// Asciidoctor emits typographic replacements (ellipsis, dashes, zero-width
+/// spaces) as numeric references, so the test DOM must decode them to compare
+/// against the expected characters.
+fn decode_numeric_entities(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut rest = s;
+
+    while let Some(amp) = rest.find("&#") {
+        result.push_str(&rest[..amp]);
+        let after = &rest[amp + 2..];
+
+        let (digits, radix) = match after.strip_prefix(['x', 'X']) {
+            Some(hex) => (hex, 16),
+            None => (after, 10),
+        };
+
+        let end = digits.find(';');
+        let parsed = end
+            .map(|e| &digits[..e])
+            .and_then(|d| u32::from_str_radix(d, radix).ok())
+            .and_then(char::from_u32);
+
+        match (end, parsed) {
+            (Some(e), Some(ch)) => {
+                result.push(ch);
+                rest = &digits[e + 1..];
+            }
+            _ => {
+                // Not a well-formed numeric reference; keep the literal `&#`.
+                result.push_str("&#");
+                rest = after;
+            }
+        }
+    }
+
+    result.push_str(rest);
+    result
 }
 
 /// Parses simple HTML inline markup from text and returns a mix of text and
@@ -479,6 +522,16 @@ fn list_block_to_node<'a>(list: &'a ListBlock<'a>) -> VirtualNode {
         list_element = list_element.with_class(style);
     }
 
+    // For ordered lists whose explicit numbering does not start at 1, emit the
+    // implicit `start` attribute (matching Asciidoctor).
+    if list.type_() == ListType::Ordered
+        && let Some(Block::ListItem(first)) = list.nested_blocks().next()
+        && let Some(ordinal) = first.list_item_marker().ordinal_value()
+        && ordinal != 1
+    {
+        list_element = list_element.with_attribute("start", ordinal.to_string());
+    }
+
     // Add all named attributes from the attrlist to the list element.
     if let Some(attrlist) = list.attrlist() {
         for attr in attrlist.attributes() {
@@ -823,8 +876,38 @@ fn compound_delimited_to_node<'a>(compound: &'a CompoundDelimitedBlock<'a>) -> V
 }
 
 fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
-    let mut node =
-        VirtualNode::new("table").with_classes(["tableblock", "frame-all", "grid-all", "stretch"]);
+    // The table-level classes mirror Asciidoctor's HTML backend: always
+    // `tableblock`, then the frame and grid classes, then a width class.
+    let mut classes = vec![
+        "tableblock".to_string(),
+        frame_class(table.frame()).to_string(),
+        grid_class(table.grid()).to_string(),
+    ];
+
+    // A table whose columns are sized to their content renders `fit-content`; a
+    // full-width (default) table renders `stretch`; a table with an explicit
+    // width renders neither (the width travels in the `width` attribute).
+    let autowidth = table.columns().iter().any(TableColumn::is_autowidth);
+    if autowidth {
+        classes.push("fit-content".to_string());
+    } else if table.width().is_none() {
+        classes.push("stretch".to_string());
+    }
+
+    if let Some(stripes) = stripes_class(table.stripes()) {
+        classes.push(stripes.to_string());
+    }
+
+    // The `float` attribute renders as a bare direction class (e.g. `left`).
+    if let Some(float) = table
+        .attrlist()
+        .and_then(|a| a.named_attribute("float"))
+        .map(|a| a.value())
+    {
+        classes.push(float.to_string());
+    }
+
+    let mut node = VirtualNode::new("table").with_classes(classes);
 
     if let Some(id) = table.id() {
         node = node.with_id(id);
@@ -832,6 +915,12 @@ fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
 
     for role in table.roles() {
         node = node.with_class(role);
+    }
+
+    // An explicit table width is carried in the `width` attribute as a
+    // percentage, matching `table[width="50%"]`-style assertions.
+    if let Some(width) = table.width() {
+        node = node.with_attribute("width", format!("{width}%"));
     }
 
     if let Some(title) = table.title() {
@@ -851,57 +940,129 @@ fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
     }
 
     let mut colgroup = VirtualNode::new("colgroup");
-    for _ in table.columns() {
-        colgroup.children.push(VirtualNode::new("col"));
+    for width in column_pcwidths(table.columns()) {
+        let mut col = VirtualNode::new("col");
+
+        // Autowidth columns are sized to their content and carry no width
+        // attribute; proportional columns expose their computed percentage.
+        if let Some(width) = width {
+            col = col.with_attribute("width", format!("{width}%"));
+        }
+
+        colgroup.children.push(col);
     }
     node.children.push(colgroup);
 
     if let Some(header) = table.header_row() {
         let mut thead = VirtualNode::new("thead");
-        thead.children.push(table_row_to_node(header, "th", false));
+        thead.children.push(table_row_to_node(header, true, false));
         node.children.push(thead);
     }
 
     if !table.body_rows().is_empty() {
         let mut tbody = VirtualNode::new("tbody");
         for row in table.body_rows() {
-            tbody.children.push(table_row_to_node(row, "td", true));
+            tbody.children.push(table_row_to_node(row, false, true));
         }
         node.children.push(tbody);
+    }
+
+    // The footer renders after the body, so the section order is
+    // thead, tbody, tfoot.
+    if let Some(footer) = table.footer_row() {
+        let mut tfoot = VirtualNode::new("tfoot");
+        tfoot.children.push(table_row_to_node(footer, false, true));
+        node.children.push(tfoot);
     }
 
     node
 }
 
-fn table_row_to_node(row: &TableRow<'_>, cell_tag: &str, wrap_in_paragraph: bool) -> VirtualNode {
+/// Renders one table row. `header_row` marks the row as the table's header (its
+/// cells become `<th>` and their content is not wrapped in a paragraph);
+/// otherwise cells are `<td>` and body content is wrapped in a
+/// `<p class="tableblock">` (`wrap_in_paragraph`).
+fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bool) -> VirtualNode {
     let mut tr = VirtualNode::new("tr");
 
     for cell in row.cells() {
-        let mut cell_node =
-            VirtualNode::new(cell_tag).with_classes(["tableblock", "halign-left", "valign-top"]);
+        // A cell carrying the header style renders as a `<th>` even outside the
+        // header row; otherwise header rows use `<th>` and body/footer rows use
+        // `<td>`.
+        let cell_tag = if header_row || cell.style() == ColumnStyle::Header {
+            "th"
+        } else {
+            "td"
+        };
+
+        let mut cell_node = VirtualNode::new(cell_tag).with_classes([
+            "tableblock".to_string(),
+            halign_class(cell.h_align()).to_string(),
+            valign_class(cell.v_align()).to_string(),
+        ]);
+
+        if cell.colspan() > 1 {
+            cell_node = cell_node.with_attribute("colspan", cell.colspan().to_string());
+        }
+        if cell.rowspan() > 1 {
+            cell_node = cell_node.with_attribute("rowspan", cell.rowspan().to_string());
+        }
 
         match cell.content() {
             TableCellContent::Simple(content) => {
                 let rendered = content.rendered().to_string();
 
-                if wrap_in_paragraph {
-                    cell_node.children.push(
-                        VirtualNode::new("p")
-                            .with_class("tableblock")
-                            .with_text(rendered),
-                    );
-                } else {
-                    cell_node = cell_node.with_text(rendered);
+                match cell.style() {
+                    // A literal cell renders its content verbatim inside a
+                    // `<div class="literal"><pre>…</pre></div>`.
+                    ColumnStyle::Literal => {
+                        cell_node.children.push(
+                            VirtualNode::new("div").with_class("literal").with_child(
+                                VirtualNode::new("pre").with_html_content(rendered),
+                            ),
+                        );
+                    }
+
+                    _ if !wrap_in_paragraph => {
+                        // Header-row cells place their content directly in the
+                        // cell, wrapped only by any style element.
+                        match style_wrapper(cell.style()) {
+                            Some(tag) => cell_node.children.push(
+                                VirtualNode::new(tag).with_html_content(rendered),
+                            ),
+                            None => cell_node = cell_node.with_html_content(rendered),
+                        }
+                    }
+
+                    // An empty body cell renders as an empty `<td>` with no
+                    // paragraph.
+                    _ if rendered.is_empty() => {}
+
+                    style => {
+                        // Body and footer cells wrap their content in a
+                        // `<p class="tableblock">`, with an inner style element
+                        // (`<strong>`, `<em>`, `<code>`) when the cell carries a
+                        // text style.
+                        let p = VirtualNode::new("p").with_class("tableblock");
+                        let p = match style_wrapper(style) {
+                            Some(tag) => p.with_child(
+                                VirtualNode::new(tag).with_html_content(rendered),
+                            ),
+                            None => p.with_html_content(rendered),
+                        };
+                        cell_node.children.push(p);
+                    }
                 }
             }
 
             // An AsciiDoc-styled cell holds a nested sequence of blocks, which
-            // render directly into the cell rather than into a single
-            // paragraph.
+            // render into a `<div class="content">` wrapper inside the cell.
             TableCellContent::AsciiDoc(blocks) => {
+                let mut content = VirtualNode::new("div").with_class("content");
                 for block in blocks {
-                    cell_node.children.push(block.to_virtual_dom());
+                    content.children.push(block.to_virtual_dom());
                 }
+                cell_node.children.push(content);
             }
         }
 
@@ -909,6 +1070,124 @@ fn table_row_to_node(row: &TableRow<'_>, cell_tag: &str, wrap_in_paragraph: bool
     }
 
     tr
+}
+
+/// Computes the per-column percentage width that Asciidoctor's HTML backend
+/// renders on each `<col>`. Returns `None` for an autowidth column (which
+/// carries no width attribute).
+///
+/// This mirrors `Table#assign_column_widths` in Asciidoctor: percentages are
+/// truncated to four decimal places and the rounding balance is donated to the
+/// final column so the widths sum to exactly 100.
+fn column_pcwidths(columns: &[TableColumn]) -> Vec<Option<String>> {
+    // When any column is autowidth, the proportional columns are treated as
+    // literal percentages and the autowidth columns get no width.
+    if columns.iter().any(TableColumn::is_autowidth) {
+        return columns
+            .iter()
+            .map(|c| {
+                if c.is_autowidth() {
+                    None
+                } else {
+                    Some(format_pcwidth(c.width() as f64))
+                }
+            })
+            .collect();
+    }
+
+    let base: usize = columns.iter().map(TableColumn::width).sum();
+    if base == 0 {
+        return columns.iter().map(|_| None).collect();
+    }
+
+    let truncated: Vec<f64> = columns
+        .iter()
+        .map(|c| truncate4(c.width() as f64 * 100.0 / base as f64))
+        .collect();
+
+    let total: f64 = truncated.iter().sum();
+    let mut widths: Vec<Option<String>> =
+        truncated.iter().map(|w| Some(format_pcwidth(*w))).collect();
+
+    // Donate the rounding balance to the final column.
+    if (total - 100.0).abs() > 1e-9 {
+        let last = truncated.len() - 1;
+        let donated = round4(100.0 - (total - truncated[last]));
+        widths[last] = Some(format_pcwidth(donated));
+    }
+
+    widths
+}
+
+fn truncate4(x: f64) -> f64 {
+    (x * 10000.0).trunc() / 10000.0
+}
+
+fn round4(x: f64) -> f64 {
+    (x * 10000.0).round() / 10000.0
+}
+
+/// Formats a percentage width the way Asciidoctor serializes it: whole numbers
+/// have no decimal part, and fractional values keep up to four significant
+/// decimal places with trailing zeros trimmed (e.g. `50`, `17.647`, `33.3334`).
+fn format_pcwidth(x: f64) -> String {
+    let s = format!("{x:.4}");
+    let trimmed = s.trim_end_matches('0').trim_end_matches('.');
+    trimmed.to_string()
+}
+
+/// The inline element a text-styled cell wraps its content in, if any.
+fn style_wrapper(style: ColumnStyle) -> Option<&'static str> {
+    match style {
+        ColumnStyle::Strong => Some("strong"),
+        ColumnStyle::Emphasis => Some("em"),
+        ColumnStyle::Monospace => Some("code"),
+        _ => None,
+    }
+}
+
+fn frame_class(frame: Frame) -> &'static str {
+    match frame {
+        Frame::All => "frame-all",
+        Frame::Ends => "frame-ends",
+        Frame::Sides => "frame-sides",
+        Frame::None => "frame-none",
+    }
+}
+
+fn grid_class(grid: Grid) -> &'static str {
+    match grid {
+        Grid::All => "grid-all",
+        Grid::Rows => "grid-rows",
+        Grid::Cols => "grid-cols",
+        Grid::None => "grid-none",
+    }
+}
+
+fn stripes_class(stripes: Stripes) -> Option<&'static str> {
+    match stripes {
+        Stripes::None => None,
+        Stripes::Even => Some("stripes-even"),
+        Stripes::Odd => Some("stripes-odd"),
+        Stripes::All => Some("stripes-all"),
+        Stripes::Hover => Some("stripes-hover"),
+    }
+}
+
+fn halign_class(align: HorizontalAlignment) -> &'static str {
+    match align {
+        HorizontalAlignment::Left => "halign-left",
+        HorizontalAlignment::Center => "halign-center",
+        HorizontalAlignment::Right => "halign-right",
+    }
+}
+
+fn valign_class(align: VerticalAlignment) -> &'static str {
+    match align {
+        VerticalAlignment::Top => "valign-top",
+        VerticalAlignment::Middle => "valign-middle",
+        VerticalAlignment::Bottom => "valign-bottom",
+    }
 }
 
 fn preamble_to_node<'a>(preamble: &'a Preamble<'a>) -> VirtualNode {

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -172,38 +172,6 @@ static HTML_ATTR: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*"([^"]*)""#).unwrap()
 });
 
-/// Matches an inline `{set:cellbgcolor:VALUE}` / `{set:cellbgcolor!}` attribute
-/// directive in cell text. The capture group holds the value for the set form;
-/// the unset (`!`) form leaves it absent.
-static CELL_BGCOLOR_DIRECTIVE: LazyLock<Regex> = LazyLock::new(|| {
-    #[allow(clippy::unwrap_used)]
-    Regex::new(r"\{set:cellbgcolor(?::([^}]*)|!)\}").unwrap()
-});
-
-/// Applies any `{set:cellbgcolor:…}` / `{set:cellbgcolor!}` directives found in
-/// a cell's rendered text, updating `current` to the resulting cell-background
-/// color (the document attribute persists across cells), and returns the text
-/// with the directives stripped.
-///
-/// The crate's substitution layer does not yet implement the `{set:NAME:VALUE}`
-/// attribute-assignment reference (a sibling of the counter references tracked
-/// in <https://github.com/asciidoc-rs/asciidoc-parser/issues/514>), so the
-/// directives survive into the cell's rendered string. This test-only helper
-/// interprets the `cellbgcolor` case so the table renderer can reproduce
-/// Asciidoctor's per-cell `background-color` style.
-fn apply_cellbgcolor_directives(rendered: &str, current: &mut Option<String>) -> String {
-    if !rendered.contains("{set:cellbgcolor") {
-        return rendered.to_string();
-    }
-
-    CELL_BGCOLOR_DIRECTIVE
-        .replace_all(rendered, |caps: &regex::Captures<'_>| {
-            *current = caps.get(1).map(|value| value.as_str().to_string());
-            String::new()
-        })
-        .into_owned()
-}
-
 /// Parses the attributes from an opening tag's content and applies them to
 /// `node`, routing `id` and `class` to their dedicated fields and everything
 /// else into the generic attribute map.
@@ -1006,25 +974,16 @@ fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
     }
     node.children.push(colgroup);
 
-    // The `cellbgcolor` document attribute set inside a cell persists to later
-    // cells, so the resolved background color is threaded through the rows in
-    // render order (header, body, footer).
-    let mut cell_bgcolor: Option<String> = None;
-
     if let Some(header) = table.header_row() {
         let mut thead = VirtualNode::new("thead");
-        thead
-            .children
-            .push(table_row_to_node(header, true, false, &mut cell_bgcolor));
+        thead.children.push(table_row_to_node(header, true, false));
         node.children.push(thead);
     }
 
     if !table.body_rows().is_empty() {
         let mut tbody = VirtualNode::new("tbody");
         for row in table.body_rows() {
-            tbody
-                .children
-                .push(table_row_to_node(row, false, true, &mut cell_bgcolor));
+            tbody.children.push(table_row_to_node(row, false, true));
         }
         node.children.push(tbody);
     }
@@ -1033,9 +992,7 @@ fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
     // thead, tbody, tfoot.
     if let Some(footer) = table.footer_row() {
         let mut tfoot = VirtualNode::new("tfoot");
-        tfoot
-            .children
-            .push(table_row_to_node(footer, false, true, &mut cell_bgcolor));
+        tfoot.children.push(table_row_to_node(footer, false, true));
         node.children.push(tfoot);
     }
 
@@ -1046,12 +1003,7 @@ fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
 /// cells become `<th>` and their content is not wrapped in a paragraph);
 /// otherwise cells are `<td>` and body content is wrapped in a
 /// `<p class="tableblock">` (`wrap_in_paragraph`).
-fn table_row_to_node(
-    row: &TableRow<'_>,
-    header_row: bool,
-    wrap_in_paragraph: bool,
-    cell_bgcolor: &mut Option<String>,
-) -> VirtualNode {
+fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bool) -> VirtualNode {
     let mut tr = VirtualNode::new("tr");
 
     for cell in row.cells() {
@@ -1079,10 +1031,7 @@ fn table_row_to_node(
 
         match cell.content() {
             TableCellContent::Simple(content) => {
-                // Interpret and strip any `{set:cellbgcolor:…}` directive before
-                // rendering the cell text; the resolved color is applied as an
-                // inline `style` below.
-                let rendered = apply_cellbgcolor_directives(content.rendered(), cell_bgcolor);
+                let rendered = content.rendered().to_string();
 
                 match cell.style() {
                     // A literal cell renders its content verbatim inside a
@@ -1175,12 +1124,6 @@ fn table_row_to_node(
 
                 cell_node.children.push(content);
             }
-        }
-
-        // Apply the currently-effective cell background color (set by this cell's
-        // own `{set:cellbgcolor:…}` directive or persisted from an earlier cell).
-        if let Some(color) = cell_bgcolor.as_deref() {
-            cell_node = cell_node.with_attribute("style", format!("background-color: {color};"));
         }
 
         tr.children.push(cell_node);

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -941,9 +941,7 @@ fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
 
     // A table with no rows at all (e.g. every row was dropped for exceeding the
     // column count) renders as a bare `<table>` with no colgroup or sections.
-    if table.header_row().is_none()
-        && table.body_rows().is_empty()
-        && table.footer_row().is_none()
+    if table.header_row().is_none() && table.body_rows().is_empty() && table.footer_row().is_none()
     {
         return node;
     }
@@ -1026,9 +1024,9 @@ fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bo
                     // `<div class="literal"><pre>…</pre></div>`.
                     ColumnStyle::Literal => {
                         cell_node.children.push(
-                            VirtualNode::new("div").with_class("literal").with_child(
-                                VirtualNode::new("pre").with_html_content(rendered),
-                            ),
+                            VirtualNode::new("div")
+                                .with_class("literal")
+                                .with_child(VirtualNode::new("pre").with_html_content(rendered)),
                         );
                     }
 
@@ -1036,9 +1034,9 @@ fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bo
                         // Header-row cells place their content directly in the
                         // cell, wrapped only by any style element.
                         match style_wrapper(cell.style()) {
-                            Some(tag) => cell_node.children.push(
-                                VirtualNode::new(tag).with_html_content(rendered),
-                            ),
+                            Some(tag) => cell_node
+                                .children
+                                .push(VirtualNode::new(tag).with_html_content(rendered)),
                             None => cell_node = cell_node.with_html_content(rendered),
                         }
                     }
@@ -1053,9 +1051,9 @@ fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bo
                         // (`<strong>`, `<em>`, `<code>`).
                         Some(tag) => {
                             cell_node.children.push(
-                                VirtualNode::new("p").with_class("tableblock").with_child(
-                                    VirtualNode::new(tag).with_html_content(rendered),
-                                ),
+                                VirtualNode::new("p")
+                                    .with_class("tableblock")
+                                    .with_child(VirtualNode::new(tag).with_html_content(rendered)),
                             );
                         }
 

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -1068,10 +1068,8 @@ fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bo
                         // Asciidoctor (the parser stores them as one cell with
                         // embedded blank lines).
                         None => {
-                            for para in rendered
-                                .split("\n\n")
-                                .map(str::trim)
-                                .filter(|p| !p.is_empty())
+                            for para in
+                                split_cell_paragraphs(content.original().data(), content.rendered())
                             {
                                 cell_node.children.push(
                                     VirtualNode::new("p")
@@ -1174,6 +1172,49 @@ fn column_pcwidths(columns: &[TableColumn]) -> Vec<String> {
     }
 
     pct.iter().map(|w| format_pcwidth(*w)).collect()
+}
+
+/// Splits a plain (non-styled) table cell's content into paragraphs, returning
+/// the rendered text of each.
+///
+/// A paragraph break is a blank line in the **source**, not the rendered text.
+/// This matters for an attribute reference such as `{blank}`: a line containing
+/// only `{blank}` renders as an empty line but is not blank in the source, so
+/// it must not split the paragraph (matching Asciidoctor). Inline substitution
+/// is line-preserving, so the source and rendered line counts line up; each
+/// non-blank source line contributes its rendered counterpart to the current
+/// paragraph. If the two ever diverge in length, fall back to splitting the
+/// rendered text on blank lines.
+fn split_cell_paragraphs(source: &str, rendered: &str) -> Vec<String> {
+    let source_lines: Vec<&str> = source.split('\n').collect();
+    let rendered_lines: Vec<&str> = rendered.split('\n').collect();
+
+    if source_lines.len() != rendered_lines.len() {
+        return rendered
+            .split("\n\n")
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty())
+            .collect();
+    }
+
+    let mut paragraphs: Vec<String> = vec![];
+    let mut current: Vec<&str> = vec![];
+    for (src, rendered) in source_lines.iter().zip(rendered_lines.iter()) {
+        if src.trim().is_empty() {
+            if !current.is_empty() {
+                paragraphs.push(current.join("\n").trim().to_string());
+                current.clear();
+            }
+        } else {
+            current.push(rendered);
+        }
+    }
+    if !current.is_empty() {
+        paragraphs.push(current.join("\n").trim().to_string());
+    }
+
+    paragraphs.retain(|p| !p.is_empty());
+    paragraphs
 }
 
 fn truncate4(x: f64) -> f64 {

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -1038,29 +1038,48 @@ fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bo
                     // paragraph.
                     _ if rendered.is_empty() => {}
 
-                    style => {
-                        // Body and footer cells wrap their content in a
-                        // `<p class="tableblock">`, with an inner style element
-                        // (`<strong>`, `<em>`, `<code>`) when the cell carries a
-                        // text style.
-                        let p = VirtualNode::new("p").with_class("tableblock");
-                        let p = match style_wrapper(style) {
-                            Some(tag) => p.with_child(
-                                VirtualNode::new(tag).with_html_content(rendered),
-                            ),
-                            None => p.with_html_content(rendered),
-                        };
-                        cell_node.children.push(p);
-                    }
+                    style => match style_wrapper(style) {
+                        // A text-styled cell wraps its content in a
+                        // `<p class="tableblock">` with an inner style element
+                        // (`<strong>`, `<em>`, `<code>`).
+                        Some(tag) => {
+                            cell_node.children.push(
+                                VirtualNode::new("p").with_class("tableblock").with_child(
+                                    VirtualNode::new(tag).with_html_content(rendered),
+                                ),
+                            );
+                        }
+
+                        // A plain cell renders each blank-line-separated
+                        // paragraph as its own `<p class="tableblock">`, matching
+                        // Asciidoctor (the parser stores them as one cell with
+                        // embedded blank lines).
+                        None => {
+                            for para in rendered
+                                .split("\n\n")
+                                .map(str::trim)
+                                .filter(|p| !p.is_empty())
+                            {
+                                cell_node.children.push(
+                                    VirtualNode::new("p")
+                                        .with_class("tableblock")
+                                        .with_html_content(para),
+                                );
+                            }
+                        }
+                    },
                 }
             }
 
             // An AsciiDoc-styled cell holds a nested sequence of blocks, which
             // render into a `<div class="content">` wrapper inside the cell.
+            // The blocks render as they would at the top level of a document
+            // (e.g. paragraphs wrapped in `<div class="paragraph">`), so the
+            // cell reuses `add_block_with_title`.
             TableCellContent::AsciiDoc(blocks) => {
                 let mut content = VirtualNode::new("div").with_class("content");
                 for block in blocks {
-                    content.children.push(block.to_virtual_dom());
+                    add_block_with_title(&mut content, block);
                 }
                 cell_node.children.push(content);
             }

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -939,6 +939,15 @@ fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
         );
     }
 
+    // A table with no rows at all (e.g. every row was dropped for exceeding the
+    // column count) renders as a bare `<table>` with no colgroup or sections.
+    if table.header_row().is_none()
+        && table.body_rows().is_empty()
+        && table.footer_row().is_none()
+    {
+        return node;
+    }
+
     let mut colgroup = VirtualNode::new("colgroup");
     for width in column_pcwidths(table.columns()) {
         let mut col = VirtualNode::new("col");

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -947,13 +947,19 @@ fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {
     }
 
     let mut colgroup = VirtualNode::new("colgroup");
-    for width in column_pcwidths(table.columns()) {
-        let mut col = VirtualNode::new("col");
+    for (column, pcwidth) in table.columns().iter().zip(column_pcwidths(table.columns())) {
+        // Every column exposes its computed percentage width in `colpcwidth`,
+        // mirroring the model attribute Asciidoctor assigns to each column.
+        let mut col = VirtualNode::new("col").with_attribute("colpcwidth", pcwidth.clone());
 
-        // Autowidth columns are sized to their content and carry no width
-        // attribute; proportional columns expose their computed percentage.
-        if let Some(width) = width {
-            col = col.with_attribute("width", format!("{width}%"));
+        if column.is_autowidth() {
+            // An autowidth column is sized to its content: it carries the
+            // `autowidth-option` marker (present with an empty value) and no HTML
+            // `width` attribute.
+            col = col.with_attribute("autowidth-option", "");
+        } else {
+            // A proportional column emits its percentage as the HTML `width`.
+            col = col.with_attribute("width", format!("{pcwidth}%"));
         }
 
         colgroup.children.push(col);
@@ -1098,51 +1104,76 @@ fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bo
     tr
 }
 
-/// Computes the per-column percentage width that Asciidoctor's HTML backend
-/// renders on each `<col>`. Returns `None` for an autowidth column (which
-/// carries no width attribute).
+/// Computes the `colpcwidth` (percentage width) that Asciidoctor assigns to
+/// every column, mirroring `Table#assign_column_widths`.
 ///
-/// This mirrors `Table#assign_column_widths` in Asciidoctor: percentages are
-/// truncated to four decimal places and the rounding balance is donated to the
-/// final column so the widths sum to exactly 100.
-fn column_pcwidths(columns: &[TableColumn]) -> Vec<Option<String>> {
-    // When any column is autowidth, the proportional columns are treated as
-    // literal percentages and the autowidth columns get no width.
-    if columns.iter().any(TableColumn::is_autowidth) {
-        return columns
+/// Each autowidth column takes an equal share of the space the fixed columns
+/// leave free (`(100 - fixed_total) / autowidth_count`); every column's
+/// percentage is then truncated to four decimal places and the rounding balance
+/// is donated to the final column so the widths sum to exactly 100. The value
+/// is returned for every column (including autowidth columns, which carry the
+/// percentage in the model even though the HTML backend omits their `width`
+/// attribute).
+fn column_pcwidths(columns: &[TableColumn]) -> Vec<String> {
+    let n = columns.len();
+    if n == 0 {
+        return vec![];
+    }
+
+    let fixed_total: usize = columns
+        .iter()
+        .filter(|c| !c.is_autowidth())
+        .map(TableColumn::width)
+        .sum();
+
+    // Resolve the effective per-column width and the base they are a percentage
+    // of. With autowidth columns present the base is the full 100% and each
+    // autowidth column takes an equal share of the remaining space (collapsing
+    // to zero when the fixed columns already exceed 100%); otherwise each
+    // column's own proportional width is taken over the sum of all widths.
+    let (effective, base): (Vec<f64>, f64) = if columns.iter().any(TableColumn::is_autowidth) {
+        let autowidth_count = columns.iter().filter(|c| c.is_autowidth()).count();
+        let (share, base) = if fixed_total > 100 {
+            (0.0, fixed_total as f64)
+        } else {
+            (
+                truncate4((100.0 - fixed_total as f64) / autowidth_count as f64),
+                100.0,
+            )
+        };
+        let effective = columns
             .iter()
             .map(|c| {
                 if c.is_autowidth() {
-                    None
+                    share
                 } else {
-                    Some(format_pcwidth(c.width() as f64))
+                    c.width() as f64
                 }
             })
             .collect();
-    }
+        (effective, base)
+    } else {
+        let base = if fixed_total == 0 {
+            n as f64
+        } else {
+            fixed_total as f64
+        };
+        (columns.iter().map(|c| c.width() as f64).collect(), base)
+    };
 
-    let base: usize = columns.iter().map(TableColumn::width).sum();
-    if base == 0 {
-        return columns.iter().map(|_| None).collect();
-    }
-
-    let truncated: Vec<f64> = columns
+    let mut pct: Vec<f64> = effective
         .iter()
-        .map(|c| truncate4(c.width() as f64 * 100.0 / base as f64))
+        .map(|w| truncate4(w * 100.0 / base))
         .collect();
 
-    let total: f64 = truncated.iter().sum();
-    let mut widths: Vec<Option<String>> =
-        truncated.iter().map(|w| Some(format_pcwidth(*w))).collect();
-
     // Donate the rounding balance to the final column.
+    let total: f64 = pct.iter().sum();
     if (total - 100.0).abs() > 1e-9 {
-        let last = truncated.len() - 1;
-        let donated = round4(100.0 - (total - truncated[last]));
-        widths[last] = Some(format_pcwidth(donated));
+        let last = n - 1;
+        pct[last] = round4(100.0 - total + pct[last]);
     }
 
-    widths
+    pct.iter().map(|w| format_pcwidth(*w)).collect()
 }
 
 fn truncate4(x: f64) -> f64 {

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -341,6 +341,14 @@ impl ToVirtualDom for Document<'_> {
             node = node.with_id(id);
         }
 
+        // The document title renders as an `<h1>` when it is shown (the
+        // effective `showtitle`/`notitle` state).
+        if self.show_doctitle()
+            && let Some(title) = self.doctitle()
+        {
+            node.children.push(VirtualNode::new("h1").with_text(title));
+        }
+
         // Add child blocks, including block titles as separate siblings.
         for block in self.nested_blocks() {
             add_block_with_title(&mut node, block);
@@ -1082,16 +1090,38 @@ fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bo
                 }
             }
 
-            // An AsciiDoc-styled cell holds a nested sequence of blocks, which
-            // render into a `<div class="content">` wrapper inside the cell.
-            // The blocks render as they would at the top level of a document
-            // (e.g. paragraphs wrapped in `<div class="paragraph">`), so the
-            // cell reuses `add_block_with_title`.
-            TableCellContent::AsciiDoc(blocks) => {
+            // An AsciiDoc-styled cell holds a nested document, which renders into
+            // a `<div class="content">` wrapper inside the cell. The blocks
+            // render as they would at the top level of a document (e.g.
+            // paragraphs wrapped in `<div class="paragraph">`), so the cell
+            // reuses `add_block_with_title`.
+            TableCellContent::AsciiDoc(cell) => {
                 let mut content = VirtualNode::new("div").with_class("content");
-                for block in blocks {
-                    add_block_with_title(&mut content, block);
+
+                // The nested document's title renders as an `<h1>` when shown.
+                if let Some(title) = cell.title() {
+                    content
+                        .children
+                        .push(VirtualNode::new("h1").with_text(title));
                 }
+
+                if cell.is_inline() {
+                    // An `inline` doctype renders block content as bare inline
+                    // content, without the `<div class="paragraph"><p>` wrapper.
+                    for block in cell.blocks() {
+                        match block.rendered_content() {
+                            Some(rendered) => {
+                                content.children.extend(parse_html_content(rendered));
+                            }
+                            None => add_block_with_title(&mut content, block),
+                        }
+                    }
+                } else {
+                    for block in cell.blocks() {
+                        add_block_with_title(&mut content, block);
+                    }
+                }
+
                 cell_node.children.push(content);
             }
         }

--- a/parser/src/tests/assert_dom/xpath.rs
+++ b/parser/src/tests/assert_dom/xpath.rs
@@ -1133,6 +1133,18 @@ fn matches_single_predicate(node: &VirtualNode, predicate: &str) -> bool {
         }
     }
 
+    // Check for attribute-existence predicates `[@attr]` (no value).
+    if let Some(attr_name) = predicate.strip_prefix('@')
+        && !attr_name.contains('=')
+    {
+        let attr_name = attr_name.trim();
+        return match attr_name {
+            "class" => !node.classes.is_empty(),
+            "id" => node.id.is_some(),
+            _ => node.attributes.contains_key(attr_name),
+        };
+    }
+
     // Numeric predicate [N]: Would need to be handled by caller with context.
     // For now, just return `true` to pass through.
     true

--- a/parser/src/tests/fixtures/blocks/table.rs
+++ b/parser/src/tests/fixtures/blocks/table.rs
@@ -89,6 +89,7 @@ fn cell_content_eq(fixture: &TableCellContent, observed: &crate::blocks::TableCe
     match (fixture, observed) {
         (TableCellContent::Simple(f), crate::blocks::TableCellContent::Simple(o)) => f == o,
         (TableCellContent::AsciiDoc(f), crate::blocks::TableCellContent::AsciiDoc(o)) => {
+            let o = o.blocks();
             f.len() == o.len() && f.iter().zip(o.iter()).all(|(fb, ob)| fb == ob)
         }
         _ => false,

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -82,6 +82,9 @@ pub enum WarningType {
 
     #[error("Dropping table cell because it exceeds the specified number of columns")]
     TableCellExceedsColumnCount,
+
+    #[error("Unclosed quote in CSV data; setting cell to empty")]
+    TableCsvDataHasUnclosedQuote,
 }
 
 impl std::fmt::Debug for WarningType {
@@ -158,6 +161,10 @@ impl std::fmt::Debug for WarningType {
 
             WarningType::TableCellExceedsColumnCount => {
                 write!(f, "WarningType::TableCellExceedsColumnCount")
+            }
+
+            WarningType::TableCsvDataHasUnclosedQuote => {
+                write!(f, "WarningType::TableCsvDataHasUnclosedQuote")
             }
         }
     }
@@ -416,6 +423,13 @@ mod tests {
                 let warning = WarningType::TableCellExceedsColumnCount;
                 let debug_output = format!("{:?}", warning);
                 assert_eq!(debug_output, "WarningType::TableCellExceedsColumnCount");
+            }
+
+            #[test]
+            fn table_csv_data_has_unclosed_quote() {
+                let warning = WarningType::TableCsvDataHasUnclosedQuote;
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(debug_output, "WarningType::TableCsvDataHasUnclosedQuote");
             }
         }
     }

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -85,6 +85,9 @@ pub enum WarningType {
 
     #[error("Unclosed quote in CSV data; setting cell to empty")]
     TableCsvDataHasUnclosedQuote,
+
+    #[error("Table is missing a leading separator; recovering automatically")]
+    TableMissingLeadingSeparator,
 }
 
 impl std::fmt::Debug for WarningType {
@@ -165,6 +168,10 @@ impl std::fmt::Debug for WarningType {
 
             WarningType::TableCsvDataHasUnclosedQuote => {
                 write!(f, "WarningType::TableCsvDataHasUnclosedQuote")
+            }
+
+            WarningType::TableMissingLeadingSeparator => {
+                write!(f, "WarningType::TableMissingLeadingSeparator")
             }
         }
     }
@@ -430,6 +437,13 @@ mod tests {
                 let warning = WarningType::TableCsvDataHasUnclosedQuote;
                 let debug_output = format!("{:?}", warning);
                 assert_eq!(debug_output, "WarningType::TableCsvDataHasUnclosedQuote");
+            }
+
+            #[test]
+            fn table_missing_leading_separator() {
+                let warning = WarningType::TableMissingLeadingSeparator;
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(debug_output, "WarningType::TableMissingLeadingSeparator");
             }
         }
     }

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -88,6 +88,9 @@ pub enum WarningType {
 
     #[error("Table is missing a leading separator; recovering automatically")]
     TableMissingLeadingSeparator,
+
+    #[error("Dropping cells from incomplete row; detected end of table")]
+    TableDroppingIncompleteRowAtEndOfTable,
 }
 
 impl std::fmt::Debug for WarningType {
@@ -172,6 +175,10 @@ impl std::fmt::Debug for WarningType {
 
             WarningType::TableMissingLeadingSeparator => {
                 write!(f, "WarningType::TableMissingLeadingSeparator")
+            }
+
+            WarningType::TableDroppingIncompleteRowAtEndOfTable => {
+                write!(f, "WarningType::TableDroppingIncompleteRowAtEndOfTable")
             }
         }
     }
@@ -444,6 +451,16 @@ mod tests {
                 let warning = WarningType::TableMissingLeadingSeparator;
                 let debug_output = format!("{:?}", warning);
                 assert_eq!(debug_output, "WarningType::TableMissingLeadingSeparator");
+            }
+
+            #[test]
+            fn table_dropping_incomplete_row_at_end_of_table() {
+                let warning = WarningType::TableDroppingIncompleteRowAtEndOfTable;
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(
+                    debug_output,
+                    "WarningType::TableDroppingIncompleteRowAtEndOfTable"
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary

Ports Ruby Asciidoctor's `test/tables_test.rb` (PSV/DSV/CSV) into `parser/src/tests/asciidoctor_rb/tables_test.rs`, following the same convention as the existing `lists_test`/`paragraphs_test`/`substitutions_test` ports: each Ruby `test` becomes a `#[test] fn`, modules mirror the Ruby `context` blocks, and Ruby `assert_xpath`/`assert_css` map to the same-named `assert_dom` helpers run against `doc.to_virtual_dom()`.

The port surfaced parser divergences from Asciidoctor and several genuinely-missing features; rather than stub everything, this PR also **implements** the table behaviors needed for a functionally-complete tables implementation. The six original divergence fixes were developed in #541 and have since been **merged into this branch**, so this PR delivers the test port, those parser fixes, and the newly-implemented features together. The branch is up to date with `tables`.

**Outcome:** of the 113 ported `#[test] fn`s, **97 pass** and **16 remain `#[ignore]`d** (each blocked on an out-of-scope feature and linked to a tracking issue). DocBook / compat-mode tests are omitted with one-line notes. Full lib suite stays green (**2185 passed, 0 failed**), and **patch coverage is 100%**.

## Parser fixes (merged from #541)

Each verified against the locally installed `asciidoctor`:

- **PSV cell splitting** — an unescaped `|` is always a cell boundary; the preceding token is a specifier only when it's a valid specifier anchored by whitespace/line-start, else content (so `|a|b` → two cells). Explicit `\|` escape handling added.
- **Colspec forms** — `cols=3` (bare integer), `cols="<,"` (empty record → default column), and `cols="1s;3m"` (semicolon separator) now match Asciidoctor's `parse_colspecs`.
- **Literal/AsciiDoc cell trimming** — literal cells keep the first content line's indentation; AsciiDoc cells treat a leading-indented first line as a literal block.
- **Implicit header** — suppressed when the first row spans multiple lines (PSV continuation line, or CSV/TSV unclosed quote on the first line).
- **CSV AsciiDoc-cell stripping** — a CSV/TSV field's content span points at the inner unquoted value, so an AsciiDoc cell parses the stripped content.
- **CSV unclosed-quote warning** — a lone-`"` cell is emptied and logs `WarningType::TableCsvDataHasUnclosedQuote`.

## Parser features implemented on this branch

Beyond the #541 fixes, this branch implements table behaviors the port required (each cross-checked against `asciidoctor`):

- **Nested-document attribute inheritance for AsciiDoc cells** (Ruby 1383–1641) — an `a` cell behaves as a nested document: `doctype` resets to `article` with its derived `backend-html5-doctype-*` attribute refreshed, `showtitle`/`notitle` resolve the cell's title visibility, and API-locked attributes are honored. Adds `Parser::resolve_show_title` / `force_doctype` / `refresh_doctype_derived_attr` and `Document::show_doctitle`/`doctitle`.
- **AsciiDoc cell `include::` expansion** (Ruby 1717) — a cell whose first line is an `include::` owns its preprocessed source via an `Arc<self_cell>` (`AsciiDocCell::Owned`), keeping `TableCellContent` `Clone`/`Eq`/`Debug` with no API change; non-include cells still parse in place from the parent source (preserving spans/line numbers).
- **Per-cell source-map line numbers** (Ruby 1694) — `TableCell` carries a `source` span / `HasSpan`, so warnings inside cells report correct lines.
- **Doctitle isolation** (Ruby 2105) — a cell does not inherit the parent's doctitle, so its content is never promoted to a `#preamble`.
- **TSV trailing empty cell via include** (Ruby 2387) — a tab-terminated TSV record's empty trailing field survives when loaded from an include file.
- **Behavioral divergences** — drop incomplete trailing row + warning (1265), per-column cell style applied to repeated/duplicated content (1282), `{blank}`-adjacent paragraph splitting (1331), and `colpcwidth`/`autowidth-option` column model attributes (320/347).

## Test-infrastructure changes (all under `parser/src/tests/`)

To let the HTML-shaped Ruby assertions port faithfully, the test-only virtual DOM and query engines were extended:

- **`virtual_dom.rs`** — table rendering emits `<tfoot>`, per-cell `halign-*`/`valign-*` classes, `colspan`/`rowspan`, cell style wrappers (`<strong>`/`<em>`/`<code>`), literal/AsciiDoc cell wrappers, computed `<col>`/`<table>` percentage widths (Asciidoctor's truncate-to-4-and-donate algorithm), `frame-*`/`grid-*`/`stripes-*`/float classes, blank-line paragraph splitting in cells, and an empty-table guard. Document/cell titles render as `<h1>` gated on the effective `showtitle`; `inline` doctype renders bare inline content. Also decodes numeric HTML entities and emits the implicit ordered-list `start` attribute.
- **`css.rs`** — adds `[attr="v"]` / `[attr*="v"]` selectors, `:nth-child(N)`, `:empty`, and pseudo-class chaining (`td:nth-child(3):empty`); fixes a `>`-chain-then-descendant combinator bug (`a > b > c d`) and de-duplicates descendant matches reachable through multiple ancestors.
- **`xpath.rs`** — adds `[@attr]` attribute-existence and `[@attr="v"]` arbitrary-attribute predicate support.

A handful of crate unit tests (`blocks/tests/table.rs`, two `lists_test` assertions) that had encoded the old behavior were corrected, each re-verified against `asciidoctor`.

## Remaining `#[ignore]`d tests (16)

Each is blocked on an out-of-scope feature and carries a `TODO` linking its tracking issue:

- **Admonition rendering in cells** — 2 tests ([#456](https://github.com/asciidoc-rs/asciidoc-parser/issues/456))
- **Anchor cataloging / xref resolution from cells** — 5 tests ([#543](https://github.com/asciidoc-rs/asciidoc-parser/issues/543))
- **Table of contents rendering** — 4 tests ([#546](https://github.com/asciidoc-rs/asciidoc-parser/issues/546))
- **Nested-document option introspection (`to_dir`)** — 1 test ([#545](https://github.com/asciidoc-rs/asciidoc-parser/issues/545))
- **Footnote isolation between cell and main document** — 1 test ([#544](https://github.com/asciidoc-rs/asciidoc-parser/issues/544))
- **Nested-cell warning cursor (source-map threading)** — 1 test ([#542](https://github.com/asciidoc-rs/asciidoc-parser/issues/542))
- **Cell background color via `{set:cellbgcolor:…}`** — 1 test ([#547](https://github.com/asciidoc-rs/asciidoc-parser/issues/547)); a test-only emulation was implemented then reverted, since `{set:…}`'s status in the AsciiDoc language is uncertain.
- **Colspan-overrun row grouping** — 1 test ([#548](https://github.com/asciidoc-rs/asciidoc-parser/issues/548))

## Verification

- `cargo test -p asciidoc-parser --lib tests::asciidoctor_rb::tables_test` — 97 passed, 16 ignored
- `cargo test -p asciidoc-parser --lib` — 2185 passed, 0 failed
- `cargo llvm-cov` — 100% patch coverage (defensive `Arc::get_mut`-None and non-`Value` doctype branches covered by unit tests)
- `cargo +nightly fmt --check` and `cargo +nightly doc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

