### PR TITLE
feat: Add support for callouts

### DIFF
--- a/parser/src/blocks/list.rs
+++ b/parser/src/blocks/list.rs
@@ -148,6 +148,7 @@ impl<'src> ListBlock<'src> {
             ListItemMarker::RomanNumeralLower(_) => ListType::Ordered,
             ListItemMarker::RomanNumeralUpper(_) => ListType::Ordered,
             ListItemMarker::ArabicNumeral(_) => ListType::Ordered,
+            ListItemMarker::Callout(_) => ListType::Callout,
 
             ListItemMarker::DefinedTerm {
                 term: _,
@@ -203,6 +204,7 @@ impl<'src> ListBlock<'src> {
                 }
             }
             ListItemMarker::ArabicNumeral(_) => Some("arabic"),
+            ListItemMarker::Callout(_) => Some("arabic"),
             ListItemMarker::AlphaListLower(_) => Some("loweralpha"),
             ListItemMarker::AlphaListCapital(_) => Some("upperalpha"),
             ListItemMarker::RomanNumeralLower(_) => Some("lowerroman"),
@@ -285,6 +287,11 @@ pub enum ListType {
     /// A description list is an association list that consists of one or more
     /// terms (or sets of terms) that each have a description.
     Description,
+
+    /// A callout list provides annotations for lines in a preceding verbatim
+    /// block. Its items are marked with `<1>`, `<2>`, … (or `<.>` for automatic
+    /// numbering).
+    Callout,
 }
 
 impl std::fmt::Debug for ListType {
@@ -293,6 +300,7 @@ impl std::fmt::Debug for ListType {
             ListType::Unordered => write!(f, "ListType::Unordered"),
             ListType::Ordered => write!(f, "ListType::Ordered"),
             ListType::Description => write!(f, "ListType::Description"),
+            ListType::Callout => write!(f, "ListType::Callout"),
         }
     }
 }
@@ -528,6 +536,43 @@ mod tests {
             format!("{:#?}", ListType::Description),
             "ListType::Description"
         );
+
+        assert_eq!(format!("{:#?}", ListType::Callout), "ListType::Callout");
+    }
+
+    #[test]
+    fn callout_list() {
+        let list = list_parse("<1> First\n<2> Second\n").unwrap();
+
+        assert_eq!(list.item.type_(), ListType::Callout);
+        assert_eq!(list.item.marker_style(), Some("arabic"));
+
+        let items: Vec<_> = list.item.nested_blocks().collect();
+        assert_eq!(items.len(), 2);
+
+        assert_eq!(
+            items[0].nested_blocks().next().unwrap().rendered_content(),
+            Some("First")
+        );
+        assert_eq!(
+            items[1].nested_blocks().next().unwrap().rendered_content(),
+            Some("Second")
+        );
+    }
+
+    #[test]
+    fn callout_list_auto_numbered() {
+        // `<.>` markers form a single callout list.
+        let list = list_parse("<.> First\n<.> Second\n<.> Third\n").unwrap();
+
+        assert_eq!(list.item.type_(), ListType::Callout);
+        assert_eq!(list.item.nested_blocks().count(), 3);
+    }
+
+    #[test]
+    fn callout_list_marker_only_trailing_bracket_is_not_a_list() {
+        // `1>` (trailing bracket only) is not a callout list marker.
+        assert!(list_parse("1> Not a callout list item\n").is_none());
     }
 
     #[test]

--- a/parser/src/blocks/list.rs
+++ b/parser/src/blocks/list.rs
@@ -157,6 +157,23 @@ impl<'src> ListBlock<'src> {
             } => ListType::Description,
         };
 
+        // A callout list annotates the callouts of a preceding verbatim block.
+        // Each item, by position, must correspond to a callout that was
+        // registered while substituting that block; warn about any that does
+        // not, then close the list so the next block's callouts start fresh.
+        if type_ == ListType::Callout {
+            for (index, item) in items.iter().enumerate() {
+                let ordinal = (index + 1) as u32;
+                if !parser.callout_defined(ordinal) {
+                    warnings.push(Warning {
+                        source: item.span(),
+                        warning: WarningType::NoCalloutFound(ordinal as usize),
+                    });
+                }
+            }
+            parser.close_callout_list();
+        }
+
         Some(MatchedItem {
             item: Self {
                 type_,
@@ -329,6 +346,25 @@ mod tests {
         assert!(warnings.is_empty());
 
         result
+    }
+
+    /// Like [`list_parse`], but also returns the warnings produced. Used for
+    /// callout lists, which warn when an item has no matching callout in a
+    /// preceding verbatim block.
+    fn list_parse_with_warnings<'a>(
+        source: &'a str,
+    ) -> (
+        Option<MatchedItem<'a, crate::blocks::ListBlock<'a>>>,
+        Vec<Warning<'a>>,
+    ) {
+        let mut parser = crate::Parser::default();
+        let mut warnings: Vec<Warning<'a>> = vec![];
+
+        let metadata = BlockMetadata::parse(crate::Span::new(source), &mut parser).item;
+
+        let result = crate::blocks::list::ListBlock::parse(&metadata, &mut parser, &mut warnings);
+
+        (result, warnings)
     }
 
     #[test]
@@ -542,7 +578,10 @@ mod tests {
 
     #[test]
     fn callout_list() {
-        let list = list_parse("<1> First\n<2> Second\n").unwrap();
+        // Parsed in isolation (no preceding verbatim block), so each item warns
+        // that it has no matching callout.
+        let (list, warnings) = list_parse_with_warnings("<1> First\n<2> Second\n");
+        let list = list.unwrap();
 
         assert_eq!(list.item.type_(), ListType::Callout);
         assert_eq!(list.item.marker_style(), Some("arabic"));
@@ -558,15 +597,28 @@ mod tests {
             items[1].nested_blocks().next().unwrap().rendered_content(),
             Some("Second")
         );
+
+        let warning_types: Vec<_> = warnings.iter().map(|w| &w.warning).collect();
+        assert_eq!(
+            warning_types,
+            vec![
+                &WarningType::NoCalloutFound(1),
+                &WarningType::NoCalloutFound(2),
+            ]
+        );
     }
 
     #[test]
     fn callout_list_auto_numbered() {
         // `<.>` markers form a single callout list.
-        let list = list_parse("<.> First\n<.> Second\n<.> Third\n").unwrap();
+        let (list, warnings) = list_parse_with_warnings("<.> First\n<.> Second\n<.> Third\n");
+        let list = list.unwrap();
 
         assert_eq!(list.item.type_(), ListType::Callout);
         assert_eq!(list.item.nested_blocks().count(), 3);
+
+        // No preceding verbatim block defines these callouts.
+        assert_eq!(warnings.len(), 3);
     }
 
     #[test]

--- a/parser/src/blocks/list.rs
+++ b/parser/src/blocks/list.rs
@@ -158,16 +158,34 @@ impl<'src> ListBlock<'src> {
         };
 
         // A callout list annotates the callouts of a preceding verbatim block.
-        // Each item, by position, must correspond to a callout that was
-        // registered while substituting that block; warn about any that does
-        // not, then close the list so the next block's callouts start fresh.
+        // For each item (by position): an explicit `<N>` marker that doesn't
+        // match the item's position is out of sequence, and an item position
+        // with no callout registered while substituting the block has no
+        // matching callout. Both mirror Asciidoctor's `parse_callout_list`
+        // warnings. The list is then closed so the next block's callouts start
+        // fresh.
         if type_ == ListType::Callout {
             for (index, item) in items.iter().enumerate() {
-                let ordinal = (index + 1) as u32;
-                if !parser.callout_defined(ordinal) {
+                let position = (index + 1) as u32;
+
+                if let Some(marker_number) = item
+                    .as_list_item()
+                    .and_then(|li| li.list_item_marker().callout_number())
+                    && marker_number != position
+                {
                     warnings.push(Warning {
                         source: item.span(),
-                        warning: WarningType::NoCalloutFound(ordinal as usize),
+                        warning: WarningType::CalloutListItemOutOfSequence(
+                            position as usize,
+                            marker_number as usize,
+                        ),
+                    });
+                }
+
+                if !parser.callout_defined(position) {
+                    warnings.push(Warning {
+                        source: item.span(),
+                        warning: WarningType::NoCalloutFound(position as usize),
                     });
                 }
             }

--- a/parser/src/blocks/list_item_marker.rs
+++ b/parser/src/blocks/list_item_marker.rs
@@ -40,6 +40,10 @@ pub enum ListItemMarker<'src> {
     /// Explicit Arabic numeral followed by dot (e.g., "7.").
     ArabicNumeral(Span<'src>),
 
+    /// A callout list marker (`<1>` or `<.>`), used to annotate lines in a
+    /// preceding verbatim block.
+    Callout(Span<'src>),
+
     /// A term to be defined.
     DefinedTerm {
         /// The name of the term being defined.
@@ -56,10 +60,23 @@ pub enum ListItemMarker<'src> {
 impl<'src> ListItemMarker<'src> {
     pub(crate) fn starts_with_marker(source: Span<'src>) -> bool {
         LIST_ITEM_MARKER.is_match(source.data())
+            || CALLOUT_LIST_MARKER.is_match(source.discard_whitespace().data())
     }
 
     pub(crate) fn parse(source: Span<'src>, parser: &Parser) -> Option<MatchedItem<'src, Self>> {
         let source = source.discard_whitespace();
+
+        // A callout list marker (`<1>` or `<.>`) is not matched by
+        // `LIST_ITEM_MARKER`, so it is checked first.
+        if let Some(captures) = CALLOUT_LIST_MARKER.captures(source.data()) {
+            let marker = source.slice(0..captures[1].len());
+            let after = source.slice_from(captures[1].len()..).discard_whitespace();
+
+            return Some(MatchedItem {
+                item: Self::Callout(marker),
+                after,
+            });
+        }
 
         if let Some(captures) = LIST_ITEM_MARKER.captures(source.data()) {
             let marker = source.slice(0..captures[1].len());
@@ -272,6 +289,10 @@ impl<'src> ListItemMarker<'src> {
                 matches!(other, Self::ArabicNumeral(_other_span))
             }
 
+            Self::Callout(_self_span) => {
+                matches!(other, Self::Callout(_other_span))
+            }
+
             Self::DefinedTerm {
                 term: _,
                 marker: self_marker,
@@ -375,6 +396,7 @@ impl<'src> HasSpan<'src> for ListItemMarker<'src> {
             Self::RomanNumeralLower(x) => *x,
             Self::RomanNumeralUpper(x) => *x,
             Self::ArabicNumeral(x) => *x,
+            Self::Callout(x) => *x,
 
             Self::DefinedTerm {
                 term: _,
@@ -418,6 +440,8 @@ impl std::fmt::Debug for ListItemMarker<'_> {
                 .field(x)
                 .finish(),
 
+            Self::Callout(x) => f.debug_tuple("ListItemMarker::Callout").field(x).finish(),
+
             Self::DefinedTerm {
                 term,
                 marker,
@@ -445,6 +469,22 @@ static LIST_ITEM_MARKER: LazyLock<Regex> = LazyLock::new(|| {
                 |[a-zA-Z]\.             # Letter followed by dot (alpha list)
                 |[ivxlcdm]+\)           # Lowercase Roman numerals followed by )
                 |[IVXLCDM]+\)           # Uppercase Roman numerals followed by )
+            )
+            [\ \t]                  # Required whitespace after marker
+        "#,
+    )
+    .unwrap()
+});
+
+/// Matches a callout list item marker: `<` followed by a number or `.`, then
+/// `>`, then required whitespace. Mirrors Asciidoctor's `CalloutListRx`.
+static CALLOUT_LIST_MARKER: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(
+        r#"(?x)
+            ^                       # Start of line
+            (                       # Capture group 1: the marker
+                <(?:\d+|\.)>            # `<` then digits or a dot, then `>`
             )
             [\ \t]                  # Required whitespace after marker
         "#,
@@ -985,5 +1025,78 @@ mod tests {
                 offset: 3,
             }
         );
+    }
+
+    #[test]
+    fn callout() {
+        // Not callout markers: no leading bracket, no trailing whitespace, or
+        // a non-numeric/non-dot body.
+        assert!(lim_parse("1> blah").is_none());
+        assert!(lim_parse("<1>blah").is_none());
+        assert!(lim_parse("<1>").is_none());
+        assert!(lim_parse("<a> blah").is_none());
+
+        let lim = lim_parse("<1> blah").unwrap();
+
+        assert_eq!(
+            lim.item,
+            ListItemMarker::Callout(Span {
+                data: "<1>",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },)
+        );
+
+        assert_eq!(
+            lim.after,
+            Span {
+                data: "blah",
+                line: 1,
+                col: 5,
+                offset: 4,
+            }
+        );
+
+        assert_eq!(
+            lim.item.span(),
+            Span {
+                data: "<1>",
+                line: 1,
+                col: 1,
+                offset: 0,
+            }
+        );
+
+        // Ordinal helpers do not apply to callout markers.
+        assert!(lim.item.ordinal_value().is_none());
+        assert!(lim.item.ordinal_to_marker_text(1).is_none());
+
+        // Callout markers of any number match each other (so a single list is
+        // formed), but not markers of other kinds.
+        let lim2 = lim_parse("<.> blah").unwrap();
+        assert_eq!(
+            lim2.item,
+            ListItemMarker::Callout(Span {
+                data: "<.>",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },)
+        );
+        assert!(lim.item.is_match_for(&lim2.item));
+        assert!(!lim.item.is_match_for(&lim_parse("- blah").unwrap().item));
+
+        assert_eq!(
+            format!("{:#?}", lim.item),
+            "ListItemMarker::Callout(\n    Span {\n        data: \"<1>\",\n        line: 1,\n        col: 1,\n        offset: 0,\n    },\n)"
+        );
+
+        assert!(crate::blocks::ListItemMarker::starts_with_marker(
+            crate::Span::new("<1> blah")
+        ));
+        assert!(!crate::blocks::ListItemMarker::starts_with_marker(
+            crate::Span::new("1> blah")
+        ));
     }
 }

--- a/parser/src/blocks/list_item_marker.rs
+++ b/parser/src/blocks/list_item_marker.rs
@@ -59,8 +59,11 @@ pub enum ListItemMarker<'src> {
 
 impl<'src> ListItemMarker<'src> {
     pub(crate) fn starts_with_marker(source: Span<'src>) -> bool {
-        LIST_ITEM_MARKER.is_match(source.data())
-            || CALLOUT_LIST_MARKER.is_match(source.discard_whitespace().data())
+        // Discard leading whitespace before matching, mirroring `parse` (which
+        // does the same for every marker kind), so both marker regexes see the
+        // same input.
+        let source = source.discard_whitespace();
+        LIST_ITEM_MARKER.is_match(source.data()) || CALLOUT_LIST_MARKER.is_match(source.data())
     }
 
     pub(crate) fn parse(source: Span<'src>, parser: &Parser) -> Option<MatchedItem<'src, Self>> {
@@ -1097,6 +1100,15 @@ mod tests {
         ));
         assert!(!crate::blocks::ListItemMarker::starts_with_marker(
             crate::Span::new("1> blah")
+        ));
+
+        // Leading whitespace is discarded consistently for every marker kind,
+        // matching `parse`.
+        assert!(crate::blocks::ListItemMarker::starts_with_marker(
+            crate::Span::new("  <1> blah")
+        ));
+        assert!(crate::blocks::ListItemMarker::starts_with_marker(
+            crate::Span::new("  - blah")
         ));
     }
 }

--- a/parser/src/blocks/list_item_marker.rs
+++ b/parser/src/blocks/list_item_marker.rs
@@ -1104,6 +1104,12 @@ mod tests {
         assert!(lim.item.is_match_for(&lim2.item));
         assert!(!lim.item.is_match_for(&lim_parse("- blah").unwrap().item));
 
+        // An explicit `<N>` marker reports its number; an automatic `<.>`
+        // marker and any non-callout marker report `None`.
+        assert_eq!(lim.item.callout_number(), Some(1));
+        assert!(lim2.item.callout_number().is_none());
+        assert!(lim_parse("- blah").unwrap().item.callout_number().is_none());
+
         assert_eq!(
             format!("{:#?}", lim.item),
             "ListItemMarker::Callout(\n    Span {\n        data: \"<1>\",\n        line: 1,\n        col: 1,\n        offset: 0,\n    },\n)"

--- a/parser/src/blocks/list_item_marker.rs
+++ b/parser/src/blocks/list_item_marker.rs
@@ -249,6 +249,20 @@ impl<'src> ListItemMarker<'src> {
         }
     }
 
+    /// Returns the explicit number of a `<N>` callout marker, or `None` for an
+    /// automatically-numbered (`<.>`) callout or any non-callout marker.
+    pub(crate) fn callout_number(&self) -> Option<u32> {
+        match self {
+            Self::Callout(span) => span
+                .data()
+                .trim_start_matches('<')
+                .trim_end_matches('>')
+                .parse::<u32>()
+                .ok(),
+            _ => None,
+        }
+    }
+
     /// Test for equality, disregarding span offsets.
     pub(crate) fn is_match_for(&self, other: &Self) -> bool {
         match self {

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -104,7 +104,10 @@ impl SubstitutionGroup {
             }
 
             if step == "v" || step == "verbatim" {
-                steps = vec![SubstitutionStep::SpecialCharacters];
+                steps = vec![
+                    SubstitutionStep::SpecialCharacters,
+                    SubstitutionStep::Callouts,
+                ];
                 continue;
             }
 
@@ -143,6 +146,7 @@ impl SubstitutionGroup {
                 "r" | "replacements" => SubstitutionStep::CharacterReplacements,
                 "m" | "macros" => SubstitutionStep::Macros,
                 "p" | "post_replacements" => SubstitutionStep::PostReplacement,
+                "callouts" => SubstitutionStep::Callouts,
                 _ => {
                     return None;
                 }
@@ -232,7 +236,10 @@ impl SubstitutionGroup {
                 SubstitutionStep::AttributeReferences,
             ],
 
-            Self::Verbatim => &[SubstitutionStep::SpecialCharacters],
+            Self::Verbatim => &[
+                SubstitutionStep::SpecialCharacters,
+                SubstitutionStep::Callouts,
+            ],
 
             Self::Pass | Self::None => &[],
 
@@ -453,12 +460,20 @@ mod tests {
                 SubstitutionGroup::from_custom_string(None, "v,-r"),
                 Some(SubstitutionGroup::Custom(vec![
                     SubstitutionStep::SpecialCharacters,
+                    SubstitutionStep::Callouts,
                 ]))
             );
 
             assert_eq!(
                 SubstitutionGroup::from_custom_string(None, "v,-c"),
-                Some(SubstitutionGroup::Custom(vec![]))
+                Some(SubstitutionGroup::Custom(vec![SubstitutionStep::Callouts]))
+            );
+
+            assert_eq!(
+                SubstitutionGroup::from_custom_string(None, "v,-callouts"),
+                Some(SubstitutionGroup::Custom(vec![
+                    SubstitutionStep::SpecialCharacters,
+                ]))
             );
         }
 
@@ -481,6 +496,7 @@ mod tests {
                 SubstitutionGroup::from_custom_string(None, "v,m"),
                 Some(SubstitutionGroup::Custom(vec![
                     SubstitutionStep::SpecialCharacters,
+                    SubstitutionStep::Callouts,
                     SubstitutionStep::Macros,
                 ]))
             );
@@ -505,6 +521,7 @@ mod tests {
                 SubstitutionGroup::from_custom_string(None, "v,m"),
                 Some(SubstitutionGroup::Custom(vec![
                     SubstitutionStep::SpecialCharacters,
+                    SubstitutionStep::Callouts,
                     SubstitutionStep::Macros,
                 ]))
             );
@@ -520,6 +537,7 @@ mod tests {
                 Some(SubstitutionGroup::Custom(vec![
                     SubstitutionStep::AttributeReferences,
                     SubstitutionStep::SpecialCharacters,
+                    SubstitutionStep::Callouts,
                 ]))
             );
 
@@ -540,6 +558,7 @@ mod tests {
                 ),
                 Some(SubstitutionGroup::Custom(vec![
                     SubstitutionStep::SpecialCharacters,
+                    SubstitutionStep::Callouts,
                     SubstitutionStep::AttributeReferences,
                 ]))
             );

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -904,6 +904,12 @@ impl LookaheadReplacer for CalloutReplacer<'_> {
             number_raw.to_string()
         };
 
+        // Register this callout so the callout list that annotates this block
+        // can be validated against the callouts it references.
+        if let Ok(n) = number.parse::<u32>() {
+            self.parser.register_callout(n);
+        }
+
         // Mirror Asciidoctor's guard resolution: a captured line-comment prefix
         // takes precedence; otherwise an XML callout uses the XML guard; failing
         // both, there is no guard.

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -1326,5 +1326,20 @@ mod tests {
                 r#"-- <b class="conum">(1)</b>"#
             );
         }
+
+        #[test]
+        fn document_line_comment_attribute() {
+            // The `line-comment` attribute can be set at the document level
+            // (here, with no block attrlist), and is honored as a fallback.
+            let p = Parser::default().with_intrinsic_attribute(
+                "line-comment",
+                "%",
+                ModificationContext::Anywhere,
+            );
+            assert_eq!(
+                render_callouts("hello() -> % &lt;1&gt;", &p),
+                r#"hello() -> % <b class="conum">(1)</b>"#
+            );
+        }
     }
 }

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -798,7 +798,7 @@ fn apply_callouts(content: &mut Content<'_>, parser: &Parser, attrlist: Option<&
         renderer: &*parser.renderer,
         parser,
         autonum: 0,
-        tail: &tail_rx,
+        tail: tail_rx,
     };
 
     if let Cow::Owned(new_result) =
@@ -808,6 +808,29 @@ fn apply_callouts(content: &mut Content<'_>, parser: &Parser, attrlist: Option<&
     }
 }
 
+/// Callout regex for the default `line-comment` mode: recognizes the common
+/// line-comment prefixes and XML callouts.
+static DEFAULT_CALLOUT_RX: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(
+        r"(?P<prefix>(?://|#|--|;;) ?)?(?P<esc>\\)?(?:&lt;!--(?P<xnum>\d+|\.)--&gt;|&lt;(?P<num>\d+|\.)&gt;)",
+    )
+    .unwrap()
+});
+
+/// Trailing-position lookahead regex for the default `line-comment` mode.
+static DEFAULT_CALLOUT_TAIL_RX: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(r"^(?: ?\\?(?:&lt;!--(?:\d+|\.)--&gt;|&lt;(?:\d+|\.)&gt;))*(?:\n|$)").unwrap()
+});
+
+/// Trailing-position lookahead regex for a custom or empty `line-comment` mode
+/// (no XML callout form).
+static CUSTOM_CALLOUT_TAIL_RX: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(r"^(?: ?\\?&lt;(?:\d+|\.)&gt;)*(?:\n|$)").unwrap()
+});
+
 /// Builds the `(callout, tail)` regex pair for the given `line-comment` mode.
 ///
 /// The `callout` regex matches a single callout token (with the optional
@@ -816,22 +839,14 @@ fn apply_callouts(content: &mut Content<'_>, parser: &Parser, attrlist: Option<&
 /// is only honored when the remainder of its line consists solely of further
 /// callouts. Rust's regex engine supports neither lookahead nor backreferences,
 /// so the lookahead is applied manually against the post-match text.
-fn build_callout_regexes(line_comment: Option<&str>) -> (Regex, Regex) {
-    #[allow(clippy::unwrap_used)]
+///
+/// The default-mode regexes and both tail regexes are constant, so they are
+/// built once. Only a custom (non-empty) prefix requires building a regex from
+/// the attribute value, which is borrowed otherwise.
+fn build_callout_regexes(line_comment: Option<&str>) -> (Cow<'static, Regex>, &'static Regex) {
     match line_comment {
         // Default: recognize the common line-comment prefixes and XML callouts.
-        None => {
-            let callout = Regex::new(
-                r"(?P<prefix>(?://|#|--|;;) ?)?(?P<esc>\\)?(?:&lt;!--(?P<xnum>\d+|\.)--&gt;|&lt;(?P<num>\d+|\.)&gt;)",
-            )
-            .unwrap();
-
-            let tail =
-                Regex::new(r"^(?: ?\\?(?:&lt;!--(?:\d+|\.)--&gt;|&lt;(?:\d+|\.)&gt;))*(?:\n|$)")
-                    .unwrap();
-
-            (callout, tail)
-        }
+        None => (Cow::Borrowed(&DEFAULT_CALLOUT_RX), &DEFAULT_CALLOUT_TAIL_RX),
 
         // A custom or empty `line-comment`: only the bare (non-XML) callout form
         // is recognized, optionally behind the custom prefix.
@@ -842,14 +857,13 @@ fn build_callout_regexes(line_comment: Option<&str>) -> (Regex, Regex) {
                 format!(r"(?P<prefix>{} ?)?", regex::escape(prefix))
             };
 
+            #[allow(clippy::unwrap_used)]
             let callout = Regex::new(&format!(
                 r"{prefix_pattern}(?P<esc>\\)?&lt;(?P<num>\d+|\.)&gt;"
             ))
             .unwrap();
 
-            let tail = Regex::new(r"^(?: ?\\?&lt;(?:\d+|\.)&gt;)*(?:\n|$)").unwrap();
-
-            (callout, tail)
+            (Cow::Owned(callout), &CUSTOM_CALLOUT_TAIL_RX)
         }
     }
 }

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -9,8 +9,8 @@ use crate::{
     document::InterpretedValue,
     internal::{LookaheadReplacer, LookaheadResult, replace_with_lookahead},
     parser::{
-        CharacterReplacementType, InlineSubstitutionRenderer, QuoteScope, QuoteType,
-        SpecialCharacter,
+        CalloutGuard, CalloutRenderParams, CharacterReplacementType, InlineSubstitutionRenderer,
+        QuoteScope, QuoteType, SpecialCharacter,
     },
 };
 
@@ -73,8 +73,8 @@ impl SubstitutionStep {
             Self::PostReplacement => {
                 apply_post_replacements(content, parser, attrlist);
             }
-            _ => {
-                todo!("Implement apply for SubstitutionStep::{self:?}");
+            Self::Callouts => {
+                apply_callouts(content, parser, attrlist);
             }
         }
     }
@@ -744,6 +744,188 @@ static HARD_LINE_BREAK: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(?m)^(.*) \+$"#).unwrap()
 });
 
+/// Processes [callouts] in literal, listing, and source blocks.
+///
+/// Callout numbers (`<1>`, `<.>`, or `<!--1-->` for XML) that appear at the end
+/// of a line are replaced with the renderer's callout markup. Callouts may be
+/// tucked behind a line comment (`//`, `#`, `--`, or `;;` by default, or a
+/// custom prefix specified by the `line-comment` attribute), and a callout may
+/// be escaped with a leading backslash to render it literally.
+///
+/// This substitution runs after [special characters] have been replaced, so the
+/// angle brackets that delimit a callout appear in `content.rendered` as
+/// `&lt;` and `&gt;`. This mirrors Asciidoctor's `sub_callouts` /
+/// `CalloutSourceRx`.
+///
+/// [callouts]: https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/
+/// [special characters]: https://docs.asciidoctor.org/asciidoc/latest/subs/special-characters/
+fn apply_callouts(content: &mut Content<'_>, parser: &Parser, attrlist: Option<&Attrlist<'_>>) {
+    // A callout's opening bracket is always rendered as `&lt;` by the special
+    // characters substitution, so we can cheaply skip content without any.
+    if !content.rendered.contains("&lt;") {
+        return;
+    }
+
+    // The `line-comment` attribute (block-level, falling back to document-level)
+    // customizes or disables line-comment recognition:
+    //
+    // * absent           -> default prefixes (`//`, `#`, `--`, `;;`) and XML
+    //   callouts are recognized.
+    // * present (custom)  -> only the given prefix is recognized; XML callouts are
+    //   not.
+    // * present but empty -> no line-comment prefix is recognized; XML callouts are
+    //   not.
+    let line_comment: Option<String> = attrlist
+        .and_then(|a| a.named_attribute("line-comment"))
+        .map(|a| a.value().to_string())
+        .or_else(|| {
+            if parser.has_attribute("line-comment") {
+                Some(
+                    parser
+                        .attribute_value("line-comment")
+                        .as_maybe_str()
+                        .unwrap_or("")
+                        .to_string(),
+                )
+            } else {
+                None
+            }
+        });
+
+    let (callout_rx, tail_rx) = build_callout_regexes(line_comment.as_deref());
+
+    let replacer = CalloutReplacer {
+        renderer: &*parser.renderer,
+        parser,
+        autonum: 0,
+        tail: &tail_rx,
+    };
+
+    if let Cow::Owned(new_result) =
+        replace_with_lookahead(&callout_rx, content.rendered.as_ref(), replacer)
+    {
+        content.rendered = new_result.into();
+    }
+}
+
+/// Builds the `(callout, tail)` regex pair for the given `line-comment` mode.
+///
+/// The `callout` regex matches a single callout token (with the optional
+/// line-comment prefix and escape that may precede it). The `tail` regex is
+/// used to emulate Asciidoctor's trailing-position lookahead: a matched callout
+/// is only honored when the remainder of its line consists solely of further
+/// callouts. Rust's regex engine supports neither lookahead nor backreferences,
+/// so the lookahead is applied manually against the post-match text.
+fn build_callout_regexes(line_comment: Option<&str>) -> (Regex, Regex) {
+    #[allow(clippy::unwrap_used)]
+    match line_comment {
+        // Default: recognize the common line-comment prefixes and XML callouts.
+        None => {
+            let callout = Regex::new(
+                r"(?P<prefix>(?://|#|--|;;) ?)?(?P<esc>\\)?(?:&lt;!--(?P<xnum>\d+|\.)--&gt;|&lt;(?P<num>\d+|\.)&gt;)",
+            )
+            .unwrap();
+
+            let tail =
+                Regex::new(r"^(?: ?\\?(?:&lt;!--(?:\d+|\.)--&gt;|&lt;(?:\d+|\.)&gt;))*(?:\n|$)")
+                    .unwrap();
+
+            (callout, tail)
+        }
+
+        // A custom or empty `line-comment`: only the bare (non-XML) callout form
+        // is recognized, optionally behind the custom prefix.
+        Some(prefix) => {
+            let prefix_pattern = if prefix.is_empty() {
+                String::new()
+            } else {
+                format!(r"(?P<prefix>{} ?)?", regex::escape(prefix))
+            };
+
+            let callout = Regex::new(&format!(
+                r"{prefix_pattern}(?P<esc>\\)?&lt;(?P<num>\d+|\.)&gt;"
+            ))
+            .unwrap();
+
+            let tail = Regex::new(r"^(?: ?\\?&lt;(?:\d+|\.)&gt;)*(?:\n|$)").unwrap();
+
+            (callout, tail)
+        }
+    }
+}
+
+/// Replacer that renders each trailing callout token, emulating Asciidoctor's
+/// `sub_callouts`.
+struct CalloutReplacer<'r> {
+    renderer: &'r dyn InlineSubstitutionRenderer,
+    parser: &'r Parser,
+
+    /// Running counter for automatically-numbered (`<.>`) callouts, scoped to a
+    /// single block.
+    autonum: u32,
+
+    /// Trailing-position lookahead regex (see [`build_callout_regexes`]).
+    tail: &'r Regex,
+}
+
+impl LookaheadReplacer for CalloutReplacer<'_> {
+    fn replace_append(
+        &mut self,
+        caps: &Captures<'_>,
+        dest: &mut String,
+        after: &str,
+    ) -> LookaheadResult {
+        // Honor the trailing-position requirement: a callout is only recognized
+        // when nothing but further callouts follows it on the line.
+        if !self.tail.is_match(after) {
+            dest.push_str(&caps[0]);
+            return LookaheadResult::Continue;
+        }
+
+        // Honor the escape: emit the matched text with the escaping backslash
+        // removed so the callout renders literally.
+        if caps.name("esc").is_some() {
+            dest.push_str(&caps[0].replacen('\\', "", 1));
+            return LookaheadResult::Continue;
+        }
+
+        let (number_raw, is_xml) = if let Some(xnum) = caps.name("xnum") {
+            (xnum.as_str(), true)
+        } else {
+            // The regex guarantees one of `xnum` or `num` is present.
+            #[allow(clippy::unwrap_used)]
+            (caps.name("num").unwrap().as_str(), false)
+        };
+
+        let number = if number_raw == "." {
+            self.autonum += 1;
+            self.autonum.to_string()
+        } else {
+            number_raw.to_string()
+        };
+
+        // Mirror Asciidoctor's guard resolution: a captured line-comment prefix
+        // takes precedence; otherwise an XML callout uses the XML guard; failing
+        // both, there is no guard.
+        let guard = match caps.name("prefix") {
+            Some(prefix) => CalloutGuard::LineComment(prefix.as_str()),
+            None if is_xml => CalloutGuard::Xml,
+            None => CalloutGuard::LineComment(""),
+        };
+
+        self.renderer.render_callout(
+            &CalloutRenderParams {
+                number: &number,
+                guard,
+                parser: self.parser,
+            },
+            dest,
+        );
+
+        LookaheadResult::Continue
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
@@ -941,18 +1123,188 @@ mod tests {
     mod callouts {
         use crate::{
             content::{Content, SubstitutionStep},
+            parser::ModificationContext,
             strings::CowStr,
             tests::prelude::*,
         };
 
+        /// Builds a `Content` whose `rendered` text is `text` (as if special
+        /// characters had already been substituted), applies the callouts step,
+        /// and returns the resulting rendered text.
+        fn render_callouts(text: &str, parser: &Parser) -> String {
+            let mut content = Content::from(crate::Span::new(text));
+            // `Content::from` copies the source verbatim into `rendered`, which
+            // is exactly the post-special-characters state we want to exercise.
+            SubstitutionStep::Callouts.apply(&mut content, parser, None);
+            content.rendered.to_string()
+        }
+
         #[test]
-        #[should_panic]
-        fn not_yet_implemented() {
+        fn empty() {
             let mut content = Content::from(crate::Span::default());
             let p = Parser::default();
             SubstitutionStep::Callouts.apply(&mut content, &p, None);
             assert!(content.is_empty());
             assert_eq!(content.rendered, CowStr::Borrowed(""));
+        }
+
+        #[test]
+        fn no_callouts() {
+            let p = Parser::default();
+            assert_eq!(render_callouts("just some text", &p), "just some text");
+        }
+
+        #[test]
+        fn lt_without_callout_is_untouched() {
+            let p = Parser::default();
+            assert_eq!(render_callouts("a &lt;b&gt; c", &p), "a &lt;b&gt; c");
+        }
+
+        #[test]
+        fn basic_explicit() {
+            let p = Parser::default();
+            assert_eq!(
+                render_callouts("require 'x' &lt;1&gt;", &p),
+                r#"require 'x' <b class="conum">(1)</b>"#
+            );
+        }
+
+        #[test]
+        fn line_comment_prefix_preserved() {
+            let p = Parser::default();
+            assert_eq!(
+                render_callouts("puts 'x' # &lt;1&gt;", &p),
+                r#"puts 'x' # <b class="conum">(1)</b>"#
+            );
+        }
+
+        #[test]
+        fn multiple_on_one_line() {
+            let p = Parser::default();
+            assert_eq!(
+                render_callouts("puts x &lt;5&gt;&lt;6&gt;", &p),
+                r#"puts x <b class="conum">(5)</b><b class="conum">(6)</b>"#
+            );
+        }
+
+        #[test]
+        fn not_at_end_of_line() {
+            let p = Parser::default();
+            assert_eq!(
+                render_callouts("puts \"&lt;1&gt; in the middle\"", &p),
+                "puts \"&lt;1&gt; in the middle\""
+            );
+        }
+
+        #[test]
+        fn auto_numbering() {
+            let p = Parser::default();
+            assert_eq!(
+                render_callouts("a &lt;.&gt;\nb &lt;.&gt;\nc &lt;.&gt;", &p),
+                "a <b class=\"conum\">(1)</b>\nb <b class=\"conum\">(2)</b>\nc <b class=\"conum\">(3)</b>"
+            );
+        }
+
+        #[test]
+        fn mixed_numbering_ignores_explicit() {
+            // Auto-numbering is not aware of explicit numbers.
+            let p = Parser::default();
+            assert_eq!(
+                render_callouts("a &lt;.&gt;\nb &lt;1&gt;\nc &lt;.&gt;", &p),
+                "a <b class=\"conum\">(1)</b>\nb <b class=\"conum\">(1)</b>\nc <b class=\"conum\">(2)</b>"
+            );
+        }
+
+        #[test]
+        fn xml_callout() {
+            let p = Parser::default();
+            assert_eq!(
+                render_callouts("&lt;child/&gt; &lt;!--1--&gt;", &p),
+                r#"&lt;child/&gt; &lt;!--<b class="conum">(1)</b>--&gt;"#
+            );
+        }
+
+        #[test]
+        fn half_xml_comment_is_not_a_callout() {
+            let p = Parser::default();
+            assert_eq!(
+                render_callouts("First line &lt;1--&gt;", &p),
+                "First line &lt;1--&gt;"
+            );
+        }
+
+        #[test]
+        fn escaped_callout() {
+            let p = Parser::default();
+            assert_eq!(
+                render_callouts("require 'x' # \\&lt;1&gt;", &p),
+                "require 'x' # &lt;1&gt;"
+            );
+        }
+
+        #[test]
+        fn icons_font() {
+            let p = Parser::default().with_intrinsic_attribute(
+                "icons",
+                "font",
+                ModificationContext::Anywhere,
+            );
+            assert_eq!(
+                render_callouts("puts x # &lt;1&gt;", &p),
+                r#"puts x <i class="conum" data-value="1"></i><b>(1)</b>"#
+            );
+        }
+
+        #[test]
+        fn icons_image() {
+            let p = Parser::default().with_intrinsic_attribute(
+                "icons",
+                "",
+                ModificationContext::Anywhere,
+            );
+            assert_eq!(
+                render_callouts("puts x &lt;1&gt;", &p),
+                r#"puts x <img src="./images/icons/callouts/1.png" alt="1">"#
+            );
+        }
+
+        #[test]
+        fn custom_line_comment_prefix() {
+            // line-comment=% (Erlang). Only `%` is recognized as a prefix.
+            let mut content = Content::from(crate::Span::new("hello() -> % &lt;1&gt;"));
+            let attrlist = crate::attributes::Attrlist::parse(
+                crate::Span::new("source,erlang,line-comment=%"),
+                &Parser::default(),
+                crate::attributes::AttrlistContext::Block,
+            )
+            .item
+            .item;
+            let p = Parser::default();
+            SubstitutionStep::Callouts.apply(&mut content, &p, Some(&attrlist));
+            assert_eq!(
+                content.rendered.to_string(),
+                r#"hello() -> % <b class="conum">(1)</b>"#
+            );
+        }
+
+        #[test]
+        fn disabled_line_comment_preserves_leading_chars() {
+            // line-comment= (empty) disables prefix recognition, so the `--`
+            // before the callout is preserved verbatim.
+            let mut content = Content::from(crate::Span::new("-- &lt;1&gt;"));
+            let attrlist = crate::attributes::Attrlist::parse(
+                crate::Span::new("source,asciidoc,line-comment="),
+                &Parser::default(),
+                crate::attributes::AttrlistContext::Block,
+            )
+            .item
+            .item;
+            let p = Parser::default();
+            SubstitutionStep::Callouts.apply(&mut content, &p, Some(&attrlist));
+            assert_eq!(
+                content.rendered.to_string(),
+                r#"-- <b class="conum">(1)</b>"#
+            );
         }
     }
 }

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -769,9 +769,9 @@ fn apply_callouts(content: &mut Content<'_>, parser: &Parser, attrlist: Option<&
     // The `line-comment` attribute (block-level, falling back to document-level)
     // customizes or disables line-comment recognition:
     //
-    // * absent           -> default prefixes (`//`, `#`, `--`, `;;`) and XML
-    //   callouts are recognized.
-    // * present (custom)  -> only the given prefix is recognized; XML callouts are
+    // * absent -> default prefixes (`//`, `#`, `--`, `;;`) and XML callouts are
+    //   recognized.
+    // * present (custom) -> only the given prefix is recognized; XML callouts are
     //   not.
     // * present but empty -> no line-comment prefix is recognized; XML callouts are
     //   not.

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -157,6 +157,15 @@ pub trait InlineSubstitutionRenderer: Debug {
     /// reference could not be resolved and the renderer should emit a sensible
     /// fallback (e.g. a link to the raw target with bracketed text).
     fn render_xref(&self, params: &XrefRenderParams, dest: &mut String);
+
+    /// Renders a [callout] number that annotates a line in a verbatim block.
+    ///
+    /// The renderer should write an appropriate rendering of the callout number
+    /// to `dest`. The rendering typically depends on whether font-based or
+    /// image-based icons are enabled (via the `icons` document attribute).
+    ///
+    /// [callout]: https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/
+    fn render_callout(&self, params: &CalloutRenderParams, dest: &mut String);
 }
 
 /// Specifies which special character is being replaced in a call to
@@ -332,6 +341,41 @@ pub struct LinkRenderParams<'a> {
 pub enum LinkRenderType {
     /// TEMPORARY: I don't know the different types of links yet.
     Link,
+}
+
+/// Provides parameters for rendering a [callout] number.
+///
+/// [callout]: https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/
+#[derive(Clone, Debug)]
+pub struct CalloutRenderParams<'a> {
+    /// The callout number to display. For automatically-numbered callouts
+    /// (`<.>`), this is the resolved sequential number.
+    pub number: &'a str,
+
+    /// The guard surrounding the callout in the source. This controls whether
+    /// (and how) the line-comment or XML-comment characters that hide the
+    /// callout in the raw source are preserved in the output when icons are not
+    /// enabled.
+    pub guard: CalloutGuard<'a>,
+
+    /// Parser. The renderer reads the `icons`, `iconsdir`, and `icontype`
+    /// document attributes to decide how to render the callout.
+    pub parser: &'a Parser,
+}
+
+/// Describes the characters that guard (hide) a callout number in verbatim
+/// source.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CalloutGuard<'a> {
+    /// A line-comment (or absent) guard. Holds the line-comment prefix that
+    /// precedes the callout in the source (e.g. `# `), or an empty string when
+    /// the callout is not tucked behind a line comment. When icons are not
+    /// enabled, the prefix is preserved ahead of the rendered callout number.
+    LineComment(&'a str),
+
+    /// An XML comment guard (`<!--N-->`). When icons are not enabled, the XML
+    /// comment delimiters are preserved around the rendered callout number.
+    Xml,
 }
 
 /// Provides parameters for rendering a cross-reference.
@@ -739,6 +783,39 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
                     r##"<a href="#{target}">{text}</a>"##,
                     target = params.target
                 ));
+            }
+        }
+    }
+
+    fn render_callout(&self, params: &CalloutRenderParams, dest: &mut String) {
+        let n = params.number;
+        let parser = params.parser;
+
+        if parser.attribute_value("icons").as_maybe_str() == Some("font") {
+            dest.push_str(&format!(
+                r#"<i class="conum" data-value="{n}"></i><b>({n})</b>"#
+            ));
+        } else if parser.has_attribute("icons") {
+            let icontype = parser
+                .attribute_value("icontype")
+                .as_maybe_str()
+                .unwrap_or("png")
+                .to_owned();
+
+            let icon = format!("callouts/{n}.{icontype}");
+            let src = self.image_uri(&icon, parser, Some("iconsdir"));
+
+            dest.push_str(&format!(r#"<img src="{src}" alt="{n}">"#));
+        } else {
+            match params.guard {
+                CalloutGuard::Xml => {
+                    dest.push_str(&format!(r#"&lt;!--<b class="conum">({n})</b>--&gt;"#));
+                }
+
+                CalloutGuard::LineComment(prefix) => {
+                    dest.push_str(prefix);
+                    dest.push_str(&format!(r#"<b class="conum">({n})</b>"#));
+                }
             }
         }
     }

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -12,9 +12,9 @@ pub use include_file_handler::IncludeFileHandler;
 
 mod inline_substitution_renderer;
 pub use inline_substitution_renderer::{
-    CharacterReplacementType, HtmlSubstitutionRenderer, IconRenderParams, ImageRenderParams,
-    InlineSubstitutionRenderer, LinkRenderParams, LinkRenderType, QuoteScope, QuoteType,
-    SpecialCharacter, XrefRenderParams,
+    CalloutGuard, CalloutRenderParams, CharacterReplacementType, HtmlSubstitutionRenderer,
+    IconRenderParams, ImageRenderParams, InlineSubstitutionRenderer, LinkRenderParams,
+    LinkRenderType, QuoteScope, QuoteType, SpecialCharacter, XrefRenderParams,
 };
 
 mod parser;

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -845,6 +845,10 @@ mod tests {
         fn render_xref(&self, params: &crate::parser::XrefRenderParams, dest: &mut String) {
             dest.push_str(&format!("[XREF:{}]", params.target));
         }
+
+        fn render_callout(&self, params: &crate::parser::CalloutRenderParams, dest: &mut String) {
+            dest.push_str(&format!("[CALLOUT:{}]", params.number));
+        }
     }
 
     #[test]

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -101,6 +101,27 @@ pub struct Parser {
     /// `separator` attribute. The counter is incremented and decremented around
     /// each AsciiDoc cell, so it nests correctly.
     pub(crate) nested_document_depth: usize,
+
+    /// Catalog of callout numbers registered by verbatim blocks, used to
+    /// validate the callout lists that annotate them.
+    ///
+    /// Wrapped in a [`RefCell`] because callouts are registered deep inside the
+    /// callouts substitution step, where only a shared `&Parser` is available.
+    callouts: RefCell<CalloutCatalog>,
+}
+
+/// Tracks the callout numbers defined by verbatim blocks so that a callout list
+/// can be validated against the callouts it annotates.
+///
+/// This mirrors the relevant behavior of Asciidoctor's `Callouts` catalog: each
+/// verbatim block registers the callout numbers it defines into the current
+/// list, and each callout list checks its items against that list (warning
+/// about any item with no matching callout) before the list is closed.
+#[derive(Clone, Debug, Default)]
+struct CalloutCatalog {
+    /// Callout numbers registered (in document order) since the last callout
+    /// list was closed.
+    current: Vec<u32>,
 }
 
 impl Default for Parser {
@@ -123,6 +144,7 @@ impl Default for Parser {
             counters: HashMap::new(),
             locked_attribute_names: HashSet::new(),
             nested_document_depth: 0,
+            callouts: RefCell::new(CalloutCatalog::default()),
         }
     }
 }
@@ -192,6 +214,9 @@ impl Parser {
         // NOTE: `Document::parse` will transfer the catalog to itself at the end of the
         // parsing operation. Start each parse with a fresh catalog.
         *self.catalog.borrow_mut() = Catalog::new();
+
+        // Start each parse with an empty callout catalog.
+        *self.callouts.borrow_mut() = CalloutCatalog::default();
 
         // Reset section numbering for each new document.
         self.last_section_number = SectionNumber::default();
@@ -370,6 +395,26 @@ impl Parser {
         self.catalog
             .borrow_mut()
             .register_ref(id, reftext, ref_type)
+    }
+
+    /// Registers a callout number defined by a verbatim block.
+    ///
+    /// Takes `&self` so it can be called from the callouts substitution step,
+    /// which only holds a shared reference to the parser.
+    pub(crate) fn register_callout(&self, number: u32) {
+        self.callouts.borrow_mut().current.push(number);
+    }
+
+    /// Returns `true` if a callout numbered `number` was registered for the
+    /// current (not-yet-closed) callout list.
+    pub(crate) fn callout_defined(&self, number: u32) -> bool {
+        self.callouts.borrow().current.contains(&number)
+    }
+
+    /// Closes the current callout list, so callouts registered afterward belong
+    /// to the next list.
+    pub(crate) fn close_callout_list(&self) {
+        self.callouts.borrow_mut().current.clear();
     }
 
     /// Generate a unique ID derived from `base_id` and register it in the

--- a/parser/src/tests/asciidoc_lang/attributes/attribute_entry_substitutions.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/attribute_entry_substitutions.rs
@@ -170,6 +170,7 @@ You can inspect the value stored in an attribute using this trick:
                 substitution_group: SubstitutionGroup::Custom(vec![
                     SubstitutionStep::AttributeReferences,
                     SubstitutionStep::SpecialCharacters,
+                    SubstitutionStep::Callouts,
                 ],),
             },)
         );
@@ -252,6 +253,7 @@ If the macro is absent, the value is processed with the header substitution grou
                 substitution_group: SubstitutionGroup::Custom(vec![
                     SubstitutionStep::AttributeReferences,
                     SubstitutionStep::SpecialCharacters,
+                    SubstitutionStep::Callouts,
                 ],),
             },)
         );

--- a/parser/src/tests/asciidoc_lang/subs/apply_subs_to_blocks.rs
+++ b/parser/src/tests/asciidoc_lang/subs/apply_subs_to_blocks.rs
@@ -592,14 +592,9 @@ include::example$subs.adoc[tag=subs-add]
         );
     }
 
-    #[ignore]
     #[test]
     fn example_subtract() {
-        // The `subs=-callouts` modifier is now supported, but this example is
-        // still blocked on `include::example$subs.adoc[tag=...]` resolution in
-        // the test harness.
-
-        to_do_verifies!(
+        verifies!(
             r#"
 Similarly, you can remove the `callouts` substitution from a block's default substitution group by placing the minus (`-`) modifier in front of the `callouts` value.
 
@@ -611,16 +606,36 @@ include::example$subs.adoc[tag=subs-sub]
 
 "#
         );
+
+        use inline_file_handler::InlineFileHandler;
+
+        // Preload the `subs-sub` example (an illegal XML tag) via the debug-only
+        // include handler.
+        let handler = InlineFileHandler::from_pairs([(
+            "example$subs.adoc",
+            "[source,xml,subs=\"-callouts\"]\n.An illegal XML tag\n----\n<1>\n  content inside \"1\" tag\n</1>\n----",
+        )]);
+
+        let mut parser = Parser::default().with_include_file_handler(handler);
+        let doc = parser.parse("include::example$subs.adoc[tag=subs-sub]\n");
+
+        let block = doc.nested_blocks().next().unwrap();
+        let Block::RawDelimited(block) = block else {
+            panic!("Unexpected block type: {block:?}");
+        };
+
+        // Removing `callouts` from the verbatim group leaves only special
+        // characters, so the lone `<1>` is rendered literally rather than as a
+        // callout number.
+        assert_eq!(
+            block.content().rendered(),
+            "&lt;1&gt;\n  content inside \"1\" tag\n&lt;/1&gt;"
+        );
     }
 
-    #[ignore]
     #[test]
     fn plus_before_or_after() {
-        // The `subs=-callouts` modifier is now supported, but this example is
-        // still blocked on `include::example$subs.adoc[tag=...]` resolution in
-        // the test harness.
-
-        to_do_verifies!(
+        verifies!(
             r#"
 You can also specify whether the substitution type is added to the end of the substitution group.
 If a `{plus}` comes before the name of the substitution, then it's added to the end of the existing list, whereas if a `{plus}` comes after the name, it's added to the beginning of the list.
@@ -633,6 +648,32 @@ include::example$subs.adoc[tag=subs-multi]
 In the above example, the `attributes` substitution step is added to the beginning of the default substitution group, the `replacements` step is added to the end of the group, and the `callouts` step is removed from the group.
 
 "#
+        );
+
+        use inline_file_handler::InlineFileHandler;
+
+        // Preload the `subs-multi` example via the debug-only include handler.
+        let handler = InlineFileHandler::from_pairs([(
+            "example$subs.adoc",
+            "[source,xml,subs=\"attributes+,+replacements,-callouts\"]\n----\n<version>{version}</version>\n<copyright>(C) ACME</copyright>\n<1>\n  content inside \"1\" tag\n</1>\n----",
+        )]);
+
+        let mut parser = Parser::default()
+            .with_intrinsic_attribute("version", "1.0", ModificationContext::Anywhere)
+            .with_include_file_handler(handler);
+        let doc = parser.parse("include::example$subs.adoc[tag=subs-multi]\n");
+
+        let block = doc.nested_blocks().next().unwrap();
+        let Block::RawDelimited(block) = block else {
+            panic!("Unexpected block type: {block:?}");
+        };
+
+        // `attributes` (prepended) resolves `{version}`, `replacements`
+        // (appended) converts `(C)`, and `callouts` (removed) leaves the lone
+        // `<1>` literal.
+        assert_eq!(
+            block.content().rendered(),
+            "&lt;version&gt;1.0&lt;/version&gt;\n&lt;copyright&gt;&#169; ACME&lt;/copyright&gt;\n&lt;1&gt;\n  content inside \"1\" tag\n&lt;/1&gt;"
         );
     }
 

--- a/parser/src/tests/asciidoc_lang/subs/apply_subs_to_blocks.rs
+++ b/parser/src/tests/asciidoc_lang/subs/apply_subs_to_blocks.rs
@@ -132,12 +132,9 @@ For source blocks, this substitution step enables syntax highlighting as well.
         );
     }
 
-    #[ignore]
     #[test]
     fn callouts() {
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311):
-        // Implement this test when implementing callouts.
-        to_do_verifies!(
+        verifies!(
             r#"
 `callouts`:: Substitution step that processes callouts in literal, listing, and source blocks.
 
@@ -154,9 +151,11 @@ For source blocks, this substitution step enables syntax highlighting as well.
             panic!("Unexpected block type: {block1:?}");
         };
 
+        // The verbatim group applies only special characters and callouts; the
+        // input has no callout markers, so only `&` is replaced.
         assert_eq!(
             block1.content().rendered(),
-            "This &amp; that and icon:github[] +\nanother line with a{sp}space there ..."
+            "This &amp; _that_ and icon:github[] +\nanother line with a{sp}space there ..."
         );
     }
 
@@ -596,8 +595,9 @@ include::example$subs.adoc[tag=subs-add]
     #[ignore]
     #[test]
     fn example_subtract() {
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311):
-        // Implement this test when implementing callouts.
+        // The `subs=-callouts` modifier is now supported, but this example is
+        // still blocked on `include::example$subs.adoc[tag=...]` resolution in
+        // the test harness.
 
         to_do_verifies!(
             r#"
@@ -616,8 +616,9 @@ include::example$subs.adoc[tag=subs-sub]
     #[ignore]
     #[test]
     fn plus_before_or_after() {
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311):
-        // Implement this test when implementing callouts.
+        // The `subs=-callouts` modifier is now supported, but this example is
+        // still blocked on `include::example$subs.adoc[tag=...]` resolution in
+        // the test harness.
 
         to_do_verifies!(
             r#"

--- a/parser/src/tests/asciidoc_lang/verbatim/callouts.rs
+++ b/parser/src/tests/asciidoc_lang/verbatim/callouts.rs
@@ -1,0 +1,326 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/verbatim/pages/callouts.adoc");
+
+non_normative!(
+    r#"
+= Callouts
+
+Callout numbers (aka callouts) provide a means to add annotations to lines in a verbatim block.
+
+"#
+);
+
+#[test]
+fn callout_syntax() {
+    verifies!(
+        r#"
+== Callout syntax
+
+Each callout number used in a verbatim block must appear twice.
+The first use, which goes within the verbatim block, marks the line being annotated (i.e., the target).
+The second use, which goes below the verbatim block, defines the annotation text.
+Multiple callout numbers may be used on a single line.
+
+IMPORTANT: The callout number (at the target) must be placed at the end of the line.
+
+Here's a basic example of a verbatim block that uses callouts:
+
+.Callout syntax
+[source#ex-basic,subs=-callouts]
+....
+include::example$callout.adoc[tag=basic]
+....
+
+The result of <<ex-basic>> is rendered below.
+
+include::example$callout.adoc[tag=basic]
+
+Since callout numbers can interfere with the syntax of the code they are annotating, an AsciiDoc processor provides several features to hide the callout numbers from both the source and the converted document.
+The sections that follow detail these features.
+
+"#
+    );
+
+    let doc = Parser::default().parse(
+        "[source,ruby]\n----\nrequire 'asciidoctor' # <1>\ndoc = Asciidoctor::Document.new # <2>\n----\n<1> Imports the library\n<2> Creates the document\n",
+    );
+
+    // The callout numbers in the verbatim block are rendered as conums.
+    assert_output_contains(&doc, r#"<b class="conum">(1)</b>"#);
+    assert_output_contains(&doc, r#"<b class="conum">(2)</b>"#);
+
+    // The annotation text below the block forms a callout list (`.colist`) with
+    // one item per callout number.
+    assert_css(&doc, ".colist ol li", 2);
+
+    // The `subs=-callouts` modifier used in the syntax examples above suppresses
+    // callout processing, so the callout numbers are shown literally.
+    let raw = Parser::default().parse("[source,subs=-callouts]\n----\nrequire 'x' # <1>\n----\n");
+    refute_output_contains(&raw, "conum");
+    assert_output_contains(&raw, "# &lt;1&gt;");
+}
+
+#[test]
+fn automatic_numbering() {
+    verifies!(
+        r#"
+== Automatic numbering
+
+Just like ordered lists, it's possible to allow the processor to automatically number the callouts.
+To leverage this capability, you replace the numbers in each callout with a dot (e.g., `<.>`).
+Each time the processor comes across a callout in either the verbatim block or the callout list, it selects the next number in the sequence (scoped to that block), starting from 1.
+
+Let's return to the previous example to see how it looks if we use automatic numbering.
+
+.Callout syntax with automatic numbering
+[source#ex-auto,subs=-callouts]
+....
+include::example$callout.adoc[tag=auto]
+....
+
+The result is exactly the same as before.
+
+"#
+    );
+
+    let doc = Parser::default().parse(
+        "[source,ruby]\n----\nrequire 'asciidoctor' # <.>\ndoc = Asciidoctor::Document.new # <.>\n----\n<.> Imports the library\n<.> Creates the document\n",
+    );
+
+    // The `<.>` markers are numbered automatically, starting from 1.
+    assert_output_contains(&doc, r#"<b class="conum">(1)</b>"#);
+    assert_output_contains(&doc, r#"<b class="conum">(2)</b>"#);
+    assert_css(&doc, ".colist ol li", 2);
+}
+
+#[test]
+fn mixed_numbering() {
+    verifies!(
+        r#"
+=== Mixed numbering
+
+The `<.>` callouts are automatically numbered based on their sequence among other `<.>`, not any callouts that have an explicit number.
+In other words, the automatic numbering is not aware of any explicit numbering.
+Therefore, you should generally avoid mixing them.
+
+However, if you want to repeat a number in the verbatim block, then you can use an explicit number to create additional occurrences of that callout number.
+
+Let's consider an example:
+
+.Callout syntax with mixed numbering
+[source#ex-auto-repeat,subs=-callouts]
+....
+include::example$callout.adoc[tag=auto-repeat]
+....
+
+The result of <<ex-auto-repeat>> is rendered below.
+
+include::example$callout.adoc[tag=auto-repeat]
+
+The risk of this approach is that you have to keep track of which numbers are being assigned automatically.
+
+"#
+    );
+
+    // The automatic numbering is not aware of the explicit `<1>`: the `<.>`
+    // markers are numbered 1 and 2 in sequence, while the explicit `<1>` repeats
+    // callout number 1. Asserted at the substitution level for an exact match.
+    let mut content = crate::content::Content::from(crate::Span::new(
+        "first &lt;.&gt;\nsecond &lt;.&gt;\nrepeat &lt;1&gt;",
+    ));
+    let parser = Parser::default();
+    crate::content::SubstitutionStep::Callouts.apply(&mut content, &parser, None);
+    assert_eq!(
+        content.rendered(),
+        "first <b class=\"conum\">(1)</b>\nsecond <b class=\"conum\">(2)</b>\nrepeat <b class=\"conum\">(1)</b>"
+    );
+}
+
+#[test]
+fn copy_and_paste_friendly_callouts() {
+    verifies!(
+        r#"
+== Copy and paste friendly callouts
+
+If you add callout numbers to example code in a verbatim (e.g., source) block, and a reader selects that source code in the generated HTML, we don't want the callout numbers to get caught up in the copied text.
+If the reader pastes that example code into a code editor and tries to run it, the extra characters that define the callout numbers will likely lead to compile or runtime errors.
+To mitigate this problem, and AsciiDoc processor uses a CSS rule to prevent the callouts from being selected.
+That way, the callout numbers won't get copied.
+
+On the other side of the coin, you don't want the callout annotations or CSS messing up your raw source code either.
+You can tuck your callouts neatly behind line comments.
+When font-based icons are enabled (e.g., `icons=font`), the AsciiDoc processor will recognize the line comments characters in front of a callout number--optionally offset by a space--and remove them when converting the document.
+When font-based icons aren't enabled, the line comment characters are not removed so that the callout numbers remain hidden by the line comment.
+
+Here are the line comments that are supported:
+
+.Prevent callout copy and paste
+[source#ex-prevent,subs=-callouts]
+....
+include::example$callout.adoc[tag=b-nonselect]
+....
+
+The result of <<ex-prevent>> is rendered below.
+
+// The listing style must be added above the rendered block so it is rendered correctly because we're setting `source-language` in the component descriptor which automatically promotes unstyled listing blocks to source blocks.
+[listing]
+include::example$callout.adoc[tag=b-nonselect]
+
+"#
+    );
+
+    // When font-based icons are not enabled, the line comment characters are
+    // preserved ahead of the callout number, keeping the callout hidden behind
+    // the comment in the raw source.
+    let doc = Parser::default()
+        .parse("[source,ruby]\n----\nputs 'Hello, world!' # <1>\n----\n<1> Ruby\n");
+    assert_output_contains(&doc, r#"# <b class="conum">(1)</b>"#);
+
+    // When font-based icons are enabled, the line comment characters are
+    // removed.
+    let doc = Parser::default()
+        .with_intrinsic_attribute("icons", "font", ModificationContext::Anywhere)
+        .parse("[source,ruby]\n----\nputs 'Hello, world!' # <1>\n----\n<1> Ruby\n");
+    assert_output_contains(
+        &doc,
+        r#"'Hello, world!' <i class="conum" data-value="1"></i><b>(1)</b>"#,
+    );
+    refute_output_contains(&doc, "# <i");
+}
+
+#[test]
+fn custom_line_comment_prefix() {
+    verifies!(
+        r#"
+=== Custom line comment prefix
+
+An AsciiDoc processor recognizes the most ubiquitous line comment prefixes as a convenience.
+If the source language you're embedding does not support one of these line comment prefixes, you can customize the prefix using the `line-comment` attribute on the block.
+
+Let's say we want to tuck a callout behind a line comment in Erlang code.
+In this case, we would set the `line-comment` character to `%`, as shown in this example:
+
+.Custom line comment prefix
+[source#ex-line-comment,subs=-callouts]
+....
+include::example$callout.adoc[tag=line-comment]
+....
+
+The result of <<ex-line-comment>> is rendered below.
+
+// The listing style must be added above the rendered block so it is rendered correctly because we're setting `source-language` in the component descriptor which automatically promotes unstyled listing blocks to source blocks.
+[listing]
+include::example$callout.adoc[tag=line-comment]
+
+Even though it's not specified in the attribute, one space is still permitted immediately following the line comment prefix.
+
+"#
+    );
+
+    // With `line-comment=%`, the `%` prefix (optionally followed by one space)
+    // is recognized as a line comment hiding the callout.
+    let doc = Parser::default().parse(
+        "[source,erlang,line-comment=%]\n----\nhello_world() -> % <1>\n  io:fwrite(\"hello~n\"). %<2>\n----\n<1> Function head.\n<2> Output.\n",
+    );
+    assert_output_contains(&doc, r#"% <b class="conum">(1)</b>"#);
+    assert_output_contains(&doc, r#"%<b class="conum">(2)</b>"#);
+}
+
+#[test]
+fn disable_line_comment_processing() {
+    verifies!(
+        r#"
+=== Disable line comment processing
+
+If the source language you're embedding does not support trailing line comments, or the line comment prefix is being misinterpreted, you can disable this feature using the `line-comment` attribute.
+
+Let's say we want to put a callout at the end of a block delimiter for an open block in AsciiDoc.
+In this case, the processor will think the double hyphen is a line comment, when in fact it's the block delimiter.
+We can disable line comment processing by setting the `line-comment` character to an empty value, as shown in this example:
+
+.No line comment prefix
+[source#ex-disable-line-comment,subs=-callouts]
+....
+include::example$callout.adoc[tag=disable-line-comment]
+....
+
+The result of <<ex-disable-line-comment>> is rendered below.
+
+// The listing style must be added above the rendered block so it is rendered correctly because we're setting `source-language` in the component descriptor which automatically promotes unstyled listing blocks to source blocks.
+[listing]
+include::example$callout.adoc[tag=disable-line-comment]
+
+Since the language doesn't support trailing line comments, there's no way to hide the callout number in the raw source.
+
+"#
+    );
+
+    // With `line-comment=` (empty), no prefix is recognized, so the `--` before
+    // the callout is preserved verbatim rather than being eaten as a comment.
+    let doc = Parser::default().parse(
+        "[source,asciidoc,line-comment=]\n----\n-- <1>\n----\n<1> The start of an open block.\n",
+    );
+    assert_output_contains(&doc, r#"-- <b class="conum">(1)</b>"#);
+}
+
+#[test]
+fn xml_callouts() {
+    verifies!(
+        r#"
+=== XML callouts
+
+XML doesn't have line comments, so our "`tuck the callout behind a line comment`" trick doesn't work here.
+To use callouts in XML, you must place the callout's angled brackets around the XML comment and callout number.
+
+Here's how it appears in a listing:
+
+.XML callout syntax
+[source#ex-xml,subs=-callouts]
+....
+include::example$callout.adoc[tag=source-xml]
+....
+
+The result of <<ex-xml>> is rendered below.
+
+include::example$callout.adoc[tag=source-xml]
+
+Notice the comment has been replaced with a circled number that cannot be selected (if not using font icons it will be
+rendered differently and selectable).
+Now both you and the reader can copy and paste XML source code containing callouts without worrying about errors.
+
+"#
+    );
+
+    // An XML callout places the angle brackets around the XML comment and
+    // number; the rendered output keeps the comment delimiters around the conum.
+    let doc = Parser::default().parse(
+        "[source,xml]\n----\n<section>\n  <title>Section Title</title> <!--1-->\n</section>\n----\n<1> The title is required.\n",
+    );
+    assert_output_contains(&doc, r#"&lt;!--<b class="conum">(1)</b>--&gt;"#);
+}
+
+#[test]
+fn callout_icons() {
+    verifies!(
+        r#"
+== Callout icons
+
+The font icons setting also enables callout icons drawn using CSS.
+
+----
+include::example$callout.adoc[tag=co-icon]
+----
+<.> Activates the font-based icons in the HTML5 backend.
+<.> Admonition block that uses a font-based icon.
+"#
+    );
+
+    // With `icons=font`, callout numbers render as font-based icons.
+    let doc = Parser::default()
+        .with_intrinsic_attribute("icons", "font", ModificationContext::Anywhere)
+        .parse("----\n:icons: font <1>\n[TIP] <2>\n----\n<.> Activates the font-based icons in the HTML5 backend.\n<.> Admonition block that uses a font-based icon.\n");
+
+    assert_output_contains(&doc, r#"<i class="conum" data-value="1"></i><b>(1)</b>"#);
+    assert_output_contains(&doc, r#"<i class="conum" data-value="2"></i><b>(2)</b>"#);
+}

--- a/parser/src/tests/asciidoc_lang/verbatim/listing_blocks.rs
+++ b/parser/src/tests/asciidoc_lang/verbatim/listing_blocks.rs
@@ -257,6 +257,7 @@ See xref:subs:apply-subs-to-blocks.adoc[] to learn more about the `subs` attribu
 
     let sg = vec![
         SubstitutionStep::SpecialCharacters,
+        SubstitutionStep::Callouts,
         SubstitutionStep::AttributeReferences,
     ];
 

--- a/parser/src/tests/asciidoc_lang/verbatim/mod.rs
+++ b/parser/src/tests/asciidoc_lang/verbatim/mod.rs
@@ -1,3 +1,4 @@
+mod callouts;
 mod highlight_lines;
 mod highlight_php;
 mod listing_blocks;

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -4968,13 +4968,24 @@ mod callout_lists {
     }
 
     #[test]
-    #[ignore]
     fn should_warn_if_numbers_in_callout_list_are_out_of_sequence() {
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311):
-        // Enable once the memory logger (callout-list out-of-sequence /
-        // "no callout found" warnings) is available.
-        let _doc = Parser::default().parse("----\n<beans> <1>\n  <bean class=\"com.example.HelloWorld\"/>\n</beans>\n----\n<1> Container of beans.\nBeans are fun.\n<3> An actual bean.\n");
-        todo!("memory logger test");
+        let doc = Parser::default().parse("----\n<beans> <1>\n  <bean class=\"com.example.HelloWorld\"/>\n</beans>\n----\n<1> Container of beans.\nBeans are fun.\n<3> An actual bean.\n");
+
+        // The callout list has two items.
+        assert_xpath(&doc, "//ol/li", 2);
+
+        // The verbatim block defines only callout 1, so the second item (whose
+        // marker is `<3>`) is both out of sequence and has no matching callout.
+        // Asciidoctor logs these via its memory logger; this crate surfaces them
+        // as document warnings.
+        let warnings: Vec<_> = doc.warnings().map(|w| &w.warning).collect();
+        assert_eq!(
+            warnings,
+            vec![
+                &WarningType::CalloutListItemOutOfSequence(2, 3),
+                &WarningType::NoCalloutFound(2),
+            ]
+        );
     }
 
     #[test]

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -5043,19 +5043,60 @@ mod callout_lists {
     }
 
     #[test]
-    #[ignore]
     fn callout_list_with_icons_enabled() {
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311):
-        // Enable once image-based callout icons render as DOM nodes inside
-        // verbatim blocks and the callout list renders as an icon table.
+        // `:icons:` (set, empty) enables image-based callout icons.
+        let doc = Parser::default().parse(":icons:\n[source, ruby]\n----\nrequire 'asciidoctor' # <1>\ndoc = Asciidoctor::Document.new('Hello, World!') # <2>\nputs doc.convert # <3>\n----\n<1> Describe the first line\n<2> Describe the second line\n<3> Describe the third line\n");
+
+        // The verbatim block renders each callout as an image inside the code.
+        assert_css(&doc, ".listingblock code > img", 3);
+        assert_xpath(
+            &doc,
+            "(/div[@class=\"listingblock\"]//code/img)[1][@src=\"./images/icons/callouts/1.png\"][@alt=\"1\"]",
+            1,
+        );
+
+        // The callout list renders as an icon table.
+        assert_css(&doc, ".colist table td img", 3);
+        assert_xpath(
+            &doc,
+            "(/div[@class=\"colist arabic\"]//td/img)[1][@src=\"./images/icons/callouts/1.png\"][@alt=\"1\"]",
+            1,
+        );
     }
 
     #[test]
-    #[ignore]
     fn callout_list_with_font_based_icons_enabled() {
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311):
-        // Enable once font-based callout icons render as DOM nodes inside
-        // verbatim blocks and the callout list renders as an icon table.
+        // `:icons: font` enables font-based callout icons.
+        let doc = Parser::default().parse(":icons: font\n[source]\n----\nrequire 'asciidoctor' # <1>\ndoc = Asciidoctor::Document.new('Hello, World!') #<2>\nputs doc.convert #<3>\n----\n<1> Describe the first line\n<2> Describe the second line\n<3> Describe the third line\n");
+
+        // The verbatim block renders each callout as a font icon followed by a
+        // bold number inside the code.
+        assert_css(&doc, ".listingblock code > i", 3);
+        assert_xpath(&doc, "(/div[@class=\"listingblock\"]//code/i)[1]", 1);
+        assert_xpath(
+            &doc,
+            "(/div[@class=\"listingblock\"]//code/i)[1][@class=\"conum\"][@data-value=\"1\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "(/div[@class=\"listingblock\"]//code/i)[1]/following-sibling::b[text()=\"(1)\"]",
+            1,
+        );
+
+        // The callout list renders as an icon table.
+        assert_css(&doc, ".colist table td i", 3);
+        assert_xpath(&doc, "(/div[@class=\"colist arabic\"]//td/i)[1]", 1);
+        assert_xpath(
+            &doc,
+            "(/div[@class=\"colist arabic\"]//td/i)[1][@class=\"conum\"][@data-value=\"1\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "(/div[@class=\"colist arabic\"]//td/i)[1]/following-sibling::b[text()=\"1\"]",
+            1,
+        );
     }
 
     #[test]

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -4764,8 +4764,6 @@ mod description_lists_redux {
 mod callout_lists {
     // Adapted from Asciidoctor's callout list tests.
     //
-    // Implemented as part of https://github.com/asciidoc-rs/asciidoc-parser/issues/311.
-    //
     // Conum markup inside a verbatim block is part of the block's rendered
     // content string (it is not promoted to a DOM node, since the crate does
     // not parse verbatim content as HTML), so it is asserted with

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -4762,38 +4762,44 @@ mod description_lists_redux {
 }
 
 mod callout_lists {
-    // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311):
-    // Implement these tests once callouts are implemented.
+    // Adapted from Asciidoctor's callout list tests.
+    //
+    // Implemented as part of https://github.com/asciidoc-rs/asciidoc-parser/issues/311.
+    //
+    // Conum markup inside a verbatim block is part of the block's rendered
+    // content string (it is not promoted to a DOM node, since the crate does
+    // not parse verbatim content as HTML), so it is asserted with
+    // `assert_output_contains`/`refute_output_contains` rather than an XPath
+    // node query. Tests that require infrastructure this crate does not have —
+    // the memory logger (for "no callout found" / out-of-sequence warnings),
+    // DocBook output, callout icon image/table rendering, or U+2028 line
+    // separators — remain `#[ignore]`d and are noted individually.
     use crate::tests::prelude::*;
 
     #[test]
-    #[ignore]
     fn does_not_recognize_callout_list_denoted_by_markers_that_only_have_a_trailing_bracket() {
-        let _doc = Parser::default()
+        let doc = Parser::default()
             .parse("----\nrequire 'asciidoctor' # <1>\n----\n1> Not a callout list item\n");
-        todo!("assert_css: '.colist', output, 0");
+        assert_css(&doc, ".colist", 0);
     }
 
     #[test]
-    #[ignore]
     fn should_not_hang_if_obsolete_callout_list_is_found_inside_list_item() {
-        let _doc = Parser::default().parse("* foo\n1> bar\n");
-        todo!("assert_css: '.colist', output, 0");
+        let doc = Parser::default().parse("* foo\n1> bar\n");
+        assert_css(&doc, ".colist", 0);
     }
 
     #[test]
-    #[ignore]
     fn should_not_hang_if_obsolete_callout_list_is_found_inside_dlist_item() {
-        let _doc = Parser::default().parse("foo::\n1> bar\n");
-        todo!("assert_css: '.colist', output, 0");
+        let doc = Parser::default().parse("foo::\n1> bar\n");
+        assert_css(&doc, ".colist", 0);
     }
 
     #[test]
-    #[ignore]
     fn should_recognize_auto_numberd_callout_list_inside_list() {
-        let _doc =
+        let doc =
             Parser::default().parse("----\nrequire 'asciidoctor' # <1>\n----\n* foo\n<.> bar\n");
-        todo!("assert_css: '.colist', output, 1");
+        assert_css(&doc, ".colist", 1);
     }
 
     #[test]
@@ -4833,16 +4839,24 @@ mod callout_lists {
     }
 
     #[test]
-    #[ignore]
     fn callout_list_retains_block_content() {
-        let _doc = Parser::default().parse("[source, ruby]\n----\nrequire 'asciidoctor' # <1>\ndoc = Asciidoctor::Document.new('Hello, World!') # <2>\nputs doc.convert # <3>\n----\n<1> Imports the library\nas a RubyGem\n<2> Creates a new document\n* Scans the lines for known blocks\n* Converts the lines into blocks\n<3> Renders the document\n+\nYou can write this to file rather than printing to stdout.\n");
-        todo!("assert_xpath: '//ol/li', output, 3");
-        todo!(
-            "assert_xpath: '((//ol/li)[1]/p[text()=\"Imports the library\\nas a RubyGem\"])', output, 1"
+        let doc = Parser::default().parse("[source, ruby]\n----\nrequire 'asciidoctor' # <1>\ndoc = Asciidoctor::Document.new('Hello, World!') # <2>\nputs doc.convert # <3>\n----\n<1> Imports the library\nas a RubyGem\n<2> Creates a new document\n* Scans the lines for known blocks\n* Converts the lines into blocks\n<3> Renders the document\n+\nYou can write this to file rather than printing to stdout.\n");
+
+        // The callout list has three items.
+        assert_xpath(&doc, "//ol/li", 3);
+
+        // The first item's text wraps onto a second line.
+        assert_output_contains(&doc, "Imports the library\nas a RubyGem");
+
+        // The second item retains a nested unordered list with two items.
+        assert_css(&doc, ".colist ol li ul", 1);
+        assert_css(&doc, ".colist ol li ul li", 2);
+
+        // The third item retains its continuation paragraph.
+        assert_output_contains(
+            &doc,
+            "You can write this to file rather than printing to stdout.",
         );
-        todo!("assert_xpath: '((//ol/li)[2]//ul)', output, 1");
-        todo!("assert_xpath: '((//ol/li)[2]//ul/li)', output, 2");
-        todo!("assert_xpath: '((//ol/li)[3]//p)', output, 2");
     }
 
     #[test]
@@ -4852,147 +4866,155 @@ mod callout_lists {
     }
 
     #[test]
-    #[ignore]
     fn escaped_callout_should_not_be_interpreted_as_a_callout() {
-        let _doc = Parser::default().parse("[source,text]\n----\nrequire 'asciidoctor' # \\<1>\nAsciidoctor.convert 'convert me!' \\<2>\n----\n");
-        todo!("assert_css: 'pre b', output, 0");
-        todo!("assert_includes output, ' # &lt;1&gt;'");
-        todo!("assert_includes output, ' &lt;2&gt;'");
+        let doc = Parser::default().parse("[source,text]\n----\nrequire 'asciidoctor' # \\<1>\nAsciidoctor.convert 'convert me!' \\<2>\n----\n");
+
+        // No callout numbers are rendered.
+        refute_output_contains(&doc, "conum");
+
+        // The escaped callouts are rendered literally (sans backslash).
+        assert_output_contains(&doc, " # &lt;1&gt;");
+        assert_output_contains(&doc, " &lt;2&gt;");
     }
 
     #[test]
-    #[ignore]
     fn should_autonumber_dot_callouts() {
-        let _doc = Parser::default().parse("[source, ruby]\n----\nrequire 'asciidoctor' # <.>\ndoc = Asciidoctor::Document.new('Hello, World!') # <.>\nputs doc.convert # <.>\n----\n<.> Describe the first line\n<.> Describe the second line\n<.> Describe the third line\n");
-        todo!("xmlnodes_at_css 'pre'");
-        todo!("assert_includes pre_html, '(1)'");
-        todo!("assert_includes pre_html, '(2)'");
-        todo!("assert_includes pre_html, '(3)'");
-        todo!("assert_css: '.colist ol', output, 1");
-        todo!("assert_css: '.colist ol li', output, 3");
+        let doc = Parser::default().parse("[source, ruby]\n----\nrequire 'asciidoctor' # <.>\ndoc = Asciidoctor::Document.new('Hello, World!') # <.>\nputs doc.convert # <.>\n----\n<.> Describe the first line\n<.> Describe the second line\n<.> Describe the third line\n");
+
+        // The `<.>` markers in the verbatim block are numbered sequentially.
+        assert_output_contains(&doc, r#"<b class="conum">(1)</b>"#);
+        assert_output_contains(&doc, r#"<b class="conum">(2)</b>"#);
+        assert_output_contains(&doc, r#"<b class="conum">(3)</b>"#);
+
+        // The callout list has three items.
+        assert_css(&doc, ".colist ol", 1);
+        assert_css(&doc, ".colist ol li", 3);
     }
 
     #[test]
-    #[ignore]
     fn should_not_recognize_callouts_in_middle_of_line() {
-        let _doc = Parser::default().parse("[source, ruby]\n----\nputs \"The syntax <1> at the end of the line makes a code callout\"\n----\n");
-        todo!("assert_xpath: '//b', output, 0");
+        let doc = Parser::default().parse("[source, ruby]\n----\nputs \"The syntax <1> at the end of the line makes a code callout\"\n----\n");
+        refute_output_contains(&doc, "conum");
     }
 
     #[test]
-    #[ignore]
     fn should_allow_multiple_callouts_on_the_same_line() {
-        let _doc = Parser::default().parse("[source, ruby]\n----\nrequire 'asciidoctor' <1>\ndoc = Asciidoctor.load('Hello, World!') # <2> <3> <4>\nputs doc.convert <5><6>\nexit 0\n----\n<1> Require library\n<2> Load document from String\n<3> Uses default backend and doctype\n<4> One more for good luck\n<5> Renders document to String\n<6> Prints output to stdout\n");
-        todo!("assert_xpath: '//code/b', output, 6");
-        todo!("assert_match: / <b class=\"conum\">\\(1\\)<\\/b>$/");
-        todo!(
-            "assert_match: / <b class=\"conum\">\\(2\\)<\\/b> <b class=\"conum\">\\(3\\)<\\/b> <b class=\"conum\">\\(4\\)<\\/b>$/"
+        let doc = Parser::default().parse("[source, ruby]\n----\nrequire 'asciidoctor' <1>\ndoc = Asciidoctor.load('Hello, World!') # <2> <3> <4>\nputs doc.convert <5><6>\nexit 0\n----\n<1> Require library\n<2> Load document from String\n<3> Uses default backend and doctype\n<4> One more for good luck\n<5> Renders document to String\n<6> Prints output to stdout\n");
+
+        // A single trailing callout.
+        assert_output_contains(&doc, r#" <b class="conum">(1)</b>"#);
+
+        // Three space-separated callouts behind a line comment.
+        assert_output_contains(
+            &doc,
+            r#" <b class="conum">(2)</b> <b class="conum">(3)</b> <b class="conum">(4)</b>"#,
         );
-        todo!("assert_match: / <b class=\"conum\">\\(5\\)<\\/b><b class=\"conum\">\\(6\\)<\\/b>$/");
+
+        // Two adjacent callouts.
+        assert_output_contains(&doc, r#" <b class="conum">(5)</b><b class="conum">(6)</b>"#);
     }
 
     #[test]
-    #[ignore]
     fn should_allow_xml_comment_style_callouts() {
-        let _doc = Parser::default().parse("[source, xml]\n----\n<section>\n  <title>Section Title</title> <!--1-->\n  <simpara>Just a paragraph</simpara> <!--2-->\n</section>\n----\n<1> The title is required\n<2> The content isn't\n");
-        todo!("assert_xpath: '//b', output, 2");
-        todo!("assert_xpath: '//b[text()=\"(1)\"]', output, 1");
-        todo!("assert_xpath: '//b[text()=\"(2)\"]', output, 1");
+        let doc = Parser::default().parse("[source, xml]\n----\n<section>\n  <title>Section Title</title> <!--1-->\n  <simpara>Just a paragraph</simpara> <!--2-->\n</section>\n----\n<1> The title is required\n<2> The content isn't\n");
+
+        assert_output_contains(&doc, r#"&lt;!--<b class="conum">(1)</b>--&gt;"#);
+        assert_output_contains(&doc, r#"&lt;!--<b class="conum">(2)</b>--&gt;"#);
     }
 
     #[test]
-    #[ignore]
     fn should_not_allow_callouts_with_half_an_xml_comment() {
-        let _doc = Parser::default().parse("----\nFirst line <1-->\nSecond line <2-->\n----\n");
-        todo!("assert_xpath: '//b', output, 0");
+        let doc = Parser::default().parse("----\nFirst line <1-->\nSecond line <2-->\n----\n");
+        refute_output_contains(&doc, "conum");
     }
 
     #[test]
     #[ignore]
     fn should_not_recognize_callouts_in_an_indented_description_list_paragraph() {
+        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311):
+        // Enable once the memory logger ("no callout found for <1>") is
+        // available.
         let _doc = Parser::default().parse("foo::\n  bar <1>\n\n<1> Not pointing to a callout\n");
         todo!("memory logger test");
-        todo!("assert_xpath: '//dl//b', output, 0");
-        todo!("assert_xpath: '//dl/dd/p[text()=\"bar <1>\"]', output, 1");
-        todo!("assert_xpath: '//ol/li/p[text()=\"Not pointing to a callout\"]', output, 1");
-        todo!("assert_message logger, :WARN, '<stdin>: line 4: no callout found for <1>'");
     }
 
     #[test]
     #[ignore]
     fn should_not_recognize_callouts_in_an_indented_outline_list_paragraph() {
+        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311):
+        // Enable once the memory logger ("no callout found for <1>") is
+        // available.
         let _doc = Parser::default().parse("* foo\n  bar <1>\n\n<1> Not pointing to a callout\n");
         todo!("memory logger test");
-        todo!("assert_xpath: '//ul//b', output, 0");
-        todo!("assert_xpath: '//ul/li/p[text()=\"foo\\nbar <1>\"]', output, 1");
-        todo!("assert_xpath: '//ol/li/p[text()=\"Not pointing to a callout\"]', output, 1");
-        todo!("assert_message logger, :WARN, '<stdin>: line 4: no callout found for <1>'");
     }
 
     #[test]
     #[ignore]
     fn should_warn_if_numbers_in_callout_list_are_out_of_sequence() {
+        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311):
+        // Enable once the memory logger (callout-list out-of-sequence /
+        // "no callout found" warnings) is available.
         let _doc = Parser::default().parse("----\n<beans> <1>\n  <bean class=\"com.example.HelloWorld\"/>\n</beans>\n----\n<1> Container of beans.\nBeans are fun.\n<3> An actual bean.\n");
         todo!("memory logger test");
-        todo!("assert_xpath: '//ol/li', output, 2");
-        todo!(
-            "assert_messages logger, [[:WARN, '<stdin>: line 8: callout list item index: expected 2, got 3'], [:WARN, '<stdin>: line 8: no callout found for <2>']]"
-        );
     }
 
     #[test]
-    #[ignore]
     fn should_preserve_line_comment_chars_that_precede_callout_number_if_icons_is_not_set() {
-        let _doc = Parser::default().parse("[source,ruby]\n----\nputs 'Hello, world!' # <1>\n----\n<1> Ruby\n\n[source,groovy]\n----\nprintln 'Hello, world!' // <1>\n----\n<1> Groovy\n\n[source,clojure]\n----\n(def hello (fn [] \"Hello, world!\")) ;; <1>\n(hello)\n----\n<1> Clojure\n\n[source,haskell]\n----\nmain = putStrLn \"Hello, World!\" -- <1>\n----\n<1> Haskell\n");
-        todo!("xmlnodes_at_css 'pre'");
-        todo!("assert_xpath: '//b', output, 4");
-        todo!("assert_equal: nodes[0].text, 'puts 'Hello, world!' # (1)'");
-        todo!("assert_equal: nodes[1].text, 'println 'Hello, world!' // (1)'");
-        todo!(
-            "assert_equal: nodes[2].text, '(def hello (fn [] \"Hello, world!\")) ;; (1)\\n(hello)'"
-        );
-        todo!("assert_equal: nodes[3].text, 'main = putStrLn \"Hello, World!\" -- (1)'");
+        let doc = Parser::default().parse("[source,ruby]\n----\nputs 'Hello, world!' # <1>\n----\n<1> Ruby\n\n[source,groovy]\n----\nprintln 'Hello, world!' // <1>\n----\n<1> Groovy\n\n[source,clojure]\n----\n(def hello (fn [] \"Hello, world!\")) ;; <1>\n(hello)\n----\n<1> Clojure\n\n[source,haskell]\n----\nmain = putStrLn \"Hello, World!\" -- <1>\n----\n<1> Haskell\n");
+
+        // When icons are not enabled, the line-comment characters are retained
+        // ahead of the rendered callout.
+        assert_output_contains(&doc, r#"# <b class="conum">(1)</b>"#);
+        assert_output_contains(&doc, r#"// <b class="conum">(1)</b>"#);
+        assert_output_contains(&doc, r#";; <b class="conum">(1)</b>"#);
+        assert_output_contains(&doc, r#"-- <b class="conum">(1)</b>"#);
     }
 
     #[test]
-    #[ignore]
     fn should_remove_line_comment_chars_that_precede_callout_number_if_icons_is_font() {
-        let _doc = Parser::default().parse("[source,ruby]\n----\nputs 'Hello, world!' # <1>\n----\n<1> Ruby\n\n[source,groovy]\n----\nprintln 'Hello, world!' // <1>\n----\n<1> Groovy\n\n[source,clojure]\n----\n(def hello (fn [] \"Hello, world!\")) ;; <1>\n(hello)\n----\n<1> Clojure\n\n[source,haskell]\n----\nmain = putStrLn \"Hello, World!\" -- <1>\n----\n<1> Haskell\n");
-        todo!("xmlnodes_at_css 'pre'");
-        todo!("assert_css: 'pre b', output, 4");
-        todo!("assert_css: 'pre i.conum', output, 4");
-        todo!("assert_equal: nodes[0].text, 'puts 'Hello, world!' (1)'");
-        todo!("assert_equal: nodes[1].text, 'println 'Hello, world!' (1)'");
-        todo!("assert_equal: nodes[2].text, '(def hello (fn [] \"Hello, world!\")) (1)\\n(hello)'");
-        todo!("assert_equal: nodes[3].text, 'main = putStrLn \"Hello, World!\" (1)'");
-    }
+        let doc = Parser::default()
+            .with_intrinsic_attribute("icons", "font", ModificationContext::Anywhere)
+            .parse("[source,ruby]\n----\nputs 'Hello, world!' # <1>\n----\n<1> Ruby\n\n[source,groovy]\n----\nprintln 'Hello, world!' // <1>\n----\n<1> Groovy\n\n[source,clojure]\n----\n(def hello (fn [] \"Hello, world!\")) ;; <1>\n(hello)\n----\n<1> Clojure\n\n[source,haskell]\n----\nmain = putStrLn \"Hello, World!\" -- <1>\n----\n<1> Haskell\n");
 
-    #[test]
-    #[ignore]
-    fn should_allow_line_comment_chars_that_precede_callout_number_to_be_specified() {
-        let _doc = Parser::default().parse("[source,erlang,line-comment=%]\n----\nhello_world() -> % <1>\n  io:fwrite(\"hello, world~n\"). %<2>\n----\n<1> Erlang function clause head.\n<2> ~n adds a new line to the output.\n");
-        todo!("xmlnodes_at_css 'pre'");
-        todo!("assert_xpath: '//b', output, 2");
-        todo!(
-            "assert_equal: nodes[0].text, 'hello_world() -> % (1)\\n  io:fwrite(\"hello, world~n\"). %(2)'"
+        // When font icons are enabled, the line-comment characters are removed.
+        assert_output_contains(
+            &doc,
+            r#"'Hello, world!' <i class="conum" data-value="1"></i><b>(1)</b>"#,
         );
+        refute_output_contains(&doc, "# <i");
+        refute_output_contains(&doc, "// <i");
+        refute_output_contains(&doc, ";; <i");
+        refute_output_contains(&doc, "-- <i");
     }
 
     #[test]
-    #[ignore]
+    fn should_allow_line_comment_chars_that_precede_callout_number_to_be_specified() {
+        let doc = Parser::default().parse("[source,erlang,line-comment=%]\n----\nhello_world() -> % <1>\n  io:fwrite(\"hello, world~n\"). %<2>\n----\n<1> Erlang function clause head.\n<2> ~n adds a new line to the output.\n");
+
+        assert_output_contains(&doc, r#"% <b class="conum">(1)</b>"#);
+        assert_output_contains(&doc, r#"%<b class="conum">(2)</b>"#);
+    }
+
+    #[test]
     fn should_allow_line_comment_chars_preceding_callout_number_to_be_configurable_when_source_highlighter_is_coderay()
      {
-        let _doc = Parser::default().parse("[source,html,line-comment=-#]\n----\n-# <1>\n%p Hello\n----\n<1> Prints a paragraph with the text \"Hello\"\n");
-        todo!("xmlnodes_at_css 'pre'");
-        todo!("assert_xpath: '//b', output, 1");
-        todo!("assert_equal: nodes[0].text, '-# (1)\\n%p Hello'");
+        // Syntax highlighting is out of scope for this crate; only the
+        // configurable line-comment behavior is exercised here.
+        let doc = Parser::default().parse("[source,html,line-comment=-#]\n----\n-# <1>\n%p Hello\n----\n<1> Prints a paragraph with the text \"Hello\"\n");
+
+        assert_output_contains(&doc, r#"-# <b class="conum">(1)</b>"#);
+        assert_output_contains(&doc, "%p Hello");
     }
 
     #[test]
-    #[ignore]
     fn should_not_eat_whitespace_before_callout_number_if_line_comment_attribute_is_empty() {
-        let _doc = Parser::default().parse("[source,asciidoc,line-comment=]\n----\n-- <1>\n----\n<1> The start of an open block.\n");
-        todo!("assert_includes output, '-- <i class=\"conum\"'");
+        let doc = Parser::default()
+            .with_intrinsic_attribute("icons", "font", ModificationContext::Anywhere)
+            .parse("[source,asciidoc,line-comment=]\n----\n-- <1>\n----\n<1> The start of an open block.\n");
+
+        // With line-comment processing disabled, the `--` (and its trailing
+        // space) before the callout is preserved verbatim.
+        assert_output_contains(&doc, r#"-- <i class="conum""#);
     }
 
     #[test]
@@ -5004,61 +5026,29 @@ mod callout_lists {
     #[test]
     #[ignore]
     fn callout_list_with_icons_enabled() {
-        let _doc = Parser::default().parse("[source, ruby]\n----\nrequire 'asciidoctor' # <1>\ndoc = Asciidoctor::Document.new('Hello, World!') # <2>\nputs doc.convert # <3>\n----\n<1> Describe the first line\n<2> Describe the second line\n<3> Describe the third line\n");
-        todo!("assert_css: '.listingblock code > img', output, 3");
-        todo!(
-            "assert_xpath: '(/div[@class=\"listingblock\"]//code/img)[1][@src=\"./images/icons/callouts/1.png\"][@alt=\"1\"]', output, 1"
-        );
-        todo!("additional assertions");
-        todo!("assert_css: '.colist table td img', output, 3");
-        todo!(
-            "assert_xpath: '(/div[@class=\"colist arabic\"]//td/img)[1][@src=\"./images/icons/callouts/1.png\"][@alt=\"1\"]', output, 1"
-        );
-        todo!("additional assertions");
+        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311):
+        // Enable once image-based callout icons render as DOM nodes inside
+        // verbatim blocks and the callout list renders as an icon table.
     }
 
     #[test]
     #[ignore]
     fn callout_list_with_font_based_icons_enabled() {
-        let _doc = Parser::default().parse("[source]\n----\nrequire 'asciidoctor' # <1>\ndoc = Asciidoctor::Document.new('Hello, World!') #<2>\nputs doc.convert #<3>\n----\n<1> Describe the first line\n<2> Describe the second line\n<3> Describe the third line\n");
-        todo!("assert_css: '.listingblock code > i', output, 3");
-        todo!("assert_xpath: '(/div[@class=\"listingblock\"]//code/i)[1]', output, 1");
-        todo!(
-            "assert_xpath: '(/div[@class=\"listingblock\"]//code/i)[1][@class=\"conum\"][@data-value=\"1\"]', output, 1"
-        );
-        todo!(
-            "assert_xpath: '(/div[@class=\"listingblock\"]//code/i)[1]/following-sibling::b[text()=\"(1)\"]', output, 1"
-        );
-        todo!("additional assertions");
-        todo!("assert_css: '.colist table td i', output, 3");
-        todo!("assert_xpath: '(/div[@class=\"colist arabic\"]//td/i)[1]', output, 1");
-        todo!(
-            "assert_xpath: '(/div[@class=\"colist arabic\"]//td/i)[1][@class=\"conum\"][@data-value=\"1\"]', output, 1"
-        );
-        todo!(
-            "assert_xpath: '(/div[@class=\"colist arabic\"]//td/i)[1]/following-sibling::b[text()=\"1\"]', output, 1"
-        );
-        todo!("additional assertions");
+        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311):
+        // Enable once font-based callout icons render as DOM nodes inside
+        // verbatim blocks and the callout list renders as an icon table.
     }
 
     #[test]
     #[ignore]
     fn should_match_trailing_line_separator_in_text_of_list_item() {
-        let _doc =
-            Parser::default().parse("----\nA <1>\nB <2>\nC <3>\n----\n<1> a\n<2> b\u{2028}\n<3> c");
-        todo!("Unicode line separator (U+2028) in test input");
-        todo!("assert_css: 'li', output, 3");
-        todo!("assert_xpath: '((//li)[2]/p[text()=\"b\u{2028}\"])', output, 1");
+        // TO DO: Unicode line separator (U+2028) handling in list item text.
     }
 
     #[test]
     #[ignore]
     fn should_match_line_separator_in_text_of_list_item() {
-        let _doc = Parser::default()
-            .parse("----\nA <1>\nB <2>\nC <3>\n----\n<1> a\n<2> b\u{2028}b\n<3> c");
-        todo!("Unicode line separator (U+2028) in test input");
-        todo!("assert_css: 'li', output, 3");
-        todo!("assert_xpath: '((//li)[2]/p[text()=\"b\u{2028}b\"])', output, 1");
+        // TO DO: Unicode line separator (U+2028) handling in list item text.
     }
 }
 

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -5059,15 +5059,25 @@ mod callout_lists {
     }
 
     #[test]
-    #[ignore]
     fn should_match_trailing_line_separator_in_text_of_list_item() {
-        // TO DO: Unicode line separator (U+2028) handling in list item text.
+        // A Unicode LINE SEPARATOR (U+2028) is an ordinary character within a
+        // callout list item's text; it is not treated as a line break.
+        let doc =
+            Parser::default().parse("----\nA <1>\nB <2>\nC <3>\n----\n<1> a\n<2> b\u{2028}\n<3> c");
+
+        assert_css(&doc, "li", 3);
+        assert_xpath(&doc, "(//li)[2]/p[text()=\"b\u{2028}\"]", 1);
     }
 
     #[test]
-    #[ignore]
     fn should_match_line_separator_in_text_of_list_item() {
-        // TO DO: Unicode line separator (U+2028) handling in list item text.
+        // A Unicode LINE SEPARATOR (U+2028) embedded mid-text is preserved
+        // within the callout list item's text.
+        let doc = Parser::default()
+            .parse("----\nA <1>\nB <2>\nC <3>\n----\n<1> a\n<2> b\u{2028}b\n<3> c");
+
+        assert_css(&doc, "li", 3);
+        assert_xpath(&doc, "(//li)[2]/p[text()=\"b\u{2028}b\"]", 1);
     }
 }
 

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -4929,23 +4929,42 @@ mod callout_lists {
     }
 
     #[test]
-    #[ignore]
     fn should_not_recognize_callouts_in_an_indented_description_list_paragraph() {
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311):
-        // Enable once the memory logger ("no callout found for <1>") is
-        // available.
-        let _doc = Parser::default().parse("foo::\n  bar <1>\n\n<1> Not pointing to a callout\n");
-        todo!("memory logger test");
+        let doc = Parser::default().parse("foo::\n  bar <1>\n\n<1> Not pointing to a callout\n");
+
+        // The `<1>` in the indented description-list paragraph is not a callout;
+        // it is rendered literally and produces no conum.
+        assert_xpath(&doc, "//dl//b", 0);
+        assert_output_contains(&doc, "bar &lt;1&gt;");
+
+        // The `<1> ...` line below is recognized as a callout list item.
+        assert_xpath(&doc, "//ol/li", 1);
+        assert_output_contains(&doc, "Not pointing to a callout");
+
+        // ...but it points at a callout that does not exist. Asciidoctor logs
+        // this via its memory logger; this crate surfaces it as a document
+        // warning instead.
+        let warnings: Vec<_> = doc.warnings().map(|w| &w.warning).collect();
+        assert_eq!(warnings, vec![&WarningType::NoCalloutFound(1)]);
     }
 
     #[test]
-    #[ignore]
     fn should_not_recognize_callouts_in_an_indented_outline_list_paragraph() {
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/311):
-        // Enable once the memory logger ("no callout found for <1>") is
-        // available.
-        let _doc = Parser::default().parse("* foo\n  bar <1>\n\n<1> Not pointing to a callout\n");
-        todo!("memory logger test");
+        let doc = Parser::default().parse("* foo\n  bar <1>\n\n<1> Not pointing to a callout\n");
+
+        // The `<1>` folded into the outline-list item's paragraph is not a
+        // callout; it is rendered literally and produces no conum.
+        assert_xpath(&doc, "//ul//b", 0);
+        assert_output_contains(&doc, "foo\nbar &lt;1&gt;");
+
+        // The `<1> ...` line below is recognized as a callout list item.
+        assert_xpath(&doc, "//ol/li", 1);
+        assert_output_contains(&doc, "Not pointing to a callout");
+
+        // ...but it points at a callout that does not exist (surfaced as a
+        // document warning in place of Asciidoctor's memory logger).
+        let warnings: Vec<_> = doc.warnings().map(|w| &w.warning).collect();
+        assert_eq!(warnings, vec![&WarningType::NoCalloutFound(1)]);
     }
 
     #[test]

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -4,7 +4,7 @@
 //! documents for testing purposes. It maps AsciiDoc block structures to their
 //! HTML equivalents, enabling XPath-like queries for test assertions.
 
-use std::sync::LazyLock;
+use std::{cell::Cell, sync::LazyLock};
 
 use regex::Regex;
 
@@ -17,7 +17,46 @@ use crate::{
         SimpleBlockStyle, Stripes, TableBlock, TableCellContent, TableColumn, TableRow,
         VerticalAlignment,
     },
+    document::InterpretedValue,
 };
+
+/// The document-wide `icons` mode, which controls how callouts and callout
+/// lists render. The virtual DOM builder has no document context threaded
+/// through it, so this is captured once at the top of
+/// [`Document::to_virtual_dom`] and read where callout lists are built.
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum IconsMode {
+    /// No `icons` attribute: callouts render as text conums and callout lists
+    /// as an ordered list.
+    None,
+
+    /// `icons` set (without `font`): image-based callout icons and an icon
+    /// table for callout lists.
+    Image,
+
+    /// `icons=font`: font-based callout icons and an icon table for callout
+    /// lists.
+    Font,
+}
+
+thread_local! {
+    static ICONS_MODE: Cell<IconsMode> = const { Cell::new(IconsMode::None) };
+}
+
+/// Resolves the document's `icons` mode from its header attributes.
+fn icons_mode_from_document(doc: &Document) -> IconsMode {
+    for attr in doc.header().attributes() {
+        if attr.name().data() == "icons" {
+            return match attr.value() {
+                InterpretedValue::Value(v) if v == "font" => IconsMode::Font,
+                InterpretedValue::Unset => IconsMode::None,
+                // `:icons:` (set, empty) or any other value enables image icons.
+                _ => IconsMode::Image,
+            };
+        }
+    }
+    IconsMode::None
+}
 
 /// Decodes common HTML entities to their character equivalents.
 ///
@@ -136,9 +175,17 @@ fn try_parse_element(text: &str, pos: usize) -> Option<(VirtualNode, usize)> {
     let tag_content = &text[pos + 1..pos + 1 + tag_end];
     let tag_name = extract_tag_name(tag_content)?;
 
-    // Check for self-closing tag.
-    if tag_content.ends_with('/') {
-        return None; // Ignore self-closing tags.
+    // Void elements (e.g. `<img>`, `<br>`) and explicitly self-closing tags
+    // have no closing tag; emit them as childless element nodes (preserving
+    // their attributes) and advance past the opening tag.
+    const VOID_ELEMENTS: &[&str] = &[
+        "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param",
+        "track", "wbr",
+    ];
+    if tag_content.ends_with('/') || VOID_ELEMENTS.iter().any(|v| *v == tag_name) {
+        let after_opening = pos + 1 + tag_end + 1;
+        let element = apply_tag_attributes(VirtualNode::new(tag_name), tag_content);
+        return Some((element, after_opening));
     }
 
     // Find the closing tag.
@@ -335,6 +382,10 @@ pub trait ToVirtualDom {
 
 impl ToVirtualDom for Document<'_> {
     fn to_virtual_dom(&self) -> VirtualNode {
+        // Capture the document-wide icons mode so callout lists (built without
+        // any document context) can render an icon table when appropriate.
+        ICONS_MODE.with(|m| m.set(icons_mode_from_document(self)));
+
         let mut node = VirtualNode::new("div").with_class("document");
 
         // Add document ID if present.
@@ -538,6 +589,15 @@ fn simple_block_to_node<'a>(block: &'a SimpleBlock<'a>) -> VirtualNode {
 }
 
 fn list_block_to_node<'a>(list: &'a ListBlock<'a>) -> VirtualNode {
+    // When icons are enabled, a callout list renders as an icon table rather
+    // than an ordered list (matching Asciidoctor's `convert_colist`).
+    if list.type_() == ListType::Callout {
+        let icons = ICONS_MODE.with(|m| m.get());
+        if icons != IconsMode::None {
+            return colist_icon_table_to_node(list, icons);
+        }
+    }
+
     // Horizontal description lists render as tables instead of dl elements.
     let is_horizontal =
         list.type_() == ListType::Description && list.declared_style() == Some("horizontal");
@@ -743,6 +803,80 @@ fn list_block_to_node<'a>(list: &'a ListBlock<'a>) -> VirtualNode {
     wrapper
 }
 
+/// Renders a callout list as an icon table (`div.colist > table`), matching
+/// Asciidoctor's `convert_colist` when the `icons` attribute is set.
+fn colist_icon_table_to_node<'a>(list: &'a ListBlock<'a>, icons: IconsMode) -> VirtualNode {
+    let mut wrapper = VirtualNode::new("div").with_class("colist");
+
+    // The marker style (always "arabic" for callout lists) is added to the
+    // wrapper, producing `<div class="colist arabic">`.
+    if let Some(style) = list.marker_style() {
+        wrapper = wrapper.with_class(style);
+    }
+
+    for role in list.roles() {
+        wrapper = wrapper.with_class(role);
+    }
+
+    if let Some(id) = list.id() {
+        wrapper = wrapper.with_id(id);
+    }
+
+    if let Some(title) = list.title() {
+        wrapper
+            .children
+            .push(VirtualNode::new("div").with_class("title").with_text(title));
+    }
+
+    let mut table = VirtualNode::new("table");
+
+    for (index, item) in list.nested_blocks().enumerate() {
+        let num = index + 1;
+
+        let mut row = VirtualNode::new("tr");
+
+        // Icon cell.
+        let mut icon_cell = VirtualNode::new("td");
+        match icons {
+            IconsMode::Font => {
+                icon_cell.children.push(
+                    VirtualNode::new("i")
+                        .with_class("conum")
+                        .with_attribute("data-value", num.to_string()),
+                );
+                icon_cell
+                    .children
+                    .push(VirtualNode::new("b").with_text(num.to_string()));
+            }
+            IconsMode::Image => {
+                icon_cell.children.push(
+                    VirtualNode::new("img")
+                        .with_attribute("src", format!("./images/icons/callouts/{num}.png"))
+                        .with_attribute("alt", num.to_string()),
+                );
+            }
+            IconsMode::None => {}
+        }
+        row.children.push(icon_cell);
+
+        // Text cell: the callout list item's annotation text.
+        let mut text_cell = VirtualNode::new("td");
+        if let Some(text) = item
+            .nested_blocks()
+            .next()
+            .and_then(|b| b.rendered_content())
+        {
+            text_cell = text_cell.with_html_content(text);
+        }
+        row.children.push(text_cell);
+
+        table.children.push(row);
+    }
+
+    wrapper.children.push(table);
+    wrapper
+}
+
 fn list_item_to_node<'a>(item: &'a ListItem<'a>) -> VirtualNode {
     let mut node = VirtualNode::new("li");
 
@@ -879,9 +1013,10 @@ fn raw_delimited_to_node<'a>(raw: &'a RawDelimitedBlock<'a>) -> VirtualNode {
                 }
             }
 
-            // Add the block's rendered content to the code element.
+            // Add the block's rendered content to the code element, parsing any
+            // inline HTML (e.g. callout conums) into child nodes.
             if let Some(content) = raw.rendered_content() {
-                code = code.with_text(content);
+                code = code.with_html_content(content);
             }
 
             let pre = VirtualNode::new("pre").with_child(code);
@@ -889,7 +1024,7 @@ fn raw_delimited_to_node<'a>(raw: &'a RawDelimitedBlock<'a>) -> VirtualNode {
         } else {
             let mut pre = VirtualNode::new("pre");
             if let Some(content) = raw.rendered_content() {
-                pre = pre.with_text(content);
+                pre = pre.with_html_content(content);
             }
             node.children.push(pre);
         }

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -552,6 +552,7 @@ fn list_block_to_node<'a>(list: &'a ListBlock<'a>) -> VirtualNode {
                 ("dl", "dlist")
             }
         }
+        ListType::Callout => ("ol", "colist"),
     };
 
     let mut list_element = VirtualNode::new(list_tag);
@@ -709,9 +710,9 @@ fn list_block_to_node<'a>(list: &'a ListBlock<'a>) -> VirtualNode {
     // Wrap the list in a div container (matching Asciidoctor's HTML structure).
     let mut wrapper = VirtualNode::new("div").with_class(base_class);
 
-    // For ordered lists, add style class to the wrapper based on marker length,
-    // but only if no explicit style is declared.
-    if list.type_() == ListType::Ordered
+    // For ordered and callout lists, add style class to the wrapper based on
+    // marker length, but only if no explicit style is declared.
+    if matches!(list.type_(), ListType::Ordered | ListType::Callout)
         && list.declared_style().is_none()
         && let Some(style) = list.marker_style()
     {

--- a/parser/src/tests/fixtures/blocks/list_item_marker.rs
+++ b/parser/src/tests/fixtures/blocks/list_item_marker.rs
@@ -15,6 +15,7 @@ pub(crate) enum ListItemMarker {
     RomanNumeralLower(Span),
     RomanNumeralUpper(Span),
     ArabicNumeral(Span),
+    Callout(Span),
 
     #[allow(unused)] // TEMPORARY while building
     DefinedTerm {
@@ -56,6 +57,8 @@ impl fmt::Debug for ListItemMarker {
                 .debug_tuple("ListItemMarker::ArabicNumeral")
                 .field(x)
                 .finish(),
+
+            Self::Callout(x) => f.debug_tuple("ListItemMarker::Callout").field(x).finish(),
 
             Self::DefinedTerm {
                 term,
@@ -142,6 +145,11 @@ fn fixture_eq_observed(
             crate::blocks::ListItemMarker::ArabicNumeral(observed_span) => {
                 fixture_span == observed_span
             }
+            _ => false,
+        },
+
+        ListItemMarker::Callout(fixture_span) => match observed {
+            crate::blocks::ListItemMarker::Callout(observed_span) => fixture_span == observed_span,
             _ => false,
         },
 

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -80,6 +80,9 @@ pub enum WarningType {
     #[error("List item index: expected {0}, got {1}")]
     ListItemOutOfSequence(String, String),
 
+    #[error("No callout found for <{0}>")]
+    NoCalloutFound(usize),
+
     #[error("Dropping table cell because it exceeds the specified number of columns")]
     TableCellExceedsColumnCount,
 
@@ -163,6 +166,11 @@ impl std::fmt::Debug for WarningType {
                 .debug_tuple("WarningType::ListItemOutOfSequence")
                 .field(expected)
                 .field(actual)
+                .finish(),
+
+            WarningType::NoCalloutFound(number) => f
+                .debug_tuple("WarningType::NoCalloutFound")
+                .field(number)
                 .finish(),
 
             WarningType::TableCellExceedsColumnCount => {
@@ -430,6 +438,13 @@ mod tests {
                     debug_output,
                     "WarningType::ListItemOutOfSequence(\"y\", \"z\")"
                 );
+            }
+
+            #[test]
+            fn no_callout_found() {
+                let warning = WarningType::NoCalloutFound(2);
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(debug_output, "WarningType::NoCalloutFound(2)");
             }
 
             #[test]

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -83,7 +83,7 @@ pub enum WarningType {
     #[error("No callout found for <{0}>")]
     NoCalloutFound(usize),
 
-    #[error("callout list item index: expected {0}, got {1}")]
+    #[error("Callout list item index: expected {0}, got {1}")]
     CalloutListItemOutOfSequence(usize, usize),
 
     #[error("Dropping table cell because it exceeds the specified number of columns")]

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -83,6 +83,9 @@ pub enum WarningType {
     #[error("No callout found for <{0}>")]
     NoCalloutFound(usize),
 
+    #[error("callout list item index: expected {0}, got {1}")]
+    CalloutListItemOutOfSequence(usize, usize),
+
     #[error("Dropping table cell because it exceeds the specified number of columns")]
     TableCellExceedsColumnCount,
 
@@ -171,6 +174,12 @@ impl std::fmt::Debug for WarningType {
             WarningType::NoCalloutFound(number) => f
                 .debug_tuple("WarningType::NoCalloutFound")
                 .field(number)
+                .finish(),
+
+            WarningType::CalloutListItemOutOfSequence(expected, actual) => f
+                .debug_tuple("WarningType::CalloutListItemOutOfSequence")
+                .field(expected)
+                .field(actual)
                 .finish(),
 
             WarningType::TableCellExceedsColumnCount => {
@@ -445,6 +454,16 @@ mod tests {
                 let warning = WarningType::NoCalloutFound(2);
                 let debug_output = format!("{:?}", warning);
                 assert_eq!(debug_output, "WarningType::NoCalloutFound(2)");
+            }
+
+            #[test]
+            fn callout_list_item_out_of_sequence() {
+                let warning = WarningType::CalloutListItemOutOfSequence(2, 3);
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(
+                    debug_output,
+                    "WarningType::CalloutListItemOutOfSequence(2, 3)"
+                );
             }
 
             #[test]


### PR DESCRIPTION
Implements callouts (annotation markers in verbatim blocks) and callout lists, closing #311.

## What's covered

Everything on the [Callouts spec page](docs/modules/verbatim/pages/callouts.adoc):

- **Callout substitution** (`SubstitutionStep::Callouts`): explicit (`<1>`) and auto-numbered (`<.>`) callouts, multiple per line, XML-comment callouts (`<!--1-->`), escaping (`\<1>`), and line-comment hiding using the default prefixes (`//`, `#`, `--`, `;;`), a custom prefix, or disabled — all via the `line-comment` attribute.
- **Rendering**: new `InlineSubstitutionRenderer::render_callout` (+ HTML impl) producing plain conums (`<b class="conum">(1)</b>`), font icons (`icons=font`), and image icons.
- **Substitution group**: the verbatim group now includes callouts, and `callouts` is a recognized `subs` token (so `subs=-callouts` works, as used throughout the spec examples).
- **Callout lists** (`colist`): a new `ListItemMarker::Callout` / `ListType::Callout`, recognized anywhere `<N>`/`<.>` starts a line with trailing text.

## Implementation notes

Rust's `regex` crate has no lookahead or backreferences, which Asciidoctor's `CalloutSourceRx` relies on. The trailing-position requirement ("a callout must be at the end of its line") is emulated by matching a single callout token and verifying the post-match text with a separate "tail" regex via the existing `replace_with_lookahead` helper. The HTML inline-callout converter ignores the callout catalog/id, so no catalog is needed for faithful output.

## Tests

- Enables the previously-ignored callout tests ported from the Asciidoctor suite (callout lists, line-comment variants, XML, escaping, auto-numbering, multiple callouts, etc.).
- Adds line-by-line spec coverage for `callouts.adoc` (`parser/src/tests/asciidoc_lang/verbatim/callouts.rs`), verified with `cd sdd && cargo run`.
- Tests requiring infrastructure this crate lacks (memory-logger warnings, DocBook output, callout-icon DOM nodes, U+2028 line separators) remain `#[ignore]`d with updated notes.

All workspace tests pass; `cargo +nightly fmt`, `clippy`, and `+nightly doc` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)