### PR TITLE
feat: Drop blocks whose macro target references a missing attribute

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -6,7 +6,8 @@ use crate::{
     blocks::{
         AdmonitionBlock, Break, CompoundDelimitedBlock, ContentModel, IsBlock, ListBlock, ListItem,
         ListItemMarker, MediaBlock, Preamble, QuoteBlock, RawDelimitedBlock, SectionBlock,
-        SimpleBlock, TableBlock, metadata::BlockMetadata, starts_with_admonition_label,
+        SimpleBlock, TableBlock, media::TargetResolution, metadata::BlockMetadata,
+        starts_with_admonition_label,
     },
     content::{Content, SubstitutionGroup},
     document::{Attribute, RefType},
@@ -117,14 +118,67 @@ impl<'src> std::fmt::Debug for Block<'src> {
     }
 }
 
+/// Outcome of attempting to parse a single [`Block`].
+///
+/// Most blocks parse to [`Parsed`](Self::Parsed). [`Dropped`](Self::Dropped)
+/// supports `attribute-missing=drop-line`: when a block-macro target references
+/// a missing attribute, Asciidoctor discards the whole block, which the parser
+/// must distinguish both from a successful parse and from "no block matched"
+/// (so the block-collection loops advance past the dropped source rather than
+/// spinning or mis-parsing it).
+// `Parsed` embeds a `Block`, which is itself a large enum (see the matching
+// allow on `Block`). This outcome is short-lived and returned by value on the
+// hot parse path, so boxing it would just trade the size for an allocation.
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum BlockParseOutcome<'src> {
+    /// A block was parsed.
+    Parsed(MatchedItem<'src, Block<'src>>),
+
+    /// The input was recognized as a block macro but dropped at parse time
+    /// because its target referenced a missing attribute under
+    /// `attribute-missing=drop-line`. The contained span is where parsing
+    /// should resume (the dropped block's `after`).
+    Dropped(Span<'src>),
+
+    /// No block matched. This happens only for empty or all-blank input.
+    NoMatch,
+}
+
 impl<'src> Block<'src> {
     /// Parse a block of any type and return a `Block` that describes it.
     ///
     /// Consumes any blank lines before and after the block.
+    ///
+    /// This is a test-only convenience wrapper over
+    /// [`parse_with_outcome`](Self::parse_with_outcome) that flattens the
+    /// drop-line outcome to an `Option`; production code uses
+    /// `parse_with_outcome` so it can react to a dropped block.
+    #[cfg(test)]
     pub(crate) fn parse(
         source: Span<'src>,
         parser: &mut Parser,
     ) -> MatchAndWarnings<'src, Option<MatchedItem<'src, Self>>> {
+        let MatchAndWarnings { item, warnings } = Self::parse_internal(source, parser, None, false);
+
+        MatchAndWarnings {
+            item: match item {
+                BlockParseOutcome::Parsed(mi) => Some(mi),
+                BlockParseOutcome::Dropped(_) | BlockParseOutcome::NoMatch => None,
+            },
+            warnings,
+        }
+    }
+
+    /// Parse a block of any type, returning the full [`BlockParseOutcome`] so a
+    /// block-collection loop can advance past a block that was dropped at parse
+    /// time (`attribute-missing=drop-line`). Consumes any blank lines before
+    /// and after the block.
+    ///
+    /// This is the entry point used by production block-collection loops.
+    pub(crate) fn parse_with_outcome(
+        source: Span<'src>,
+        parser: &mut Parser,
+    ) -> MatchAndWarnings<'src, BlockParseOutcome<'src>> {
         Self::parse_internal(source, parser, None, false)
     }
 
@@ -143,17 +197,18 @@ impl<'src> Block<'src> {
         parser: &mut Parser,
         parent_list_markers: &[ListItemMarker<'src>],
         is_continuation: bool,
-    ) -> MatchAndWarnings<'src, Option<MatchedItem<'src, Self>>> {
+    ) -> MatchAndWarnings<'src, BlockParseOutcome<'src>> {
         Self::parse_internal(source, parser, Some(parent_list_markers), is_continuation)
     }
 
-    /// Shared parser for [`Block::parse`] and [`Block::parse_for_list_item`].
+    /// Shared parser for [`parse_with_outcome`](Self::parse_with_outcome) and
+    /// [`parse_for_list_item`](Self::parse_for_list_item).
     fn parse_internal(
         source: Span<'src>,
         parser: &mut Parser,
         parent_list_markers: Option<&[ListItemMarker<'src>]>,
         is_continuation: bool,
-    ) -> MatchAndWarnings<'src, Option<MatchedItem<'src, Self>>> {
+    ) -> MatchAndWarnings<'src, BlockParseOutcome<'src>> {
         // Optimization: If the first line doesn't match any of the early indications
         // for delimited blocks, titles, or attrlists, we can skip directly to treating
         // this as a simple block. That saves quite a bit of parsing time.
@@ -202,7 +257,7 @@ impl<'src> Block<'src> {
             );
 
             return MatchAndWarnings {
-                item: Some(MatchedItem { item: block, after }),
+                item: BlockParseOutcome::Parsed(MatchedItem { item: block, after }),
                 warnings,
             };
         }
@@ -216,7 +271,7 @@ impl<'src> Block<'src> {
             parser.set_attribute_from_body(&attr.item, &mut warnings);
 
             return MatchAndWarnings {
-                item: Some(MatchedItem {
+                item: BlockParseOutcome::Parsed(MatchedItem {
                     item: Self::DocumentAttribute(attr.item),
                     after: attr.after,
                 }),
@@ -267,7 +322,7 @@ impl<'src> Block<'src> {
                 );
 
                 return MatchAndWarnings {
-                    item: Some(MatchedItem {
+                    item: BlockParseOutcome::Parsed(MatchedItem {
                         item: block,
                         after: adm.after,
                     }),
@@ -293,7 +348,7 @@ impl<'src> Block<'src> {
                 );
 
                 return MatchAndWarnings {
-                    item: Some(MatchedItem {
+                    item: BlockParseOutcome::Parsed(MatchedItem {
                         item: block,
                         after: quote.after,
                     }),
@@ -319,7 +374,7 @@ impl<'src> Block<'src> {
                 );
 
                 return MatchAndWarnings {
-                    item: Some(MatchedItem {
+                    item: BlockParseOutcome::Parsed(MatchedItem {
                         item: block,
                         after: rdb.after,
                     }),
@@ -345,7 +400,7 @@ impl<'src> Block<'src> {
                 );
 
                 return MatchAndWarnings {
-                    item: Some(MatchedItem {
+                    item: BlockParseOutcome::Parsed(MatchedItem {
                         item: block,
                         after: cdb.after,
                     }),
@@ -371,7 +426,7 @@ impl<'src> Block<'src> {
                 );
 
                 return MatchAndWarnings {
-                    item: Some(MatchedItem {
+                    item: BlockParseOutcome::Parsed(MatchedItem {
                         item: block,
                         after: table.after,
                     }),
@@ -384,16 +439,26 @@ impl<'src> Block<'src> {
 
             if line.item.starts_with("image::")
                 || line.item.starts_with("video::")
-                || line.item.starts_with("video::")
+                || line.item.starts_with("audio::")
             {
                 let mut media_block_maw = MediaBlock::parse(&metadata, parser);
 
-                if let Some(media_block) = media_block_maw.item {
+                if let Some(mut media_block) = media_block_maw.item {
                     // Only propagate warnings from media block parsing if we think this
                     // *is* a media block. Otherwise, there would likely be too many false
                     // positives.
                     if !media_block_maw.warnings.is_empty() {
                         warnings.append(&mut media_block_maw.warnings);
+                    }
+
+                    // Resolve attribute references in the macro target. Under
+                    // `attribute-missing=drop-line`, a reference to a missing
+                    // attribute drops the entire block (Asciidoctor behavior).
+                    if media_block.item.resolve_target(parser) == TargetResolution::Drop {
+                        return MatchAndWarnings {
+                            item: BlockParseOutcome::Dropped(media_block.after),
+                            warnings,
+                        };
                     }
 
                     let block = Self::Media(media_block.item);
@@ -407,7 +472,7 @@ impl<'src> Block<'src> {
                     );
 
                     return MatchAndWarnings {
-                        item: Some(MatchedItem {
+                        item: BlockParseOutcome::Parsed(MatchedItem {
                             item: block,
                             after: media_block.after,
                         }),
@@ -427,7 +492,7 @@ impl<'src> Block<'src> {
                 // continue quietly if `SectionBlock` parser rejects this block.
 
                 return MatchAndWarnings {
-                    item: Some(MatchedItem {
+                    item: BlockParseOutcome::Parsed(MatchedItem {
                         item: Self::Section(mi_section_block.item),
                         after: mi_section_block.after,
                     }),
@@ -444,7 +509,7 @@ impl<'src> Block<'src> {
                 // Continue quietly if `Break` parser rejects this block.
 
                 return MatchAndWarnings {
-                    item: Some(MatchedItem {
+                    item: BlockParseOutcome::Parsed(MatchedItem {
                         item: Self::Break(mi_break.item),
                         after: mi_break.after,
                     }),
@@ -459,7 +524,7 @@ impl<'src> Block<'src> {
                 && let Some(mi_list) = ListBlock::parse(&metadata, parser, &mut warnings)
             {
                 return MatchAndWarnings {
-                    item: Some(MatchedItem {
+                    item: BlockParseOutcome::Parsed(MatchedItem {
                         item: Self::List(mi_list.item),
                         after: mi_list.after,
                     }),
@@ -514,14 +579,17 @@ impl<'src> Block<'src> {
         };
 
         let mut result = MatchAndWarnings {
-            item: simple_block_mi.map(|mi| MatchedItem {
-                item: Self::Simple(mi.item),
-                after: mi.after,
-            }),
+            item: match simple_block_mi {
+                Some(mi) => BlockParseOutcome::Parsed(MatchedItem {
+                    item: Self::Simple(mi.item),
+                    after: mi.after,
+                }),
+                None => BlockParseOutcome::NoMatch,
+            },
             warnings,
         };
 
-        if let Some(ref matched_item) = result.item {
+        if let BlockParseOutcome::Parsed(ref matched_item) = result.item {
             Self::register_block_id(
                 matched_item.item.id(),
                 matched_item.item.title(),

--- a/parser/src/blocks/list_item.rs
+++ b/parser/src/blocks/list_item.rs
@@ -5,7 +5,7 @@ use crate::{
     attributes::Attrlist,
     blocks::{
         Block, CompoundDelimitedBlock, ContentModel, IsBlock, ListBlock, ListItemMarker,
-        RawDelimitedBlock, SimpleBlock, metadata::BlockMetadata,
+        RawDelimitedBlock, SimpleBlock, block::BlockParseOutcome, metadata::BlockMetadata,
     },
     content::Content,
     internal::debug::DebugSliceReference,
@@ -388,7 +388,23 @@ impl<'src> ListItem<'src> {
             );
             warnings.extend(indented_block_maw.warnings);
 
-            let Some(indented_block_mi) = indented_block_maw.item else {
+            // A block dropped at parse time (`attribute-missing=drop-line` on a
+            // block-macro target) attaches nothing, but — like a real block —
+            // it consumes any active continuation and requires the next block
+            // to be indented or reintroduced with a `+`. (A dropped block is
+            // always a block macro, never `+`-prefixed content, so it can't set
+            // `had_content_starting_with_plus`.)
+            if let BlockParseOutcome::Dropped(after) = indented_block_maw.item {
+                next = after;
+                continuation_active = false;
+                next_block_must_be_indented = true;
+                continue;
+            }
+
+            // `NoMatch` only arises for empty/blank input, which is filtered out
+            // above before we get here; the defensive `break` mirrors the
+            // pre-drop-line code path.
+            let BlockParseOutcome::Parsed(indented_block_mi) = indented_block_maw.item else {
                 break;
             };
 

--- a/parser/src/blocks/media.rs
+++ b/parser/src/blocks/media.rs
@@ -2,6 +2,7 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     blocks::{ContentModel, IsBlock, metadata::BlockMetadata},
+    content::substitute_attributes_in_macro_target,
     span::MatchedItem,
     strings::CowStr,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -12,6 +13,7 @@ use crate::{
 pub struct MediaBlock<'src> {
     type_: MediaType,
     target: Span<'src>,
+    resolved_target: CowStr<'src>,
     macro_attrlist: Attrlist<'src>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
@@ -19,6 +21,18 @@ pub struct MediaBlock<'src> {
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
+}
+
+/// Outcome of resolving attribute references in a media block's target via
+/// [`MediaBlock::resolve_target`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TargetResolution {
+    /// The target was resolved and stored; the block should be kept.
+    Keep,
+
+    /// The target referenced a missing attribute under
+    /// `attribute-missing=drop-line`, so the entire block should be dropped.
+    Drop,
 }
 
 /// A media type may be one of three different types.
@@ -124,6 +138,11 @@ impl<'src> MediaBlock<'src> {
                 item: Self {
                     type_,
                     target: target.item,
+                    // Attribute references in the target are resolved later, in
+                    // `resolve_target` (which also decides whether a missing
+                    // reference should drop the whole block); until then, the
+                    // resolved target mirrors the raw target verbatim.
+                    resolved_target: target.item.data().into(),
                     macro_attrlist: macro_attrlist.item.item,
                     source,
                     title_source: metadata.title_source,
@@ -145,8 +164,44 @@ impl<'src> MediaBlock<'src> {
     }
 
     /// Return a [`Span`] describing the macro target.
+    ///
+    /// This is the target exactly as written in the source, _before_ any
+    /// attribute references within it are resolved. See
+    /// [`resolved_target()`](Self::resolved_target) for the resolved form.
     pub fn target(&'src self) -> Option<&'src Span<'src>> {
         Some(&self.target)
+    }
+
+    /// Return the macro target after any attribute references within it have
+    /// been resolved (honoring the [`attribute-missing`] document attribute).
+    ///
+    /// For the common case of a target with no attribute references, this is
+    /// identical to the text of [`target()`](Self::target).
+    ///
+    /// [`attribute-missing`]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unresolved-references/#missing
+    pub fn resolved_target(&self) -> &str {
+        self.resolved_target.as_ref()
+    }
+
+    /// Resolve attribute references in this block's target, honoring the
+    /// [`attribute-missing`] document attribute.
+    ///
+    /// On success the resolved target is stored (see
+    /// [`resolved_target()`](Self::resolved_target)) and
+    /// [`TargetResolution::Keep`] is returned. When the target references a
+    /// missing attribute and `attribute-missing=drop-line` is in effect,
+    /// [`TargetResolution::Drop`] is returned and the caller drops the
+    /// entire block.
+    ///
+    /// [`attribute-missing`]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unresolved-references/#missing
+    pub(crate) fn resolve_target(&mut self, parser: &Parser) -> TargetResolution {
+        match substitute_attributes_in_macro_target(self.target, parser) {
+            Some(resolved) => {
+                self.resolved_target = resolved;
+                TargetResolution::Keep
+            }
+            None => TargetResolution::Drop,
+        }
     }
 
     /// Return the macro's attribute list.
@@ -698,6 +753,142 @@ mod tests {
                 warning: WarningType::EmptyAttributeValue,
             }]
         );
+    }
+
+    mod target_resolution {
+        #![allow(clippy::indexing_slicing)]
+
+        use crate::{
+            blocks::{MediaBlock, media::TargetResolution, metadata::BlockMetadata},
+            parser::ModificationContext,
+            tests::prelude::*,
+            warnings::WarningType,
+        };
+
+        /// Parses `input` as a media block and resolves its target against
+        /// `parser`, returning the resolved [`MediaBlock`] (or `None` if the
+        /// block was dropped).
+        fn resolve<'i>(input: &'i str, parser: &mut Parser) -> Option<MediaBlock<'i>> {
+            let mut block = MediaBlock::parse(&BlockMetadata::new(input), parser)
+                .unwrap_if_no_warnings()
+                .unwrap()
+                .item;
+
+            match block.resolve_target(parser) {
+                TargetResolution::Keep => Some(block),
+                TargetResolution::Drop => None,
+            }
+        }
+
+        fn parser_with_mode(mode: &str) -> Parser {
+            Parser::default().with_intrinsic_attribute(
+                "attribute-missing",
+                mode,
+                ModificationContext::Anywhere,
+            )
+        }
+
+        #[test]
+        fn target_without_reference_is_unchanged() {
+            // The fast path (no `{`) returns the borrowed target verbatim.
+            let mut p = Parser::default();
+            let block = resolve("image::foo.png[]", &mut p).unwrap();
+            assert_eq!(block.resolved_target(), "foo.png");
+        }
+
+        #[test]
+        fn resolves_a_defined_reference() {
+            let mut p = Parser::default().with_intrinsic_attribute(
+                "name",
+                "bar",
+                ModificationContext::Anywhere,
+            );
+            let block = resolve("image::pre-{name}-post.png[]", &mut p).unwrap();
+            assert_eq!(block.resolved_target(), "pre-bar-post.png");
+        }
+
+        #[test]
+        fn skip_leaves_a_missing_reference_in_place() {
+            // `skip` is the default `attribute-missing` mode.
+            let mut p = Parser::default();
+            let block = resolve("image::a{missing}b.png[]", &mut p).unwrap();
+            assert_eq!(block.resolved_target(), "a{missing}b.png");
+            assert!(p.take_substitution_warnings().is_empty());
+        }
+
+        #[test]
+        fn drop_removes_only_the_missing_reference() {
+            let mut p = parser_with_mode("drop");
+            let block = resolve("image::a{missing}b.png[]", &mut p).unwrap();
+            assert_eq!(block.resolved_target(), "ab.png");
+        }
+
+        #[test]
+        fn warn_leaves_the_reference_and_records_a_warning() {
+            let mut p = parser_with_mode("warn");
+            let block = resolve("image::a{missing}b.png[]", &mut p).unwrap();
+            assert_eq!(block.resolved_target(), "a{missing}b.png");
+
+            let warnings = p.take_substitution_warnings();
+            assert_eq!(warnings.len(), 1);
+            assert_eq!(
+                warnings[0].warning,
+                WarningType::SkippingReferenceToMissingAttribute("missing".to_string())
+            );
+        }
+
+        #[test]
+        fn drop_line_drops_the_whole_block() {
+            let mut p = parser_with_mode("drop-line");
+            assert!(resolve("image::a{missing}b.png[]", &mut p).is_none());
+        }
+
+        #[test]
+        fn drop_line_keeps_a_block_whose_reference_resolves() {
+            let mut p = parser_with_mode("drop-line").with_intrinsic_attribute(
+                "name",
+                "bar",
+                ModificationContext::Anywhere,
+            );
+            let block = resolve("image::{name}.png[]", &mut p).unwrap();
+            assert_eq!(block.resolved_target(), "bar.png");
+        }
+
+        #[test]
+        fn drop_line_drops_a_top_level_block_but_keeps_following_blocks() {
+            // Exercises the drop at the document (non-list) level, which flows
+            // through `parse_blocks_until`.
+            let doc = Parser::default().parse(
+                ":attribute-missing: drop-line\n\nimage::{unresolved}[]\n\nparagraph after\n",
+            );
+
+            assert_css(&doc, ".imageblock", 0);
+            assert_css(&doc, ".paragraph", 1);
+        }
+
+        #[test]
+        fn drop_line_drops_a_top_level_audio_block() {
+            // Audio is a block macro too, so it honors `drop-line` just like an
+            // image block.
+            let doc = Parser::default().parse(
+                ":attribute-missing: drop-line\n\naudio::{unresolved}[]\n\nparagraph after\n",
+            );
+
+            assert_css(&doc, ".audioblock", 0);
+            assert_css(&doc, ".paragraph", 1);
+        }
+
+        #[test]
+        fn escaped_missing_reference_never_drops_the_block() {
+            // An escaped reference is not a missing reference, so even under
+            // `drop-line` the block survives. (As elsewhere in the crate, the
+            // escaping backslash is preserved verbatim by the attribute
+            // substitution.)
+            let mut p = parser_with_mode("drop-line");
+            let block = resolve("image::a\\{missing}b.png[]", &mut p).unwrap();
+            assert_eq!(block.resolved_target(), "a\\{missing}b.png");
+            assert!(p.take_substitution_warnings().is_empty());
+        }
     }
 
     mod media_type {

--- a/parser/src/blocks/parse_utils.rs
+++ b/parser/src/blocks/parse_utils.rs
@@ -1,6 +1,6 @@
 use crate::{
     Parser, Span,
-    blocks::Block,
+    blocks::{Block, block::BlockParseOutcome},
     span::MatchedItem,
     warnings::{MatchAndWarnings, Warning},
 };
@@ -25,16 +25,26 @@ where
             break;
         }
 
-        let mut maw = Block::parse(source, parser);
+        let mut maw = Block::parse_with_outcome(source, parser);
 
         if !maw.warnings.is_empty() {
             warnings.append(&mut maw.warnings);
         }
 
-        if let Some(mi) = maw.item {
+        if let BlockParseOutcome::Parsed(mi) = maw.item {
             source = mi.after.discard_empty_lines();
             blocks.push(mi.item);
+        } else if let BlockParseOutcome::Dropped(after) = maw.item {
+            // A dropped block (`attribute-missing=drop-line`) contributes no
+            // block, but parsing must still advance past its source.
+            source = after.discard_empty_lines();
         }
+
+        // `BlockParseOutcome::NoMatch` is intentionally not handled: it only
+        // arises for empty/blank input, which never reaches here because the
+        // loop guard and the `discard_empty_lines` calls above keep `source`
+        // non-blank. (Matching the behavior before drop-line support, which
+        // likewise only advanced on a successful parse.)
     }
 
     MatchAndWarnings {

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -16,3 +16,4 @@ pub use substitution_group::SubstitutionGroup;
 
 mod substitution_step;
 pub use substitution_step::SubstitutionStep;
+pub(crate) use substitution_step::substitute_attributes_in_macro_target;

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -12,6 +12,7 @@ use crate::{
         CalloutGuard, CalloutRenderParams, CharacterReplacementType, InlineSubstitutionRenderer,
         QuoteScope, QuoteType, SpecialCharacter,
     },
+    strings::CowStr,
     warnings::WarningType,
 };
 
@@ -613,6 +614,47 @@ fn apply_attributes(content: &mut Content<'_>, parser: &Parser) {
     if changed {
         content.rendered = out.into();
     }
+}
+
+/// Applies the attribute-references substitution to a block macro target (the
+/// portion between the `::` and the `[` of an `image::`, `video::`, or
+/// `audio::` macro), honoring the [`attribute-missing`] document attribute.
+///
+/// Block macro targets are always a single line, so (unlike
+/// [`apply_attributes`]) there is no line splitting. Returns `None` when the
+/// target references a missing attribute under
+/// [`AttributeMissing::DropLine`] — signaling that the entire block should be
+/// dropped — and otherwise returns the substituted target.
+///
+/// [`attribute-missing`]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unresolved-references/#missing
+pub(crate) fn substitute_attributes_in_macro_target<'src>(
+    target: Span<'src>,
+    parser: &Parser,
+) -> Option<CowStr<'src>> {
+    let text = target.data();
+
+    // Without a reference there is nothing to substitute (and nothing that
+    // could trigger a drop), so the borrowed target is returned as-is.
+    if !text.contains('{') {
+        return Some(text.into());
+    }
+
+    let mode = AttributeMissing::from_parser(parser);
+
+    let mut replacer = AttributeReplacer {
+        parser,
+        mode,
+        source: target,
+        missing_on_line: false,
+    };
+
+    let replaced = ATTRIBUTE_REFERENCE.replace_all(text, replacer.by_ref());
+
+    if replacer.missing_on_line && mode == AttributeMissing::DropLine {
+        return None;
+    }
+
+    Some(replaced.into())
 }
 
 fn apply_character_replacements(

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -697,10 +697,10 @@ impl Parser {
         self.attribute_values.insert(attr_name, attribute_value);
     }
 
-    /// Called from [`Block::parse()`] to accept or reject an attribute value
-    /// from a document (body) attribute.
+    /// Called while parsing a block (see [`Block::parse_with_outcome()`]) to
+    /// accept or reject an attribute value from a document (body) attribute.
     ///
-    /// [`Block::parse()`]: crate::blocks::Block::parse
+    /// [`Block::parse_with_outcome()`]: crate::blocks::Block::parse_with_outcome
     pub(crate) fn set_attribute_from_body<'src>(
         &mut self,
         attr: &Attribute<'src>,

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -2702,25 +2702,17 @@ mod description_lists_dlist {
         }
 
         #[test]
-        #[ignore]
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/478):
-        // `attribute-missing` is now handled for inline content substitution
-        // (see `attributes::unresolved_references`), but this case additionally
-        // requires substituting attribute references in a *block macro target*
-        // (`image::{unresolved}[]`) and dropping the whole block when the target
-        // resolves to a missing attribute under `attribute-missing=drop-line`.
-        // That block-level drop mechanism is not yet implemented. Enable this
-        // test once it is.
         fn should_continue_to_parse_subsequent_blocks_attached_to_list_item_after_first_block_is_dropped()
          {
-            let _doc = Parser::default().parse(
+            let doc = Parser::default().parse(
                 ":attribute-missing: drop-line\n\nterm::\n+\nimage::{unresolved}[]\n+\nparagraph\n",
             );
-            todo!("assert_css: 'dl', output, 1");
-            todo!("assert_css: 'dl > dt', output, 1");
-            todo!("assert_css: 'dl > dt + dd', output, 1");
-            todo!("assert_css: 'dl > dt + dd > .imageblock', output, 0");
-            todo!("assert_css: 'dl > dt + dd > .paragraph', output, 1");
+
+            assert_css(&doc, "dl", 1);
+            assert_css(&doc, "dl > dt", 1);
+            assert_css(&doc, "dl > dt + dd", 1);
+            assert_css(&doc, "dl > dt + dd > .imageblock", 0);
+            assert_css(&doc, "dl > dt + dd > .paragraph", 1);
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Implements block-level `attribute-missing=drop-line` for block macro targets, the remaining piece after inline `attribute-missing` handling (#563). When a block macro target (`image::`, `video::`, `audio::`) contains a reference to a missing attribute and `attribute-missing=drop-line` is set, Asciidoctor drops the entire block — this PR matches that behavior. Closes #478.

Example — the `image::` block is dropped, the `paragraph` survives:

```adoc
:attribute-missing: drop-line

term::
+
image::{unresolved}[]
+
paragraph
```

## What changed

**1. Substituting attribute references in block-macro targets**
- `substitute_attributes_in_macro_target` (in `substitution_step.rs`) runs the attribute-references substitution over a single target span, reusing the existing `AttributeReplacer`/`AttributeMissing` machinery so all four `attribute-missing` modes (`skip`, `drop`, `drop-line`, `warn`) behave exactly as for inline content. Verified against the locally-installed `asciidoctor`.
- `MediaBlock` now stores a `resolved_target` (exposed via `resolved_target()`) alongside the raw `target()` span, which is unchanged.

**2. Dropping a whole block at parse time**
- New `BlockParseOutcome` enum (`Parsed` / `Dropped(after)` / `NoMatch`) threaded through `Block::parse_internal`. The previous `Option` couldn't distinguish "dropped" from "not this block type".
- `parse_blocks_until` and the list-continuation loop in `list_item.rs` advance past a dropped block without emitting one. In a list, a dropped block still consumes its `+` continuation so a following block re-attaches correctly.
- `Block::parse` is retained as a `#[cfg(test)]` `Option`-flattening wrapper; production code uses `parse_with_outcome`.

**3. Drive-by fix**
- The media dispatch in `block.rs` checked `video::` twice and never `audio::`, so `audio::` block macros silently parsed as paragraphs at the document level. Fixed (no test depended on the broken behavior).

## Testing
- Un-ignored `should_continue_to_parse_subsequent_blocks_attached_to_list_item_after_first_block_is_dropped` (lists_test) and filled in real `assert_css` assertions.
- Added 11 unit tests covering all four modes, defined/escaped/no-reference targets, top-level drop, audio drop, and list-continuation drop.
- Full suite (2433 passing, 70 ignored — down one), `clippy --all-targets`, `+nightly fmt --check`, `+nightly doc`, and the `sdd` spec-coverage tool all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)