### PR TITLE
feat: Add support for admonitions

### DIFF
--- a/parser/src/blocks/admonition.rs
+++ b/parser/src/blocks/admonition.rs
@@ -587,19 +587,19 @@ mod tests {
     #[test]
     fn not_an_admonition_when_lowercase_label() {
         let block = parse_one("note: not an admonition");
-        assert!(matches!(block, Block::Simple(_)));
+        assert_eq!(block.raw_context().deref(), "paragraph");
     }
 
     #[test]
     fn not_an_admonition_without_separating_space() {
         let block = parse_one("NOTE:no space");
-        assert!(matches!(block, Block::Simple(_)));
+        assert_eq!(block.raw_context().deref(), "paragraph");
     }
 
     #[test]
     fn not_an_admonition_for_partial_label() {
         let block = parse_one("NOTES: a longer word");
-        assert!(matches!(block, Block::Simple(_)));
+        assert_eq!(block.raw_context().deref(), "paragraph");
     }
 
     #[test]
@@ -607,7 +607,7 @@ mod tests {
         // Indented content is a literal block; the leading whitespace means the
         // line is not an admonition paragraph.
         let block = parse_one("  NOTE: indented text");
-        assert!(matches!(block, Block::Simple(_)));
+        assert_eq!(block.raw_context().deref(), "paragraph");
     }
 
     #[test]
@@ -630,7 +630,7 @@ mod tests {
         let maw = Block::parse(crate::Span::new("[NOTE]\n====\nunclosed"), &mut parser);
 
         let block = maw.item.unwrap().item;
-        assert!(matches!(block, Block::Admonition(_)));
+        assert_eq!(block.raw_context().deref(), "admonition");
         assert_eq!(maw.warnings.len(), 1);
         assert_eq!(
             maw.warnings.first().unwrap().warning,
@@ -707,6 +707,65 @@ mod tests {
         let block = parse_one("NOTE: clone me");
         let admonition = as_admonition(&block).clone();
         assert_eq!(admonition.variant(), AdmonitionVariant::Note);
+    }
+
+    #[test]
+    fn masquerade_without_content_is_not_an_admonition() {
+        // A masquerade style with no following block content cannot form an
+        // admonition; the masquerade parser reports no block and the line is
+        // treated as an ordinary block with a missing-block warning.
+        let mut parser = Parser::default();
+        let maw = Block::parse(crate::Span::new("[NOTE]\n"), &mut parser);
+
+        // The lone attribute list has no block to attach to: a missing-block
+        // warning is emitted and the line is treated as an ordinary paragraph,
+        // not an admonition.
+        let block = maw.item.unwrap().item;
+        assert_eq!(block.raw_context().deref(), "paragraph");
+        assert_eq!(maw.warnings.len(), 1);
+        assert_eq!(
+            maw.warnings.first().unwrap().warning,
+            crate::warnings::WarningType::MissingBlockAfterTitleOrAttributeList
+        );
+    }
+
+    #[test]
+    fn block_enum_delegates_to_admonition() {
+        // Exercise the `Block`-level `IsBlock`/`Debug` arms for an admonition
+        // (rather than calling through the unwrapped `AdmonitionBlock`).
+        let simple = parse_one("NOTE: text");
+        assert_eq!(simple.content_model(), ContentModel::Simple);
+        assert_eq!(simple.rendered_content(), Some("text"));
+        assert_eq!(simple.raw_context().deref(), "admonition");
+        assert_eq!(simple.declared_style(), Some("NOTE"));
+        assert!(simple.title_source().is_none());
+        assert!(simple.anchor_reftext().is_none());
+        assert_eq!(simple.substitution_group(), SubstitutionGroup::Normal);
+        assert!(simple.nested_blocks().next().is_none());
+        assert!(format!("{simple:?}").starts_with("Block::Admonition"));
+
+        let compound = parse_one("[NOTE]\n====\nx\n====");
+        assert_eq!(compound.content_model(), ContentModel::Compound);
+        assert_eq!(compound.nested_blocks().count(), 1);
+    }
+
+    #[test]
+    fn block_declared_style_for_non_admonition_kinds() {
+        // The `Block::declared_style` delegation returns `None` for block kinds
+        // that have no positional style: a media block, a list item, and a
+        // document-attribute block.
+        let media = parse_one("image::a.png[]");
+        assert_eq!(media.raw_context().deref(), "image");
+        assert!(media.declared_style().is_none());
+
+        let list = parse_one("* item");
+        let item = list.nested_blocks().next().unwrap();
+        assert_eq!(item.raw_context().deref(), "list_item");
+        assert!(item.declared_style().is_none());
+
+        let attribute = parse_one(":foo: bar");
+        assert_eq!(attribute.raw_context().deref(), "attribute");
+        assert!(attribute.declared_style().is_none());
     }
 
     mod caption_and_icons {

--- a/parser/src/blocks/admonition.rs
+++ b/parser/src/blocks/admonition.rs
@@ -189,6 +189,13 @@ impl<'src> AdmonitionBlock<'src> {
             );
         }
 
+        // Unreachable in practice: `parse_paragraph` is only called after
+        // `admonition_paragraph_prefix` matched, which requires a non-whitespace
+        // character after the label on the first line (trailing whitespace is
+        // trimmed before the match). `content_start` therefore points at
+        // non-empty content, so `SimpleBlock::parse` always returns `Some`. This
+        // fall-through is kept as a defensive default that mirrors
+        // `parse_masquerade`.
         MatchAndWarnings {
             item: None,
             warnings: vec![],
@@ -431,6 +438,9 @@ mod tests {
     fn as_admonition<'a>(block: &'a Block<'a>) -> &'a crate::blocks::AdmonitionBlock<'a> {
         match block {
             Block::Admonition(admonition) => admonition,
+            // Only reached if a test parses an input that is not an admonition;
+            // it exists to fail that test loudly, so it is uncovered while the
+            // tests pass.
             other => panic!("expected an admonition block, got {other:?}"),
         }
     }

--- a/parser/src/blocks/admonition.rs
+++ b/parser/src/blocks/admonition.rs
@@ -1,0 +1,719 @@
+use std::slice::Iter;
+
+use crate::{
+    HasSpan, Parser, Span,
+    attributes::Attrlist,
+    blocks::{
+        AdmonitionVariant, Block, CompoundDelimitedBlock, ContentModel, IsBlock, RawDelimitedBlock,
+        SimpleBlock, TableBlock, metadata::BlockMetadata,
+    },
+    content::Content,
+    document::InterpretedValue,
+    internal::debug::DebugSliceReference,
+    span::MatchedItem,
+    strings::CowStr,
+    warnings::MatchAndWarnings,
+};
+
+/// An admonition draws attention to a statement by taking it out of the
+/// content's flow and labeling it with a priority (its type).
+///
+/// An admonition can be written in two ways:
+///
+/// * As a **paragraph** whose first line begins with one of the five admonition
+///   labels followed by a colon (e.g., `NOTE: This is a note.`). This produces
+///   an admonition with the [`Simple`] content model.
+/// * As a **block** by setting one of the labels as the block style in an
+///   attribute list (e.g., `[NOTE]`). This is referred to as *masquerading*.
+///   When the style is set on a delimited block that can contain other blocks
+///   (such as an example block), the admonition uses the [`Compound`] content
+///   model; otherwise it uses the [`Simple`] content model.
+///
+/// [`Simple`]: ContentModel::Simple
+/// [`Compound`]: ContentModel::Compound
+#[derive(Clone, Eq, PartialEq)]
+pub struct AdmonitionBlock<'src> {
+    variant: AdmonitionVariant,
+    label: String,
+    icons_font: bool,
+    content_model: ContentModel,
+    content: Option<Content<'src>>,
+    blocks: Vec<Block<'src>>,
+    source: Span<'src>,
+    title_source: Option<Span<'src>>,
+    title: Option<String>,
+    anchor: Option<Span<'src>>,
+    anchor_reftext: Option<Span<'src>>,
+    attrlist: Option<Attrlist<'src>>,
+}
+
+impl<'src> AdmonitionBlock<'src> {
+    /// Parse an admonition block, if the given metadata and content describe
+    /// one.
+    ///
+    /// Returns `None` (without consuming the block) when the content is not an
+    /// admonition, so that the caller can fall through to other block parsers.
+    pub(crate) fn parse(
+        metadata: &BlockMetadata<'src>,
+        parser: &mut Parser,
+    ) -> Option<MatchAndWarnings<'src, Option<MatchedItem<'src, Self>>>> {
+        // Masquerade form: the block style names an admonition type.
+        if let Some(style) = metadata.attrlist.as_ref().and_then(|a| a.block_style())
+            && let Some(variant) = AdmonitionVariant::from_style(style)
+        {
+            return Some(Self::parse_masquerade(metadata, parser, variant));
+        }
+
+        // Paragraph form: the first line begins with `LABEL: `. This form does
+        // not apply when a block style was declared (that would be a
+        // masquerade), so it is only reached when there is no admonition style.
+        if metadata
+            .attrlist
+            .as_ref()
+            .and_then(|a| a.block_style())
+            .is_none()
+            && let Some((variant, content_start)) =
+                admonition_paragraph_prefix(metadata.block_start)
+        {
+            return Some(Self::parse_paragraph(
+                metadata,
+                parser,
+                variant,
+                content_start,
+            ));
+        }
+
+        None
+    }
+
+    /// Parse the masquerade form, where the admonition style is set on a block.
+    fn parse_masquerade(
+        metadata: &BlockMetadata<'src>,
+        parser: &mut Parser,
+        variant: AdmonitionVariant,
+    ) -> MatchAndWarnings<'src, Option<MatchedItem<'src, Self>>> {
+        let first_line = metadata.block_start.take_normalized_line().item;
+
+        // An admonition style masquerades only over an example block, an open
+        // block, or a paragraph. Over an example or open block it yields
+        // compound content.
+        if is_example_or_open_delimiter(&first_line)
+            && let Some(MatchAndWarnings {
+                item: Some(inner),
+                warnings,
+            }) = CompoundDelimitedBlock::parse(metadata, parser)
+        {
+            let after = inner.after;
+            let blocks = inner.item.into_nested_blocks();
+            return Self::finish(
+                metadata,
+                parser,
+                variant,
+                ContentModel::Compound,
+                None,
+                blocks,
+                after,
+                warnings,
+            );
+        }
+
+        // Any other structural container (sidebar, quote, listing, literal,
+        // passthrough, table, comment) keeps its own context and ignores the
+        // admonition style, so this is not an admonition.
+        if RawDelimitedBlock::is_valid_delimiter(&first_line)
+            || CompoundDelimitedBlock::is_valid_delimiter(&first_line)
+            || TableBlock::is_table_delimiter(&first_line)
+        {
+            return MatchAndWarnings {
+                item: None,
+                warnings: vec![],
+            };
+        }
+
+        // Otherwise the style is applied to a paragraph: simple content.
+        if let Some(inner) = SimpleBlock::parse(metadata, parser) {
+            return Self::finish(
+                metadata,
+                parser,
+                variant,
+                ContentModel::Simple,
+                Some(inner.item.content().clone()),
+                vec![],
+                inner.after,
+                vec![],
+            );
+        }
+
+        MatchAndWarnings {
+            item: None,
+            warnings: vec![],
+        }
+    }
+
+    /// Parse the paragraph form, where the first line begins with `LABEL: `.
+    fn parse_paragraph(
+        metadata: &BlockMetadata<'src>,
+        parser: &mut Parser,
+        variant: AdmonitionVariant,
+        content_start: Span<'src>,
+    ) -> MatchAndWarnings<'src, Option<MatchedItem<'src, Self>>> {
+        // Build a metadata that begins after the stripped label so that the
+        // paragraph content is parsed without it. The admonition retains the
+        // outer block's title, anchor, and attribute list.
+        let inner_metadata = BlockMetadata {
+            title_source: None,
+            title: None,
+            anchor: None,
+            anchor_reftext: None,
+            attrlist: None,
+            source: content_start,
+            block_start: content_start,
+        };
+
+        if let Some(inner) = SimpleBlock::parse(&inner_metadata, parser) {
+            return Self::finish(
+                metadata,
+                parser,
+                variant,
+                ContentModel::Simple,
+                Some(inner.item.content().clone()),
+                vec![],
+                inner.after,
+                vec![],
+            );
+        }
+
+        MatchAndWarnings {
+            item: None,
+            warnings: vec![],
+        }
+    }
+
+    /// Assemble the final admonition block from its parsed parts, resolving the
+    /// caption and icon state from the current document attributes.
+    #[allow(clippy::too_many_arguments)]
+    fn finish(
+        metadata: &BlockMetadata<'src>,
+        parser: &Parser,
+        variant: AdmonitionVariant,
+        content_model: ContentModel,
+        content: Option<Content<'src>>,
+        blocks: Vec<Block<'src>>,
+        after: Span<'src>,
+        warnings: Vec<crate::warnings::Warning<'src>>,
+    ) -> MatchAndWarnings<'src, Option<MatchedItem<'src, Self>>> {
+        let source = metadata
+            .source
+            .trim_remainder(after)
+            .trim_trailing_whitespace();
+
+        MatchAndWarnings {
+            item: Some(MatchedItem {
+                item: Self {
+                    variant,
+                    label: resolve_caption(variant, parser),
+                    icons_font: icons_are_font(parser),
+                    content_model,
+                    content,
+                    blocks,
+                    source,
+                    title_source: metadata.title_source,
+                    title: metadata.title.clone(),
+                    anchor: metadata.anchor,
+                    anchor_reftext: metadata.anchor_reftext,
+                    attrlist: metadata.attrlist.clone(),
+                },
+                after,
+            }),
+            warnings,
+        }
+    }
+
+    /// Returns the admonition type (e.g., [`AdmonitionVariant::Note`]).
+    pub fn variant(&self) -> AdmonitionVariant {
+        self.variant
+    }
+
+    /// Returns the lowercase name for this admonition (e.g., `note`).
+    pub fn name(&self) -> &'static str {
+        self.variant.name()
+    }
+
+    /// Returns the caption (label) text shown for this admonition (e.g.,
+    /// `Note`).
+    ///
+    /// This is the value of the `<type>-caption` document attribute if set, or
+    /// the default caption for the admonition type otherwise.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Returns `true` if font-based icons are enabled (i.e., the `icons`
+    /// document attribute is set to `font`).
+    pub fn icons_font(&self) -> bool {
+        self.icons_font
+    }
+
+    /// Returns the simple content of this admonition, if it has the
+    /// [`Simple`](ContentModel::Simple) content model.
+    pub fn content(&self) -> Option<&Content<'src>> {
+        self.content.as_ref()
+    }
+}
+
+/// Returns `true` if `line` is the opening delimiter of an example block
+/// (`====`) or an open block (`--`).
+///
+/// These are the only delimited blocks over which an admonition style may
+/// masquerade.
+fn is_example_or_open_delimiter(line: &Span<'_>) -> bool {
+    let data = line.data();
+
+    if data == "--" {
+        return true;
+    }
+
+    data.len() >= 4 && data.starts_with("====") && data[4..].chars().all(|c| c == '=')
+}
+
+/// Resolve the caption (label) text for an admonition variant from the current
+/// document attributes, falling back to the variant's default caption.
+fn resolve_caption(variant: AdmonitionVariant, parser: &Parser) -> String {
+    let key = format!("{}-caption", variant.name());
+    match parser.attribute_value(key) {
+        InterpretedValue::Value(value) => value,
+        _ => variant.default_caption().to_string(),
+    }
+}
+
+/// Returns `true` if the `icons` document attribute is set to `font`.
+fn icons_are_font(parser: &Parser) -> bool {
+    matches!(parser.attribute_value("icons"), InterpretedValue::Value(value) if value == "font")
+}
+
+/// If the first line of `block_start` begins with an admonition label followed
+/// by a colon and at least one space (e.g., `NOTE: `), return the admonition
+/// variant and a span positioned at the start of the paragraph content (after
+/// the stripped label).
+pub(crate) fn admonition_paragraph_prefix(
+    block_start: Span<'_>,
+) -> Option<(AdmonitionVariant, Span<'_>)> {
+    let line = block_start.take_normalized_line().item;
+    let data = line.data();
+
+    for variant in [
+        AdmonitionVariant::Note,
+        AdmonitionVariant::Tip,
+        AdmonitionVariant::Important,
+        AdmonitionVariant::Caution,
+        AdmonitionVariant::Warning,
+    ] {
+        if let Some(rest) = data.strip_prefix(variant.style())
+            && let Some(rest) = rest.strip_prefix(':')
+            && (rest.starts_with(' ') || rest.starts_with('\t'))
+        {
+            let whitespace_len = rest.len() - rest.trim_start_matches([' ', '\t']).len();
+            let prefix_len = variant.style().len() + 1 + whitespace_len;
+            return Some((variant, block_start.discard(prefix_len)));
+        }
+    }
+
+    None
+}
+
+/// Returns `true` if the first line of `line` begins with an admonition
+/// paragraph label (e.g., `NOTE: `).
+pub(crate) fn starts_with_admonition_label(line: Span<'_>) -> bool {
+    admonition_paragraph_prefix(line).is_some()
+}
+
+impl<'src> IsBlock<'src> for AdmonitionBlock<'src> {
+    fn content_model(&self) -> ContentModel {
+        self.content_model
+    }
+
+    fn raw_context(&self) -> CowStr<'src> {
+        "admonition".into()
+    }
+
+    fn declared_style(&'src self) -> Option<&'src str> {
+        Some(self.variant.style())
+    }
+
+    fn rendered_content(&'src self) -> Option<&'src str> {
+        self.content.as_ref().map(|content| content.rendered())
+    }
+
+    fn nested_blocks(&'src self) -> Iter<'src, Block<'src>> {
+        self.blocks.iter()
+    }
+
+    fn nested_blocks_mut(&mut self) -> &mut [Block<'src>] {
+        &mut self.blocks
+    }
+
+    fn content_mut(&mut self) -> Option<&mut Content<'src>> {
+        self.content.as_mut()
+    }
+
+    fn title_source(&'src self) -> Option<Span<'src>> {
+        self.title_source
+    }
+
+    fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    fn anchor(&'src self) -> Option<Span<'src>> {
+        self.anchor
+    }
+
+    fn anchor_reftext(&'src self) -> Option<Span<'src>> {
+        self.anchor_reftext
+    }
+
+    fn attrlist(&'src self) -> Option<&'src Attrlist<'src>> {
+        self.attrlist.as_ref()
+    }
+}
+
+impl<'src> HasSpan<'src> for AdmonitionBlock<'src> {
+    fn span(&self) -> Span<'src> {
+        self.source
+    }
+}
+
+impl std::fmt::Debug for AdmonitionBlock<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AdmonitionBlock")
+            .field("variant", &self.variant)
+            .field("label", &self.label)
+            .field("icons_font", &self.icons_font)
+            .field("content_model", &self.content_model)
+            .field("content", &self.content)
+            .field("blocks", &DebugSliceReference(&self.blocks))
+            .field("source", &self.source)
+            .field("title_source", &self.title_source)
+            .field("title", &self.title)
+            .field("anchor", &self.anchor)
+            .field("anchor_reftext", &self.anchor_reftext)
+            .field("attrlist", &self.attrlist)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::panic)]
+
+    use std::ops::Deref;
+
+    use crate::{
+        blocks::{AdmonitionVariant, Block, ContentModel, IsBlock},
+        tests::prelude::*,
+    };
+
+    fn parse_one(input: &'static str) -> Block<'static> {
+        let mut parser = Parser::default();
+        Block::parse(crate::Span::new(input), &mut parser)
+            .unwrap_if_no_warnings()
+            .unwrap()
+            .item
+    }
+
+    fn as_admonition<'a>(block: &'a Block<'a>) -> &'a crate::blocks::AdmonitionBlock<'a> {
+        match block {
+            Block::Admonition(admonition) => admonition,
+            other => panic!("expected an admonition block, got {other:?}"),
+        }
+    }
+
+    mod admonition_variant {
+        use crate::blocks::AdmonitionVariant;
+
+        #[test]
+        fn style() {
+            assert_eq!(AdmonitionVariant::Note.style(), "NOTE");
+            assert_eq!(AdmonitionVariant::Tip.style(), "TIP");
+            assert_eq!(AdmonitionVariant::Important.style(), "IMPORTANT");
+            assert_eq!(AdmonitionVariant::Caution.style(), "CAUTION");
+            assert_eq!(AdmonitionVariant::Warning.style(), "WARNING");
+        }
+
+        #[test]
+        fn name() {
+            assert_eq!(AdmonitionVariant::Note.name(), "note");
+            assert_eq!(AdmonitionVariant::Tip.name(), "tip");
+            assert_eq!(AdmonitionVariant::Important.name(), "important");
+            assert_eq!(AdmonitionVariant::Caution.name(), "caution");
+            assert_eq!(AdmonitionVariant::Warning.name(), "warning");
+        }
+
+        #[test]
+        fn default_caption() {
+            assert_eq!(AdmonitionVariant::Note.default_caption(), "Note");
+            assert_eq!(AdmonitionVariant::Tip.default_caption(), "Tip");
+            assert_eq!(AdmonitionVariant::Important.default_caption(), "Important");
+            assert_eq!(AdmonitionVariant::Caution.default_caption(), "Caution");
+            assert_eq!(AdmonitionVariant::Warning.default_caption(), "Warning");
+        }
+
+        #[test]
+        fn from_style() {
+            assert_eq!(
+                AdmonitionVariant::from_style("NOTE"),
+                Some(AdmonitionVariant::Note)
+            );
+            assert_eq!(
+                AdmonitionVariant::from_style("TIP"),
+                Some(AdmonitionVariant::Tip)
+            );
+            assert_eq!(
+                AdmonitionVariant::from_style("IMPORTANT"),
+                Some(AdmonitionVariant::Important)
+            );
+            assert_eq!(
+                AdmonitionVariant::from_style("CAUTION"),
+                Some(AdmonitionVariant::Caution)
+            );
+            assert_eq!(
+                AdmonitionVariant::from_style("WARNING"),
+                Some(AdmonitionVariant::Warning)
+            );
+
+            // The match is case-sensitive and rejects non-labels.
+            assert_eq!(AdmonitionVariant::from_style("note"), None);
+            assert_eq!(AdmonitionVariant::from_style("Note"), None);
+            assert_eq!(AdmonitionVariant::from_style("example"), None);
+        }
+
+        #[test]
+        fn impl_debug() {
+            assert_eq!(
+                format!("{:?}", AdmonitionVariant::Note),
+                "AdmonitionVariant::Note"
+            );
+            assert_eq!(
+                format!("{:?}", AdmonitionVariant::Tip),
+                "AdmonitionVariant::Tip"
+            );
+            assert_eq!(
+                format!("{:?}", AdmonitionVariant::Important),
+                "AdmonitionVariant::Important"
+            );
+            assert_eq!(
+                format!("{:?}", AdmonitionVariant::Caution),
+                "AdmonitionVariant::Caution"
+            );
+            assert_eq!(
+                format!("{:?}", AdmonitionVariant::Warning),
+                "AdmonitionVariant::Warning"
+            );
+        }
+
+        #[test]
+        fn impl_clone() {
+            // Silly test to mark the #[derive(...)] line as covered.
+            let v1 = AdmonitionVariant::Note;
+            let v2 = v1;
+            assert_eq!(v1, v2);
+        }
+    }
+
+    #[test]
+    fn paragraph_form() {
+        let block = parse_one("NOTE: This is a note.");
+        let admonition = as_admonition(&block);
+
+        assert_eq!(admonition.variant(), AdmonitionVariant::Note);
+        assert_eq!(admonition.name(), "note");
+        assert_eq!(admonition.label(), "Note");
+        assert!(!admonition.icons_font());
+        assert_eq!(admonition.content_model(), ContentModel::Simple);
+        assert_eq!(admonition.content().unwrap().rendered(), "This is a note.");
+        assert_eq!(admonition.rendered_content(), Some("This is a note."));
+        assert_eq!(admonition.raw_context().deref(), "admonition");
+        assert_eq!(admonition.resolved_context().deref(), "admonition");
+        assert_eq!(admonition.declared_style(), Some("NOTE"));
+        assert!(admonition.nested_blocks().next().is_none());
+        assert!(admonition.title().is_none());
+        assert!(admonition.attrlist().is_none());
+    }
+
+    #[test]
+    fn paragraph_form_all_variants() {
+        for (input, variant, name) in [
+            ("NOTE: x", AdmonitionVariant::Note, "note"),
+            ("TIP: x", AdmonitionVariant::Tip, "tip"),
+            ("IMPORTANT: x", AdmonitionVariant::Important, "important"),
+            ("CAUTION: x", AdmonitionVariant::Caution, "caution"),
+            ("WARNING: x", AdmonitionVariant::Warning, "warning"),
+        ] {
+            let block = parse_one(input);
+            let admonition = as_admonition(&block);
+            assert_eq!(admonition.variant(), variant);
+            assert_eq!(admonition.name(), name);
+        }
+    }
+
+    #[test]
+    fn paragraph_form_multiline() {
+        let block = parse_one("NOTE: first line\nsecond line");
+        let admonition = as_admonition(&block);
+        assert_eq!(
+            admonition.content().unwrap().rendered(),
+            "first line\nsecond line"
+        );
+    }
+
+    #[test]
+    fn paragraph_form_tab_separator() {
+        let block = parse_one("NOTE:\tindented with a tab");
+        let admonition = as_admonition(&block);
+        assert_eq!(admonition.variant(), AdmonitionVariant::Note);
+        assert_eq!(
+            admonition.content().unwrap().rendered(),
+            "indented with a tab"
+        );
+    }
+
+    #[test]
+    fn not_an_admonition_when_lowercase_label() {
+        let block = parse_one("note: not an admonition");
+        assert!(matches!(block, Block::Simple(_)));
+    }
+
+    #[test]
+    fn not_an_admonition_without_separating_space() {
+        let block = parse_one("NOTE:no space");
+        assert!(matches!(block, Block::Simple(_)));
+    }
+
+    #[test]
+    fn not_an_admonition_for_partial_label() {
+        let block = parse_one("NOTES: a longer word");
+        assert!(matches!(block, Block::Simple(_)));
+    }
+
+    #[test]
+    fn indented_label_is_a_literal_block_not_an_admonition() {
+        // Indented content is a literal block; the leading whitespace means the
+        // line is not an admonition paragraph.
+        let block = parse_one("  NOTE: indented text");
+        assert!(matches!(block, Block::Simple(_)));
+    }
+
+    #[test]
+    fn masquerade_on_example_block_is_compound() {
+        let block = parse_one("[NOTE]\n====\nCompound content.\n====");
+        let admonition = as_admonition(&block);
+        assert_eq!(admonition.variant(), AdmonitionVariant::Note);
+        assert_eq!(admonition.content_model(), ContentModel::Compound);
+        assert!(admonition.content().is_none());
+        assert!(admonition.rendered_content().is_none());
+        assert_eq!(admonition.nested_blocks().count(), 1);
+    }
+
+    #[test]
+    fn masquerade_on_open_block_is_compound() {
+        let block = parse_one("[WARNING]\n--\npara one\n\npara two\n--");
+        let admonition = as_admonition(&block);
+        assert_eq!(admonition.variant(), AdmonitionVariant::Warning);
+        assert_eq!(admonition.content_model(), ContentModel::Compound);
+        assert_eq!(admonition.nested_blocks().count(), 2);
+    }
+
+    #[test]
+    fn masquerade_on_paragraph_is_simple() {
+        let block = parse_one("[TIP]\nA single paragraph.");
+        let admonition = as_admonition(&block);
+        assert_eq!(admonition.variant(), AdmonitionVariant::Tip);
+        assert_eq!(admonition.content_model(), ContentModel::Simple);
+        assert_eq!(
+            admonition.content().unwrap().rendered(),
+            "A single paragraph."
+        );
+    }
+
+    #[test]
+    fn masquerade_with_title() {
+        let block = parse_one("[NOTE]\n.A title\n====\nContent.\n====");
+        let admonition = as_admonition(&block);
+        assert_eq!(admonition.title(), Some("A title"));
+    }
+
+    #[test]
+    fn masquerade_does_not_apply_to_other_containers() {
+        // Sidebar, quote, listing, literal, and passthrough blocks keep their
+        // own context; the admonition style is ignored.
+        assert_eq!(
+            parse_one("[NOTE]\n****\nx\n****").raw_context().deref(),
+            "sidebar"
+        );
+        assert_eq!(
+            parse_one("[NOTE]\n____\nx\n____").raw_context().deref(),
+            "quote"
+        );
+        assert_eq!(
+            parse_one("[NOTE]\n----\nx\n----").raw_context().deref(),
+            "listing"
+        );
+        assert_eq!(
+            parse_one("[NOTE]\n....\nx\n....").raw_context().deref(),
+            "literal"
+        );
+        assert_eq!(
+            parse_one("[NOTE]\n++++\nx\n++++").raw_context().deref(),
+            "pass"
+        );
+    }
+
+    #[test]
+    fn impl_debug() {
+        let block = parse_one("NOTE: hi");
+        let admonition = as_admonition(&block);
+        let debug = format!("{admonition:?}");
+        assert!(debug.starts_with("AdmonitionBlock {"));
+        assert!(debug.contains("variant: AdmonitionVariant::Note"));
+    }
+
+    #[test]
+    fn impl_clone() {
+        // Silly test to mark the #[derive(...)] line as covered.
+        let block = parse_one("NOTE: clone me");
+        let admonition = as_admonition(&block).clone();
+        assert_eq!(admonition.variant(), AdmonitionVariant::Note);
+    }
+
+    mod caption_and_icons {
+        use crate::tests::prelude::*;
+
+        #[test]
+        fn default_caption_when_icons_unset() {
+            let doc = Parser::default().parse("CAUTION: Slippery when wet.");
+            assert_xpath(
+                &doc,
+                "//td[@class=\"icon\"]/div[@class=\"title\"][text()=\"Caution\"]",
+                1,
+            );
+        }
+
+        #[test]
+        fn caption_override_via_attribute() {
+            let doc = Parser::default().parse(":note-caption: Remarque\n\nNOTE: Bonjour.");
+            assert_xpath(
+                &doc,
+                "//td[@class=\"icon\"]/div[@class=\"title\"][text()=\"Remarque\"]",
+                1,
+            );
+        }
+
+        #[test]
+        fn font_icons_when_enabled() {
+            let doc = Parser::default().parse(":icons: font\n\nNOTE: This is a note.");
+            assert_css(&doc, "td.icon i.fa.icon-note", 1);
+            assert_css(&doc, "td.icon .title", 0);
+        }
+    }
+}

--- a/parser/src/blocks/admonition.rs
+++ b/parser/src/blocks/admonition.rs
@@ -97,6 +97,12 @@ impl<'src> AdmonitionBlock<'src> {
         // An admonition style masquerades only over an example block, an open
         // block, or a paragraph. Over an example or open block it yields
         // compound content.
+        //
+        // For a valid example/open delimiter, `CompoundDelimitedBlock::parse`
+        // always returns `item: Some(..)` — even for an unterminated block, in
+        // which case it also reports an `UnterminatedDelimitedBlock` warning.
+        // Those `warnings` are bound here and forwarded through `finish`, so no
+        // diagnostic is lost on the masquerade path.
         if is_example_or_open_delimiter(&first_line)
             && let Some(MatchAndWarnings {
                 item: Some(inner),
@@ -613,6 +619,23 @@ mod tests {
         assert!(admonition.content().is_none());
         assert!(admonition.rendered_content().is_none());
         assert_eq!(admonition.nested_blocks().count(), 1);
+    }
+
+    #[test]
+    fn masquerade_propagates_unterminated_warning() {
+        // An unterminated example block under an admonition style still parses
+        // as a (compound) admonition, and its `UnterminatedDelimitedBlock`
+        // warning is not swallowed by the masquerade path.
+        let mut parser = Parser::default();
+        let maw = Block::parse(crate::Span::new("[NOTE]\n====\nunclosed"), &mut parser);
+
+        let block = maw.item.unwrap().item;
+        assert!(matches!(block, Block::Admonition(_)));
+        assert_eq!(maw.warnings.len(), 1);
+        assert_eq!(
+            maw.warnings.first().unwrap().warning,
+            crate::warnings::WarningType::UnterminatedDelimitedBlock
+        );
     }
 
     #[test]

--- a/parser/src/blocks/admonition.rs
+++ b/parser/src/blocks/admonition.rs
@@ -273,7 +273,7 @@ fn is_example_or_open_delimiter(line: &Span<'_>) -> bool {
         return true;
     }
 
-    data.len() >= 4 && data.starts_with("====") && data[4..].chars().all(|c| c == '=')
+    data.len() >= 4 && data.chars().all(|c| c == '=')
 }
 
 /// Resolve the caption (label) text for an admonition variant from the current

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -100,7 +100,6 @@ impl<'src> std::fmt::Debug for Block<'src> {
                 .finish(),
 
             Block::Admonition(block) => f.debug_tuple("Block::Admonition").field(block).finish(),
-
             Block::Table(block) => f.debug_tuple("Block::Table").field(block).finish(),
             Block::Preamble(block) => f.debug_tuple("Block::Preamble").field(block).finish(),
             Block::Break(break_) => f.debug_tuple("Block::Break").field(break_).finish(),

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -4,9 +4,9 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::Attrlist,
     blocks::{
-        Break, CompoundDelimitedBlock, ContentModel, IsBlock, ListBlock, ListItem, ListItemMarker,
-        MediaBlock, Preamble, RawDelimitedBlock, SectionBlock, SimpleBlock, TableBlock,
-        metadata::BlockMetadata,
+        AdmonitionBlock, Break, CompoundDelimitedBlock, ContentModel, IsBlock, ListBlock, ListItem,
+        ListItemMarker, MediaBlock, Preamble, RawDelimitedBlock, SectionBlock, SimpleBlock,
+        TableBlock, metadata::BlockMetadata, starts_with_admonition_label,
     },
     content::{Content, SubstitutionGroup},
     document::{Attribute, RefType},
@@ -61,6 +61,11 @@ pub enum Block<'src> {
     /// A delimited block that can contain other blocks.
     CompoundDelimited(CompoundDelimitedBlock<'src>),
 
+    /// An admonition draws attention to a statement by taking it out of the
+    /// content's flow and labeling it with a priority (e.g., a note or a
+    /// warning).
+    Admonition(AdmonitionBlock<'src>),
+
     /// A table block arranges content into a grid of rows and columns.
     Table(TableBlock<'src>),
 
@@ -93,6 +98,8 @@ impl<'src> std::fmt::Debug for Block<'src> {
                 .debug_tuple("Block::CompoundDelimited")
                 .field(block)
                 .finish(),
+
+            Block::Admonition(block) => f.debug_tuple("Block::Admonition").field(block).finish(),
 
             Block::Table(block) => f.debug_tuple("Block::Table").field(block).finish(),
             Block::Preamble(block) => f.debug_tuple("Block::Preamble").field(block).finish(),
@@ -159,6 +166,7 @@ impl<'src> Block<'src> {
             && !first_line.contains(";;")
             && !TableBlock::is_table_delimiter(&first_line)
             && !ListItemMarker::starts_with_marker(first_line)
+            && !starts_with_admonition_label(first_line)
             && parent_list_markers.is_none()
             && let Some(MatchedItem {
                 item: simple_block,
@@ -210,6 +218,32 @@ impl<'src> Block<'src> {
             metadata.attrlist.as_ref().and_then(|a| a.block_style()) == Some("literal");
 
         if !is_literal {
+            if let Some(mut adm_maw) = AdmonitionBlock::parse(&metadata, parser)
+                && let Some(adm) = adm_maw.item
+            {
+                if !adm_maw.warnings.is_empty() {
+                    warnings.append(&mut adm_maw.warnings);
+                }
+
+                let block = Self::Admonition(adm.item);
+
+                Self::register_block_id(
+                    block.id(),
+                    block.title(),
+                    block.span(),
+                    parser,
+                    &mut warnings,
+                );
+
+                return MatchAndWarnings {
+                    item: Some(MatchedItem {
+                        item: block,
+                        after: adm.after,
+                    }),
+                    warnings,
+                };
+            }
+
             if let Some(mut rdb_maw) = RawDelimitedBlock::parse(&metadata, parser)
                 && let Some(rdb) = rdb_maw.item
             {
@@ -509,10 +543,28 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.content_model(),
             Self::RawDelimited(b) => b.content_model(),
             Self::CompoundDelimited(b) => b.content_model(),
+            Self::Admonition(b) => b.content_model(),
             Self::Table(b) => b.content_model(),
             Self::Preamble(b) => b.content_model(),
             Self::Break(b) => b.content_model(),
             Self::DocumentAttribute(b) => b.content_model(),
+        }
+    }
+
+    fn declared_style(&'src self) -> Option<&'src str> {
+        match self {
+            Self::Simple(b) => b.declared_style(),
+            Self::Media(b) => b.declared_style(),
+            Self::Section(b) => b.declared_style(),
+            Self::List(b) => b.declared_style(),
+            Self::ListItem(b) => b.declared_style(),
+            Self::RawDelimited(b) => b.declared_style(),
+            Self::CompoundDelimited(b) => b.declared_style(),
+            Self::Admonition(b) => b.declared_style(),
+            Self::Table(b) => b.declared_style(),
+            Self::Preamble(b) => b.declared_style(),
+            Self::Break(b) => b.declared_style(),
+            Self::DocumentAttribute(b) => b.declared_style(),
         }
     }
 
@@ -525,6 +577,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.rendered_content(),
             Self::RawDelimited(b) => b.rendered_content(),
             Self::CompoundDelimited(b) => b.rendered_content(),
+            Self::Admonition(b) => b.rendered_content(),
             Self::Table(b) => b.rendered_content(),
             Self::Preamble(b) => b.rendered_content(),
             Self::Break(b) => b.rendered_content(),
@@ -541,6 +594,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.raw_context(),
             Self::RawDelimited(b) => b.raw_context(),
             Self::CompoundDelimited(b) => b.raw_context(),
+            Self::Admonition(b) => b.raw_context(),
             Self::Table(b) => b.raw_context(),
             Self::Preamble(b) => b.raw_context(),
             Self::Break(b) => b.raw_context(),
@@ -557,6 +611,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.nested_blocks(),
             Self::RawDelimited(b) => b.nested_blocks(),
             Self::CompoundDelimited(b) => b.nested_blocks(),
+            Self::Admonition(b) => b.nested_blocks(),
             Self::Table(b) => b.nested_blocks(),
             Self::Preamble(b) => b.nested_blocks(),
             Self::Break(b) => b.nested_blocks(),
@@ -573,6 +628,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.nested_blocks_mut(),
             Self::RawDelimited(b) => b.nested_blocks_mut(),
             Self::CompoundDelimited(b) => b.nested_blocks_mut(),
+            Self::Admonition(b) => b.nested_blocks_mut(),
             Self::Table(b) => b.nested_blocks_mut(),
             Self::Preamble(b) => b.nested_blocks_mut(),
             Self::Break(b) => b.nested_blocks_mut(),
@@ -589,6 +645,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.content_mut(),
             Self::RawDelimited(b) => b.content_mut(),
             Self::CompoundDelimited(b) => b.content_mut(),
+            Self::Admonition(b) => b.content_mut(),
             Self::Table(b) => b.content_mut(),
             Self::Preamble(b) => b.content_mut(),
             Self::Break(b) => b.content_mut(),
@@ -605,6 +662,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.title_source(),
             Self::RawDelimited(b) => b.title_source(),
             Self::CompoundDelimited(b) => b.title_source(),
+            Self::Admonition(b) => b.title_source(),
             Self::Table(b) => b.title_source(),
             Self::Preamble(b) => b.title_source(),
             Self::Break(b) => b.title_source(),
@@ -621,6 +679,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.title(),
             Self::RawDelimited(b) => b.title(),
             Self::CompoundDelimited(b) => b.title(),
+            Self::Admonition(b) => b.title(),
             Self::Table(b) => b.title(),
             Self::Preamble(b) => b.title(),
             Self::Break(b) => b.title(),
@@ -637,6 +696,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.anchor(),
             Self::RawDelimited(b) => b.anchor(),
             Self::CompoundDelimited(b) => b.anchor(),
+            Self::Admonition(b) => b.anchor(),
             Self::Table(b) => b.anchor(),
             Self::Preamble(b) => b.anchor(),
             Self::Break(b) => b.anchor(),
@@ -653,6 +713,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.anchor_reftext(),
             Self::RawDelimited(b) => b.anchor_reftext(),
             Self::CompoundDelimited(b) => b.anchor_reftext(),
+            Self::Admonition(b) => b.anchor_reftext(),
             Self::Table(b) => b.anchor_reftext(),
             Self::Preamble(b) => b.anchor_reftext(),
             Self::Break(b) => b.anchor_reftext(),
@@ -669,6 +730,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.attrlist(),
             Self::RawDelimited(b) => b.attrlist(),
             Self::CompoundDelimited(b) => b.attrlist(),
+            Self::Admonition(b) => b.attrlist(),
             Self::Table(b) => b.attrlist(),
             Self::Preamble(b) => b.attrlist(),
             Self::Break(b) => b.attrlist(),
@@ -685,6 +747,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::ListItem(b) => b.substitution_group(),
             Self::RawDelimited(b) => b.substitution_group(),
             Self::CompoundDelimited(b) => b.substitution_group(),
+            Self::Admonition(b) => b.substitution_group(),
             Self::Table(b) => b.substitution_group(),
             Self::Preamble(b) => b.substitution_group(),
             Self::Break(b) => b.substitution_group(),
@@ -703,6 +766,7 @@ impl<'src> HasSpan<'src> for Block<'src> {
             Self::ListItem(b) => b.span(),
             Self::RawDelimited(b) => b.span(),
             Self::CompoundDelimited(b) => b.span(),
+            Self::Admonition(b) => b.span(),
             Self::Table(b) => b.span(),
             Self::Preamble(b) => b.span(),
             Self::Break(b) => b.span(),

--- a/parser/src/blocks/compound_delimited.rs
+++ b/parser/src/blocks/compound_delimited.rs
@@ -61,6 +61,11 @@ impl<'src> CompoundDelimitedBlock<'src> {
         }
     }
 
+    /// Consume this block and return its nested blocks.
+    pub(crate) fn into_nested_blocks(self) -> Vec<Block<'src>> {
+        self.blocks
+    }
+
     pub(crate) fn parse(
         metadata: &BlockMetadata<'src>,
         parser: &mut Parser,

--- a/parser/src/blocks/context.rs
+++ b/parser/src/blocks/context.rs
@@ -30,3 +30,98 @@ pub(crate) fn is_built_in_context(context: &str) -> bool {
             | "video"
     )
 }
+
+/// The five admonition types provided by the AsciiDoc language.
+///
+/// An admonition draws attention to a statement by taking it out of the
+/// content's flow and labeling it with a priority. The variant is determined by
+/// the assigned type (i.e., the uppercase label), which is specified either as
+/// a special paragraph prefix (e.g., `NOTE:`) or as the block style in an
+/// attribute list (e.g., `[NOTE]`).
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub enum AdmonitionVariant {
+    /// The `NOTE` admonition type.
+    Note,
+
+    /// The `TIP` admonition type.
+    Tip,
+
+    /// The `IMPORTANT` admonition type.
+    Important,
+
+    /// The `CAUTION` admonition type.
+    Caution,
+
+    /// The `WARNING` admonition type.
+    Warning,
+}
+
+impl AdmonitionVariant {
+    /// Resolve an uppercase style label (e.g., `NOTE`) to its admonition
+    /// variant, if it names one.
+    ///
+    /// The match is case-sensitive: the label must be uppercase, per the
+    /// AsciiDoc language specification.
+    pub(crate) fn from_style(style: &str) -> Option<Self> {
+        Some(match style {
+            "NOTE" => Self::Note,
+            "TIP" => Self::Tip,
+            "IMPORTANT" => Self::Important,
+            "CAUTION" => Self::Caution,
+            "WARNING" => Self::Warning,
+            _ => return None,
+        })
+    }
+
+    /// Returns the uppercase style label for this variant (e.g., `NOTE`).
+    pub fn style(self) -> &'static str {
+        match self {
+            Self::Note => "NOTE",
+            Self::Tip => "TIP",
+            Self::Important => "IMPORTANT",
+            Self::Caution => "CAUTION",
+            Self::Warning => "WARNING",
+        }
+    }
+
+    /// Returns the lowercase name for this variant (e.g., `note`).
+    ///
+    /// This is the name used for the block's CSS class and for the
+    /// `<type>-caption` document attribute that controls the label text.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Note => "note",
+            Self::Tip => "tip",
+            Self::Important => "important",
+            Self::Caution => "caution",
+            Self::Warning => "warning",
+        }
+    }
+
+    /// Returns the default caption (label) text for this variant (e.g.,
+    /// `Note`).
+    ///
+    /// This text is shown to the reader (in place of an icon) unless it is
+    /// overridden by setting the `<type>-caption` document attribute.
+    pub fn default_caption(self) -> &'static str {
+        match self {
+            Self::Note => "Note",
+            Self::Tip => "Tip",
+            Self::Important => "Important",
+            Self::Caution => "Caution",
+            Self::Warning => "Warning",
+        }
+    }
+}
+
+impl std::fmt::Debug for AdmonitionVariant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Note => write!(f, "AdmonitionVariant::Note"),
+            Self::Tip => write!(f, "AdmonitionVariant::Tip"),
+            Self::Important => write!(f, "AdmonitionVariant::Important"),
+            Self::Caution => write!(f, "AdmonitionVariant::Caution"),
+            Self::Warning => write!(f, "AdmonitionVariant::Warning"),
+        }
+    }
+}

--- a/parser/src/blocks/mod.rs
+++ b/parser/src/blocks/mod.rs
@@ -22,6 +22,10 @@
 //! Block>` throughout the codebase, but also needed to provide for
 //! externally-described block types.
 
+mod admonition;
+pub use admonition::AdmonitionBlock;
+pub(crate) use admonition::starts_with_admonition_label;
+
 mod block;
 pub use block::Block;
 
@@ -32,6 +36,7 @@ mod compound_delimited;
 pub use compound_delimited::CompoundDelimitedBlock;
 
 mod context;
+pub use context::AdmonitionVariant;
 pub(crate) use context::is_built_in_context;
 
 mod is_block;

--- a/parser/src/tests/asciidoc_lang/attributes/reference_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/reference_attributes.rs
@@ -165,23 +165,27 @@ Actually, please don't.
                     anchor_reftext: None,
                     attrlist: None,
                 },),
-                Block::Simple(SimpleBlock {
-                    content: Content {
+                Block::Admonition(AdmonitionBlock {
+                    variant: AdmonitionVariant::Warning,
+                    label: "Warning",
+                    icons_font: false,
+                    content_model: ContentModel::Simple,
+                    content: Some(Content {
                         original: Span {
-                            data: "WARNING: {disclaimer}\nIf you're missing a lime colored sock, file a ticket in\nthe {url-repo}/issues[Asciidoctor issue tracker].\n(Actually, please don't).",
+                            data: "{disclaimer}\nIf you're missing a lime colored sock, file a ticket in\nthe {url-repo}/issues[Asciidoctor issue tracker].\n(Actually, please don't).",
                             line: 8,
-                            col: 1,
-                            offset: 230,
+                            col: 10,
+                            offset: 239,
                         },
-                        rendered: "WARNING: Don&#8217;t pet the wild Wolpertingers. We&#8217;re not responsible for any loss of hair, chocolate, or purple socks.\nIf you&#8217;re missing a lime colored sock, file a ticket in\nthe <a href=\"https://github.com/asciidoctor/asciidoctor/issues\">Asciidoctor issue tracker</a>.\n(Actually, please don&#8217;t).",
-                    },
+                        rendered: "Don&#8217;t pet the wild Wolpertingers. We&#8217;re not responsible for any loss of hair, chocolate, or purple socks.\nIf you&#8217;re missing a lime colored sock, file a ticket in\nthe <a href=\"https://github.com/asciidoctor/asciidoctor/issues\">Asciidoctor issue tracker</a>.\n(Actually, please don&#8217;t).",
+                    },),
+                    blocks: &[],
                     source: Span {
                         data: "WARNING: {disclaimer}\nIf you're missing a lime colored sock, file a ticket in\nthe {url-repo}/issues[Asciidoctor issue tracker].\n(Actually, please don't).",
                         line: 8,
                         col: 1,
                         offset: 230,
                     },
-                    style: SimpleBlockStyle::Paragraph,
                     title_source: None,
                     title: None,
                     anchor: None,
@@ -249,23 +253,27 @@ Our servers don't like them either.
                     offset: 0,
                 },
             },
-            blocks: &[Block::Simple(SimpleBlock {
-                content: Content {
+            blocks: &[Block::Admonition(AdmonitionBlock {
+                variant: AdmonitionVariant::Tip,
+                label: "Tip",
+                icons_font: false,
+                content_model: ContentModel::Simple,
+                content: Some(Content {
                     original: Span {
-                        data: "TIP: Wolpertingers don't like temperatures above 100{deg}C.\nOur servers don't like them either.",
+                        data: "Wolpertingers don't like temperatures above 100{deg}C.\nOur servers don't like them either.",
                         line: 1,
-                        col: 1,
-                        offset: 0,
+                        col: 6,
+                        offset: 5,
                     },
-                    rendered: "TIP: Wolpertingers don&#8217;t like temperatures above 100&#176;C.\nOur servers don&#8217;t like them either.",
-                },
+                    rendered: "Wolpertingers don&#8217;t like temperatures above 100&#176;C.\nOur servers don&#8217;t like them either.",
+                },),
+                blocks: &[],
                 source: Span {
                     data: "TIP: Wolpertingers don't like temperatures above 100{deg}C.\nOur servers don't like them either.",
                     line: 1,
                     col: 1,
                     offset: 0,
                 },
-                style: SimpleBlockStyle::Paragraph,
                 title_source: None,
                 title: None,
                 anchor: None,

--- a/parser/src/tests/asciidoc_lang/blocks/admonitions.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/admonitions.rs
@@ -19,10 +19,15 @@ The only requirement is that they be offset from the main text and labeled appro
 
 #[test]
 fn admonition_types() {
-    verifies!(
+    non_normative!(
         r#"
 == Admonition types
 
+"#
+    );
+
+    verifies!(
+        r#"
 The rendered style of an admonition is determined by the assigned type (i.e., name).
 The AsciiDoc language provides five admonition types represented by the following labels:
 
@@ -49,7 +54,7 @@ The label becomes visible to the reader unless icons are enabled, in which case 
     assert_css(&doc, ".admonitionblock.caution", 1);
     assert_css(&doc, ".admonitionblock.warning", 1);
 
-    // The label may be specified as a paragraph prefix...
+    // The label may be specified as a paragraph prefix ...
     let mut parser = Parser::default();
     let block =
         crate::blocks::Block::parse(crate::Span::new("NOTE: paragraph prefix"), &mut parser)
@@ -59,7 +64,7 @@ The label becomes visible to the reader unless icons are enabled, in which case 
     assert_eq!(block.resolved_context().as_ref(), "admonition");
     assert_eq!(block.declared_style(), Some("NOTE"));
 
-    // ...or as the block style.
+    // ... or as the block style.
     let mut parser = Parser::default();
     let block = crate::blocks::Block::parse(crate::Span::new("[NOTE]\nblock style"), &mut parser)
         .unwrap_if_no_warnings()
@@ -90,10 +95,15 @@ To find a deeper analysis, see https://www.differencebetween.com/difference-betw
 
 #[test]
 fn admonition_paragraph_syntax() {
-    verifies!(
+    non_normative!(
         r#"
 == Admonition syntax
 
+"#
+    );
+
+    verifies!(
+        r#"
 When you want to call attention to a single paragraph, start the first line of the paragraph with the label you want to use.
 The label must be uppercase and followed by a colon (`:`).
 
@@ -187,10 +197,15 @@ include::example$admonition.adoc[tag=bl-nest]
 
 #[test]
 fn enable_admonition_icons() {
-    verifies!(
+    non_normative!(
         r#"
 == Enable admonition icons
 
+"#
+    );
+
+    verifies!(
+        r#"
 In the examples above, the admonition is rendered in a callout box with the style label in the gutter.
 You can replace the textual labels with font icons by setting the `icons` attribute on the document and assigning it the value `font`.
 
@@ -203,6 +218,11 @@ You can replace the textual labels with font icons by setting the `icons` attrib
 include::example$admonition.adoc[tag=para]
 ----
 
+"#
+    );
+
+    non_normative!(
+        r#"
 Learn more about using Font Awesome or custom icons with admonitions in xref:macros:icons-font.adoc[].
 
 "#
@@ -233,10 +253,15 @@ Learn more about using Font Awesome or custom icons with admonitions in xref:mac
 
 #[test]
 fn using_emoji_for_admonition_icons() {
-    verifies!(
+    non_normative!(
         r#"
 == Using emoji for admonition icons
 
+"#
+    );
+
+    verifies!(
+        r#"
 If image-based or font-based icons are not available, you can leverage the admonition caption to display an emoji (or any symbol from Unicode) in the place of the admonition label, thus giving you an alternative way to make admonition icons.
 
 If the `icons` attribute is not set on the document, the admonition label is shown as text (e.g., CAUTION).

--- a/parser/src/tests/asciidoc_lang/blocks/admonitions.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/admonitions.rs
@@ -1,0 +1,316 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/blocks/pages/admonitions.adoc");
+
+non_normative!(
+    r#"
+= Admonitions
+
+There are certain statements you may want to draw attention to by taking them out of the content's flow and labeling them with a priority.
+These are called admonitions.
+This page introduces you to admonition types AsciiDoc provides, how to add admonitions to your document, and how to enhance them using icons or emoji.
+
+NOTE: The examples on this page (and in these docs) use a visual theme that differs from the style provided by AsciiDoc processors such as Asciidoctor.
+The AsciiDoc language does not require that the admonitions be rendered using a particular style.
+The only requirement is that they be offset from the main text and labeled appropriately according to their admonition type.
+
+"#
+);
+
+#[test]
+fn admonition_types() {
+    verifies!(
+        r#"
+== Admonition types
+
+The rendered style of an admonition is determined by the assigned type (i.e., name).
+The AsciiDoc language provides five admonition types represented by the following labels:
+
+* `NOTE`
+* `TIP`
+* `IMPORTANT`
+* `CAUTION`
+* `WARNING`
+
+The label is specified either as the block style or as a special paragraph prefix.
+The label becomes visible to the reader unless icons are enabled, in which case the icon is shown in its place.
+
+"#
+    );
+
+    // The five admonition types, keyed by their uppercase label, each map to a
+    // lowercase name that becomes the admonition's CSS class.
+    let doc =
+        Parser::default().parse("NOTE: n\n\nTIP: t\n\nIMPORTANT: i\n\nCAUTION: c\n\nWARNING: w");
+
+    assert_css(&doc, ".admonitionblock.note", 1);
+    assert_css(&doc, ".admonitionblock.tip", 1);
+    assert_css(&doc, ".admonitionblock.important", 1);
+    assert_css(&doc, ".admonitionblock.caution", 1);
+    assert_css(&doc, ".admonitionblock.warning", 1);
+
+    // The label may be specified as a paragraph prefix...
+    let mut parser = Parser::default();
+    let block =
+        crate::blocks::Block::parse(crate::Span::new("NOTE: paragraph prefix"), &mut parser)
+            .unwrap_if_no_warnings()
+            .unwrap()
+            .item;
+    assert_eq!(block.resolved_context().as_ref(), "admonition");
+    assert_eq!(block.declared_style(), Some("NOTE"));
+
+    // ...or as the block style.
+    let mut parser = Parser::default();
+    let block = crate::blocks::Block::parse(crate::Span::new("[NOTE]\nblock style"), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap()
+        .item;
+    assert_eq!(block.resolved_context().as_ref(), "admonition");
+    assert_eq!(block.declared_style(), Some("NOTE"));
+}
+
+non_normative!(
+    r#"
+.Caution vs. Warning
+[#caution-vs-warning]
+****
+When choosing the admonition type, you may find yourself getting confused between "`caution`" and "`warning`" as these words are often used interchangeably.
+Here's a simple rule to help you differentiate the two:
+
+* Use *CAUTION* to advise the reader to _act_ carefully (i.e., exercise care).
+* Use *WARNING* to inform the reader of danger, harm, or consequences that exist.
+
+The word caution in this context translates into attention in French, which is often a good reference for how it should be applied.
+
+To find a deeper analysis, see https://www.differencebetween.com/difference-between-caution-and-vs-warning/.
+****
+
+"#
+);
+
+#[test]
+fn admonition_paragraph_syntax() {
+    verifies!(
+        r#"
+== Admonition syntax
+
+When you want to call attention to a single paragraph, start the first line of the paragraph with the label you want to use.
+The label must be uppercase and followed by a colon (`:`).
+
+.Admonition paragraph syntax
+[#ex-label]
+----
+include::example$admonition.adoc[tag=para-c]
+----
+<.> The label must be uppercase and immediately followed by a colon (`:`).
+<.> Separate the first line of the paragraph from the label by a single space.
+
+The result of <<ex-label>> is displayed below.
+
+include::example$admonition.adoc[tag=para]
+
+"#
+    );
+
+    // The `para` example tag from the included file.
+    let doc = Parser::default().parse(
+        "WARNING: Wolpertingers are known to nest in server racks.\nEnter at your own risk.",
+    );
+
+    assert_css(&doc, ".admonitionblock.warning", 1);
+    assert_xpath(
+        &doc,
+        "//td[@class=\"content\"][normalize-space(text())=\"Wolpertingers are known to nest in server racks. Enter at your own risk.\"]",
+        1,
+    );
+
+    // The label must be uppercase: a lowercase label is not an admonition.
+    let doc = Parser::default().parse("note: This is not an admonition.");
+    assert_css(&doc, ".admonitionblock", 0);
+    assert_css(&doc, ".paragraph", 1);
+
+    // The label must be separated from the content by a space: without one, it
+    // is not an admonition.
+    let doc = Parser::default().parse("NOTE:This is not an admonition.");
+    assert_css(&doc, ".admonitionblock", 0);
+    assert_css(&doc, ".paragraph", 1);
+}
+
+#[test]
+fn admonition_block_syntax() {
+    verifies!(
+        r#"
+When you want to apply an admonition to compound content, set the label as a style attribute on a block.
+As seen in the next example, admonition labels are commonly set on example blocks.
+This behavior is referred to as *masquerading*.
+The label must be uppercase when set as an attribute on a block.
+
+.Admonition block syntax
+[#ex-block]
+----
+include::example$admonition.adoc[tag=bl-c]
+----
+<.> Set the label in an attribute list on a delimited block.
+The label must be uppercase.
+<.> Admonition styles are commonly set on example blocks.
+Example blocks are delimited by four equal signs (`====`).
+
+The result of <<ex-block>> is displayed below.
+
+include::example$admonition.adoc[tag=bl-nest]
+
+"#
+    );
+
+    // The `bl-nest` example tag: an `[IMPORTANT]` style masquerading on an
+    // example block produces an admonition with compound content.
+    let doc = Parser::default().parse(
+        "[IMPORTANT]\n.Feeding the Werewolves\n======\nWhile werewolves are hardy community members, keep in mind the following dietary concerns:\n\n. They are allergic to cinnamon.\n. More than two glasses of orange juice in 24 hours makes them howl in harmony with alarms and sirens.\n. Celery makes them sad.\n======",
+    );
+
+    assert_css(&doc, ".admonitionblock.important", 1);
+    // The block title renders inside the content cell.
+    assert_xpath(
+        &doc,
+        "//td[@class=\"content\"]/div[@class=\"title\"][text()=\"Feeding the Werewolves\"]",
+        1,
+    );
+    // The compound content holds the nested ordered list.
+    assert_css(&doc, ".admonitionblock.important td.content .olist", 1);
+
+    // The label must be uppercase: a lowercase style is not an admonition (it
+    // remains an example block).
+    let doc = Parser::default().parse("[important]\n====\nNot an admonition.\n====");
+    assert_css(&doc, ".admonitionblock", 0);
+    assert_css(&doc, ".exampleblock", 1);
+}
+
+#[test]
+fn enable_admonition_icons() {
+    verifies!(
+        r#"
+== Enable admonition icons
+
+In the examples above, the admonition is rendered in a callout box with the style label in the gutter.
+You can replace the textual labels with font icons by setting the `icons` attribute on the document and assigning it the value `font`.
+
+.Admonition paragraph with icons set
+[#ex-icon]
+----
+= Document Title
+:icons: font
+
+include::example$admonition.adoc[tag=para]
+----
+
+Learn more about using Font Awesome or custom icons with admonitions in xref:macros:icons-font.adoc[].
+
+"#
+    );
+
+    // With `icons` set to `font`, the textual label is replaced with a font
+    // icon.
+    let doc = Parser::default().parse(
+        "= Document Title\n:icons: font\n\nWARNING: Wolpertingers are known to nest in server racks.\nEnter at your own risk.",
+    );
+
+    assert_css(
+        &doc,
+        ".admonitionblock.warning td.icon i.fa.icon-warning",
+        1,
+    );
+    assert_css(&doc, "td.icon .title", 0);
+
+    // Without the `icons` attribute, the textual label is shown.
+    let doc = Parser::default().parse("WARNING: text");
+    assert_css(&doc, "td.icon i", 0);
+    assert_xpath(
+        &doc,
+        "//td[@class=\"icon\"]/div[@class=\"title\"][text()=\"Warning\"]",
+        1,
+    );
+}
+
+#[test]
+fn using_emoji_for_admonition_icons() {
+    verifies!(
+        r#"
+== Using emoji for admonition icons
+
+If image-based or font-based icons are not available, you can leverage the admonition caption to display an emoji (or any symbol from Unicode) in the place of the admonition label, thus giving you an alternative way to make admonition icons.
+
+If the `icons` attribute is not set on the document, the admonition label is shown as text (e.g., CAUTION).
+The text for this label comes from an AsciiDoc attribute.
+The name of the attribute is `<type>-caption`, where `<type>` is the admonition type in lowercase.
+For example, the attribute for a tip admonition is `tip-caption`.
+
+Instead of a word, you can assign a Unicode glyph to this attribute:
+
+----
+:tip-caption: 💡
+
+[TIP]
+It's possible to use Unicode glyphs as admonition icons.
+----
+
+Here's the result you get in the HTML:
+
+[,html]
+----
+<td class="icon">
+<div class="title">💡</div>
+</td>
+----
+
+"#
+    );
+
+    // When icons are not set, the label is shown as text drawn from the
+    // `<type>-caption` attribute, which defaults to the capitalized type name.
+    let doc = Parser::default().parse("CAUTION: Slippery when wet.");
+    assert_xpath(
+        &doc,
+        "//td[@class=\"icon\"]/div[@class=\"title\"][text()=\"Caution\"]",
+        1,
+    );
+
+    // Assigning a Unicode glyph to the `<type>-caption` attribute makes that
+    // glyph the label.
+    let doc = Parser::default().parse(
+        ":tip-caption: 💡\n\n[TIP]\nIt's possible to use Unicode glyphs as admonition icons.",
+    );
+    assert_xpath(
+        &doc,
+        "//td[@class=\"icon\"]/div[@class=\"title\"][text()=\"💡\"]",
+        1,
+    );
+}
+
+non_normative!(
+    r#"
+Instead of entering the glyph directly, you can enter a character reference instead.
+However, since you're defining the character reference in an attribute entry, you (currently) have to disable substitutions on the value.
+
+----
+:tip-caption: pass:[&#128161;]
+
+[TIP]
+It's possible to use Unicode glyphs as admonition icons.
+----
+
+On GitHub, the HTML output from the AsciiDoc processor is run through a postprocessing filter that substitutes emoji shortcodes with emoji symbols.
+That means you can use these shortcodes instead in the value of the attribute:
+
+----
+\ifdef::env-github[]
+:tip-caption: :bulb:
+\endif::[]
+
+[TIP]
+It's possible to use emojis as admonition icons on GitHub.
+----
+
+When the document is processed through the GitHub interface, the shortcodes get replaced with real emojis.
+This is the only known way to get admonition icons to work on GitHub.
+"#
+);

--- a/parser/src/tests/asciidoc_lang/blocks/admonitions.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/admonitions.rs
@@ -311,8 +311,10 @@ Here's the result you get in the HTML:
     );
 }
 
-non_normative!(
-    r#"
+#[test]
+fn caption_from_character_reference() {
+    verifies!(
+        r#"
 Instead of entering the glyph directly, you can enter a character reference instead.
 However, since you're defining the character reference in an attribute entry, you (currently) have to disable substitutions on the value.
 
@@ -323,6 +325,24 @@ However, since you're defining the character reference in an attribute entry, yo
 It's possible to use Unicode glyphs as admonition icons.
 ----
 
+"#
+    );
+
+    // The character reference is assigned with substitutions disabled (via the
+    // `pass` macro), so it reaches the label as written; the rendered HTML shows
+    // the referenced glyph.
+    let doc = Parser::default().parse(
+        ":tip-caption: pass:[&#128161;]\n\n[TIP]\nIt's possible to use Unicode glyphs as admonition icons.",
+    );
+    assert_xpath(
+        &doc,
+        "//td[@class=\"icon\"]/div[@class=\"title\"][text()=\"💡\"]",
+        1,
+    );
+}
+
+non_normative!(
+    r#"
 On GitHub, the HTML output from the AsciiDoc processor is run through a postprocessing filter that substitutes emoji shortcodes with emoji symbols.
 That means you can use these shortcodes instead in the value of the attribute:
 

--- a/parser/src/tests/asciidoc_lang/blocks/mod.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/mod.rs
@@ -1,4 +1,5 @@
 mod add_title;
+mod admonitions;
 mod assign_id;
 mod breaks;
 mod build_basic_block;

--- a/parser/src/tests/asciidoc_lang/lists/continuation.rs
+++ b/parser/src/tests/asciidoc_lang/lists/continuation.rs
@@ -1615,23 +1615,27 @@ include::example$complex.adoc[tag=complex-o]
                                         attrlist: None,
                                         substitution_group: SubstitutionGroup::Verbatim,
                                     },),
-                                    Block::Simple(SimpleBlock {
-                                        content: Content {
+                                    Block::Admonition(AdmonitionBlock {
+                                        variant: AdmonitionVariant::Note,
+                                        label: "Note",
+                                        icons_font: false,
+                                        content_model: ContentModel::Simple,
+                                        content: Some(Content {
                                             original: Span {
-                                                data: "NOTE: The header is optional.",
+                                                data: "The header is optional.",
                                                 line: 10,
-                                                col: 1,
-                                                offset: 132,
+                                                col: 7,
+                                                offset: 138,
                                             },
-                                            rendered: "NOTE: The header is optional.",
-                                        },
+                                            rendered: "The header is optional.",
+                                        },),
+                                        blocks: &[],
                                         source: Span {
                                             data: "NOTE: The header is optional.",
                                             line: 10,
                                             col: 1,
                                             offset: 132,
                                         },
-                                        style: SimpleBlockStyle::Paragraph,
                                         title_source: None,
                                         title: None,
                                         anchor: None,

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -472,7 +472,7 @@ mod bulleted_lists {
                 "//ul/li/p[text()=\"first-line text\nwrapped text\"]",
                 1,
             );
-            assert_css(&doc, "ul > li > .admonitionblock.note", 1);
+            assert_css(&doc, "ul > li > p + .admonitionblock.note", 1);
             assert_xpath(
                 &doc,
                 "//ul/li/*[@class=\"admonitionblock note\"]//td[@class=\"content\"][normalize-space(text())=\"This is a note.\"]",

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -460,36 +460,34 @@ mod bulleted_lists {
         }
 
         #[test]
-        #[ignore]
-        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/456):
-        // Enable this test when admonitions are implemented.
         fn an_admonition_paragraph_attached_by_a_line_continuation_to_a_list_item_with_wrapped_text_should_produce_admonition()
          {
-            let _doc = Parser::default()
+            let doc = Parser::default()
                 .parse("- first-line text\n  wrapped text\n+\nNOTE: This is a note.\n");
-            todo!("assert_css: 'ul', output, 1");
-            todo!("assert_css: 'ul > li', output, 1");
-            todo!("assert_css: 'ul > li > p', output, 1");
-            todo!(
-                "assert_xpath: '//ul/li/p[text()=\"first-line text\\nwrapped text\"]', output, 1"
+            assert_css(&doc, "ul", 1);
+            assert_css(&doc, "ul > li", 1);
+            assert_css(&doc, "ul > li > p", 1);
+            assert_xpath(
+                &doc,
+                "//ul/li/p[text()=\"first-line text\nwrapped text\"]",
+                1,
             );
-            todo!("assert_css: 'ul > li > p + .admonitionblock.note', output, 1");
-            todo!(
-                "assert_xpath: '//ul/li/*[@class=\"admonitionblock note\"]//td[@class=\"content\"][normalize-space(text())=\"This is a note.\"]', output, 1"
+            assert_css(&doc, "ul > li > .admonitionblock.note", 1);
+            assert_xpath(
+                &doc,
+                "//ul/li/*[@class=\"admonitionblock note\"]//td[@class=\"content\"][normalize-space(text())=\"This is a note.\"]",
+                1,
             );
         }
 
         #[test]
-        #[ignore]
-        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/456):
-        // Enable this test when admonitions are implemented.
         fn paragraph_like_blocks_attached_to_an_ancestor_list_item_by_a_list_continuation_should_produce_blocks()
          {
-            let _doc = Parser::default().parse("* parent\n ** child\n\n+\nNOTE: This is a note.\n\n* another parent\n ** another child\n\n+\n'''\n");
-            todo!("assert_css: 'ul ul .admonitionblock.note', output, 0");
-            todo!("assert_xpath: '(//ul)[1]/li/*[@class=\"admonitionblock note\"]', output, 1");
-            todo!("assert_css: 'ul ul hr', output, 0");
-            todo!("assert_xpath: '(//ul)[1]/li/hr', output, 1");
+            let doc = Parser::default().parse("* parent\n ** child\n\n+\nNOTE: This is a note.\n\n* another parent\n ** another child\n\n+\n'''\n");
+            assert_css(&doc, "ul ul .admonitionblock.note", 0);
+            assert_xpath(&doc, "(//ul)[1]/li/*[@class=\"admonitionblock note\"]", 1);
+            assert_css(&doc, "ul ul hr", 0);
+            assert_xpath(&doc, "(//ul)[1]/li/hr", 1);
         }
 
         #[test]

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1079,10 +1079,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/456): The
-    // admonition inside the open block does not render as `.admonitionblock`.
-    // Enable when admonitions are implemented.
     fn basic_asciidoc_cell() {
         let doc = Parser::default().parse("|===\na|--\nNOTE: content\n\ncontent\n--\n|===");
 
@@ -1151,15 +1147,41 @@ mod psv {
         assert_rendered_contains(&doc, "{backend-html5-doctype-article}");
     }
 
-    // Deferred: "should not allow AsciiDoc table cell to set a document
-    // attribute that was hard set by the API" (Ruby 1457) observes the lock via
-    // a NOTE admonition's icon, and admonitions are not implemented. The same
-    // API-lock path is covered by
-    // `should_not_allow_locked_attribute_unset_in_parent_document_to_be_set_in_asciidoc_table_cell`.
+    #[test]
+    fn should_not_allow_asciidoc_table_cell_to_set_a_document_attribute_that_was_hard_set_by_the_api()
+     {
+        // `icons` is hard set to `font` by the API, so the cell's `:icons:`
+        // (which would otherwise change it) is ignored: the cell's NOTE
+        // admonition still renders with a font-based icon.
+        let doc = Parser::default()
+            .with_intrinsic_attribute("icons", "font", ModificationContext::ApiOnly)
+            .parse(
+                "|===\na|\n:icons:\n\nNOTE: This admonition does not have a font-based icon.\n|===",
+            );
 
-    // Deferred: "should not allow AsciiDoc table cell to set a document
-    // attribute that was hard unset by the API" (Ruby 1472) — same admonition
-    // dependency as above.
+        assert_css(&doc, "td.icon .title", 0);
+        assert_css(&doc, "td.icon i.icon-note", 1);
+    }
+
+    #[test]
+    fn should_not_allow_asciidoc_table_cell_to_set_a_document_attribute_that_was_hard_unset_by_the_api()
+     {
+        // `icons` is hard unset by the API, so the cell's `:icons: font` is
+        // ignored: the cell's NOTE admonition renders with a text label.
+        let doc = Parser::default()
+            .with_intrinsic_attribute_bool("icons", false, ModificationContext::ApiOnly)
+            .parse(
+                "|===\na|\n:icons: font\n\nNOTE: This admonition does not have a font-based icon.\n|===",
+            );
+
+        assert_css(&doc, "td.icon .title", 1);
+        assert_css(&doc, "td.icon i.icon-note", 0);
+        assert_xpath(
+            &doc,
+            "//td[@class=\"icon\"]/*[@class=\"title\"][text()=\"Note\"]",
+            1,
+        );
+    }
 
     #[test]
     fn should_keep_attribute_unset_in_asciidoc_table_cell_if_unset_in_parent_document() {
@@ -1260,10 +1282,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/456): The
-    // NOTE admonition and nested blocks do not render as `.admonitionblock` /
-    // `.dlist` inside the cell. Enable when admonitions are implemented.
     fn asciidoc_content() {
         let doc = Parser::default().parse(
             "[cols=\"1e,1,5a\"]\n|===\n|Name |Backends |Description\n\n|badges |xhtml11, html5 |\nLink badges.\n\n[NOTE]\n====\nThe path names are relative.\n====\n|docinfo |All backends |\nThese attributes control docinfo:\n\ndocinfo:: Include x\ndocinfo1:: Include y\n|===",

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -881,6 +881,12 @@ fn compound_delimited_to_node<'a>(compound: &'a CompoundDelimitedBlock<'a>) -> V
         node = node.with_id(id);
     }
 
+    // Render each child through `add_block_with_title` (rather than a bare
+    // `child.to_virtual_dom()`) so that a child block's title surfaces as a
+    // sibling `div.title` and a child paragraph is wrapped in `div.paragraph`,
+    // matching Asciidoctor's output. This applies to every compound block type
+    // (example, sidebar, quote, open), not just admonitions: before this, a
+    // titled child inside one of these blocks had its title dropped.
     for child in compound.nested_blocks() {
         add_block_with_title(&mut node, child);
     }

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -11,10 +11,10 @@ use regex::Regex;
 use crate::{
     Document, HasSpan,
     blocks::{
-        Block, Break, ColumnStyle, CompoundDelimitedBlock, Frame, Grid, HorizontalAlignment,
-        IsBlock, ListBlock, ListItem, ListItemMarker, ListType, MediaBlock, Preamble,
-        RawDelimitedBlock, SectionBlock, SimpleBlock, SimpleBlockStyle, Stripes, TableBlock,
-        TableCellContent, TableColumn, TableRow, VerticalAlignment,
+        AdmonitionBlock, Block, Break, ColumnStyle, CompoundDelimitedBlock, ContentModel, Frame,
+        Grid, HorizontalAlignment, IsBlock, ListBlock, ListItem, ListItemMarker, ListType,
+        MediaBlock, Preamble, RawDelimitedBlock, SectionBlock, SimpleBlock, SimpleBlockStyle,
+        Stripes, TableBlock, TableCellContent, TableColumn, TableRow, VerticalAlignment,
     },
 };
 
@@ -365,8 +365,12 @@ impl ToVirtualDom for Document<'_> {
 /// skip adding a separate title element for those.
 fn add_block_with_title<'a>(parent: &mut VirtualNode, block: &'a Block<'a>) {
     // Check if this block type handles its own title internally. Lists render
-    // their title inside the list wrapper; tables render it as a <caption>.
-    let handles_title_internally = matches!(block, Block::List(_) | Block::Table(_));
+    // their title inside the list wrapper; tables render it as a <caption>;
+    // admonitions render it inside the content cell.
+    let handles_title_internally = matches!(
+        block,
+        Block::List(_) | Block::Table(_) | Block::Admonition(_)
+    );
 
     // Add title as a separate sibling element if the block doesn't handle it
     // internally.
@@ -448,6 +452,7 @@ impl ToVirtualDom for Block<'_> {
             Block::Media(media) => media_to_node(media),
             Block::RawDelimited(raw) => raw_delimited_to_node(raw),
             Block::CompoundDelimited(compound) => compound_delimited_to_node(compound),
+            Block::Admonition(admonition) => admonition_to_node(admonition),
             Block::Table(table) => table_to_node(table),
             Block::Preamble(preamble) => preamble_to_node(preamble),
             Block::Break(break_) => break_to_node(break_),
@@ -877,10 +882,83 @@ fn compound_delimited_to_node<'a>(compound: &'a CompoundDelimitedBlock<'a>) -> V
     }
 
     for child in compound.nested_blocks() {
-        node.children.push(child.to_virtual_dom());
+        add_block_with_title(&mut node, child);
     }
 
     node
+}
+
+fn admonition_to_node<'a>(admonition: &'a AdmonitionBlock<'a>) -> VirtualNode {
+    // The outer wrapper carries `admonitionblock`, the admonition name (e.g.
+    // `note`), then any roles. The ID, if any, is set on this element.
+    let mut node = VirtualNode::new("div")
+        .with_class("admonitionblock")
+        .with_class(admonition.name());
+
+    for role in admonition.roles() {
+        node = node.with_class(role);
+    }
+
+    if let Some(id) = admonition.id() {
+        node = node.with_id(id);
+    }
+
+    // The label/icon and content are laid out in a single-row table.
+    let mut icon_cell = VirtualNode::new("td").with_class("icon");
+    if admonition.icons_font() {
+        // With font icons enabled, the label is rendered as a Font Awesome icon
+        // whose `title` carries the caption text.
+        icon_cell = icon_cell.with_child(
+            VirtualNode::new("i")
+                .with_class("fa")
+                .with_class(format!("icon-{}", admonition.name()))
+                .with_attribute("title", admonition.label()),
+        );
+    } else {
+        // Otherwise the caption text (or emoji glyph) is shown as a title.
+        icon_cell = icon_cell.with_child(
+            VirtualNode::new("div")
+                .with_class("title")
+                .with_text(admonition.label()),
+        );
+    }
+
+    let mut content_cell = VirtualNode::new("td").with_class("content");
+
+    // The admonition's own title renders inside the content cell, before the
+    // content itself.
+    if let Some(title) = admonition.title() {
+        content_cell
+            .children
+            .push(VirtualNode::new("div").with_class("title").with_text(title));
+    }
+
+    match admonition.content_model() {
+        ContentModel::Compound => {
+            for child in admonition.nested_blocks() {
+                add_block_with_title(&mut content_cell, child);
+            }
+        }
+
+        // Simple content is rendered directly in the content cell (no wrapping
+        // paragraph), matching Asciidoctor's HTML output.
+        _ => {
+            if let Some(content) = admonition.content() {
+                let rendered = content.rendered();
+                if rendered.contains('<') {
+                    content_cell.children.extend(parse_html_content(rendered));
+                } else {
+                    content_cell.text = Some(decode_html_entities(rendered));
+                }
+            }
+        }
+    }
+
+    let row = VirtualNode::new("tr")
+        .with_child(icon_cell)
+        .with_child(content_cell);
+
+    node.with_child(VirtualNode::new("table").with_child(row))
 }
 
 fn table_to_node<'a>(table: &'a TableBlock<'a>) -> VirtualNode {

--- a/parser/src/tests/fixtures/blocks/admonition.rs
+++ b/parser/src/tests/fixtures/blocks/admonition.rs
@@ -1,0 +1,153 @@
+use std::fmt;
+
+use crate::{
+    HasSpan,
+    blocks::{AdmonitionVariant, ContentModel, IsBlock},
+    tests::fixtures::{Span, attributes::Attrlist, blocks::Block, content::Content},
+};
+
+#[derive(Eq, PartialEq)]
+pub(crate) struct AdmonitionBlock {
+    pub variant: AdmonitionVariant,
+    pub label: &'static str,
+    pub icons_font: bool,
+    pub content_model: ContentModel,
+    pub content: Option<Content>,
+    pub blocks: &'static [Block],
+    pub source: Span,
+    pub title_source: Option<Span>,
+    pub title: Option<&'static str>,
+    pub anchor: Option<Span>,
+    pub anchor_reftext: Option<Span>,
+    pub attrlist: Option<Attrlist>,
+}
+
+impl fmt::Debug for AdmonitionBlock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AdmonitionBlock")
+            .field("variant", &self.variant)
+            .field("label", &self.label)
+            .field("icons_font", &self.icons_font)
+            .field("content_model", &self.content_model)
+            .field("content", &self.content)
+            .field("blocks", &self.blocks)
+            .field("source", &self.source)
+            .field("title_source", &self.title_source)
+            .field("title", &self.title)
+            .field("anchor", &self.anchor)
+            .field("anchor_reftext", &self.anchor_reftext)
+            .field("attrlist", &self.attrlist)
+            .finish()
+    }
+}
+
+impl<'src> PartialEq<crate::blocks::AdmonitionBlock<'src>> for AdmonitionBlock {
+    fn eq(&self, other: &crate::blocks::AdmonitionBlock<'src>) -> bool {
+        fixture_eq_observed(self, other)
+    }
+}
+
+impl PartialEq<AdmonitionBlock> for crate::blocks::AdmonitionBlock<'_> {
+    fn eq(&self, other: &AdmonitionBlock) -> bool {
+        fixture_eq_observed(other, self)
+    }
+}
+
+fn fixture_eq_observed(
+    fixture: &AdmonitionBlock,
+    observed: &crate::blocks::AdmonitionBlock,
+) -> bool {
+    if fixture.variant != observed.variant() {
+        return false;
+    }
+
+    if fixture.label != observed.label() {
+        return false;
+    }
+
+    if fixture.icons_font != observed.icons_font() {
+        return false;
+    }
+
+    if fixture.content_model != observed.content_model() {
+        return false;
+    }
+
+    if fixture.content.is_some() != observed.content().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_content) = fixture.content
+        && let Some(observed_content) = observed.content()
+        && fixture_content != observed_content
+    {
+        return false;
+    }
+
+    if fixture.blocks.len() != observed.nested_blocks().len() {
+        return false;
+    }
+
+    for (fixture_block, observed_block) in fixture.blocks.iter().zip(observed.nested_blocks()) {
+        if fixture_block != observed_block {
+            return false;
+        }
+    }
+
+    if fixture.title_source.is_some() != observed.title_source().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_title_source) = fixture.title_source
+        && let Some(ref observed_title_source) = observed.title_source()
+        && fixture_title_source != observed_title_source
+    {
+        return false;
+    }
+
+    if fixture.title.is_some() != observed.title().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_title) = fixture.title
+        && let Some(ref observed_title) = observed.title()
+        && fixture_title != observed_title
+    {
+        return false;
+    }
+
+    if fixture.anchor.is_some() != observed.anchor().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_anchor) = fixture.anchor
+        && let Some(ref observed_anchor) = observed.anchor()
+        && fixture_anchor != observed_anchor
+    {
+        return false;
+    }
+
+    if fixture.anchor_reftext.is_some() != observed.anchor_reftext().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_anchor_reftext) = fixture.anchor_reftext
+        && let Some(ref observed_anchor_reftext) = observed.anchor_reftext()
+        && fixture_anchor_reftext != observed_anchor_reftext
+    {
+        return false;
+    }
+
+    if fixture.attrlist.is_some() != observed.attrlist().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_attrlist) = fixture.attrlist
+        && let Some(ref observed_attrlist) = observed.attrlist()
+        && &fixture_attrlist != observed_attrlist
+    {
+        return false;
+    }
+
+    fixture.source == observed.span()
+}

--- a/parser/src/tests/fixtures/blocks/block.rs
+++ b/parser/src/tests/fixtures/blocks/block.rs
@@ -1,6 +1,6 @@
 use crate::tests::fixtures::{
     blocks::{
-        Break, CompoundDelimitedBlock, ListBlock, ListItem, MediaBlock, Preamble,
+        AdmonitionBlock, Break, CompoundDelimitedBlock, ListBlock, ListItem, MediaBlock, Preamble,
         RawDelimitedBlock, SectionBlock, SimpleBlock, TableBlock,
     },
     document::Attribute,
@@ -15,6 +15,7 @@ pub(crate) enum Block {
     ListItem(ListItem),
     RawDelimited(RawDelimitedBlock),
     CompoundDelimited(CompoundDelimitedBlock),
+    Admonition(AdmonitionBlock),
     Table(TableBlock),
     Preamble(Preamble),
     Break(Break),
@@ -69,6 +70,11 @@ fn fixture_eq_observed(fixture: &Block, observed: &crate::blocks::Block) -> bool
 
         Block::CompoundDelimited(cdb_fixture) => match observed {
             crate::blocks::Block::CompoundDelimited(cdb_observed) => cdb_fixture == cdb_observed,
+            _ => false,
+        },
+
+        Block::Admonition(adm_fixture) => match observed {
+            crate::blocks::Block::Admonition(adm_observed) => adm_fixture == adm_observed,
             _ => false,
         },
 

--- a/parser/src/tests/fixtures/blocks/mod.rs
+++ b/parser/src/tests/fixtures/blocks/mod.rs
@@ -1,3 +1,6 @@
+mod admonition;
+pub(crate) use admonition::AdmonitionBlock;
+
 mod block;
 pub(crate) use block::Block;
 

--- a/parser/src/tests/prelude.rs
+++ b/parser/src/tests/prelude.rs
@@ -7,8 +7,8 @@ pub(crate) use std::collections::HashMap;
 pub(crate) use crate::{
     HasSpan, Parser,
     blocks::{
-        ColumnStyle, Frame, Grid, HorizontalAlignment, IsBlock, SectionType, SimpleBlockStyle,
-        Stripes, VerticalAlignment,
+        AdmonitionVariant, ColumnStyle, ContentModel, Frame, Grid, HorizontalAlignment, IsBlock,
+        SectionType, SimpleBlockStyle, Stripes, VerticalAlignment,
     },
     content::SubstitutionGroup,
     parser::ModificationContext,


### PR DESCRIPTION
## Summary

Implements the AsciiDoc admonitions feature described in [`docs/modules/blocks/pages/admonitions.adoc`](docs/modules/blocks/pages/admonitions.adoc), and resolves the open admonition TODOs ([#456](https://github.com/asciidoc-rs/asciidoc-parser/issues/456)).

### Features implemented (per the spec page)

- **Five admonition types** — `NOTE`, `TIP`, `IMPORTANT`, `CAUTION`, `WARNING`.
- **Paragraph form** — a paragraph whose first line begins with an uppercase label followed by `:` and a space (e.g. `NOTE: ...`) becomes an admonition with **simple** content. Lowercase labels, missing separators, and indented lines are *not* admonitions (matching Asciidoctor).
- **Block (masquerade) form** — an admonition style in an attribute list (`[NOTE]`) over an **example** block (`====`) or **open** block (`--`) yields **compound** content; over a paragraph it yields **simple** content. Other structural containers (sidebar, quote, listing, literal, passthrough) keep their own context and ignore the style, exactly as Asciidoctor does.
- **Captions** — resolved from the `<type>-caption` document attribute, defaulting to `Note`/`Tip`/`Important`/`Caution`/`Warning`. Supports Unicode glyph captions (e.g. `:tip-caption: 💡`).
- **Font icons** — `:icons: font` renders the label as a Font Awesome icon (`<i class="fa icon-note" …>`) instead of a text label.

### Implementation

- New `Block::Admonition(AdmonitionBlock)` variant and a public `AdmonitionVariant` type (`blocks::context`).
- `AdmonitionBlock` parsing reuses the existing `SimpleBlock` / `CompoundDelimitedBlock` parsers and resolves caption + icon state from document attributes at parse time.
- Virtual-DOM rendering of the `admonitionblock` table structure (icon cell + content cell), with the block title rendered inside the content cell. Compound blocks now wrap their child paragraphs in `div.paragraph` to match Asciidoctor.
- New test fixture (`fixtures::blocks::AdmonitionBlock`).

### Tests / coverage

- Full spec coverage for the admonitions page (`asciidoc_lang/blocks/admonitions.rs`) — every line of the page is accounted for; verified with `cd sdd && cargo run`.
- Comprehensive unit tests in `blocks/admonition.rs` covering every parse branch and the `AdmonitionVariant` helpers.
- Enables the four [#456](https://github.com/asciidoc-rs/asciidoc-parser/issues/456) tests that were blocked on admonitions (list-continuation cases in `lists_test.rs`, AsciiDoc table cells in `tables_test.rs`).
- Ports the two previously-deferred table-cell attribute-lock tests that observe the lock through an admonition's icon.

All 2227 parser tests pass; `cargo +nightly fmt --check`, `cargo clippy --all-targets`, and `cargo +nightly doc` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)