### PR TITLE
fix: Table parser divergences (PSV split, colspec, cell trim, implicit header, CSV)

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1832,12 +1832,18 @@ pub enum TableCellContent<'src> {
     AsciiDoc(Vec<Block<'src>>),
 }
 
-/// Parse the value of the `cols` attribute into a list of columns.
+/// Parse the value of the `cols` attribute into a list of columns, mirroring
+/// Asciidoctor's `parse_colspecs`.
 ///
-/// The value is a comma-separated list of column specifiers. A specifier may be
-/// preceded by a multiplier (`<n>*`) that repeats the column `n` times. The
-/// alignment operators and proportional width of a specifier are interpreted;
-/// the style operator is not yet.
+/// All spaces are first removed from the value. A wholly blank value yields no
+/// columns (the caller then takes the column count from the first row), and a
+/// lone integer (the deprecated `cols="3"` form) yields that many default
+/// columns. Otherwise the value is a list of column specifiers separated by
+/// commas, or by semicolons when no comma is present. An empty record (e.g. the
+/// trailing field of `cols="1,,1"`) contributes a default column, and a
+/// specifier may be preceded by a multiplier (`<n>*`) that repeats the column
+/// `n` times. Each specifier's alignment operators, proportional width, and
+/// [style operator](parse_col_spec) are interpreted.
 fn parse_cols(value: &str) -> Vec<TableColumn> {
     // Asciidoctor strips every space from the cols value before parsing, so
     // `cols=" 1, 1 "` is equivalent to `cols="1,1"`.
@@ -2064,20 +2070,23 @@ fn expand_duplicates(cells: Vec<RawCell<'_>>) -> Vec<RawCell<'_>> {
 /// Scan a region for PSV cell boundaries, returning the [specifier](CellSpec)
 /// and raw (untrimmed) content span of each cell.
 ///
-/// A cell boundary is the table's `separator` (the vertical bar (`|`) by
-/// default, the exclamation mark (`!`) for a nested table, or any string set
-/// with the `separator` attribute, e.g. the broken bar `¦`) that appears at the
-/// start of a line or is preceded by whitespace, optionally with a
-/// [cell specifier](CellSpec) (e.g. `^`, `2+`, `.>`) directly in front of the
-/// separator. The token immediately preceding a separator is taken to be a
-/// specifier when it parses as one (see [`parse_cell_spec`]); a token that
-/// doesn't parse as a specifier means the separator is not a cell boundary.
-/// Content before the first boundary is ignored.
+/// Every unescaped occurrence of the table's `separator` (the vertical bar
+/// (`|`) by default, the exclamation mark (`!`) for a nested table, or any
+/// string set with the `separator` attribute, e.g. the broken bar `¦`) is a
+/// cell boundary, matching Asciidoctor. The token immediately preceding a
+/// separator is treated as that cell's [specifier](CellSpec) (e.g. `^`, `2+`,
+/// `.>`) only when it parses as one (see [`parse_cell_spec`]) *and* is anchored
+/// at the line start or preceded by whitespace; otherwise the token is ordinary
+/// content of the preceding cell and the separator is a plain boundary (so the
+/// `a` in `|a|b` is content, not a style operator). Content before the first
+/// boundary is ignored.
 ///
-/// An escaped separator (e.g. `\|`) is preceded by a backslash, which is not a
-/// valid specifier, so the separator already fails the boundary test and needs
-/// no special handling here; the backslash is stripped later in
-/// [`TableCell::parse`].
+/// A separator immediately preceded by a backslash (e.g. `\|`) is escaped: it
+/// is literal content rather than a boundary, and the backslash is stripped
+/// later in [`TableCell::parse`]. Only the single byte before the separator is
+/// inspected, so `\\|` is also read as an escaped separator — matching
+/// Asciidoctor, whose check is likewise the single-character
+/// `pre_match.end_with? '\'`.
 fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
     let data = region.data();
     let bytes = data.as_bytes();

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1191,7 +1191,7 @@ fn build_data_table<'src>(
     let (fields, first_row_len) = if data_format == DataFormat::Dsv {
         parse_dsv_fields(inside, separator)
     } else {
-        parse_csv_fields(inside, separator)
+        parse_csv_fields(inside, separator, warnings)
     };
 
     let ncols = if cols_attr.is_empty() {
@@ -1253,7 +1253,11 @@ struct DataField<'src> {
 /// value. As a result a value whose opening quote is never properly closed (or
 /// that has trailing characters after its closing quote) keeps its quotes and
 /// absorbs the following separators, rather than being treated as enclosed.
-fn parse_csv_fields<'src>(region: Span<'src>, separator: &str) -> (Vec<DataField<'src>>, usize) {
+fn parse_csv_fields<'src>(
+    region: Span<'src>,
+    separator: &str,
+    warnings: &mut Vec<Warning<'src>>,
+) -> (Vec<DataField<'src>>, usize) {
     let data = region.data();
     let n = data.len();
     let sep_len = separator.len().max(1);
@@ -1294,7 +1298,7 @@ fn parse_csv_fields<'src>(region: Span<'src>, separator: &str) -> (Vec<DataField
         // blank cell that follows a separator on a populated line is kept.
         let blank_skip = (at_nl || at_eof) && fields_in_row == 0 && raw.trim().is_empty();
         if !blank_skip {
-            fields.push(make_csv_field(region, cell_start, i));
+            fields.push(make_csv_field(region, cell_start, i, warnings));
             fields_in_row += 1;
             if !first_row_done {
                 first_row_len = fields_in_row;
@@ -1327,37 +1331,42 @@ fn parse_csv_fields<'src>(region: Span<'src>, separator: &str) -> (Vec<DataField
 /// applying Asciidoctor's `close_cell` value processing.
 ///
 /// The value is stripped of surrounding whitespace; then, if it is enclosed in
-/// double quotes, the quotes are removed and the inner value is stripped again;
-/// finally any run of consecutive double quotes is collapsed to one (so an
-/// escaped `""` becomes a single `"`). A value that is not enclosed (no leading
-/// quote, an unclosed quote, or trailing characters after the closing quote)
-/// keeps its quotes and is only collapsed.
-fn make_csv_field<'src>(region: Span<'src>, start: usize, end: usize) -> DataField<'src> {
+/// double quotes, the quotes are removed and the inner value is stripped again,
+/// so the field's [content](DataField::content) span points at the actual value
+/// (this matters for an AsciiDoc cell, which parses that span). Finally any run
+/// of consecutive double quotes is collapsed to one (so an escaped `""` becomes
+/// a single `"`). A value that is not enclosed (no leading quote, or trailing
+/// characters after the closing quote) keeps its quotes and is only collapsed.
+///
+/// A lone double quote is an unclosed quoted value: it logs an error and the
+/// cell is set to empty (matching Asciidoctor).
+fn make_csv_field<'src>(
+    region: Span<'src>,
+    start: usize,
+    end: usize,
+    warnings: &mut Vec<Warning<'src>>,
+) -> DataField<'src> {
     let trimmed = trim_surrounding_whitespace(region.slice(start..end));
-    let value = csv_cell_value(trimmed.data());
-    let replacement = (value != trimmed.data()).then_some(value);
-    DataField {
-        content: trimmed,
-        replacement,
-    }
-}
+    let data = trimmed.data();
 
-/// Apply Asciidoctor's CSV value processing to an already-stripped cell value:
-/// unquote an enclosed value and collapse escaped double quotes (`""` -> `"`).
-fn csv_cell_value(text: &str) -> String {
-    if text.is_empty() || !text.contains('"') {
-        return text.to_string();
-    }
-
-    // An enclosed value (leading and trailing quote) has its quotes removed and
-    // is stripped again; a lone `"` becomes empty. Anything else keeps its text.
-    if text.starts_with('"') && text.ends_with('"') {
-        match text.get(1..text.len() - 1) {
-            Some(inner) => squeeze_quotes(inner.trim()),
-            None => String::new(),
-        }
+    let content = if data == "\"" {
+        warnings.push(Warning {
+            source: trimmed,
+            warning: WarningType::TableCsvDataHasUnclosedQuote,
+        });
+        trimmed.slice(0..0)
+    } else if data.len() >= 2 && data.starts_with('"') && data.ends_with('"') {
+        trim_surrounding_whitespace(trimmed.slice(1..data.len() - 1))
     } else {
-        squeeze_quotes(text)
+        trimmed
+    };
+
+    let value = squeeze_quotes(content.data());
+    let replacement = (value != content.data()).then_some(value);
+
+    DataField {
+        content,
+        replacement,
     }
 }
 

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -217,7 +217,22 @@ impl<'src> TableBlock<'src> {
         let line1_blank = line1.item.data().trim().is_empty();
         let line2_blank =
             !line1.after.is_empty() && line1.after.take_line().item.data().trim().is_empty();
-        let has_header = opts_header || (!opts_noheader && !line1_blank && line2_blank);
+
+        // An implicit header additionally requires that the first row be complete
+        // on the first line. If the first cell spans multiple lines — for PSV,
+        // the first non-blank line after the blank gap continues the cell instead
+        // of starting a new one; for CSV/TSV, the first line opens a quoted value
+        // that is not closed on that line — there is no implicit header (matching
+        // Asciidoctor, which cancels the implicit header in these cases).
+        let first_row_complete = match data_format {
+            DataFormat::Psv => first_nonblank_line(line1.after)
+                .is_none_or(|line| psv_line_starts_cell(line.data(), separator.as_str())),
+            DataFormat::Csv | DataFormat::Tsv => !line_has_unclosed_quote(line1.item.data()),
+            DataFormat::Dsv => true,
+        };
+
+        let has_header =
+            opts_header || (!opts_noheader && !line1_blank && line2_blank && first_row_complete);
 
         // A titled table is given a caption (e.g. "Table 1. ") that a processor
         // prepends to the title.
@@ -2352,4 +2367,37 @@ fn trim_cell_content(s: Span<'_>, style: ColumnStyle) -> Span<'_> {
         }
         _ => trim_surrounding_whitespace(s),
     }
+}
+
+/// Returns the first non-blank line in `rest`, or `None` when every remaining
+/// line is blank (or `rest` is empty).
+fn first_nonblank_line(mut rest: Span<'_>) -> Option<Span<'_>> {
+    while !rest.is_empty() {
+        let line = rest.take_line();
+        if !line.item.data().trim().is_empty() {
+            return Some(line.item);
+        }
+        rest = line.after;
+    }
+    None
+}
+
+/// Returns `true` when `line` begins a new PSV cell, i.e. it contains the
+/// separator and the text before the first separator (after any leading
+/// whitespace) is either empty or a valid cell specifier. A line that continues
+/// the previous cell returns `false`.
+fn psv_line_starts_cell(line: &str, separator: &str) -> bool {
+    match line.find(separator) {
+        Some(pos) => {
+            let prefix = line[..pos].trim_start();
+            prefix.is_empty() || parse_cell_spec(prefix).is_some()
+        }
+        None => false,
+    }
+}
+
+/// Returns `true` when `line` contains an odd number of double quotes, i.e. it
+/// opens a quoted CSV/TSV value that is not closed on the same line.
+fn line_has_unclosed_quote(line: &str) -> bool {
+    line.bytes().filter(|&b| b == b'"').count() % 2 == 1
 }

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -2073,12 +2073,18 @@ fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
             .get(i..)
             .is_some_and(|rest| rest.starts_with(separator))
         {
+            // A separator immediately preceded by a backslash is escaped: it is
+            // literal content, not a cell boundary. The backslash is stripped
+            // from the rendered cell later (see `TableCell::parse`).
+            if i > 0 && bytes.get(i - 1).copied() == Some(b'\\') {
+                i += sep_len;
+                continue;
+            }
+
             // Walk back to the start of the token directly preceding this
             // separator. The token (a possible cell specifier) runs back to the
             // previous whitespace, tab, or newline, or to the start of the
-            // region; either way the token is anchored at a line start or after
-            // whitespace, as a cell boundary requires. (When `tok_start == i`
-            // the token is empty and the separator is plain.)
+            // region.
             let mut tok_start = i;
             while tok_start > 0
                 && !matches!(
@@ -2096,21 +2102,30 @@ fn scan_cells<'src>(region: Span<'src>, separator: &str) -> Vec<RawCell<'src>> {
                 parse_cell_spec(token)
             };
 
-            if let Some(spec) = spec {
-                if let Some(start) = content_start {
-                    // The previous cell's content ends at the start of this
-                    // cell's specifier; the separating whitespace, included in
-                    // the slice, is trimmed later in `TableCell::parse`.
-                    cells.push(RawCell {
-                        spec: cur_spec,
-                        content: region.slice(start..tok_start),
-                    });
-                }
-                cur_spec = spec;
-                content_start = Some(i + sep_len);
-                i += sep_len;
-                continue;
+            // Every unescaped separator is a cell boundary (matching
+            // Asciidoctor). When the token is empty or a valid specifier it
+            // belongs to the *next* cell, so the previous cell's content ends
+            // before the token. Otherwise the token is ordinary content of the
+            // previous cell (e.g. the `a` in `|a|b`, where `a` is not preceded
+            // by whitespace and so is not a specifier), the separator is plain,
+            // and the next cell takes the default specifier.
+            let (content_end, next_spec) = match spec {
+                Some(spec) => (tok_start, spec),
+                None => (i, CellSpec::default()),
+            };
+
+            if let Some(start) = content_start {
+                // The separating whitespace, included in the slice, is trimmed
+                // later in `TableCell::parse`.
+                cells.push(RawCell {
+                    spec: cur_spec,
+                    content: region.slice(start..content_end),
+                });
             }
+            cur_spec = next_spec;
+            content_start = Some(i + sep_len);
+            i += sep_len;
+            continue;
         }
 
         i += 1;

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1815,16 +1815,37 @@ pub enum TableCellContent<'src> {
 /// alignment operators and proportional width of a specifier are interpreted;
 /// the style operator is not yet.
 fn parse_cols(value: &str) -> Vec<TableColumn> {
+    // Asciidoctor strips every space from the cols value before parsing, so
+    // `cols=" 1, 1 "` is equivalent to `cols="1,1"`.
+    let records: String = value.chars().filter(|c| !c.is_whitespace()).collect();
+
+    // A wholly blank cols value is ignored: the caller falls back to the column
+    // count of the first row.
+    if records.is_empty() {
+        return vec![];
+    }
+
+    // Deprecated single-integer form: `cols=3` is equivalent to `cols="3*"` and
+    // produces that many equally sized columns.
+    if let Ok(count) = records.parse::<usize>() {
+        return vec![TableColumn::default(); count];
+    }
+
+    // Split on commas when present, otherwise on semicolons (Asciidoctor accepts
+    // either as the column-spec separator, but not a mix). Empty records are
+    // kept: each one contributes a default column.
+    let parts: Vec<&str> = if records.contains(',') {
+        records.split(',').collect()
+    } else {
+        records.split(';').collect()
+    };
+
     let mut columns: Vec<TableColumn> = vec![];
-
-    for part in value.split(',') {
-        let part = part.trim();
+    for part in parts {
         if part.is_empty() {
-            continue;
-        }
-
-        if let Some((count, spec)) = part.split_once('*') {
-            let repeat = count.trim().parse::<usize>().unwrap_or(1).max(1);
+            columns.push(TableColumn::default());
+        } else if let Some((count, spec)) = part.split_once('*') {
+            let repeat = count.parse::<usize>().unwrap_or(1).max(1);
             let column = parse_col_spec(spec);
             for _ in 0..repeat {
                 columns.push(column.clone());

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1651,7 +1651,7 @@ impl<'src> TableCell<'src> {
             raw.spec.style.unwrap_or(column.style)
         };
 
-        let trimmed = trim_surrounding_whitespace(raw.content);
+        let trimmed = trim_cell_content(raw.content, style);
 
         // An escaped cell separator (a backslash in front of the table's
         // separator, e.g. `\|` or `\!`) is unescaped to the bare separator. Only
@@ -2296,4 +2296,45 @@ fn trim_surrounding_whitespace(s: Span<'_>) -> Span<'_> {
     let start = data.len() - data.trim_start().len();
     let len = data.trim().len();
     s.slice(start..start + len)
+}
+
+/// Trim a PSV cell's content according to its [style](ColumnStyle), matching
+/// Asciidoctor's `Table::Cell` initializer:
+///
+/// * A [`Literal`](ColumnStyle::Literal) cell has its trailing whitespace
+///   removed and any leading blank lines stripped, but the leading indentation
+///   of its first content line is preserved (so an indented literal cell keeps
+///   its indentation).
+/// * An [`AsciiDoc`](ColumnStyle::AsciiDoc) cell likewise removes trailing
+///   whitespace; if the remaining content begins with a newline it strips the
+///   leading blank lines (preserving the first content line's indentation, so a
+///   leading-indented line is interpreted as a literal block), otherwise it
+///   strips the leading whitespace.
+/// * Every other style has all surrounding whitespace removed.
+fn trim_cell_content(s: Span<'_>, style: ColumnStyle) -> Span<'_> {
+    let data = s.data();
+    match style {
+        ColumnStyle::Literal => {
+            let end = data.trim_end().len();
+            let mut start = 0;
+            while data[start..end].starts_with('\n') {
+                start += 1;
+            }
+            s.slice(start..end)
+        }
+        ColumnStyle::AsciiDoc => {
+            let end = data.trim_end().len();
+            if data[..end].starts_with('\n') {
+                let mut start = 0;
+                while data[start..end].starts_with('\n') {
+                    start += 1;
+                }
+                s.slice(start..end)
+            } else {
+                let start = end - data[..end].trim_start().len();
+                s.slice(start..end)
+            }
+        }
+        _ => trim_surrounding_whitespace(s),
+    }
 }

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -1010,9 +1010,24 @@ fn csv_unclosed_quote_is_literal() {
     let table = parse_table("[format=csv]\n|===\n\",a\n|===");
     assert_eq!(table.columns().len(), 1);
     assert_eq!(row_text(&table.body_rows()[0]), ["\",a"]);
+}
 
-    // A cell that is a single bare quote is an unclosed, empty quoted value.
-    let table = parse_table("[format=csv]\n|===\n\"\n|===");
+#[test]
+fn csv_lone_quote_is_unclosed_and_empty_with_warning() {
+    // A cell that is a single bare quote is an unclosed, empty quoted value: it is
+    // set to empty and an error is logged (matching Asciidoctor).
+    let mut parser = Parser::default();
+    let maw = Block::parse(Span::new("[format=csv]\n|===\n\"\n|==="), &mut parser);
+
+    assert!(maw.warnings.iter().any(|w| matches!(
+        w.warning,
+        crate::warnings::WarningType::TableCsvDataHasUnclosedQuote
+    )));
+
+    let table = match maw.item.unwrap().item {
+        Block::Table(table) => table,
+        other => panic!("expected a table block, got {other:?}"),
+    };
     assert_eq!(table.columns().len(), 1);
     assert_eq!(row_text(&table.body_rows()[0]), [""]);
 }

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -282,6 +282,20 @@ fn escaped_cell_separator() {
 }
 
 #[test]
+fn separator_after_backslash_is_escaped() {
+    // The escape check inspects only the single byte before the separator, so a
+    // separator preceded by a backslash is escaped even when that backslash is
+    // itself preceded by another one. `|a\\|b` is therefore one cell whose
+    // content is `a\|b` (the escaping backslash is stripped), matching
+    // Asciidoctor, whose check is likewise the single-character
+    // `pre_match.end_with? '\'`.
+    let table = parse_table("|===\n|a\\\\|b\n|===");
+
+    assert_eq!(table.body_rows().len(), 1);
+    assert_eq!(row_text(&table.body_rows()[0]), vec!["a\\|b".to_string()]);
+}
+
+#[test]
 fn cols_with_empty_specifier() {
     // An empty entry in the `cols` list (e.g. from a doubled comma) contributes a
     // default column, matching Asciidoctor: `cols="1,,1"` yields three columns.

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -283,10 +283,11 @@ fn escaped_cell_separator() {
 
 #[test]
 fn cols_with_empty_specifier() {
-    // Empty entries in the `cols` list (e.g. from a doubled comma) are skipped.
-    let table = parse_table("[cols=\"1,,1\"]\n|===\n|a |b\n|===");
+    // An empty entry in the `cols` list (e.g. from a doubled comma) contributes a
+    // default column, matching Asciidoctor: `cols="1,,1"` yields three columns.
+    let table = parse_table("[cols=\"1,,1\"]\n|===\n|a |b |c\n|===");
 
-    assert_eq!(table.columns().len(), 2);
+    assert_eq!(table.columns().len(), 3);
 }
 
 #[test]

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -739,29 +739,27 @@ fn cell_specifier_span_operator_without_factor_locates_separator() {
 }
 
 #[test]
-fn non_specifier_token_is_not_a_cell_separator() {
+fn non_specifier_token_is_a_plain_cell_separator() {
     // A token in front of a `|` that does not parse as a cell specifier (here the
-    // word `foo`, which is more than a single style letter) means the `|` is not
-    // a cell separator: `a foo|b` is a single cell whose content includes the
-    // literal `|`.
+    // word `foo`, which is more than a single style letter) is ordinary content:
+    // the `|` is still a plain cell separator, so `a foo|b` is two cells (matching
+    // Asciidoctor).
     let table = parse_table("|===\n|a foo|b\n|===");
 
-    assert_eq!(table.columns().len(), 1);
     let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
-    assert_eq!(rows, vec![vec!["a foo|b".to_string()]]);
+    assert_eq!(rows, vec![vec!["a foo".to_string(), "b".to_string()]]);
 }
 
 #[test]
-fn dot_not_followed_by_vertical_operator_is_not_a_cell_separator() {
+fn dot_not_followed_by_vertical_operator_is_a_plain_cell_separator() {
     // A vertical alignment operator is a dot followed by `<`, `>`, or `^`. A dot
     // followed by anything else (here `.x`) is not a valid cell specifier, so the
-    // `|` is not a cell separator: `a .x|b` is a single cell whose content
-    // includes the literal `.x|`.
+    // `.x` is content and the `|` is a plain cell separator: `a .x|b` is two cells
+    // (matching Asciidoctor).
     let table = parse_table("|===\n|a .x|b\n|===");
 
-    assert_eq!(table.columns().len(), 1);
     let rows: Vec<_> = table.body_rows().iter().map(row_text).collect();
-    assert_eq!(rows, vec![vec!["a .x|b".to_string()]]);
+    assert_eq!(rows, vec![vec!["a .x".to_string(), "b".to_string()]]);
 }
 
 #[test]

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -228,11 +228,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate strips the leading indentation from the first
-    // content line of a literal (`l`) cell, producing "one\n  two\nthree"
-    // instead of Asciidoctor's "  one\n  two\nthree". A literal cell should
-    // preserve leading spaces on every line. Enable once fixed.
     fn should_preserve_leading_spaces_but_not_leading_newlines_or_trailing_spaces_in_literal_table_cells()
      {
         let doc =
@@ -541,10 +536,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate does not treat a leading-indented line in an
-    // AsciiDoc (`a`) cell as a literal block, so no `<pre>` is produced. Enable
-    // once leading indent is interpreted inside AsciiDoc cells.
     fn should_interpret_leading_indent_if_first_cell_is_asciidoc_and_there_is_no_implicit_header_row()
      {
         let doc = Parser::default().parse("[cols=\"1a,1\"]\n|===\n|\n  literal\n| normal\n|===");
@@ -1157,10 +1148,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): A leading-indented line inside an AsciiDoc cell is not
-    // rendered as a literal block (`<pre>`). Related to the `1a`-column leading
-    // indent gap. Enable once interpreted.
     fn should_preserve_leading_indentation_in_contents_of_asciidoc_table_cell_if_contents_starts_with_newline()
      {
         let doc = Parser::default().parse("|===\na|\n $ command\na| paragraph\n|===");

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -339,10 +339,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate does not support the deprecated bare-integer
-    // colspec (`cols="3"` meaning three columns); it parses a single column of
-    // width 3. Enable once the deprecated syntax is supported.
     fn table_with_explicit_deprecated_colspec_syntax_can_have_multiple_rows_on_a_single_line() {
         let doc = Parser::default().parse("[cols=\"3\"]\n|===\n|one |two\n|1 |2 |a |b\n|===");
 
@@ -352,10 +348,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate does not add a column for an empty trailing
-    // record in the colspec (`cols="<,"` should yield two columns); it parses a
-    // single column. Enable once empty colspec records are honored.
     fn columns_are_added_for_empty_records_in_colspec_attribute() {
         let doc = Parser::default().parse("[cols=\"<,\"]\n|===\n|one |two\n|1 |2 |a |b\n|===");
 
@@ -365,10 +357,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate does not accept a semicolon as the colspec
-    // separator (`cols="1s;3m"` should yield two columns); it parses a single
-    // column. Enable once `;`-separated colspecs are supported.
     fn cols_may_be_separated_by_semi_colon_instead_of_comma() {
         let doc = Parser::default().parse("[cols=\"1s;3m\"]\n|===\n| strong\n| mono\n|===");
 

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1391,12 +1391,19 @@ mod csv {
     fn should_log_error_but_not_crash_if_cell_data_has_unclosed_quote() {
         let doc = Parser::default().parse(",===\na,b\nc,\"\n,===");
 
-        // The unclosed quote recovers to an empty cell without crashing.
-        // NOTE: Asciidoctor also logs an ERROR ("unclosed quote in CSV data");
-        // the crate recovers silently, so that warning assertion is not ported.
+        // The unclosed quote recovers to an empty cell without crashing, and an
+        // error is logged for line 3 (the `c,"` line).
         assert_css(&doc, "table", 1);
         assert_css(&doc, "table td", 4);
         assert_xpath(&doc, "(//td)[4]/p", 0);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::TableCsvDataHasUnclosedQuote
+        );
+        assert_eq!(warnings[0].source.line(), 3);
     }
 
     #[test]
@@ -1535,12 +1542,6 @@ mod csv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): For a multi-line, whitespace-padded quoted CSV value
-    // feeding an AsciiDoc (`a`) column, the crate does not strip the surrounding
-    // quotes or whitespace — the cell renders `"\n  one sentence, one line\n  "`
-    // verbatim instead of the trimmed `one sentence, one line`. Enable once the
-    // CSV quote/whitespace stripping handles this case.
     fn should_strip_whitespace_around_contents_of_asciidoc_cell() {
         let doc = Parser::default().parse(
             "[cols=\"1,1,1a\",separator=;]\n,===\nelement;description;example\n\nparagraph;contiguous lines of words and phrases;\"\n  one sentence, one line\n  \"\n,===",

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -493,12 +493,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate mis-parses this table — it creates an implicit
-    // header row even though the first cell spans multiple lines, and (blocked
-    // by the PSV cell-splitting divergence, see `ignores_escaped_separators`)
-    // drops cells from the multi-line `A1 continued|B1` row. Enable once both
-    // are fixed.
     fn no_implicit_header_row_if_cell_in_first_line_spans_multiple_lines() {
         let doc =
             Parser::default().parse("[cols=2*]\n|===\n|A1\n\n\nA1 continued|B1\n\n|A2\n|B2\n|===");
@@ -548,11 +542,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate creates an implicit header row even though the
-    // first cell (an AsciiDoc cell) spans multiple lines; Asciidoctor suppresses
-    // the implicit header in that case. Enable once implicit-header detection
-    // accounts for multi-line first cells.
     fn no_implicit_header_row_if_asciidoc_cell_in_first_line_spans_multiple_lines() {
         let doc = Parser::default().parse(
             "[cols=2*]\n|===\na|contains AsciiDoc content\n\n* a\n* b\n* c\na|contains no AsciiDoc content\n\njust text\n|A2\n|B2\n|===",
@@ -1319,11 +1308,6 @@ mod psv {
     // docbook 5", "table with unbreakable option docbook 5").
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): Blocked by the multi-line-first-cell implicit-header
-    // divergence — the quoted first cell spans multiple lines, so Asciidoctor
-    // suppresses the implicit header, but the crate creates one (see
-    // `no_implicit_header_row_if_cell_in_first_line_spans_multiple_lines`).
     fn no_implicit_header_row_if_cell_in_first_line_is_quoted_and_spans_multiple_lines() {
         let doc =
             Parser::default().parse("[cols=2*l]\n,===\n\"A1\n\nA1 continued\",B1\nA2,B2\n,===");

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -155,12 +155,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): The crate diverges from Asciidoctor on PSV cell
-    // splitting: it treats a `|` as a cell separator only when preceded by a
-    // delimiter boundary (e.g. a space), so `|a|b` parses as a single cell
-    // whereas Asciidoctor (and this test) splits it into two. Enable once the
-    // parser splits on any unescaped `|`.
     fn ignores_escaped_separators() {
         let doc = Parser::default().parse("|===\n|A \\| here| a \\| there\n|===");
 
@@ -599,11 +593,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): Blocked by the PSV cell-splitting divergence (see
-    // `ignores_escaped_separators`): `|Occupation| Website` is not split into
-    // two cells, so the header/footer rows are mis-parsed. Enable once the
-    // parser splits on any unescaped `|`.
     fn styles_not_applied_to_header_cells() {
         let doc = Parser::default().parse(
             "[cols=\"1h,1s,1e\",options=\"header,footer\"]\n|===\n|Name |Occupation| Website\n|Octocat |Social coding| https://github.com\n|Name |Occupation| Website\n|===",
@@ -660,11 +649,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): Blocked by the PSV cell-splitting divergence (see
-    // `ignores_escaped_separators`): `|Occupation| Website` is not split into
-    // two cells, so the rows are mis-parsed. Enable once the parser splits on
-    // any unescaped `|`.
     fn vertical_table_headers_use_th_element_instead_of_header_class() {
         let doc = Parser::default().parse(
             "[cols=\"1h,1s,1e\"]\n|===\n\n|Name |Occupation| Website\n\n|Octocat |Social coding| https://github.com\n\n|Name |Occupation| Website\n\n|===",
@@ -1314,11 +1298,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (issue TBD): Blocked by the deprecated bare-integer colspec
-    // divergence — `cols=2` should yield two columns but the crate parses one
-    // (see `table_with_explicit_deprecated_colspec_syntax_can_have_multiple_rows_on_a_single_line`).
-    // Enable once `cols=2` is supported.
     fn custom_separator_for_an_asciidoc_table_cell() {
         let doc = Parser::default().parse(
             "[cols=2,separator=!]\n|===\n!Pipe output to vim\na!\n----\nasciidoctor -o - -s test.adoc | view -\n----\n|===",

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -82,6 +82,9 @@ pub enum WarningType {
 
     #[error("Dropping table cell because it exceeds the specified number of columns")]
     TableCellExceedsColumnCount,
+
+    #[error("Unclosed quote in CSV data; setting cell to empty")]
+    TableCsvDataHasUnclosedQuote,
 }
 
 impl std::fmt::Debug for WarningType {
@@ -158,6 +161,10 @@ impl std::fmt::Debug for WarningType {
 
             WarningType::TableCellExceedsColumnCount => {
                 write!(f, "WarningType::TableCellExceedsColumnCount")
+            }
+
+            WarningType::TableCsvDataHasUnclosedQuote => {
+                write!(f, "WarningType::TableCsvDataHasUnclosedQuote")
             }
         }
     }
@@ -416,6 +423,13 @@ mod tests {
                 let warning = WarningType::TableCellExceedsColumnCount;
                 let debug_output = format!("{:?}", warning);
                 assert_eq!(debug_output, "WarningType::TableCellExceedsColumnCount");
+            }
+
+            #[test]
+            fn table_csv_data_has_unclosed_quote() {
+                let warning = WarningType::TableCsvDataHasUnclosedQuote;
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(debug_output, "WarningType::TableCsvDataHasUnclosedQuote");
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes the table-parser divergences from Asciidoctor that the table-test port ([#540](https://github.com/asciidoc-rs/asciidoc-parser/pull/540)) surfaced. Each fix is verified against the locally installed `asciidoctor` and un-ignores the corresponding ported tests.

**Stacked on `port-tables-tests`** (PR #540) because these fixes un-ignore tests that live on that branch. Retarget to `tables` once #540 merges.

## Fixes (one commit each)

1. **PSV cell splitting** — an unescaped `|` is now always a cell boundary. The token before it is a cell specifier only when it's a valid specifier anchored by whitespace or line start; otherwise it's content (so `|a|b` → two cells, `|a foo|b` → `a foo` + `b`). Adds explicit `\|` escape handling.
2. **Colspec forms** — `parse_cols` matches Asciidoctor's `parse_colspecs`: strips spaces, treats a lone integer (`cols=3`) as a column count, splits on `,` (else `;`), and keeps empty records (each empty record → a default column).
3. **Literal/AsciiDoc cell trimming** — literal cells keep the first content line's indentation; AsciiDoc cells strip leading blank lines when content starts with a newline (so a leading-indented line becomes a literal block), else lstrip.
4. **Implicit header** — suppressed when the first row isn't complete on the first line: for PSV when the line after the blank gap continues the cell, and for CSV/TSV when the first line opens an unclosed quoted value.
5. **CSV AsciiDoc-cell stripping** — a CSV/TSV field's content span now points at the inner unquoted value, so an AsciiDoc-styled cell parses the stripped content instead of the raw quoted text (quotes/whitespace are no longer retained).
6. **CSV unclosed-quote warning** — a lone-`"` cell is an unclosed quoted value: it is emptied and now logs the new `TableCsvDataHasUnclosedQuote` warning, matching Asciidoctor.

## Tests

- Un-ignores 12 ported tests in `asciidoctor_rb/tables_test.rs` (escaped separators, 3 colspec, literal/asciidoc indent ×3, 2 style/header, custom separator, 3 implicit-header, CSV asciidoc-cell strip), and extends the CSV unclosed-quote test to assert the warning.
- Corrects/splits crate unit tests in `blocks/tests/table.rs` that had encoded the old divergent behavior (`cols="1,,1"` → 3 columns; `|a foo|b` / `|a .x|b` → two cells; lone-`"` cell warns), each re-verified against `asciidoctor`. Adds a Debug/round-trip test for the new warning type.
- `cargo test -p asciidoc-parser --lib` — 2156 passed, 0 failed. `fmt`/`clippy`/`doc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
