### PR TITLE
feat: Enable the subs-page "Tables" coverage tests blocked on #296

### DIFF
--- a/parser/src/tests/asciidoc_lang/subs/attributes.rs
+++ b/parser/src/tests/asciidoc_lang/subs/attributes.rs
@@ -306,20 +306,34 @@ mod default_attributes_substitution {
         assert_eq!(block1.content().rendered(), "Stuff nonsense");
     }
 
-    #[ignore]
     #[test]
     fn tables() {
-        to_do_verifies!(
+        verifies!(
             r#"
 |Tables |Varies
 
 "#
         );
 
-        todo!("Write test once table parsing is implemented");
+        // The attributes substitution applies to default table cells but not to
+        // literal (`l`) cells, hence "Varies".
+        let doc = Parser::default().parse(":val: subd\n\n|===\n|{val}\nl|{val}\n|===");
 
-        // Blocked on https://github.com/asciidoc-rs/asciidoc-parser/issues/296:
-        // Implement table parsing
+        let Some(Block::Table(table)) = doc.nested_blocks().next() else {
+            panic!("expected a table block");
+        };
+
+        let cells: Vec<_> = table.body_rows().iter().flat_map(|r| r.cells()).collect();
+
+        let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(default_cell.rendered(), "subd");
+
+        let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(literal_cell.rendered(), "{val}");
     }
 
     #[test]

--- a/parser/src/tests/asciidoc_lang/subs/macros.rs
+++ b/parser/src/tests/asciidoc_lang/subs/macros.rs
@@ -305,20 +305,38 @@ mod default_macros_substitution {
         );
     }
 
-    #[ignore]
     #[test]
     fn tables() {
-        to_do_verifies!(
+        verifies!(
             r#"
 |Tables |Varies
 
 "#
         );
 
-        todo!("Write test once table parsing is implemented");
+        // The macros substitution applies to default table cells but not to
+        // literal (`l`) cells, hence "Varies".
+        let doc = Parser::default()
+            .parse("|===\n|https://example.org[Example]\nl|https://example.org[Example]\n|===");
 
-        // Blocked on https://github.com/asciidoc-rs/asciidoc-parser/issues/296:
-        // Implement table parsing
+        let Some(Block::Table(table)) = doc.nested_blocks().next() else {
+            panic!("expected a table block");
+        };
+
+        let cells: Vec<_> = table.body_rows().iter().flat_map(|r| r.cells()).collect();
+
+        let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(
+            default_cell.rendered(),
+            r#"<a href="https://example.org">Example</a>"#
+        );
+
+        let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(literal_cell.rendered(), "https://example.org[Example]");
     }
 
     #[test]

--- a/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
+++ b/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
@@ -318,20 +318,34 @@ mod default_post_replacements_substitution {
         assert_eq!(block1.content().rendered(), "abc<br>\ndef");
     }
 
-    #[ignore]
     #[test]
     fn tables() {
-        to_do_verifies!(
+        verifies!(
             r#"
 |Tables |Varies
 
 "#
         );
 
-        todo!("Write test once table parsing is implemented");
+        // The post replacements substitution (the line-break `+`) applies to
+        // default table cells but not to literal (`l`) cells, hence "Varies".
+        let doc = Parser::default().parse("|===\n|abc +\ndef\nl|abc +\nghi\n|===");
 
-        // Blocked on https://github.com/asciidoc-rs/asciidoc-parser/issues/296:
-        // Implement table parsing
+        let Some(Block::Table(table)) = doc.nested_blocks().next() else {
+            panic!("expected a table block");
+        };
+
+        let cells: Vec<_> = table.body_rows().iter().flat_map(|r| r.cells()).collect();
+
+        let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(default_cell.rendered(), "abc<br>\ndef");
+
+        let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(literal_cell.rendered(), "abc +\nghi");
     }
 
     #[ignore]

--- a/parser/src/tests/asciidoc_lang/subs/quotes.rs
+++ b/parser/src/tests/asciidoc_lang/subs/quotes.rs
@@ -512,20 +512,34 @@ mod default_quotes_substitution {
         assert_eq!(block1.content().rendered(), "Stuff over <em>nonsense</em>");
     }
 
-    #[ignore]
     #[test]
     fn tables() {
-        to_do_verifies!(
+        verifies!(
             r#"
-|Tables |{y}
+|Tables |Varies
 
 "#
         );
 
-        todo!("Write test once table parsing is implemented");
+        // The quotes substitution applies to default table cells but not to
+        // literal (`l`) cells, hence "Varies".
+        let doc = Parser::default().parse("|===\n|*bold*\nl|*lit*\n|===");
 
-        // Blocked on https://github.com/asciidoc-rs/asciidoc-parser/issues/296:
-        // Implement table parsing
+        let Some(Block::Table(table)) = doc.nested_blocks().next() else {
+            panic!("expected a table block");
+        };
+
+        let cells: Vec<_> = table.body_rows().iter().flat_map(|r| r.cells()).collect();
+
+        let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(default_cell.rendered(), "<strong>bold</strong>");
+
+        let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(literal_cell.rendered(), "*lit*");
     }
 
     #[test]

--- a/parser/src/tests/asciidoc_lang/subs/replacements.rs
+++ b/parser/src/tests/asciidoc_lang/subs/replacements.rs
@@ -555,20 +555,34 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
         assert_eq!(block1.content().rendered(), "Stuff &#169; nonsense");
     }
 
-    #[ignore]
     #[test]
     fn tables() {
-        to_do_verifies!(
+        verifies!(
             r#"
 |Tables |Varies
 
 "#
         );
 
-        todo!("Write test once table parsing is implemented");
+        // The replacements substitution applies to default table cells but not to
+        // literal (`l`) cells, hence "Varies".
+        let doc = Parser::default().parse("|===\n|(C)\nl|(C)\n|===");
 
-        // Blocked on https://github.com/asciidoc-rs/asciidoc-parser/issues/296:
-        // Implement table parsing
+        let Some(Block::Table(table)) = doc.nested_blocks().next() else {
+            panic!("expected a table block");
+        };
+
+        let cells: Vec<_> = table.body_rows().iter().flat_map(|r| r.cells()).collect();
+
+        let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(default_cell.rendered(), "&#169;");
+
+        let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(literal_cell.rendered(), "(C)");
     }
 
     #[test]

--- a/parser/src/tests/asciidoc_lang/subs/special_characters.rs
+++ b/parser/src/tests/asciidoc_lang/subs/special_characters.rs
@@ -371,20 +371,35 @@ mod default_special_characters_substitution {
         assert_eq!(block1.content().rendered(), "Stuff &gt; nonsense");
     }
 
-    #[ignore]
     #[test]
     fn tables() {
-        to_do_verifies!(
+        verifies!(
             r#"
 |Tables |{y}
 
 "#
         );
 
-        todo!("Write test once table parsing is implemented");
+        // Special character substitution always applies to table cell content,
+        // including literal (`l`) cells, where most other substitution steps are
+        // skipped.
+        let doc = Parser::default().parse("|===\n|a > b\nl|c > d\n|===");
 
-        // Blocked on https://github.com/asciidoc-rs/asciidoc-parser/issues/296:
-        // Implement table parsing
+        let Some(Block::Table(table)) = doc.nested_blocks().next() else {
+            panic!("expected a table block");
+        };
+
+        let cells: Vec<_> = table.body_rows().iter().flat_map(|r| r.cells()).collect();
+
+        let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(default_cell.rendered(), "a &gt; b");
+
+        let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
+            panic!("expected simple cell content");
+        };
+        assert_eq!(literal_cell.rendered(), "c &gt; d");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Issue [#296](https://github.com/asciidoc-rs/asciidoc-parser/issues/296) ("Implement table parsing") had six spec-coverage tests parked behind it: the `tables()` tests on each `subs/` page in `parser/src/tests/asciidoc_lang/subs/`. They were `#[ignore]`d `todo!()` stubs because there was no way to construct a table and check how a substitution step applied to cell content. The `tables` branch implements table parsing, so this PR turns each stub into a real `verifies!` test.

Each test parses a table and asserts the page's substitution behavior on cell content:

| Page | Spec value | Verifies |
|---|---|---|
| `special_characters` | `{y}` (always) | `>` escapes to `&gt;` in **both** default and literal (`l`) cells |
| `quotes` | `Varies` | `*bold*` → `<strong>` in default cell, stays literal in `l` cell |
| `attributes` | `Varies` | `{val}` resolved in default cell, left as `{val}` in `l` cell |
| `replacements` | `Varies` | `(C)` → `&#169;` in default cell, stays `(C)` in `l` cell |
| `macros` | `Varies` | link macro → `<a href>` in default cell, stays raw in `l` cell |
| `post_replacements` | `Varies` | trailing `+` → `<br>` in default cell, preserved in `l` cell |

For each: dropped `#[ignore]`, changed `to_do_verifies!` → `verifies!`, removed the `todo!()` and `// Blocked on #296` comments.

## Note: one latent spec mismatch fixed

The `quotes` stub had captured the spec value as `|Tables |{y}`, but the spec actually says `|Tables |Varies`. This was invisible while the test used `to_do_verifies!` (which doesn't check the text), but `verifies!` checks verbatim — so it's corrected here.

## Verification

- All six `tables` tests pass; full `asciidoc-parser` suite: 0 failures.
- No remaining references to issue #296 in the codebase.
- `cargo +nightly fmt` clean.
- Spec-coverage tool (`cd sdd && cargo run`) exits 0 with no warnings.

Closes #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)