### PR TITLE
feat: Complete ID-attribute features (xreflabel + inline shorthand ID registration)

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -250,7 +250,7 @@ impl<'src> Block<'src> {
 
             Self::register_block_id(
                 block.id(),
-                block.title(),
+                Self::block_reftext(&block),
                 block.span(),
                 parser,
                 &mut warnings,
@@ -315,7 +315,7 @@ impl<'src> Block<'src> {
 
                 Self::register_block_id(
                     block.id(),
-                    block.title(),
+                    Self::block_reftext(&block),
                     block.span(),
                     parser,
                     &mut warnings,
@@ -341,7 +341,7 @@ impl<'src> Block<'src> {
 
                 Self::register_block_id(
                     block.id(),
-                    block.title(),
+                    Self::block_reftext(&block),
                     block.span(),
                     parser,
                     &mut warnings,
@@ -367,7 +367,7 @@ impl<'src> Block<'src> {
 
                 Self::register_block_id(
                     block.id(),
-                    block.title(),
+                    Self::block_reftext(&block),
                     block.span(),
                     parser,
                     &mut warnings,
@@ -393,7 +393,7 @@ impl<'src> Block<'src> {
 
                 Self::register_block_id(
                     block.id(),
-                    block.title(),
+                    Self::block_reftext(&block),
                     block.span(),
                     parser,
                     &mut warnings,
@@ -419,7 +419,7 @@ impl<'src> Block<'src> {
 
                 Self::register_block_id(
                     block.id(),
-                    block.title(),
+                    Self::block_reftext(&block),
                     block.span(),
                     parser,
                     &mut warnings,
@@ -465,7 +465,7 @@ impl<'src> Block<'src> {
 
                     Self::register_block_id(
                         block.id(),
-                        block.title(),
+                        Self::block_reftext(&block),
                         block.span(),
                         parser,
                         &mut warnings,
@@ -592,7 +592,7 @@ impl<'src> Block<'src> {
         if let BlockParseOutcome::Parsed(ref matched_item) = result.item {
             Self::register_block_id(
                 matched_item.item.id(),
-                matched_item.item.title(),
+                Self::block_reftext(&matched_item.item),
                 matched_item.item.span(),
                 parser,
                 &mut result.warnings,
@@ -602,23 +602,32 @@ impl<'src> Block<'src> {
         result
     }
 
+    /// Determine the reftext (a.k.a. xreflabel) used as the link text when a
+    /// block is the target of a cross reference. Asciidoctor's precedence is:
+    /// an explicit `reftext` attribute, then the reftext supplied with a
+    /// block anchor (`[[id,reftext]]`), and finally the block title.
+    fn block_reftext<'a>(block: &'a Block<'a>) -> Option<&'a str> {
+        block
+            .attrlist()
+            .and_then(|attrlist| attrlist.named_attribute("reftext"))
+            .map(|attr| attr.value())
+            .or_else(|| block.anchor_reftext().map(|span| span.data()))
+            .or_else(|| block.title())
+    }
+
     /// Register a block's ID with the catalog if the block has an ID.
     ///
     /// This should be called for all block types except `SectionBlock`,
     /// which handles its own catalog registration.
     fn register_block_id(
         id: Option<&str>,
-        title: Option<&str>,
+        reftext: Option<&str>,
         span: Span<'src>,
         parser: &mut Parser,
         warnings: &mut Vec<Warning<'src>>,
     ) {
         if let Some(id) = id
-            && let Err(_duplicate_error) = parser.register_ref(
-                id,
-                title, // Use block title as reftext if available
-                RefType::Anchor,
-            )
+            && let Err(_duplicate_error) = parser.register_ref(id, reftext, RefType::Anchor)
         {
             // If registration fails due to duplicate ID, issue a warning.
             warnings.push(Warning {

--- a/parser/src/blocks/media.rs
+++ b/parser/src/blocks/media.rs
@@ -148,7 +148,7 @@ impl<'src> MediaBlock<'src> {
                     title_source: metadata.title_source,
                     title: metadata.title.clone(),
                     anchor: metadata.anchor,
-                    anchor_reftext: None,
+                    anchor_reftext: metadata.anchor_reftext,
                     attrlist: metadata.attrlist.clone(),
                 },
 

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -6,7 +6,7 @@ use crate::{
     Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     content::Content,
-    document::InterpretedValue,
+    document::{InterpretedValue, RefType},
     internal::{LookaheadReplacer, LookaheadResult, replace_with_lookahead},
     parser::{
         CalloutGuard, CalloutRenderParams, CharacterReplacementType, InlineSubstitutionRenderer,
@@ -378,6 +378,14 @@ impl LookaheadReplacer for QuoteReplacer<'_> {
                         .as_ref()
                         .and_then(|a| a.id().map(|s| s.to_string()));
 
+                    // Assigning an ID to inline quoted text (e.g.,
+                    // `[#free_the_world]#free the world#`) makes that phrase
+                    // referenceable, so register it in the catalog. A duplicate
+                    // ID here is non-fatal (first registration wins).
+                    if let Some(id) = &id {
+                        let _ = self.parser.register_ref(id, None, RefType::Anchor);
+                    }
+
                     self.parser.renderer.render_quoted_substitition(
                         type_, self.scope, attrlist, id, &caps[3], dest,
                     );
@@ -412,6 +420,14 @@ impl LookaheadReplacer for QuoteReplacer<'_> {
                 let id = attrlist
                     .as_ref()
                     .and_then(|a| a.id().map(|s| s.to_string()));
+
+                // Assigning an ID to inline quoted text (e.g.,
+                // `[#free_the_world]#free the world#`) makes that phrase
+                // referenceable, so register it in the catalog. A duplicate ID
+                // here is non-fatal (first registration wins).
+                if let Some(id) = &id {
+                    let _ = self.parser.register_ref(id, None, RefType::Anchor);
+                }
 
                 self.parser
                     .renderer

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -1243,6 +1243,25 @@ mod tests {
                 CowStr::Boxed(r#"<span id="id">a few words</span>"#.to_string().into_boxed_str())
             );
         }
+
+        #[test]
+        fn unconstrained_marked_string_with_id_is_registered() {
+            // An ID assigned to *unconstrained* quoted text (here, `##...##`)
+            // is rendered as the element's `id` and registered in the catalog
+            // so the phrase can be the target of a cross reference.
+            let doc = Parser::default().parse(r#"[#the_id]##marked text##"#);
+
+            assert_eq!(
+                doc.nested_blocks()
+                    .next()
+                    .unwrap()
+                    .rendered_content()
+                    .unwrap(),
+                r#"<span id="the_id">marked text</span>"#
+            );
+
+            assert!(doc.catalog().contains_id("the_id"));
+        }
     }
 
     mod attribute_references {

--- a/parser/src/tests/asciidoc_lang/attributes/element_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/element_attributes.rs
@@ -468,7 +468,17 @@ Specifically, it does not support named attributes, only the attribute shorthand
                 },
                 warnings: &[],
                 source_map: SourceMap(&[]),
-                catalog: Catalog::default(),
+                catalog: Catalog {
+                    refs: HashMap::from([(
+                        "idname",
+                        RefEntry {
+                            id: "idname",
+                            reftext: None,
+                            ref_type: crate::document::RefType::Anchor,
+                        },
+                    )]),
+                    reftext_to_id: HashMap::default(),
+                },
             }
         );
     }

--- a/parser/src/tests/asciidoc_lang/attributes/id.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/id.rs
@@ -1638,4 +1638,300 @@ include::example$id.adoc[tag=anchor-shorthand]
             }
         );
     }
+
+    #[test]
+    fn invalid_anchor_before_list_item() {
+        verifies!(
+            r#"
+=== On a list item
+
+In addition to being able to define anchors on sections and blocks, anchors can be defined inline wherever you can type normal text (anchors are a macros substitution).
+The anchors in the text get replaced with invisible anchor points in the output.
+
+For example, you would not put an anchor in front of a list item:
+
+.*Invalid* position for an anchor ID in front of a list item
+[source]
+----
+include::example$id.adoc[tag=anchor-wrong]
+----
+
+"#
+        );
+
+        // An anchor in front of a list marker does not produce a list item. The
+        // line is parsed as an ordinary paragraph: the inline anchor is rendered
+        // and registered, and the `*` is left as literal text.
+        let doc = Parser::default().parse("[[anchor-point]]* list item with invalid anchor");
+
+        let block = doc.nested_blocks().next().unwrap();
+        assert_eq!(
+            block.rendered_content().unwrap(),
+            "<a id=\"anchor-point\"></a>* list item with invalid anchor"
+        );
+
+        assert!(doc.catalog().contains_id("anchor-point"));
+    }
+
+    #[test]
+    fn anchor_on_list_item() {
+        verifies!(
+            r#"
+Instead, you would put it at the start of the text of the list item:
+
+.Define an inline anchor on a list item
+[source]
+----
+include::example$id.adoc[tag=anchor-list-item]
+----
+
+"#
+        );
+
+        // The inline anchor at the start of the principal text is rendered and
+        // registered as the list item's referenceable ID.
+        let doc = Parser::default().parse("* First item\n* [[step2]]Second item\n* Third item");
+
+        assert!(doc.catalog().contains_id("step2"));
+    }
+
+    #[test]
+    fn anchor_on_description_list_item() {
+        verifies!(
+            r#"
+For a description list, the anchor must be placed at the start of the term:
+
+.Define an inline anchor on a description list item
+[source]
+----
+include::example$id.adoc[tag=anchor-dlist-item]
+----
+
+"#
+        );
+
+        // The anchor at the start of each term is registered as the term's
+        // referenceable ID. Its reftext is the explicit value when one is given
+        // (`[[cpu,CPU]]`), otherwise the term text (`Hard drive`).
+        let doc = Parser::default().parse(
+            "[[cpu,CPU]]Central Processing Unit (CPU)::\nThe brain of the computer.\n\n[[hard-drive]]Hard drive::\nPermanent storage for operating system and/or user files.",
+        );
+
+        assert_eq!(
+            doc.catalog().get_ref("cpu").unwrap().reftext.as_deref(),
+            Some("CPU")
+        );
+        assert_eq!(
+            doc.catalog()
+                .get_ref("hard-drive")
+                .unwrap()
+                .reftext
+                .as_deref(),
+            Some("Hard drive")
+        );
+    }
+
+    #[test]
+    fn multiple_anchors_on_list_item() {
+        verifies!(
+            r#"
+You can add multiple anchors to a list item or description list term.
+However, only the first anchor is registered for use as an xref within the document.
+The remaining anchors are auxiliary and are used for making deep links (i.e., accessible from a URL fragment).
+
+"#
+        );
+
+        // Each anchor is rendered as an invisible anchor point and registered so
+        // that it can be the target of a deep link.
+        let doc = Parser::default().parse("* [[a1]][[a2]]Item");
+
+        assert!(doc.catalog().contains_id("a1"));
+        assert!(doc.catalog().contains_id("a2"));
+    }
+
+    #[test]
+    fn anchor_on_table_cell() {
+        verifies!(
+            r#"
+=== On a table cell
+
+You can assign an ID to a table cell by placing an inline anchor at the start of the cell.
+
+.Assigning an ID to a table cell using an inline anchor
+[source]
+----
+|===
+|[[my_cell]]The table cell I want to jump to.
+|===
+----
+
+"#
+        );
+
+        // The inline anchor at the start of the cell is registered as the cell's
+        // referenceable ID.
+        let doc =
+            Parser::default().parse("|===\n|[[my_cell]]The table cell I want to jump to.\n|===");
+
+        assert!(doc.catalog().contains_id("my_cell"));
+    }
+
+    #[test]
+    fn inline_image_adjacent_anchor_shorthand() {
+        verifies!(
+            r#"
+=== On an inline image
+
+You cannot currently define an ID on an inline image.
+Instead you need to place an inline anchor adjacent to it.
+
+.Placing an inline anchor adjacent to an inline image using shorthand
+[source]
+----
+include::example$id.adoc[tag=inline-anchor-brackets]
+----
+
+"#
+        );
+
+        // The anchor adjacent to the inline image is rendered as an anchor point
+        // immediately before the image and registered as a referenceable ID.
+        let doc = Parser::default().parse("[[tiger-image]]image:tiger.png[Image of a tiger]");
+
+        let block = doc.nested_blocks().next().unwrap();
+        assert_eq!(
+            block.rendered_content().unwrap(),
+            "<a id=\"tiger-image\"></a><span class=\"image\"><img src=\"tiger.png\" alt=\"Image of a tiger\"></span>"
+        );
+
+        assert!(doc.catalog().contains_id("tiger-image"));
+    }
+
+    #[test]
+    fn inline_image_adjacent_anchor_macro() {
+        verifies!(
+            r#"
+Instead of the shorthand form, you can use the macro `anchor` to achieve the same goal.
+
+.Placing an inline anchor adjacent to an inline image using a macro
+[source]
+----
+include::example$id.adoc[tag=inline-anchor-macro]
+----
+
+"#
+        );
+
+        // The `anchor` macro produces the same anchor point and registration as
+        // the shorthand form.
+        let doc = Parser::default().parse("anchor:tiger-image[]image:tiger.png[Image of a tiger]");
+
+        let block = doc.nested_blocks().next().unwrap();
+        assert_eq!(
+            block.rendered_content().unwrap(),
+            "<a id=\"tiger-image\"></a><span class=\"image\"><img src=\"tiger.png\" alt=\"Image of a tiger\"></span>"
+        );
+
+        assert!(doc.catalog().contains_id("tiger-image"));
+    }
+}
+
+mod add_additional_anchors_to_a_section {
+    use crate::tests::prelude::*;
+
+    #[test]
+    fn section_extra_anchors() {
+        verifies!(
+            r#"
+== Add additional anchors to a section
+
+To add additional anchors to a section (with or without an autogenerated ID), place the anchors in front of the title (without any spaces).
+
+.Add additional anchors to a section using inline anchors
+[source]
+----
+include::example$id.adoc[tag=anchor-header-extra]
+----
+
+"#
+        );
+
+        // The anchors placed in front of the title are registered as additional
+        // (auxiliary) referenceable IDs alongside the section's own ID.
+        let doc = Parser::default().parse("[#version-4_9]\n=== [[current]][[latest]]Version 4.9");
+
+        assert!(doc.catalog().contains_id("version-4_9"));
+        assert!(doc.catalog().contains_id("current"));
+        assert!(doc.catalog().contains_id("latest"));
+    }
+
+    non_normative!(
+        r#"
+CAUTION: You cannot use inline anchors in a section title to make internal references to that section.
+The processor will flag these as possible invalid references.
+These additional anchors are only intended for making deep links using an alternate ID.
+
+Remember that inline anchors are discovered wherever the macros substitution is applied (e.g., paragraph text).
+If text content doesn't belong somewhere, neither does an inline anchor point.
+
+"#
+    );
+}
+
+mod customize_automatic_xreftext {
+    use crate::tests::prelude::*;
+
+    non_normative!(
+        r#"
+== Customize automatic xreftext
+
+It's possible to customize the text that will be used in the cross reference link (called `xreflabel`).
+If not defined, the AsciiDoc processor does it best to find suitable text (the solution differs from case to case).
+In case of an image, the image caption will be used.
+In case of a section header, the text of the section's title will be used.
+
+To define the `xreflabel`, add it in the anchor definition right after the ID (separated by a comma).
+
+"#
+    );
+
+    #[test]
+    fn anchor_xreflabel() {
+        verifies!(
+            r#"
+.An anchor ID with a defined xreflabel. The caption will not be used as link text.
+[source]
+----
+include::example$id.adoc[tag=anchor-xreflabel]
+----
+"#
+        );
+
+        // The reftext supplied after the ID (the `xreflabel`) is used as the
+        // cross-reference link text in preference to the image caption.
+        let doc = Parser::default().parse(
+            "[[tiger-image,Image of a tiger]]\n.This image represents a Bengal tiger also called the Indian tiger\nimage::tiger.png[]\n\nSee <<tiger-image>>.",
+        );
+
+        assert_eq!(
+            doc.catalog()
+                .get_ref("tiger-image")
+                .unwrap()
+                .reftext
+                .as_deref(),
+            Some("Image of a tiger")
+        );
+
+        let xref_paragraph = doc
+            .nested_blocks()
+            .filter_map(|block| block.rendered_content())
+            .find(|rendered| rendered.contains("href"))
+            .unwrap();
+
+        assert_eq!(
+            xref_paragraph,
+            "See <a href=\"#tiger-image\">Image of a tiger</a>."
+        );
+    }
 }

--- a/parser/src/tests/asciidoc_lang/attributes/id.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/id.rs
@@ -845,7 +845,17 @@ The id (`#`) shorthand can be used on inline quoted text.
                 },
                 warnings: &[],
                 source_map: SourceMap(&[]),
-                catalog: Catalog::default(),
+                catalog: Catalog {
+                    refs: HashMap::from([(
+                        "free_the_world",
+                        RefEntry {
+                            id: "free_the_world",
+                            reftext: None,
+                            ref_type: crate::document::RefType::Anchor,
+                        },
+                    )]),
+                    reftext_to_id: HashMap::default(),
+                },
             }
         );
     }
@@ -1282,7 +1292,17 @@ The shorthand form in an attribute list does not impose this restriction.
                 },
                 warnings: &[],
                 source_map: SourceMap(&[]),
-                catalog: Catalog::default(),
+                catalog: Catalog {
+                    refs: HashMap::from([(
+                        "1start_with_number",
+                        RefEntry {
+                            id: "1start_with_number",
+                            reftext: None,
+                            ref_type: crate::document::RefType::Anchor,
+                        },
+                    )]),
+                    reftext_to_id: HashMap::default(),
+                },
             }
         );
     }
@@ -1634,7 +1654,17 @@ include::example$id.adoc[tag=anchor-shorthand]
                 },
                 warnings: &[],
                 source_map: SourceMap(&[]),
-                catalog: Catalog::default(),
+                catalog: Catalog {
+                    refs: HashMap::from([(
+                        "bookmark-b",
+                        RefEntry {
+                            id: "bookmark-b",
+                            reftext: None,
+                            ref_type: crate::document::RefType::Anchor,
+                        },
+                    )]),
+                    reftext_to_id: HashMap::default(),
+                },
             }
         );
     }

--- a/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
@@ -586,7 +586,17 @@ Formatted text does not support a style, so the first and only positional attrib
                 },
                 warnings: &[],
                 source_map: SourceMap(&[]),
-                catalog: Catalog::default(),
+                catalog: Catalog {
+                    refs: HashMap::from([(
+                        "free-world",
+                        RefEntry {
+                            id: "free-world",
+                            reftext: None,
+                            ref_type: crate::document::RefType::Anchor,
+                        },
+                    )]),
+                    reftext_to_id: HashMap::default(),
+                },
             }
         );
     }


### PR DESCRIPTION
## Summary

Implements the remaining features documented on [`docs/modules/attributes/pages/id.adoc`](https://github.com/asciidoc-rs/asciidoc-parser/blob/main/docs/modules/attributes/pages/id.adoc) and fixes two cross-reference gaps that were left incomplete because ID references were not fully implemented. The `id.adoc` page is now at 100% line coverage in the SDD tool.

Most of the page already worked (inline anchors on list items, description-list terms, table cells, and inline images; additional anchors in front of a section title). This PR adds spec coverage for all of those sections and fixes the two cases below. Expected outputs were verified against Ruby Asciidoctor 2.0.23.

## Fix 1 — block anchor reftext (xreflabel) was dropped

The **Customize automatic xreftext** section documents defining an `xreflabel` via `[[id,reftext]]`. That reftext was discarded, so a cross reference to the block rendered the `[id]` fallback instead of the label:

```adoc
[[tiger-image,Image of a tiger]]
image::tiger.png[]

See <<tiger-image>>.
```

| | link text |
|---|---|
| Before | `<a href="#tiger-image">[tiger-image]</a>` |
| After (and Ruby Asciidoctor) | `<a href="#tiger-image">Image of a tiger</a>` |

- `MediaBlock` now preserves `metadata.anchor_reftext` instead of setting it to `None`.
- `Block::register_block_id` registers the reftext using Asciidoctor's precedence — explicit `reftext` attribute → block anchor reftext (`[[id,reftext]]`) → block title — instead of only the title. (Title remains the fallback, so existing behavior is preserved.)

## Fix 2 — inline shorthand IDs were not registered

An ID assigned to inline quoted text via the shorthand syntax was rendered as an `id` attribute but never registered in the catalog, so cross references to it didn't resolve:

```adoc
[#free_the_world]#free the world#

See <<free_the_world>>.
```

Now the ID is registered (in the quoted-text substitution step, both constrained and unconstrained scopes), matching Ruby Asciidoctor, so `<<free_the_world>>` resolves. Duplicate IDs are non-fatal here (first registration wins), consistent with the existing `[[id]]` / `anchor:` inline anchor handling. Spec-coverage fixtures that previously asserted an empty catalog for these cases are updated.

## Tests

- New spec-coverage tests in `tests/asciidoc_lang/attributes/id.rs` for: anchor on a list item (and the invalid-position case), description-list term, multiple anchors, table cell, inline image (shorthand and `anchor:` macro), additional section anchors, and the xreflabel behavior.
- Updated fixtures in `id.rs`, `element_attributes.rs`, and `positional_and_named_attributes.rs` to reflect inline shorthand ID registration.
- Full suite: **2433 passed, 0 failed**. `cargo +nightly fmt --check`, `cargo clippy`, and `cargo +nightly doc` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)