### PR TITLE
feat: Add support for open blocks

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -231,8 +231,14 @@ impl<'src> Block<'src> {
             mut warnings,
         } = BlockMetadata::parse(source, parser);
 
-        let is_literal =
-            metadata.attrlist.as_ref().and_then(|a| a.block_style()) == Some("literal");
+        // The `[literal]` block style normally marks a literal *paragraph*,
+        // which is handled directly as a simple (literal) block below, bypassing
+        // the delimited-block parsers. The one exception is when it is set on an
+        // open block (`--`), where it masquerades as a verbatim literal block;
+        // that case must fall through to `RawDelimitedBlock`.
+        let is_literal = metadata.attrlist.as_ref().and_then(|a| a.block_style())
+            == Some("literal")
+            && metadata.block_start.take_normalized_line().item.data() != "--";
 
         // A simple block may be parsed speculatively inside the `!is_literal`
         // branch below (to detect the "metadata with no block" edge case). When

--- a/parser/src/blocks/quote.rs
+++ b/parser/src/blocks/quote.rs
@@ -127,16 +127,24 @@ impl<'src> QuoteBlock<'src> {
         let is_quote_delimiter = is_quote_verse_delimiter(&first_line);
 
         // A `[quote]` or `[verse]` style masquerades over a quote-delimited
-        // block or a paragraph.
+        // block, an open block, or a paragraph.
         if let Some(type_) = styled_type {
             if is_quote_delimiter {
                 return Some(Self::parse_delimited(metadata, parser, type_));
             }
 
+            // A `[quote]`/`[verse]` style also masquerades over an open block
+            // (`--`): the open delimiter adopts the quote/verse context. This is
+            // unique to the open block — every other structural container (below)
+            // keeps its own context and ignores the style.
+            if first_line.data() == "--" {
+                return Some(Self::parse_delimited(metadata, parser, type_));
+            }
+
             // The style is set on some other structural container (example,
-            // open, sidebar, listing, literal, passthrough, table). That
-            // container keeps its own context and the style is ignored, so this
-            // is not a blockquote.
+            // sidebar, listing, literal, passthrough, table). That container
+            // keeps its own context and the style is ignored, so this is not a
+            // blockquote.
             if RawDelimitedBlock::is_valid_delimiter(&first_line)
                 || CompoundDelimitedBlock::is_valid_delimiter(&first_line)
                 || TableBlock::is_table_delimiter(&first_line)

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -19,6 +19,12 @@ use crate::{
 /// | `----`    | Listing      |
 /// | `....`    | Literal      |
 /// | `++++`    | Passthrough  |
+///
+/// In addition, an open-block delimiter (`--`) is recognized here when it
+/// carries a verbatim masquerade style: `source` or `listing` (parsed as a
+/// listing block) or `literal` (parsed as a literal block). Every other open
+/// block is handled by
+/// [`CompoundDelimitedBlock`](crate::blocks::CompoundDelimitedBlock).
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RawDelimitedBlock<'src> {
     content: Content<'src>,

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -63,37 +63,51 @@ impl<'src> RawDelimitedBlock<'src> {
         parser: &mut Parser,
     ) -> Option<MatchAndWarnings<'src, Option<MatchedItem<'src, Self>>>> {
         let delimiter = metadata.block_start.take_normalized_line();
+        let delimiter_data = delimiter.item.data();
 
-        if delimiter.item.len() < 4 {
-            return None;
-        }
-
-        let (content_model, context, mut substitution_group) = match delimiter
-            .item
-            .data()
-            .split_at_checked(delimiter.item.data().len().min(4))?
-            .0
-        {
-            "////" => (ContentModel::Raw, "comment", SubstitutionGroup::None),
-            "----" => (
-                ContentModel::Verbatim,
-                "listing",
-                SubstitutionGroup::Verbatim,
-            ),
-            "...." => (
-                ContentModel::Verbatim,
-                "literal",
-                SubstitutionGroup::Verbatim,
-            ),
-            "++++" => (ContentModel::Raw, "pass", SubstitutionGroup::Pass),
-            _ => {
+        // A `--` open-block delimiter normally forms a compound (open) block, but
+        // a verbatim masquerade style (`source`, `listing`, or `literal`) set on
+        // it turns the block into a verbatim raw block. Every other delimiter
+        // must be at least four characters long.
+        let (content_model, context, mut substitution_group) = if delimiter_data == "--" {
+            // A plain or compound-styled open block returns `None` here and is
+            // handled by `CompoundDelimitedBlock` instead.
+            open_block_verbatim_masquerade(metadata.attrlist.as_ref())?
+        } else {
+            if delimiter.item.len() < 4 {
                 return None;
             }
-        };
 
-        if !Self::is_valid_delimiter(&delimiter.item) {
-            return None;
-        }
+            let block_type = match delimiter_data
+                .split_at_checked(delimiter_data.len().min(4))?
+                .0
+            {
+                "////" => (ContentModel::Raw, "comment", SubstitutionGroup::None),
+                "----" => (
+                    ContentModel::Verbatim,
+                    "listing",
+                    SubstitutionGroup::Verbatim,
+                ),
+                "...." => (
+                    ContentModel::Verbatim,
+                    "literal",
+                    SubstitutionGroup::Verbatim,
+                ),
+                "++++" => (ContentModel::Raw, "pass", SubstitutionGroup::Pass),
+                _ => {
+                    return None;
+                }
+            };
+
+            // The four-character delimiters require a validity check (the
+            // trailing characters must match the first four); the `--` open
+            // delimiter is matched exactly above.
+            if !Self::is_valid_delimiter(&delimiter.item) {
+                return None;
+            }
+
+            block_type
+        };
 
         let content_start = delimiter.after;
         let mut next = content_start;
@@ -167,6 +181,33 @@ impl<'src> RawDelimitedBlock<'src> {
     /// Return the interpreted content of this block.
     pub fn content(&self) -> &Content<'src> {
         &self.content
+    }
+}
+
+/// Resolve a verbatim masquerade style set on an open block (`--`).
+///
+/// A block style replaces the open-block context only on an open block (every
+/// other delimited block keeps its own context). When that style is one of the
+/// verbatim contexts — `source` and `listing` (both rendered as a listing
+/// block), or `literal` — the open block becomes a verbatim raw block. Returns
+/// the resulting content model, context, and substitution group, or `None` when
+/// the style is absent or names a non-verbatim context (e.g. `sidebar`,
+/// `example`, `quote`), which is handled elsewhere.
+fn open_block_verbatim_masquerade(
+    attrlist: Option<&Attrlist<'_>>,
+) -> Option<(ContentModel, &'static str, SubstitutionGroup)> {
+    match attrlist?.block_style()? {
+        "source" | "listing" => Some((
+            ContentModel::Verbatim,
+            "listing",
+            SubstitutionGroup::Verbatim,
+        )),
+        "literal" => Some((
+            ContentModel::Verbatim,
+            "literal",
+            SubstitutionGroup::Verbatim,
+        )),
+        _ => None,
     }
 }
 

--- a/parser/src/tests/asciidoc_lang/blocks/mod.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/mod.rs
@@ -10,6 +10,7 @@ mod discrete_headings;
 mod example_blocks;
 mod hard_line_breaks;
 mod index;
+mod open_blocks;
 mod paragraph_alignment;
 mod paragraphs;
 mod preamble_and_lead;

--- a/parser/src/tests/asciidoc_lang/blocks/open_blocks.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/open_blocks.rs
@@ -1,0 +1,244 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/blocks/pages/open-blocks.adoc");
+
+non_normative!(
+    r#"
+= Open Blocks
+
+"#
+);
+
+#[test]
+fn open_block_is_a_generic_container() {
+    verifies!(
+        r#"
+The most versatile block of all is the open block.
+It allows you to apply block attributes to a chunk of text without giving it any other semantics.
+In other words, it provides a generic structural container for enclosing content.
+The only notable limitation is that an open block cannot be nested inside of another open block.
+
+"#
+    );
+
+    // An open block is a generic structural container: the `--` delimiters wrap
+    // their content in `div.openblock > div.content`, adding no other semantics.
+    let doc = Parser::default().parse("--\nGeneric content.\n--");
+    assert_css(&doc, "div.openblock > div.content", 1);
+    assert_css(&doc, "div.openblock > div.content > div.paragraph", 1);
+
+    // The block's raw context is `open`, and (absent a masquerade style) its
+    // resolved context is `open` as well.
+    let open = doc.nested_blocks().next().unwrap();
+    assert_eq!(open.raw_context().as_ref(), "open");
+    assert_eq!(open.resolved_context().as_ref(), "open");
+
+    // An open block cannot be nested inside another open block: a second `--`
+    // line closes the first container rather than opening a child. Given four
+    // `--` lines, the parser pairs them into two sibling open blocks, with the
+    // intervening text left as a top-level paragraph — never an open block
+    // within an open block.
+    let doc = Parser::default().parse("--\nouter\n--\n\ninner\n\n--\nafter\n--");
+    assert_css(&doc, "div.openblock", 2);
+    assert_css(&doc, "div.openblock div.openblock", 0);
+}
+
+#[test]
+fn open_block_syntax() {
+    non_normative!(
+        r#"
+== Open block syntax
+
+.Open block syntax
+[#ex-open]
+----
+include::example$open.adoc[tag=base]
+----
+
+The result of <<ex-open>> is displayed below.
+
+include::example$open.adoc[tag=base]
+
+"#
+    );
+
+    // The `base` example: a pair of `--` delimiters forms an anonymous open
+    // block, rendered as `div.openblock > div.content` wrapping the paragraph.
+    let doc = Parser::default().parse(
+        "--\nAn open block can be an anonymous container,\nor it can masquerade as any other block.\n--",
+    );
+
+    assert_css(&doc, ".openblock", 1);
+    assert_css(&doc, "div.openblock > div.content", 1);
+    assert_css(&doc, "div.openblock > div.content > div.paragraph > p", 1);
+    assert_xpath(
+        &doc,
+        "//div[@class=\"openblock\"]/div[@class=\"content\"]/div[@class=\"paragraph\"]/p[contains(text(), \"anonymous container\")]",
+        1,
+    );
+}
+
+#[test]
+fn open_block_masquerading_as_a_sidebar() {
+    verifies!(
+        r#"
+An open block can act as any other paragraph or delimited block, with the exception of _pass_ and _table_.
+For instance, in <<ex-open-sidebar>> an open block is acting as a sidebar.
+
+"#
+    );
+
+    verifies!(
+        r#"
+.Open block masquerading as a sidebar
+[#ex-open-sidebar]
+----
+include::example$open.adoc[tag=sb]
+----
+
+The result of <<ex-open-sidebar>> is displayed below.
+
+include::example$open.adoc[tag=sb]
+
+"#
+    );
+
+    // The `sb` example: a `[sidebar]` style on an open block makes it act as a
+    // sidebar. The block adopts the sidebar context — `div.sidebarblock >
+    // div.content` — with the title rendered as the first child of the content
+    // wrapper, exactly as a `****` sidebar would render. No open block remains.
+    let doc = Parser::default().parse(
+        "[sidebar]\n.Related information\n--\nThis is aside text.\n\nIt is used to present information related to the main content.\n--",
+    );
+
+    assert_css(&doc, ".openblock", 0);
+    assert_css(&doc, "div.sidebarblock > div.content", 1);
+    assert_xpath(
+        &doc,
+        "//div[@class=\"sidebarblock\"]/div[@class=\"content\"]/div[@class=\"title\"][text()=\"Related information\"]",
+        1,
+    );
+    assert_css(&doc, "div.sidebarblock > div.content > div.paragraph", 2);
+
+    // The masquerade style replaces the open context: the resolved context is
+    // `sidebar` even though the raw (delimiter-derived) context is `open`.
+    let block = doc.nested_blocks().next().unwrap();
+    assert_eq!(block.raw_context().as_ref(), "open");
+    assert_eq!(block.resolved_context().as_ref(), "sidebar");
+}
+
+#[test]
+fn open_block_masquerading_as_a_source_block() {
+    verifies!(
+        r#"
+<<ex-open-source>> is an open block acting as a source block.
+
+"#
+    );
+
+    verifies!(
+        r#"
+.Open block masquerading as a source block
+[#ex-open-source]
+----
+include::example$open.adoc[tag=src]
+----
+
+The result of <<ex-open-source>> is displayed below.
+
+include::example$open.adoc[tag=src]
+"#
+    );
+
+    // The `src` example: a `[source]` style on an open block makes it act as a
+    // source block. The open block adopts the verbatim listing context and
+    // renders as `div.listingblock` with the body preserved verbatim inside
+    // `pre > code`, exactly as a `----` source block would. No open block
+    // remains.
+    let doc = Parser::default().parse("[source]\n--\nputs \"I'm a source block!\"\n--");
+
+    assert_css(&doc, ".openblock", 0);
+    assert_css(&doc, "div.listingblock", 1);
+    assert_xpath(
+        &doc,
+        "//div[@class=\"listingblock\"]//pre/code[contains(text(), \"I'm a source block!\")]",
+        1,
+    );
+
+    // The body is verbatim: the content model is verbatim, not the compound
+    // (nested-block) model of a plain open block.
+    let block = doc.nested_blocks().next().unwrap();
+    assert_eq!(block.content_model(), ContentModel::Verbatim);
+}
+
+// The following tests are not tied to a specific line of the spec page. They
+// cover the remaining masquerade forms implied by "can act as any other
+// paragraph or delimited block" (line 20): the `[source]` example above is one
+// of several verbatim/compound masquerades that an open block honors, none of
+// which any other delimited block does.
+
+#[test]
+fn open_block_carries_id_and_roles() {
+    // Like other blocks, an open block recognizes the `id` and `role`
+    // attributes; the id and roles travel to the outer `div.openblock`, and an
+    // optional title is rendered as a `div.title` before the content wrapper.
+    let doc = Parser::default().parse(".My open block\n[#myid.myrole]\n--\nbody.\n--");
+    assert_xpath(&doc, "//div[@id=\"myid\"]", 1);
+    assert_css(&doc, "div.openblock.myrole", 1);
+    assert_xpath(
+        &doc,
+        "//div[@class=\"openblock myrole\"]/div[@class=\"title\"][text()=\"My open block\"]",
+        1,
+    );
+    // The title precedes the content wrapper (it is not inside it).
+    assert_css(&doc, "div.openblock > div.title + div.content", 1);
+}
+
+#[test]
+fn open_block_masquerading_as_a_listing_or_literal_block() {
+    // A `[listing]` style on an open block makes it act as a listing block: the
+    // body is verbatim inside `div.listingblock > pre`.
+    let doc = Parser::default().parse("[listing]\n--\nlisting body\n--");
+    assert_css(&doc, ".openblock", 0);
+    assert_css(&doc, "div.listingblock > pre", 1);
+    assert_eq!(
+        doc.nested_blocks().next().unwrap().content_model(),
+        ContentModel::Verbatim
+    );
+
+    // A `[literal]` style on an open block makes it act as a literal block,
+    // overriding the usual treatment of `[literal]` as a paragraph style.
+    let doc = Parser::default().parse("[literal]\n--\nliteral body\n--");
+    assert_css(&doc, ".openblock", 0);
+    assert_css(&doc, "div.literalblock > pre", 1);
+    assert_eq!(
+        doc.nested_blocks().next().unwrap().content_model(),
+        ContentModel::Verbatim
+    );
+}
+
+#[test]
+fn open_block_masquerading_as_a_quote_or_verse_block() {
+    // A `[quote]` style on an open block makes it act as a quote block: the body
+    // is a compound (nested-block) content model rendered inside a
+    // `div.quoteblock > blockquote`, with the attribution surfaced.
+    let doc = Parser::default().parse("[quote,Author]\n--\nQuoted open block.\n--");
+    assert_css(&doc, ".openblock", 0);
+    assert_css(&doc, "div.quoteblock > blockquote", 1);
+
+    // A `[verse]` style on an open block makes it act as a verse block, with the
+    // body preserved verbatim inside `pre.content`.
+    let doc = Parser::default().parse("[verse]\n--\nverse line\n--");
+    assert_css(&doc, ".openblock", 0);
+    assert_css(&doc, "div.verseblock > pre.content", 1);
+}
+
+#[test]
+fn masquerade_style_only_applies_to_an_open_block() {
+    // A masquerade style replaces the context only on an open block. On any other
+    // delimited block the delimiter's own context wins and the style is ignored:
+    // a `[quote]` style on an example block (`====`) stays an example block.
+    let doc = Parser::default().parse("[quote]\n====\nx\n====");
+    assert_css(&doc, "div.exampleblock", 1);
+    assert_css(&doc, "div.quoteblock", 0);
+}

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -374,6 +374,7 @@ fn add_block_with_title<'a>(parent: &mut VirtualNode, block: &'a Block<'a>) {
     let handles_title_internally = is_collapsible(block)
         || is_sidebar(block)
         || is_example(block)
+        || is_open(block)
         || matches!(
             block,
             Block::List(_) | Block::Table(_) | Block::Admonition(_) | Block::Quote(_)
@@ -896,6 +897,20 @@ fn raw_delimited_to_node<'a>(raw: &'a RawDelimitedBlock<'a>) -> VirtualNode {
     node
 }
 
+/// Renders a compound delimited block, matching Asciidoctor's HTML output.
+///
+/// In practice this only ever renders an open block (`div.openblock`): the
+/// other compound containers are intercepted earlier — a sidebar by
+/// [`is_sidebar`], an example by [`is_example`], a quote/verse masquerade by
+/// [`QuoteBlock`], an admonition masquerade by [`AdmonitionBlock`], and a
+/// verbatim masquerade (`source`/`listing`/`literal`) by [`RawDelimitedBlock`].
+///
+/// The outer `div.openblock` carries the block's id and roles. An optional
+/// title is rendered as a `div.title` placed *before* the content wrapper
+/// (unlike a sidebar, whose title sits inside the content). The nested blocks
+/// are wrapped in a `div.content`, each routed through [`add_block_with_title`]
+/// so a child's own title surfaces as a sibling `div.title` and a child
+/// paragraph is wrapped in `div.paragraph`.
 fn compound_delimited_to_node<'a>(compound: &'a CompoundDelimitedBlock<'a>) -> VirtualNode {
     let context = compound.raw_context();
     let class = format!("{}block", context.as_ref());
@@ -910,15 +925,17 @@ fn compound_delimited_to_node<'a>(compound: &'a CompoundDelimitedBlock<'a>) -> V
         node = node.with_id(id);
     }
 
-    // Render each child through `add_block_with_title` (rather than a bare
-    // `child.to_virtual_dom()`) so that a child block's title surfaces as a
-    // sibling `div.title` and a child paragraph is wrapped in `div.paragraph`,
-    // matching Asciidoctor's output. This applies to every compound block type
-    // (example, sidebar, quote, open), not just admonitions: before this, a
-    // titled child inside one of these blocks had its title dropped.
-    for child in compound.nested_blocks() {
-        add_block_with_title(&mut node, child);
+    // The title, when present, precedes the content wrapper.
+    if let Some(title) = compound.title() {
+        node.children
+            .push(VirtualNode::new("div").with_class("title").with_text(title));
     }
+
+    let mut content = VirtualNode::new("div").with_class("content");
+    for child in compound.nested_blocks() {
+        add_block_with_title(&mut content, child);
+    }
+    node.children.push(content);
 
     node
 }
@@ -999,6 +1016,20 @@ fn collapsible_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
 /// to the `sidebar` context.
 fn is_sidebar<'a>(block: &'a Block<'a>) -> bool {
     block.resolved_context().as_ref() == "sidebar"
+}
+
+/// Returns `true` if `block` is an open block: the `--` structural container,
+/// rendered by [`compound_delimited_to_node`] as `div.openblock`.
+///
+/// Only a delimited open block (a [`Block::CompoundDelimited`] resolving to the
+/// `open` context) qualifies. Every masquerade style on a `--` block is
+/// intercepted earlier — by [`is_sidebar`], [`is_example`], `QuoteBlock`,
+/// `AdmonitionBlock`, or `RawDelimitedBlock` — so a `CompoundDelimited` block
+/// that reaches here always resolves to `open`. Like a sidebar, an open block
+/// renders its own title (as a `div.title` before its content wrapper), so
+/// [`add_block_with_title`] must not also emit one.
+fn is_open<'a>(block: &'a Block<'a>) -> bool {
+    matches!(block, Block::CompoundDelimited(_)) && block.resolved_context().as_ref() == "open"
 }
 
 /// Renders a sidebar block, matching Asciidoctor's HTML output.


### PR DESCRIPTION
Render open blocks to match Asciidoctor's HTML, per [`docs/modules/blocks/pages/open-blocks.adoc`](docs/modules/blocks/pages/open-blocks.adoc). The open block (`--`) is the most versatile block: a generic container that applies block attributes without adding semantics, and that can masquerade as any other paragraph or delimited block (except _pass_ and _table_).

## What changed

**Plain open block rendering.** A `--` block now renders as `div.openblock > div.content` wrapping its nested blocks, with an optional title as a `div.title` *before* the content wrapper. This completes the `div.content` convention left incomplete when sidebars landed — the open path was the last compound container still emitting its children directly under the block div and dropping the wrapper (and, for a `[source]` open block, dropping the masquerade entirely).

**Masquerading**, implemented faithfully to Asciidoctor's rule that a block style replaces the context *only* on an open block; every other delimited block keeps its delimiter-derived context and ignores the style:

| Style on `--` | Renders as | Where handled |
|---|---|---|
| _(none)_ | `div.openblock` | `CompoundDelimitedBlock` |
| `[sidebar]`, `[example]` | sidebar / example block | `resolved_context` (already worked) |
| `[NOTE]` … | admonition | `AdmonitionBlock` (already worked) |
| `[source]`, `[listing]`, `[literal]` | listing / literal block (verbatim) | `RawDelimitedBlock` (new) |
| `[quote]`, `[verse]` | quote / verse block | `QuoteBlock` (new) |

- `RawDelimitedBlock` now recognizes a `--` delimiter carrying a verbatim style and treats the body verbatim. The `[literal]` paragraph fast path in `Block::parse` is exempted when the style sits on an open block so it can fall through to this handling.
- `QuoteBlock` previously ignored a `[quote]`/`[verse]` style set on any structural container; it now adopts the quote/verse context for the open block specifically.

## Tests

- Full per-page spec coverage in `parser/src/tests/asciidoc_lang/blocks/open_blocks.rs` (the three page examples: base, sidebar masquerade, source masquerade).
- Behavioral tests for every masquerade form, id/role/title handling, the "cannot be nested" limitation, and the rule that a masquerade style only applies to an open block.

All 2305 parser tests pass; `clippy`, `cargo +nightly fmt`, and `cargo +nightly doc` are clean. Verified output against locally-installed Ruby Asciidoctor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)