### PR TITLE
feat: Add support for sidebars

### DIFF
--- a/parser/src/tests/asciidoc_lang/blocks/mod.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/mod.rs
@@ -12,4 +12,5 @@ mod index;
 mod paragraph_alignment;
 mod paragraphs;
 mod preamble_and_lead;
+mod sidebars;
 mod troubleshoot_blocks;

--- a/parser/src/tests/asciidoc_lang/blocks/sidebars.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/sidebars.rs
@@ -1,0 +1,170 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/blocks/pages/sidebars.adoc");
+
+non_normative!(
+    r#"
+= Sidebars
+// Moved upstream from the Antora documentation at docs.antora.org
+
+On this page, you'll learn:
+
+* [x] How to mark up a sidebar with AsciiDoc.
+
+"#
+);
+
+#[test]
+fn sidebar_content_and_substitutions() {
+    verifies!(
+        r#"
+A sidebar can contain any type of content, such as quotes, equations, and images.
+Normal substitutions are applied to sidebar content.
+
+"#
+    );
+
+    // Normal substitutions are applied to sidebar content: inline markup in the
+    // body of a sidebar is rendered, just as it would be in a paragraph.
+    let doc = Parser::default().parse("[sidebar]\nThis is *bold* content.");
+    assert_xpath(
+        &doc,
+        "//div[@class=\"sidebarblock\"]/div[@class=\"content\"]/strong[text()=\"bold\"]",
+        1,
+    );
+}
+
+#[test]
+fn sidebar_style_syntax() {
+    non_normative!(
+        r#"
+== Sidebar style syntax
+
+"#
+    );
+
+    verifies!(
+        r#"
+If the sidebar content is contiguous, the block style `sidebar` can be placed directly on top of the text in an attribute list (`[]`).
+
+.Assign sidebar block style to paragraph
+[#ex-style]
+----
+[sidebar]
+Sidebars are used to visually separate auxiliary bits of content
+that supplement the main text.
+----
+
+The result of <<ex-style>> is displayed below.
+
+[sidebar]
+Sidebars are used to visually separate auxiliary bits of content that supplement the main text.
+
+"#
+    );
+
+    // The `sidebar` block style on a contiguous paragraph produces a sidebar
+    // block: `div.sidebarblock` wrapping a single `div.content`.
+    let doc = Parser::default().parse(
+        "[sidebar]\nSidebars are used to visually separate auxiliary bits of content\nthat supplement the main text.",
+    );
+
+    assert_css(&doc, ".sidebarblock", 1);
+    assert_css(&doc, "div.sidebarblock > div.content", 1);
+
+    // The paragraph's content sits directly inside `div.content`, without a
+    // wrapping `<p>` element.
+    assert_css(&doc, "div.sidebarblock > div.content > p", 0);
+    assert_xpath(
+        &doc,
+        "//div[@class=\"sidebarblock\"]/div[@class=\"content\"][contains(normalize-space(text()), \"Sidebars are used to visually separate auxiliary bits of content that supplement the main text.\")]",
+        1,
+    );
+}
+
+#[test]
+fn delimited_sidebar_syntax() {
+    non_normative!(
+        r#"
+== Delimited sidebar syntax
+
+"#
+    );
+
+    verifies!(
+        r#"
+A delimited sidebar block is delimited by a pair of four consecutive asterisks (`pass:[****]`).
+You don't need to set the style name when you use the sidebar's delimiters.
+
+.Sidebar block delimiter syntax
+[#ex-block]
+------
+.Optional Title
+****
+Sidebars are used to visually separate auxiliary bits of content
+that supplement the main text.
+
+TIP: They can contain any type of content.
+
+.Source code block in a sidebar
+[source,js]
+----
+const { expect, expectCalledWith, heredoc } = require('../test/test-utils')
+----
+****
+------
+
+The result of <<ex-block>> is displayed below.
+
+.Optional Title
+****
+Sidebars are used to visually separate auxiliary bits of content that supplement the main text.
+
+TIP: They can contain any type of content.
+
+.Source code block in a sidebar
+[source,js]
+----
+const { expect, expectCalledWith, heredoc } = require('../test/test-utils')
+----
+****
+"#
+    );
+
+    // A pair of four consecutive asterisks delimits a sidebar block; no `sidebar`
+    // style is needed. The block can contain any type of content (here: a title,
+    // a paragraph, a TIP admonition, and a source block).
+    let doc = Parser::default().parse(
+        ".Optional Title\n****\nSidebars are used to visually separate auxiliary bits of content\nthat supplement the main text.\n\nTIP: They can contain any type of content.\n\n.Source code block in a sidebar\n[source,js]\n----\nconst { expect, expectCalledWith, heredoc } = require('../test/test-utils')\n----\n****",
+    );
+
+    assert_css(&doc, ".sidebarblock", 1);
+    assert_css(&doc, "div.sidebarblock > div.content", 1);
+
+    // The optional title is rendered as the first child of `div.content` (a
+    // `div.title`), not as a numbered caption outside the block.
+    assert_xpath(
+        &doc,
+        "//div[@class=\"sidebarblock\"]/div[@class=\"content\"]/div[@class=\"title\"][text()=\"Optional Title\"]",
+        1,
+    );
+
+    // The body paragraph is wrapped in `div.paragraph` inside the content.
+    assert_css(&doc, "div.sidebarblock > div.content > div.paragraph", 1);
+
+    // The TIP admonition renders inside the sidebar content.
+    assert_css(
+        &doc,
+        "div.sidebarblock > div.content .admonitionblock.tip",
+        1,
+    );
+
+    // The nested source block renders inside the sidebar content, carrying its
+    // own title and a `<pre><code>` with the source language.
+    assert_css(&doc, "div.sidebarblock > div.content .listingblock", 1);
+    assert_xpath(
+        &doc,
+        "//div[@class=\"sidebarblock\"]//pre/code[@data-lang=\"js\"]",
+        1,
+    );
+}

--- a/parser/src/tests/asciidoc_lang/blocks/sidebars.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/sidebars.rs
@@ -80,6 +80,22 @@ Sidebars are used to visually separate auxiliary bits of content that supplement
         "//div[@class=\"sidebarblock\"]/div[@class=\"content\"][contains(normalize-space(text()), \"Sidebars are used to visually separate auxiliary bits of content that supplement the main text.\")]",
         1,
     );
+
+    // A title on a sidebar paragraph is rendered as the first child of
+    // `div.content`, and it survives alongside inline markup in the body: the
+    // title `div.title` and the rendered `<strong>` are siblings inside the
+    // content wrapper.
+    let doc = Parser::default().parse(".My Title\n[sidebar]\nThis is *bold* content.");
+    assert_xpath(
+        &doc,
+        "//div[@class=\"sidebarblock\"]/div[@class=\"content\"]/div[@class=\"title\"][text()=\"My Title\"]",
+        1,
+    );
+    assert_xpath(
+        &doc,
+        "//div[@class=\"sidebarblock\"]/div[@class=\"content\"]/strong[text()=\"bold\"]",
+        1,
+    );
 }
 
 #[test]

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -368,8 +368,10 @@ fn add_block_with_title<'a>(parent: &mut VirtualNode, block: &'a Block<'a>) {
     // Check if this block type handles its own title internally. Lists render
     // their title inside the list wrapper; tables render it as a <caption>;
     // admonitions render it inside the content cell; a collapsible block renders
-    // it as the `<summary>` toggle text.
+    // it as the `<summary>` toggle text; a sidebar renders it as the first child
+    // of its `div.content` wrapper.
     let handles_title_internally = is_collapsible(block)
+        || is_sidebar(block)
         || matches!(
             block,
             Block::List(_) | Block::Table(_) | Block::Admonition(_) | Block::Quote(_)
@@ -414,6 +416,13 @@ impl ToVirtualDom for Block<'_> {
         // markup.
         if is_collapsible(self) {
             return collapsible_to_node(self);
+        }
+
+        // A sidebar block (the `****` structural container or the `[sidebar]`
+        // paragraph style) renders as `div.sidebarblock > div.content`, with its
+        // title and content nested inside the content wrapper.
+        if is_sidebar(self) {
+            return sidebar_to_node(self);
         }
 
         match self {
@@ -965,6 +974,65 @@ fn collapsible_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
         // A collapsible paragraph holds inline content, rendered directly inside
         // the content wrapper without a wrapping paragraph (matching
         // Asciidoctor's output for the example paragraph style).
+        _ => {
+            if let Some(rendered) = block.rendered_content() {
+                content = content.with_html_content(rendered);
+            }
+        }
+    }
+
+    node.children.push(content);
+    node
+}
+
+/// Returns `true` if `block` is a sidebar block: the `****` structural
+/// container or a paragraph carrying the `sidebar` style, both of which resolve
+/// to the `sidebar` context.
+fn is_sidebar<'a>(block: &'a Block<'a>) -> bool {
+    block.resolved_context().as_ref() == "sidebar"
+}
+
+/// Renders a sidebar block, matching Asciidoctor's HTML output.
+///
+/// The outer `div.sidebarblock` carries the block's id and roles; its sole
+/// child is a `div.content` wrapper. A title, if present, is rendered as the
+/// first child of the content wrapper (a `div.title`), unlike an example block
+/// whose title is a numbered caption placed outside the content. A delimited
+/// sidebar encloses other blocks (rendered through `add_block_with_title` so
+/// their own titles and paragraph wrappers surface); a sidebar paragraph holds
+/// inline content rendered directly inside the content wrapper without a `<p>`
+/// wrapper.
+fn sidebar_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
+    let mut node = VirtualNode::new("div").with_class("sidebarblock");
+
+    for role in block.roles() {
+        node = node.with_class(role);
+    }
+
+    if let Some(id) = block.id() {
+        node = node.with_id(id);
+    }
+
+    let mut content = VirtualNode::new("div").with_class("content");
+
+    // The title, when present, is the first child of the content wrapper.
+    if let Some(title) = block.title() {
+        content
+            .children
+            .push(VirtualNode::new("div").with_class("title").with_text(title));
+    }
+
+    match block.content_model() {
+        // A delimited sidebar encloses other blocks.
+        ContentModel::Compound => {
+            for child in block.nested_blocks() {
+                add_block_with_title(&mut content, child);
+            }
+        }
+
+        // A sidebar paragraph holds inline content, rendered directly inside the
+        // content wrapper without a wrapping paragraph (matching Asciidoctor's
+        // output for the sidebar paragraph style).
         _ => {
             if let Some(rendered) = block.rendered_content() {
                 content = content.with_html_content(rendered);

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -1015,13 +1015,6 @@ fn sidebar_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
 
     let mut content = VirtualNode::new("div").with_class("content");
 
-    // The title, when present, is the first child of the content wrapper.
-    if let Some(title) = block.title() {
-        content
-            .children
-            .push(VirtualNode::new("div").with_class("title").with_text(title));
-    }
-
     match block.content_model() {
         // A delimited sidebar encloses other blocks.
         ContentModel::Compound => {
@@ -1038,6 +1031,17 @@ fn sidebar_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
                 content = content.with_html_content(rendered);
             }
         }
+    }
+
+    // The title, when present, is the first child of the content wrapper. It is
+    // inserted *after* the body content because `with_html_content` replaces the
+    // children vector when the rendered content contains inline markup; pushing
+    // the title first would let that replacement silently drop it.
+    if let Some(title) = block.title() {
+        content.children.insert(
+            0,
+            VirtualNode::new("div").with_class("title").with_text(title),
+        );
     }
 
     node.children.push(content);


### PR DESCRIPTION
Implements all features described in `docs/modules/blocks/pages/sidebars.adoc`.

## What

Sidebar blocks now render to match Ruby Asciidoctor's HTML for both forms:

- **Delimited sidebar** — the `****` structural container.
- **Sidebar paragraph style** — `[sidebar]` over a contiguous block of text.

A sidebar renders as `div.sidebarblock > div.content`:

- The optional **title** is the first child of the `div.content` wrapper (a `div.title`) — unlike an example block, whose title is a numbered caption *outside* the content.
- A **delimited sidebar** encloses other blocks (any content: paragraphs, admonitions, source blocks, …), routed through `add_block_with_title` so nested titles and `div.paragraph` wrappers surface.
- A **sidebar paragraph** holds inline content rendered directly inside `div.content` (no wrapping `<p>`), with normal substitutions applied.

## Why "left incomplete by collapsible"

When collapsible blocks landed (#553), the disclosure renderer introduced the `div.content` wrapper convention, but the sibling sidebar path never got it. Before this PR:

- a `[sidebar]` paragraph rendered as an **empty** `div.sidebarblock` (its content was dropped, because the simple-block renderer only emitted text for `<p>` tags), and
- a titled `****` sidebar emitted its title as a **stray sibling** `div.title` with no content wrapper.

Both are now correct.

## Tests

- New `parser/src/tests/asciidoc_lang/blocks/sidebars.rs` with full per-page spec coverage (`track_file!` / `verifies!` / `non_normative!`, verbatim line-by-line) plus behavioral assertions for the style syntax, the delimited syntax, the optional title, nested content, and substitutions.
- `cd sdd && cargo run` reports complete coverage of `sidebars.adoc` (every normative line covered).
- Full parser suite green; `cargo +nightly fmt` and `cargo +nightly doc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)