### PR TITLE
test: Add spec coverage for archived blocks pages (styles.adoc, nest.adoc)

### DIFF
--- a/parser/src/tests/asciidoc_lang/blocks/mod.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/mod.rs
@@ -10,6 +10,7 @@ mod discrete_headings;
 mod example_blocks;
 mod hard_line_breaks;
 mod index;
+mod nest;
 mod open_blocks;
 mod paragraph_alignment;
 mod paragraphs;

--- a/parser/src/tests/asciidoc_lang/blocks/mod.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/mod.rs
@@ -15,5 +15,6 @@ mod paragraph_alignment;
 mod paragraphs;
 mod preamble_and_lead;
 mod sidebars;
+mod styles;
 mod troubleshoot_blocks;
 mod verses;

--- a/parser/src/tests/asciidoc_lang/blocks/nest.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/nest.rs
@@ -1,0 +1,12 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/blocks/pages/nest.adoc");
+
+non_normative!(
+    r#"
+= Nesting Blocks
+:page-archived:
+
+Moved xref:delimited.adoc#nesting[here].
+"#
+);

--- a/parser/src/tests/asciidoc_lang/blocks/styles.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/styles.rs
@@ -1,0 +1,12 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/blocks/pages/styles.adoc");
+
+non_normative!(
+    r#"
+= Block Style
+:page-archived:
+
+Moved xref:index.adoc#block-style[here].
+"#
+);


### PR DESCRIPTION
## Summary

Adds spec-coverage handlers for two archived redirect pages under `docs/modules/blocks/pages/`:

- `styles.adoc` (`= Block Style`) — forwards to the block-style section of the blocks index page.
- `nest.adoc` (`= Nesting Blocks`) — forwards to the nesting section of the delimited blocks page.

Both are `:page-archived:` redirects with no normative requirements, so each page is covered with a single `non_normative!` block reproducing its content verbatim.

The block-style and nesting material itself lives in `index.adoc#block-style` and `delimited.adoc#nesting` and will be covered separately.

## Changes

- Add `parser/src/tests/asciidoc_lang/blocks/styles.rs` tracking `styles.adoc`.
- Add `parser/src/tests/asciidoc_lang/blocks/nest.rs` tracking `nest.adoc`.
- Register `mod styles;` and `mod nest;` in `parser/src/tests/asciidoc_lang/blocks/mod.rs`.

## Verification

- `cd sdd && cargo run` reports both pages with no uncovered lines.
- `cargo test -p asciidoc-parser --lib tests::asciidoc_lang::blocks` passes (76 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)