### PR TITLE
feat: Add support for collapsible blocks

### DIFF
--- a/parser/src/tests/asciidoc_lang/blocks/collapsible.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/collapsible.rs
@@ -1,0 +1,286 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/blocks/pages/collapsible.adoc");
+
+non_normative!(
+    r#"
+= Collapsible Blocks
+
+You can designate block content to be revealed or hidden on interaction using the collapsible option and its companion, the open option.
+When the AsciiDoc source is converted to HTML, this block gets mapped to a disclosure summary element (i.e., a summary/details pair).
+If the output format does not support this interaction, it may be rendered as an unstyled block (akin to an open block).
+
+"#
+);
+
+#[test]
+fn collapsible_block_syntax() {
+    non_normative!(
+        r#"
+== Collapsible block syntax
+
+"#
+    );
+
+    verifies!(
+        r#"
+You make block content collapsible by specifying the `collapsible` option on the example structural container.
+This option changes the block from an example block to a collapsible block.
+
+.Collapsible block syntax
+[#ex-collapsible]
+----
+include::example$collapsible.adoc[tag=basic]
+----
+
+In the output, the content of this block is hidden until the reader clicks the default title, "`Details`".
+The result of <<ex-collapsible>> is displayed below.
+
+include::example$collapsible.adoc[tag=basic]
+
+Like other blocks, the collapsible block recognizes the `id` and `role` attributes.
+
+"#
+    );
+
+    // The `basic` example tag: the `collapsible` option on an example block
+    // turns it into a disclosure element rather than an example block.
+    let doc = Parser::default().parse(
+        "[%collapsible]\n====\nThis content is only revealed when the user clicks the block title.\n====",
+    );
+
+    // The block renders as a `<details>` disclosure, not an example block.
+    assert_css(&doc, "details", 1);
+    assert_css(&doc, ".exampleblock", 0);
+
+    // The default toggle text is "Details", shown in the `<summary>`.
+    assert_xpath(
+        &doc,
+        "//details/summary[@class=\"title\"][text()=\"Details\"]",
+        1,
+    );
+
+    // The hidden content is wrapped in `<div class="content">`.
+    assert_css(&doc, "details > div.content", 1);
+    assert_xpath(
+        &doc,
+        "//details/div[@class=\"content\"]//p[text()=\"This content is only revealed when the user clicks the block title.\"]",
+        1,
+    );
+
+    // The disclosure is closed by default (no `open` attribute).
+    assert_xpath(&doc, "//details[@open]", 0);
+
+    // Without the `collapsible` option, the same example block renders as an
+    // ordinary example block.
+    let doc = Parser::default().parse("====\nNot collapsible.\n====");
+    assert_css(&doc, "details", 0);
+    assert_css(&doc, ".exampleblock", 1);
+
+    // The collapsible block recognizes the `id` and `role` attributes, which
+    // travel to the `<details>` element.
+    let doc = Parser::default().parse("[#disclosure.scary%collapsible]\n====\nHidden.\n====");
+    assert_xpath(&doc, "//details[@id=\"disclosure\"]", 1);
+    assert_css(&doc, "details.scary", 1);
+}
+
+#[test]
+fn collapsible_paragraph_syntax() {
+    non_normative!(
+        r#"
+== Collapsible paragraph syntax
+
+"#
+    );
+
+    verifies!(
+        r#"
+If the content of the block is only a single paragraph, you can use the example paragraph style instead of the example structural container to make a collapsible paragraph.
+
+.Collapsible paragraph syntax
+[#ex-collapsible-paragraph]
+----
+include::example$collapsible.adoc[tag=paragraph]
+----
+
+In the output, the content of this block is hidden until the reader clicks the default title, "`Details`".
+The result of <<ex-collapsible-paragraph>> is displayed below.
+
+include::example$collapsible.adoc[tag=paragraph]
+
+"#
+    );
+
+    // The `paragraph` example tag: the example paragraph style (`example`) plus
+    // the `collapsible` option makes a single paragraph collapsible.
+    let doc = Parser::default().parse(
+        "[example%collapsible]\nThis content is only revealed when the user clicks the block title.",
+    );
+
+    assert_css(&doc, "details", 1);
+    assert_xpath(
+        &doc,
+        "//details/summary[@class=\"title\"][text()=\"Details\"]",
+        1,
+    );
+
+    // A collapsible paragraph's content sits directly in `<div class="content">`,
+    // without a wrapping paragraph.
+    assert_xpath(
+        &doc,
+        "//details/div[@class=\"content\"][normalize-space(text())=\"This content is only revealed when the user clicks the block title.\"]",
+        1,
+    );
+
+    // Inline markup in a collapsible paragraph is rendered (the content is
+    // subject to normal substitutions) directly inside the content wrapper.
+    let doc = Parser::default().parse("[example%collapsible]\nThis is *bold*.");
+    assert_xpath(
+        &doc,
+        "//details/div[@class=\"content\"]/strong[text()=\"bold\"]",
+        1,
+    );
+
+    // The example paragraph style is required: a bare `[%collapsible]` paragraph
+    // (with no `example` style) is not collapsible; it remains an ordinary
+    // paragraph.
+    let doc = Parser::default().parse(
+        "[%collapsible]\nThis content is only revealed when the user clicks the block title.",
+    );
+    assert_css(&doc, "details", 0);
+    assert_css(&doc, ".paragraph", 1);
+}
+
+#[test]
+fn customize_the_toggle_text() {
+    non_normative!(
+        r#"
+== Customize the toggle text
+
+"#
+    );
+
+    verifies!(
+        r#"
+If you want to customize the text that toggles the display of the collapsible content, specify a title on the block or paragraph.
+
+.Collapsible block with custom title
+[#ex-collapsible-with-title]
+----
+include::example$collapsible.adoc[tag=title]
+----
+
+The result of <<ex-collapsible-with-title>> is displayed below.
+
+include::example$collapsible.adoc[tag=title]
+
+Notice that even though this block has a title, it's not numbered and does not have a caption prefix.
+That's because it's not an example block and thus does not get a numbered caption prefix like an example block would.
+
+"#
+    );
+
+    // The `title` example tag: a title on the block becomes the toggle text.
+    let doc = Parser::default()
+        .parse(".Click to reveal the answer\n[%collapsible]\n====\nThis is the answer.\n====");
+
+    // The title is shown verbatim in the `<summary>` as the toggle text ...
+    assert_xpath(
+        &doc,
+        "//details/summary[@class=\"title\"][text()=\"Click to reveal the answer\"]",
+        1,
+    );
+
+    // ... and it is not numbered nor given a caption prefix: the only `.title`
+    // is the summary, with no separate `div.title` caption.
+    assert_css(&doc, "div.title", 0);
+}
+
+#[test]
+fn default_to_open() {
+    non_normative!(
+        r#"
+== Default to open
+
+"#
+    );
+
+    verifies!(
+        r#"
+If you want the collapsible block to be open by default, specify the `open` option as well.
+
+.Collapsible block that defaults to open
+[#ex-collapsible-open]
+----
+include::example$collapsible.adoc[tag=open]
+----
+
+The result of <<ex-collapsible-open>> is displayed below.
+
+include::example$collapsible.adoc[tag=open]
+
+"#
+    );
+
+    // The `open` example tag: the `open` option expands the disclosure by
+    // default, adding the boolean `open` attribute.
+    let doc = Parser::default().parse(
+        ".Too much detail? Click here.\n[%collapsible%open]\n====\nThis content is revealed by default.\n\nIf it's taking up too much space, the reader can hide it.\n====",
+    );
+
+    assert_xpath(&doc, "//details[@open]", 1);
+    assert_xpath(
+        &doc,
+        "//details/summary[@class=\"title\"][text()=\"Too much detail? Click here.\"]",
+        1,
+    );
+
+    // The enclosed content (two paragraphs) is rendered inside the disclosure.
+    assert_css(&doc, "details > div.content > div.paragraph", 2);
+}
+
+#[test]
+fn use_as_an_enclosure() {
+    non_normative!(
+        r#"
+== Use as an enclosure
+
+"#
+    );
+
+    verifies!(
+        r#"
+Much like the open block, the collapsible block is an enclosure.
+If you want to make other types of blocks collapsible, such as an listing block, you can nest the block inside the collapsible block.
+
+.Collapsible block that encloses a literal block
+[#ex-collapsible-nested]
+----
+include::example$collapsible.adoc[tag=nested]
+----
+
+The result of <<ex-collapsible-nested>> is displayed below.
+
+include::example$collapsible.adoc[tag=nested]
+
+Since the toggle text acts as the block title, you may decide to not put a title on the nested block, as in this example.
+"#
+    );
+
+    // The `nested` example tag: a collapsible block enclosing a nested literal
+    // block.
+    let doc = Parser::default().parse(
+        ".Show stacktrace\n[%collapsible]\n====\n....\nError: Content repository not found (url: https://git.example.org/repo.git)\n    at transformGitCloneError\n....\n====",
+    );
+
+    assert_css(&doc, "details", 1);
+    assert_xpath(
+        &doc,
+        "//details/summary[@class=\"title\"][text()=\"Show stacktrace\"]",
+        1,
+    );
+
+    // The nested literal block renders inside the disclosure's content wrapper.
+    assert_css(&doc, "details > div.content .literalblock", 1);
+    assert_css(&doc, "details > div.content .literalblock pre", 1);
+}

--- a/parser/src/tests/asciidoc_lang/blocks/mod.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/mod.rs
@@ -4,6 +4,7 @@ mod assign_id;
 mod blockquotes;
 mod breaks;
 mod build_basic_block;
+mod collapsible;
 mod delimited;
 mod discrete_headings;
 mod hard_line_breaks;

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -967,11 +967,7 @@ fn collapsible_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
         // Asciidoctor's output for the example paragraph style).
         _ => {
             if let Some(rendered) = block.rendered_content() {
-                if rendered.contains('<') {
-                    content.children.extend(parse_html_content(rendered));
-                } else {
-                    content.text = Some(decode_html_entities(rendered));
-                }
+                content = content.with_html_content(rendered);
             }
         }
     }

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -367,11 +367,13 @@ impl ToVirtualDom for Document<'_> {
 fn add_block_with_title<'a>(parent: &mut VirtualNode, block: &'a Block<'a>) {
     // Check if this block type handles its own title internally. Lists render
     // their title inside the list wrapper; tables render it as a <caption>;
-    // admonitions render it inside the content cell.
-    let handles_title_internally = matches!(
-        block,
-        Block::List(_) | Block::Table(_) | Block::Admonition(_) | Block::Quote(_)
-    );
+    // admonitions render it inside the content cell; a collapsible block renders
+    // it as the `<summary>` toggle text.
+    let handles_title_internally = is_collapsible(block)
+        || matches!(
+            block,
+            Block::List(_) | Block::Table(_) | Block::Admonition(_) | Block::Quote(_)
+        );
 
     // Add title as a separate sibling element if the block doesn't handle it
     // internally.
@@ -407,6 +409,13 @@ fn add_block_with_title<'a>(parent: &mut VirtualNode, block: &'a Block<'a>) {
 
 impl ToVirtualDom for Block<'_> {
     fn to_virtual_dom(&self) -> VirtualNode {
+        // A collapsible example block or paragraph renders as an HTML disclosure
+        // element (`<details>`/`<summary>`) rather than its usual example-block
+        // markup.
+        if is_collapsible(self) {
+            return collapsible_to_node(self);
+        }
+
         match self {
             Block::Simple(simple) => {
                 // Comment blocks should not be rendered.
@@ -893,6 +902,81 @@ fn compound_delimited_to_node<'a>(compound: &'a CompoundDelimitedBlock<'a>) -> V
         add_block_with_title(&mut node, child);
     }
 
+    node
+}
+
+/// Returns `true` if `block` is a collapsible block: an example block (or
+/// example-styled paragraph) carrying the `collapsible` option.
+///
+/// Asciidoctor keeps such a block's context as `example` and renders it as an
+/// HTML disclosure element rather than an example block. The same option on any
+/// other context (a sidebar, an open block, a plain paragraph, etc.) is
+/// ignored, so the resolved context being `example` is the single gate for the
+/// collapsible rendering. This also distinguishes a collapsible paragraph
+/// (`[example%collapsible]`, whose `example` style resolves to the `example`
+/// context) from a bare `[%collapsible]` paragraph (which has no `example`
+/// style and is therefore not collapsible).
+fn is_collapsible<'a>(block: &'a Block<'a>) -> bool {
+    block.resolved_context().as_ref() == "example" && block.has_option("collapsible")
+}
+
+/// Renders a collapsible block as an HTML disclosure element.
+///
+/// The block's title becomes the `<summary>` toggle text, defaulting to
+/// `Details` when no title is set. The `open` option adds the boolean `open`
+/// attribute so the disclosure starts expanded. The block's id and roles travel
+/// to the `<details>` element, mirroring Asciidoctor's HTML output. Unlike an
+/// example block, a collapsible block is never numbered and carries no caption
+/// prefix on its toggle text.
+fn collapsible_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
+    let mut node = VirtualNode::new("details");
+
+    // The `open` option expands the disclosure by default.
+    if block.has_option("open") {
+        node = node.with_attribute("open", "");
+    }
+
+    if let Some(id) = block.id() {
+        node = node.with_id(id);
+    }
+
+    for role in block.roles() {
+        node = node.with_class(role);
+    }
+
+    // The toggle text is the block's title, or the default caption "Details".
+    let summary_text = block.title().unwrap_or("Details");
+    node.children.push(
+        VirtualNode::new("summary")
+            .with_class("title")
+            .with_text(summary_text),
+    );
+
+    let mut content = VirtualNode::new("div").with_class("content");
+
+    match block.content_model() {
+        // A collapsible (example) block encloses other blocks.
+        ContentModel::Compound => {
+            for child in block.nested_blocks() {
+                add_block_with_title(&mut content, child);
+            }
+        }
+
+        // A collapsible paragraph holds inline content, rendered directly inside
+        // the content wrapper without a wrapping paragraph (matching
+        // Asciidoctor's output for the example paragraph style).
+        _ => {
+            if let Some(rendered) = block.rendered_content() {
+                if rendered.contains('<') {
+                    content.children.extend(parse_html_content(rendered));
+                } else {
+                    content.text = Some(decode_html_entities(rendered));
+                }
+            }
+        }
+    }
+
+    node.children.push(content);
     node
 }
 


### PR DESCRIPTION
## Summary

Implements collapsible blocks per `docs/modules/blocks/pages/collapsible.adoc` — the `collapsible` option (and its companion `open`) on the example structural container, which renders as an HTML disclosure element (`<details>` / `<summary>`).

A block is collapsible when its **resolved context is `example`** and it carries the **`collapsible` option**. Because `example` is a built-in context, this single gate covers both spec-described forms with no special-casing:

- the example structural container — `[%collapsible]` over `====`
- the example paragraph style — `[example%collapsible]` (whose `example` style resolves to the `example` context)

A bare `[%collapsible]` paragraph (no `example` style) and the option on any other context (sidebar, open, etc.) are correctly **ignored**, matching Asciidoctor.

The parser already retained these options in the attribute list, so the change is confined to the test virtual-DOM renderer (where this crate produces HTML), plus full per-page spec coverage and behavioral tests.

## Behavior

- Toggle text is the block title, defaulting to **"Details"**
- The `open` option starts the disclosure expanded (boolean `open` attribute)
- `id` and `role` attributes travel to the `<details>` element
- Content is enclosed in `<div class="content">` (nested blocks for the container form; inline content for the paragraph form)
- Never numbered and no caption prefix on the toggle text (unlike an example block)

## Tests & coverage

- New `blocks/collapsible.rs` reproduces the full spec page verbatim — the `sdd` tool reports **48/48 normative lines covered, 0 uncovered**
- Behavioral assertions cover every section and every renderer branch: open/closed, id/role, default vs. custom title, compound vs. paragraph content, inline markup, nested literal block, and the negative cases

## Verification

- Full parser suite passes (2274 + 5 new tests)
- `cargo +nightly fmt --check` clean
- `cargo clippy --tests` clean
- `cargo +nightly doc` clean under `-D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)