### PR TITLE
feat: Add table of contents (toc) rendering

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -10,7 +10,7 @@ use crate::{
         parse_utils::parse_blocks_until,
     },
     content::{Content, SubstitutionGroup},
-    document::InterpretedValue,
+    document::{InterpretedValue, TocMode},
     parser::{
         InlineSubstitutionRenderer, ModificationContext, ReferenceResolver, ReferenceWarning,
         preprocessor::preprocess,
@@ -1643,6 +1643,14 @@ fn process_content<'src>(
         // derived `backend-html5-doctype-*` attribute is refreshed to match.
         parser.force_doctype("article");
 
+        // Likewise, a cell does not inherit the parent's `toc` setting: a nested
+        // document starts without a table of contents and may enable its own.
+        // Reset the value to unset; the relax loop above already made `toc`
+        // modifiable inside the cell, so a cell-body `:toc:` is still honored.
+        if let Some(toc) = parser.attribute_values.get_mut("toc") {
+            toc.value = InterpretedValue::Unset;
+        }
+
         // A cell whose content holds a preprocessor directive (an `include::`)
         // is parsed from an owned, expanded source the cell carries; every other
         // cell is parsed in place from the parent document's source, which keeps
@@ -1656,7 +1664,7 @@ fn process_content<'src>(
                 // turns any future warning added to this path into a loud test
                 // failure rather than a silent loss.
                 let mut owned_warnings: Vec<Warning<'_>> = vec![];
-                let (title, inline, blocks) =
+                let (title, inline, toc_mode, blocks) =
                     parse_asciidoc_cell_body(Span::new(source), parser, &mut owned_warnings);
 
                 debug_assert!(
@@ -1668,15 +1676,18 @@ fn process_content<'src>(
                 OwnedCellInner {
                     title,
                     inline,
+                    toc_mode,
                     blocks,
                 }
             });
             AsciiDocCell::Owned(Arc::new(owned))
         } else {
-            let (title, inline, blocks) = parse_asciidoc_cell_body(trimmed, parser, warnings);
+            let (title, inline, toc_mode, blocks) =
+                parse_asciidoc_cell_body(trimmed, parser, warnings);
             AsciiDocCell::Borrowed(BorrowedCell {
                 title,
                 inline,
+                toc_mode,
                 blocks,
             })
         };
@@ -1715,7 +1726,7 @@ fn parse_asciidoc_cell_body<'src>(
     content: Span<'src>,
     parser: &mut Parser,
     warnings: &mut Vec<Warning<'src>>,
-) -> (Option<String>, bool, Vec<Block<'src>>) {
+) -> (Option<String>, bool, TocMode, Vec<Block<'src>>) {
     let first_line = content.take_line();
     let (title_source, body) = if first_line.item.data().starts_with("= ") {
         (
@@ -1749,7 +1760,13 @@ fn parse_asciidoc_cell_body<'src>(
         None
     };
 
-    (title, inline, maw.item.item)
+    // The cell is its own standalone document, so its table-of-contents
+    // placement comes from the cell's own `toc` attribute (which it does not
+    // inherit from the parent). Resolve it here, before the caller restores the
+    // parent's attribute snapshot.
+    let toc_mode = TocMode::from_parser(parser);
+
+    (title, inline, toc_mode, maw.item.item)
 }
 
 /// Returns `true` when the cell content holds an `include::` preprocessor
@@ -2046,6 +2063,18 @@ impl<'src> AsciiDocCell<'src> {
         }
     }
 
+    /// Returns where (and whether) the cell's table of contents is generated.
+    ///
+    /// The cell is a standalone nested document, so this is resolved from the
+    /// cell's own `toc` attribute and is independent of the parent document's
+    /// setting.
+    pub fn toc_mode(&self) -> TocMode {
+        match self {
+            Self::Borrowed(cell) => cell.toc_mode,
+            Self::Owned(cell) => cell.borrow_dependent().toc_mode,
+        }
+    }
+
     /// Returns the blocks parsed from the cell's content.
     pub fn blocks(&self) -> &[Block<'_>] {
         match self {
@@ -2090,6 +2119,7 @@ impl<'src> AsciiDocCell<'src> {
 pub struct BorrowedCell<'src> {
     title: Option<String>,
     inline: bool,
+    toc_mode: TocMode,
     blocks: Vec<Block<'src>>,
 }
 
@@ -2111,6 +2141,7 @@ self_cell! {
 struct OwnedCellInner<'src> {
     title: Option<String>,
     inline: bool,
+    toc_mode: TocMode,
     blocks: Vec<Block<'src>>,
 }
 
@@ -2757,7 +2788,7 @@ fn line_has_unclosed_quote(line: &str) -> bool {
 mod tests {
     use std::sync::Arc;
 
-    use super::{AsciiDocCell, OwnedCell, OwnedCellInner};
+    use super::{AsciiDocCell, OwnedCell, OwnedCellInner, TocMode};
     use crate::parser::{
         HtmlSubstitutionRenderer, ReferenceResolver, ResolutionContext, ResolvedReference,
     };
@@ -2784,6 +2815,7 @@ mod tests {
             OwnedCellInner {
                 title: None,
                 inline: false,
+                toc_mode: TocMode::Disabled,
                 blocks: vec![],
             }
         })));

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -8,7 +8,7 @@ use crate::{
     Parser, Span,
     attributes::Attrlist,
     blocks::{Block, ContentModel, IsBlock, Preamble, parse_utils::parse_blocks_until},
-    document::{Catalog, Header},
+    document::{Catalog, Header, TocMode},
     internal::debug::DebugSliceReference,
     parser::{
         CatalogResolver, InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning, SourceMap,
@@ -46,6 +46,7 @@ struct InternalDependent<'src> {
     source_map: SourceMap,
     catalog: Catalog,
     show_doctitle: bool,
+    toc_mode: TocMode,
 }
 
 self_cell! {
@@ -120,6 +121,11 @@ impl<'src> Document<'src> {
             // default is hidden), so resolve it from the final attribute state.
             let show_doctitle = parser.resolve_show_title(false);
 
+            // The `toc` attribute is header-only, so its placement is fixed once
+            // the header (and body) have been processed. Capture it here, while
+            // the parser still holds the document's resolved attribute state.
+            let toc_mode = TocMode::from_parser(parser);
+
             InternalDependent {
                 header,
                 blocks,
@@ -128,6 +134,7 @@ impl<'src> Document<'src> {
                 source_map,
                 catalog: parser.take_catalog(),
                 show_doctitle,
+                toc_mode,
             }
         });
 
@@ -153,6 +160,14 @@ impl<'src> Document<'src> {
     /// embedded document shows its title only when `showtitle` is set.
     pub fn show_doctitle(&self) -> bool {
         self.internal.borrow_dependent().show_doctitle
+    }
+
+    /// Return where (and whether) this document's table of contents is
+    /// generated, resolved from the [`toc` attribute].
+    ///
+    /// [`toc` attribute]: https://docs.asciidoctor.org/asciidoc/latest/toc/
+    pub fn toc_mode(&self) -> TocMode {
+        self.internal.borrow_dependent().toc_mode
     }
 
     /// Return an iterator over any warnings found during parsing.

--- a/parser/src/document/mod.rs
+++ b/parser/src/document/mod.rs
@@ -22,3 +22,6 @@ pub use header::Header;
 
 mod revision_line;
 pub use revision_line::RevisionLine;
+
+mod toc;
+pub use toc::TocMode;

--- a/parser/src/document/toc.rs
+++ b/parser/src/document/toc.rs
@@ -1,0 +1,44 @@
+//! Describes where (and whether) a document's table of contents is rendered.
+
+use crate::{Parser, document::InterpretedValue};
+
+/// Where (and whether) a document's table of contents (TOC) is generated,
+/// resolved from the [`toc` attribute].
+///
+/// The `toc` attribute is header-only, so this value is fixed once a document's
+/// header has been processed. A nested [AsciiDoc table cell] behaves as its own
+/// standalone document and resolves its own [`TocMode`] independently — it does
+/// **not** inherit the parent document's setting.
+///
+/// [`toc` attribute]: https://docs.asciidoctor.org/asciidoc/latest/toc/
+/// [AsciiDoc table cell]: crate::blocks::TableCellContent::AsciiDoc
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum TocMode {
+    /// The `toc` attribute is unset: no table of contents is generated.
+    Disabled,
+
+    /// The `toc` attribute names an automatic placement (`auto` — the value an
+    /// empty `:toc:` resolves to — or `left`, `right`, `preamble`). The table
+    /// of contents is generated automatically near the top of the document.
+    Auto,
+
+    /// The `toc` attribute is set to `macro`: the table of contents is
+    /// generated only where a `toc::[]` block macro appears.
+    Macro,
+}
+
+impl TocMode {
+    /// Resolves the table-of-contents placement from a parser's current `toc`
+    /// attribute state.
+    pub(crate) fn from_parser(parser: &Parser) -> Self {
+        match parser.attribute_value("toc") {
+            InterpretedValue::Unset => Self::Disabled,
+            InterpretedValue::Value(ref v) if v == "macro" => Self::Macro,
+            // An empty `:toc:` resolves to `auto`; `left`, `right`, and
+            // `preamble` are likewise automatic placements. Any other value is
+            // treated as automatic, matching Asciidoctor (which renders an
+            // auto-placed TOC for any non-`macro` value).
+            _ => Self::Auto,
+        }
+    }
+}

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1424,10 +1424,9 @@ mod psv {
     }
 
     // Attribute/option inheritance into the nested AsciiDoc-cell document is
-    // implemented; the following remain unported for narrower reasons. The
-    // `to_dir` test needs the nested cell exposed as an introspectable document
-    // object carrying inherited options; the `toc` tests need TOC rendering (a
-    // separate unimplemented feature).
+    // implemented; the `to_dir` test below remains unported for a narrower
+    // reason: it needs the nested cell exposed as an introspectable document
+    // object carrying inherited options.
 
     #[test]
     #[ignore]
@@ -1437,28 +1436,58 @@ mod psv {
     fn asciidoc_table_cell_should_inherit_to_dir_option_from_parent_document() {}
 
     #[test]
-    #[ignore]
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/546): AsciiDoc
-    // table cell should not inherit the toc setting.
-    fn asciidoc_table_cell_should_not_inherit_toc_setting_from_parent_document() {}
+    fn asciidoc_table_cell_should_not_inherit_toc_setting_from_parent_document() {
+        let doc = Parser::default().parse(
+            "= Document Title\n:toc:\n\n== Section\n\n|===\na|\n== Section in Nested Document\n\ncontent\n|===",
+        );
+
+        // The outer document renders one TOC; the nested cell does not inherit
+        // the `toc` setting, so no TOC appears inside the table.
+        assert_css(&doc, ".toc", 1);
+        assert_css(&doc, "table .toc", 0);
+    }
 
     #[test]
-    #[ignore]
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/546): enabling
-    // toc in an AsciiDoc table cell.
-    fn should_be_able_to_enable_toc_in_an_asciidoc_table_cell() {}
+    fn should_be_able_to_enable_toc_in_an_asciidoc_table_cell() {
+        let doc = Parser::default().parse(
+            "= Document Title\n\n== Section A\n\n|===\na|\n= Subdocument Title\n:toc:\n\n== Subdocument Section A\n\ncontent\n|===",
+        );
+
+        // The outer document has no TOC; the cell enables its own, so the single
+        // TOC is the one inside the table.
+        assert_css(&doc, ".toc", 1);
+        assert_css(&doc, "table .toc", 1);
+    }
 
     #[test]
-    #[ignore]
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/546): enabling
-    // toc in an AsciiDoc table cell even if hard unset by the API.
-    fn should_be_able_to_enable_toc_in_an_asciidoc_table_cell_even_if_hard_unset_by_api() {}
+    fn should_be_able_to_enable_toc_in_an_asciidoc_table_cell_even_if_hard_unset_by_api() {
+        // Hard-unsetting `toc` through the API (Ruby's `toc => nil`) suppresses
+        // the outer document's TOC but does not prevent the cell — a standalone
+        // nested document, and `toc` is one of the attributes a cell may set —
+        // from enabling its own.
+        let doc = Parser::default()
+            .with_intrinsic_attribute_bool("toc", false, ModificationContext::ApiOnly)
+            .parse(
+                "= Document Title\n\n== Section A\n\n|===\na|\n= Subdocument Title\n:toc:\n\n== Subdocument Section A\n\ncontent\n|===",
+            );
+
+        assert_css(&doc, ".toc", 1);
+        assert_css(&doc, "table .toc", 1);
+    }
 
     #[test]
-    #[ignore]
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/546): enabling
-    // toc in both the outer document and an AsciiDoc table cell.
-    fn should_be_able_to_enable_toc_in_both_outer_document_and_in_an_asciidoc_table_cell() {}
+    fn should_be_able_to_enable_toc_in_both_outer_document_and_in_an_asciidoc_table_cell() {
+        let doc = Parser::default().parse(
+            "= Document Title\n:toc:\n\n== Section A\n\n|===\na|\n= Subdocument Title\n:toc: macro\n\n[#table-cell-toc]\ntoc::[]\n\n== Subdocument Section A\n\ncontent\n|===",
+        );
+
+        // Two TOCs: the outer document's automatic TOC (`#toc`) and the cell's
+        // `toc::[]` macro TOC (carrying the `#table-cell-toc` id).
+        assert_css(&doc, ".toc", 2);
+        assert_css(&doc, "#toc", 1);
+        assert_css(&doc, "table .toc", 1);
+        assert_css(&doc, "table #table-cell-toc", 1);
+    }
 
     #[test]
     fn document_in_an_asciidoc_table_cell_should_not_see_doctitle_of_parent() {

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -4,7 +4,10 @@
 //! documents for testing purposes. It maps AsciiDoc block structures to their
 //! HTML equivalents, enabling XPath-like queries for test assertions.
 
-use std::{cell::Cell, sync::LazyLock};
+use std::{
+    cell::{Cell, RefCell},
+    sync::LazyLock,
+};
 
 use regex::Regex;
 
@@ -17,7 +20,7 @@ use crate::{
         SimpleBlockStyle, Stripes, TableBlock, TableCellContent, TableColumn, TableRow,
         VerticalAlignment,
     },
-    document::InterpretedValue,
+    document::{InterpretedValue, TocMode},
 };
 
 /// The document-wide `icons` mode, which controls how callouts and callout
@@ -41,6 +44,129 @@ enum IconsMode {
 
 thread_local! {
     static ICONS_MODE: Cell<IconsMode> = const { Cell::new(IconsMode::None) };
+}
+
+/// The number of section levels included in a table of contents when
+/// `toclevels` is not overridden. This matches Asciidoctor's default of 2
+/// (sections up to and including `===`). The virtual DOM does not yet read a
+/// custom `toclevels`, so every TOC uses this depth.
+const DEFAULT_TOCLEVELS: usize = 2;
+
+thread_local! {
+    /// The table-of-contents section list for the current `toc: macro` scope.
+    ///
+    /// The virtual DOM builder has no document context threaded through it, so
+    /// when a document (or nested AsciiDoc cell) renders with `toc: macro`, its
+    /// prebuilt list is stashed here for the duration of the body render and a
+    /// `toc::[]` macro reads it from here. The outer `Option` distinguishes "a
+    /// macro scope is active" (`Some`) from "no macro scope" (`None`, where a
+    /// stray `toc::[]` renders nothing); the inner `Option` is the `<ul>`, which
+    /// is `None` when the scope has no sections.
+    static MACRO_TOC: RefCell<Option<Option<VirtualNode>>> = const { RefCell::new(None) };
+}
+
+/// Restores [`MACRO_TOC`] to its previous value when dropped, so nested
+/// AsciiDoc cells can mask the enclosing document's macro scope and reinstate
+/// it afterward.
+struct MacroTocGuard(Option<Option<VirtualNode>>);
+
+impl Drop for MacroTocGuard {
+    fn drop(&mut self) {
+        MACRO_TOC.with(|m| *m.borrow_mut() = self.0.take());
+    }
+}
+
+/// Sets [`MACRO_TOC`] to `value` for the current scope, returning a guard that
+/// restores the previous value on drop.
+fn scoped_macro_toc(value: Option<Option<VirtualNode>>) -> MacroTocGuard {
+    MacroTocGuard(MACRO_TOC.with(|m| m.replace(value)))
+}
+
+/// A regular expression matching a `toc::[]` block macro line (with any
+/// attributes between the brackets).
+static TOC_MACRO: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^toc::\[.*\]$").unwrap());
+
+/// Returns `true` if `block` is a `toc::[]` block macro (which the parser
+/// represents as a plain paragraph, since `toc` is not a media macro).
+fn is_toc_macro(block: &Block) -> bool {
+    matches!(block, Block::Simple(simple)
+        if simple.declared_style().is_none()
+            && TOC_MACRO.is_match(simple.content().original().data().trim()))
+}
+
+/// Renders a `toc::[]` block macro: the prebuilt section list for the active
+/// `toc: macro` scope, wrapped in a `div.toc` carrying the macro's id (default
+/// `toc`). Returns `None` when no macro scope is active, in which case the
+/// macro renders nothing (matching Asciidoctor, which drops `toc::[]` unless
+/// `toc: macro` is in effect).
+fn toc_macro_node(block: &Block) -> Option<VirtualNode> {
+    MACRO_TOC.with(|m| {
+        m.borrow()
+            .as_ref()
+            .map(|ul| toc_block(block.id().unwrap_or("toc"), true, ul.clone()))
+    })
+}
+
+/// Builds the nested `<ul>` of section links for a table of contents.
+///
+/// `blocks` are the blocks at the current `level` (1 for the top-level
+/// sections); only [`Block::Section`] children contribute entries. Each entry
+/// is an `<li>` with an `<a href="#id">title</a>`, plus a nested `<ul>` of any
+/// subsections down to `max_level`. Returns `None` when there are no sections.
+fn build_toc_ul(blocks: &[Block], level: usize, max_level: usize) -> Option<VirtualNode> {
+    if level > max_level {
+        return None;
+    }
+
+    let mut ul = VirtualNode::new("ul").with_class(format!("sectlevel{level}"));
+
+    for block in blocks {
+        if let Block::Section(section) = block {
+            let mut li = VirtualNode::new("li");
+
+            let id = section.id().unwrap_or_default();
+            li.children.push(
+                VirtualNode::new("a")
+                    .with_attribute("href", format!("#{id}"))
+                    .with_text(section.section_title()),
+            );
+
+            if let Some(sub) =
+                build_toc_ul(section.nested_blocks().as_slice(), level + 1, max_level)
+            {
+                li.children.push(sub);
+            }
+
+            ul.children.push(li);
+        }
+    }
+
+    (!ul.children.is_empty()).then_some(ul)
+}
+
+/// Wraps a table-of-contents list in its `div.toc` container.
+///
+/// `id` is the container id (`toc` for an automatic placement, or the `toc::[]`
+/// macro's id). `title_class` adds `class="title"` to the title element, which
+/// Asciidoctor does for a `toc::[]` macro rendered in the document body but not
+/// for the automatic top-of-document TOC. `ul` is the section list, omitted
+/// when the document has no sections.
+fn toc_block(id: &str, title_class: bool, ul: Option<VirtualNode>) -> VirtualNode {
+    let mut node = VirtualNode::new("div").with_id(id).with_class("toc");
+
+    let mut title = VirtualNode::new("div")
+        .with_id(format!("{id}title"))
+        .with_text("Table of Contents");
+    if title_class {
+        title = title.with_class("title");
+    }
+    node.children.push(title);
+
+    if let Some(ul) = ul {
+        node.children.push(ul);
+    }
+
+    node
 }
 
 /// Resolves the document's `icons` mode from its header attributes.
@@ -401,6 +527,19 @@ impl ToVirtualDom for Document<'_> {
             node.children.push(VirtualNode::new("h1").with_text(title));
         }
 
+        // Resolve the table of contents from the `toc` attribute. An automatic
+        // placement renders the TOC at the top of the body; a `macro` placement
+        // stashes the section list for a `toc::[]` macro in the body to pick up.
+        let toc_mode = self.toc_mode();
+        let toc_ul = (toc_mode != TocMode::Disabled)
+            .then(|| build_toc_ul(self.nested_blocks().as_slice(), 1, DEFAULT_TOCLEVELS))
+            .flatten();
+
+        if toc_mode == TocMode::Auto {
+            node.children.push(toc_block("toc", false, toc_ul.clone()));
+        }
+        let _macro_toc = (toc_mode == TocMode::Macro).then(|| scoped_macro_toc(Some(toc_ul)));
+
         // Add child blocks, including block titles as separate siblings.
         for block in self.nested_blocks() {
             add_block_with_title(&mut node, block);
@@ -416,6 +555,15 @@ impl ToVirtualDom for Document<'_> {
 /// NOTE: Some block types (like lists) handle their titles internally, so we
 /// skip adding a separate title element for those.
 fn add_block_with_title<'a>(parent: &mut VirtualNode, block: &'a Block<'a>) {
+    // A `toc::[]` macro renders the table of contents (when a `toc: macro` scope
+    // is active) rather than a paragraph, and never carries a separate title.
+    if is_toc_macro(block) {
+        if let Some(toc) = toc_macro_node(block) {
+            parent.children.push(toc);
+        }
+        return;
+    }
+
     // Check if this block type handles its own title internally. Lists render
     // their title inside the list wrapper; tables render it as a <caption>;
     // admonitions render it inside the content cell; a collapsible block renders
@@ -1699,6 +1847,22 @@ fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bo
                         .push(VirtualNode::new("h1").with_text(title));
                 }
 
+                // The cell is a standalone document with its own `toc` setting
+                // (not inherited from the parent). Resolve it the same way as the
+                // top-level document, and always enter a macro scope for the cell
+                // body so a `toc::[]` here never picks up the parent's sections.
+                let toc_mode = cell.toc_mode();
+                let toc_ul = (toc_mode != TocMode::Disabled)
+                    .then(|| build_toc_ul(cell.blocks(), 1, DEFAULT_TOCLEVELS))
+                    .flatten();
+
+                if toc_mode == TocMode::Auto {
+                    content
+                        .children
+                        .push(toc_block("toc", false, toc_ul.clone()));
+                }
+                let _macro_toc = scoped_macro_toc((toc_mode == TocMode::Macro).then_some(toc_ul));
+
                 if cell.is_inline() {
                     // An `inline` doctype renders block content as bare inline
                     // content, without the `<div class="paragraph"><p>` wrapper.
@@ -1916,6 +2080,14 @@ fn preamble_to_node<'a>(preamble: &'a Preamble<'a>) -> VirtualNode {
     let mut node = VirtualNode::new("div").with_id("preamble");
 
     for child in preamble.nested_blocks() {
+        // A `toc::[]` macro in the preamble renders the table of contents.
+        if is_toc_macro(child) {
+            if let Some(toc) = toc_macro_node(child) {
+                node.children.push(toc);
+            }
+            continue;
+        }
+
         node.children.push(child.to_virtual_dom());
     }
 
@@ -2129,5 +2301,145 @@ mod tests {
             dl.children[3].children[0].text.as_deref(),
             Some("definition2")
         );
+    }
+
+    mod toc {
+        use crate::{document::TocMode, tests::prelude::*};
+
+        #[test]
+        fn no_toc_when_attribute_absent() {
+            let doc = Parser::default().parse("= Title\n\n== Section\n\ncontent");
+
+            assert_eq!(doc.toc_mode(), TocMode::Disabled);
+            assert_css(&doc, ".toc", 0);
+        }
+
+        #[test]
+        fn auto_toc_renders_at_top_of_body() {
+            let doc =
+                Parser::default().parse("= Title\n:toc:\n\n== First\n\nhi\n\n== Second\n\nbye");
+
+            assert_eq!(doc.toc_mode(), TocMode::Auto);
+
+            // Exactly one TOC, carrying both `id="toc"` and `class="toc"`.
+            assert_css(&doc, "#toc", 1);
+            assert_css(&doc, ".toc", 1);
+
+            // It is the first child of the document, ahead of the sections.
+            let vdom = doc.to_virtual_dom();
+            let toc = &vdom.children[0];
+            assert_eq!(toc.tag, "div");
+            assert_eq!(toc.id.as_deref(), Some("toc"));
+            assert!(toc.classes.contains(&"toc".to_string()));
+
+            // The title element has no `class="title"` for an automatic TOC.
+            let title = &toc.children[0];
+            assert_eq!(title.id.as_deref(), Some("toctitle"));
+            assert_eq!(title.text.as_deref(), Some("Table of Contents"));
+            assert!(title.classes.is_empty());
+
+            // One `sectlevel1` entry per top-level section, each linking to it.
+            assert_css(&doc, "ul.sectlevel1 > li > a", 2);
+            let links = &toc.children[1];
+            assert_eq!(links.tag, "ul");
+            assert!(links.classes.contains(&"sectlevel1".to_string()));
+            assert_eq!(
+                links.children[0].children[0].attributes.get("href"),
+                Some(&"#_first".to_string())
+            );
+            assert_eq!(links.children[0].children[0].text.as_deref(), Some("First"));
+        }
+
+        #[test]
+        fn placement_values_are_automatic() {
+            for placement in ["left", "right", "preamble"] {
+                let doc = Parser::default()
+                    .parse(&format!("= Title\n:toc: {placement}\n\n== Section\n\nhi"));
+
+                assert_eq!(doc.toc_mode(), TocMode::Auto, "placement: {placement}");
+                assert_css(&doc, ".toc", 1);
+            }
+        }
+
+        #[test]
+        fn auto_toc_nesting_honors_default_toclevels() {
+            let doc = Parser::default()
+                .parse("= Title\n:toc:\n\n== Level 1\n\n=== Level 2\n\n==== Level 3\n\ncontent");
+
+            // The default `toclevels` is 2, so the `==` and `===` sections appear
+            // but the `====` (level 3) section is excluded.
+            assert_css(&doc, "ul.sectlevel1", 1);
+            assert_css(&doc, "ul.sectlevel2", 1);
+            assert_css(&doc, "ul.sectlevel3", 0);
+        }
+
+        #[test]
+        fn macro_toc_renders_at_macro_not_at_top() {
+            let doc = Parser::default()
+                .parse("= Title\n:toc: macro\n\npreamble\n\ntoc::[]\n\n== Section\n\nhi");
+
+            assert_eq!(doc.toc_mode(), TocMode::Macro);
+            assert_css(&doc, ".toc", 1);
+
+            // The TOC is *not* the first child of the document body (it renders
+            // at the macro's location, inside the preamble).
+            let vdom = doc.to_virtual_dom();
+            assert_ne!(vdom.children[0].id.as_deref(), Some("toc"));
+            assert_css(&doc, "#preamble .toc", 1);
+
+            // A macro TOC's title element carries `class="title"`.
+            assert_css(&doc, "#toctitle.title", 1);
+        }
+
+        #[test]
+        fn macro_toc_uses_explicit_id() {
+            let doc = Parser::default()
+                .parse("= Title\n:toc: macro\n\n[#my-toc]\ntoc::[]\n\n== Section\n\nhi");
+
+            assert_css(&doc, "#my-toc.toc", 1);
+            assert_css(&doc, "#my-toctitle.title", 1);
+        }
+
+        #[test]
+        fn macro_placement_without_macro_renders_no_toc() {
+            // `toc: macro` only renders where a `toc::[]` macro appears; with no
+            // such macro, no TOC is generated.
+            let doc = Parser::default().parse("= Title\n:toc: macro\n\n== Section\n\nhi");
+
+            assert_eq!(doc.toc_mode(), TocMode::Macro);
+            assert_css(&doc, ".toc", 0);
+        }
+
+        #[test]
+        fn toc_macro_renders_nothing_when_toc_not_enabled() {
+            // A stray `toc::[]` with no `toc` attribute renders nothing — neither
+            // a TOC nor the literal paragraph text.
+            let doc = Parser::default().parse("= Title\n\ntoc::[]\n\n== Section\n\nhi");
+
+            assert_eq!(doc.toc_mode(), TocMode::Disabled);
+            assert_css(&doc, ".toc", 0);
+
+            let dom_text = to_dom_text(&doc);
+            assert!(
+                !dom_text.contains("toc::"),
+                "unexpected literal macro text in: {dom_text}"
+            );
+        }
+
+        /// Collects all text content in the rendered virtual DOM.
+        fn to_dom_text(doc: &crate::Document) -> String {
+            fn collect(node: &super::super::VirtualNode, out: &mut String) {
+                if let Some(text) = &node.text {
+                    out.push_str(text);
+                }
+                for child in &node.children {
+                    collect(child, out);
+                }
+            }
+
+            let mut out = String::new();
+            collect(&doc.to_virtual_dom(), &mut out);
+            out
+        }
     }
 }


### PR DESCRIPTION
## What

Implements the `toc` document attribute (issue #546): a table of contents is now generated for

- **automatic placements** — `:toc:` (resolves to `auto`), `:toc: left`, `:toc: right`, `:toc: preamble` — rendered as a `div#toc.toc` at the top of the document body, and
- **the `toc::[]` block macro** under `:toc: macro`, rendered in place and carrying the macro's id (default `#toc`).

Each TOC lists section links nested to the default `toclevels` of 2.

## How

- **`document::TocMode`** (`Disabled` / `Auto` / `Macro`) resolves the placement from the `toc` attribute. Because `toc` is header-only, the resolved state is captured at parse time — on `Document` (`Document::toc_mode()`) and on each nested AsciiDoc table cell (`AsciiDocCell::toc_mode()`) — mirroring how `show_doctitle` is already captured.
- A **nested AsciiDoc table cell is a standalone document**: it must not inherit the parent's `toc` setting. The value is reset to unset at cell entry (alongside the existing `doctype` reset), while `toc` remains one of the attributes a cell may set for itself.
- The **test virtual DOM** grows a small TOC builder: it emits the auto TOC at the top of the body and renders a `toc::[]` macro in place (the macro is otherwise a plain paragraph, since `toc` is not a media macro). A thread-local — matching the existing `ICONS_MODE` pattern — carries the active `toc: macro` section list down to the macro, with an RAII guard so nested cells mask and restore the enclosing scope.

## Tests

- The four previously-`#[ignore]`d AsciiDoc-cell TOC tests in `tables_test.rs` (the ones gated on this issue) are now ported verbatim from Ruby Asciidoctor and pass.
- Adds a `toc` unit-test module covering auto placement and structure, `left/right/preamble` placements, `toclevels` nesting, macro placement (with and without `toc::[]`), explicit macro ids, the disabled case, and that a stray `toc::[]` renders nothing.
- Full suite green (`cargo test`), plus `cargo +nightly fmt --check`, `cargo +nightly clippy --all-targets`, and `RUSTDOCFLAGS=-D warnings cargo +nightly doc` all clean.

## Scope notes

- The virtual DOM uses the default `toclevels` of 2; a custom `:toclevels:` is not yet threaded through (no current test requires it).

Closes #546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)