### PR TITLE
feat: Implement all predefined character replacement attributes

### DIFF
--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -8,59 +8,62 @@ use crate::{
 pub(super) fn built_in_attrs() -> HashMap<String, AttributeValue> {
     let mut attrs: HashMap<String, AttributeValue> = HashMap::new();
 
-    attrs.insert(
-        "blank".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::ApiOnly,
-            value: InterpretedValue::Value("".into()),
-        },
-    );
+    // ## Character replacement attributes
+    //
+    // These provide portable replacements for common typographical marks,
+    // non-visible characters, escapes for characters with special meaning in
+    // AsciiDoc, and passthroughs for characters that get encoded by default.
+    // See `docs/modules/attributes/pages/character-replacement-ref.adoc`.
+    //
+    // The entries below are listed in the same order they appear on that
+    // reference page. The replacement values match Ruby Asciidoctor's
+    // `INTRINSIC_ATTRIBUTES` table (e.g. `cpp` resolves to `C&#43;&#43;`, not a
+    // literal `C++`).
+    let char_replacement = |value: &str| AttributeValue {
+        allowable_value: AllowableValue::Any,
+        modification_context: ModificationContext::ApiOnly,
+        value: InterpretedValue::Value(value.into()),
+    };
 
-    attrs.insert(
-        "empty".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::ApiOnly,
-            value: InterpretedValue::Value("".into()),
-        },
-    );
+    // `blank` is an alias for `empty` for those who find this terminology
+    // clearer.
+    attrs.insert("blank".to_owned(), char_replacement(""));
+    attrs.insert("empty".to_owned(), char_replacement(""));
+    attrs.insert("sp".to_owned(), char_replacement(" "));
+    attrs.insert("nbsp".to_owned(), char_replacement("&#160;"));
+    attrs.insert("zwsp".to_owned(), char_replacement("&#8203;"));
+    attrs.insert("wj".to_owned(), char_replacement("&#8288;"));
+    attrs.insert("apos".to_owned(), char_replacement("&#39;"));
+    attrs.insert("quot".to_owned(), char_replacement("&#34;"));
+    attrs.insert("lsquo".to_owned(), char_replacement("&#8216;"));
+    attrs.insert("rsquo".to_owned(), char_replacement("&#8217;"));
+    attrs.insert("ldquo".to_owned(), char_replacement("&#8220;"));
+    attrs.insert("rdquo".to_owned(), char_replacement("&#8221;"));
+    attrs.insert("deg".to_owned(), char_replacement("&#176;"));
+    attrs.insert("plus".to_owned(), char_replacement("&#43;"));
+    attrs.insert("brvbar".to_owned(), char_replacement("&#166;"));
+    attrs.insert("vbar".to_owned(), char_replacement("|"));
+    attrs.insert("amp".to_owned(), char_replacement("&"));
+    attrs.insert("lt".to_owned(), char_replacement("<"));
+    attrs.insert("gt".to_owned(), char_replacement(">"));
+    attrs.insert("startsb".to_owned(), char_replacement("["));
+    attrs.insert("endsb".to_owned(), char_replacement("]"));
+    attrs.insert("caret".to_owned(), char_replacement("^"));
+    attrs.insert("asterisk".to_owned(), char_replacement("*"));
+    attrs.insert("tilde".to_owned(), char_replacement("~"));
+    attrs.insert("backslash".to_owned(), char_replacement("\\"));
+    attrs.insert("backtick".to_owned(), char_replacement("`"));
+    attrs.insert("two-colons".to_owned(), char_replacement("::"));
+    attrs.insert("two-semicolons".to_owned(), char_replacement(";;"));
+    // `cpp` is deprecated in favor of `cxx`; both resolve to the same value.
+    attrs.insert("cpp".to_owned(), char_replacement("C&#43;&#43;"));
+    attrs.insert("cxx".to_owned(), char_replacement("C&#43;&#43;"));
+    attrs.insert("pp".to_owned(), char_replacement("&#43;&#43;"));
 
-    attrs.insert(
-        "sp".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::ApiOnly,
-            value: InterpretedValue::Value(" ".into()),
-        },
-    );
-
-    attrs.insert(
-        "vbar".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::ApiOnly,
-            value: InterpretedValue::Value("|".into()),
-        },
-    );
-
-    attrs.insert(
-        "deg".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::ApiOnly,
-            value: InterpretedValue::Value("&#176;".into()),
-        },
-    );
-
-    attrs.insert(
-        "plus".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::ApiOnly,
-            value: InterpretedValue::Value("&#43;".into()),
-        },
-    );
+    // ## Other predefined document attributes
+    //
+    // These configure processor behavior rather than performing character
+    // replacement. Order is not significant.
 
     attrs.insert(
         "toc".to_owned(),

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -1,11 +1,31 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::LazyLock};
 
 use crate::{
     document::InterpretedValue,
     parser::{AllowableValue, AttributeValue, ModificationContext},
 };
 
+/// The built-in attribute table is identical for every parser, so build it
+/// once and hand out cheap clones. Cloning copies the hash table layout
+/// without re-hashing each key, which matters because [`Parser::default`]
+/// (and therefore this function) is called once per parse.
+///
+/// [`Parser::default`]: crate::Parser::default
+static BUILT_IN_ATTRS: LazyLock<HashMap<String, AttributeValue>> =
+    LazyLock::new(build_built_in_attrs);
+
+static BUILT_IN_DEFAULT_VALUES: LazyLock<HashMap<String, String>> =
+    LazyLock::new(build_built_in_default_values);
+
 pub(super) fn built_in_attrs() -> HashMap<String, AttributeValue> {
+    BUILT_IN_ATTRS.clone()
+}
+
+pub(super) fn built_in_default_values() -> HashMap<String, String> {
+    BUILT_IN_DEFAULT_VALUES.clone()
+}
+
+fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
     let mut attrs: HashMap<String, AttributeValue> = HashMap::new();
 
     // ## Character replacement attributes
@@ -171,7 +191,7 @@ pub(super) fn built_in_attrs() -> HashMap<String, AttributeValue> {
     attrs
 }
 
-pub(super) fn built_in_default_values() -> HashMap<String, String> {
+fn build_built_in_default_values() -> HashMap<String, String> {
     let mut defaults: HashMap<String, String> = HashMap::new();
 
     defaults.insert("example-caption".to_owned(), "Example".to_owned());

--- a/parser/src/tests/asciidoc_lang/attributes/character_replacement_ref.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/character_replacement_ref.rs
@@ -1,0 +1,243 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/attributes/pages/character-replacement-ref.adoc");
+
+non_normative!(
+    r#"
+= Character Replacement Attributes Reference
+:page-aliases: character-replacement-reference.adoc
+
+This page identifies built-in document attributes populated by the AsciiDoc processor that are geared towards character replacement.
+
+This category of attributes provide portable replacements for common typographical marks (e.g., smart quotes and symbols) and non-visible characters (e.g., empty and no break space), an escaping mechanism for characters which have special meaning in AsciiDoc (e.g., plus and colon), and passthroughs for characters which get encoded by default (e.g., less than and greater than).
+Like all document attributes, you can insert the value of any one of these attributes in your content using an xref:reference-attributes.adoc#reference-built-in[attribute reference] (e.g., `\{nbsp}`).
+
+NOTE: The AsciiDoc processor does not prevent you from reassigning these predefined attributes.
+However, you're encouraged to treat them as read-only.
+Only a converter should override these attributes if the output format requires the use of a different encoding scheme.
+
+"#
+);
+
+#[test]
+fn built_in_character_replacement_attributes() {
+    verifies!(
+        r#"
+.Built-in document attributes for character replacement
+[%autowidth,cols="^~m,^~l,^~"]
+|===
+|Attribute name |Replacement text |Appearance
+
+d|``blank``^[1]^
+e|nothing
+|{empty}
+
+|empty
+e|nothing
+|{empty}
+
+|sp
+e|space
+|{sp}
+
+|nbsp
+|&#160;
+|{nbsp}
+
+d|``zwsp``^[2]^
+|&#8203;
+|{zwsp}
+
+d|``wj``^[3]^
+|&#8288;
+|{wj}
+
+|apos
+|&#39;
+|{apos}
+
+|quot
+|&#34;
+|{quot}
+
+|lsquo
+|&#8216;
+|{lsquo}
+
+|rsquo
+|&#8217;
+|{rsquo}
+
+|ldquo
+|&#8220;
+|{ldquo}
+
+|rdquo
+|&#8221;
+|{rdquo}
+
+|deg
+|&#176;
+|{deg}
+
+|plus
+|&#43;
+|{plus}
+
+|brvbar
+|&#166;
+|&#166;
+
+|vbar
+|\|
+|{vbar}
+
+|amp
+|&
+|&
+
+|lt
+|<
+|<
+
+|gt
+|>
+|>
+
+|startsb
+|[
+|[
+
+|endsb
+|]
+|]
+
+|caret
+|^
+|^
+
+|asterisk
+|*
+|*
+
+|tilde
+|~
+|~
+
+|backslash
+|\
+|\
+
+|backtick
+|`
+|`
+
+|two-colons
+|::
+|::
+
+|two-semicolons
+|;;
+|;;
+
+|cpp (deprecated)
+|C++
+|C++
+
+|cxx
+|C++
+|C++
+
+|pp
+|&#43;&#43;
+|&#43;&#43;
+|===
+
+"#
+    );
+
+    // The replacement values match Ruby Asciidoctor's `INTRINSIC_ATTRIBUTES`
+    // table. Note that the page's "Replacement text" column is illustrative:
+    // the stored value for `cpp`/`cxx` is `C&#43;&#43;` (so the `+` characters
+    // are not subject to further substitution), even though the column renders
+    // it as `C++`.
+    let parser = Parser::default();
+
+    let cases: &[(&str, &str)] = &[
+        ("blank", ""),
+        ("empty", ""),
+        ("sp", " "),
+        ("nbsp", "&#160;"),
+        ("zwsp", "&#8203;"),
+        ("wj", "&#8288;"),
+        ("apos", "&#39;"),
+        ("quot", "&#34;"),
+        ("lsquo", "&#8216;"),
+        ("rsquo", "&#8217;"),
+        ("ldquo", "&#8220;"),
+        ("rdquo", "&#8221;"),
+        ("deg", "&#176;"),
+        ("plus", "&#43;"),
+        ("brvbar", "&#166;"),
+        ("vbar", "|"),
+        ("amp", "&"),
+        ("lt", "<"),
+        ("gt", ">"),
+        ("startsb", "["),
+        ("endsb", "]"),
+        ("caret", "^"),
+        ("asterisk", "*"),
+        ("tilde", "~"),
+        ("backslash", "\\"),
+        ("backtick", "`"),
+        ("two-colons", "::"),
+        ("two-semicolons", ";;"),
+        ("cpp", "C&#43;&#43;"),
+        ("cxx", "C&#43;&#43;"),
+        ("pp", "&#43;&#43;"),
+    ];
+
+    for (name, expected) in cases {
+        assert_eq!(
+            parser.attribute_value(name).as_maybe_str(),
+            Some(*expected),
+            "built-in character replacement attribute `{name}` should resolve to its documented value",
+        );
+    }
+}
+
+#[test]
+fn reference_a_character_replacement_attribute() {
+    // An attribute reference is replaced verbatim with the attribute's value,
+    // so `{deg}` is rendered as the numeric character reference `&#176;`.
+    let mut parser = Parser::default();
+    let doc = parser.parse("Wolpertingers don't like temperatures above 100{deg}C.");
+
+    let block = doc.nested_blocks().next().unwrap();
+    let crate::blocks::Block::Simple(block) = block else {
+        panic!("expected a simple block");
+    };
+
+    assert_eq!(
+        block.content().rendered(),
+        "Wolpertingers don&#8217;t like temperatures above 100&#176;C."
+    );
+}
+
+non_normative!(
+    r#"
+^[1]^ An alias for the attribute `empty`, for those who find this terminology clearer.
+
+^[2]^ The Zero Width Space (ZWSP) is a code point in Unicode that shows where a long word can be split if necessary.
+
+^[3]^ The word joiner (WJ) is a code point in Unicode that prevents a line break at its position.
+
+Notice that some replacement values are Unicode characters, whereas others are numeric character references (e.g., \&#34;).
+The numeric character reference is when the Unicode character could interfere with the AsciiDoc syntax.
+In this case, it's the responsibility of the converter to transform that numeric character reference into a format that is compatible with the output format.
+For example, in the man page converter, each character reference is replaced with a troff macro.
+
+Thus, the abstraction of using AsciiDoc attributes for character replacements not only gives the author control over how the document is interpreted, it also helps decouple content and presentation.
+In other words, it's more portable to use an attribute reference in the content rather than hardcode a numeric character reference.
+"#
+);

--- a/parser/src/tests/asciidoc_lang/attributes/mod.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/mod.rs
@@ -3,6 +3,7 @@ mod attribute_entries;
 mod attribute_entry_substitutions;
 mod boolean_attributes;
 mod built_in_attributes;
+mod character_replacement_ref;
 mod custom_attributes;
 mod document_attributes;
 mod element_attributes;


### PR DESCRIPTION
## Summary

Implements all remaining predefined character replacement document attributes documented in [`character-replacement-ref.adoc`](docs/modules/attributes/pages/character-replacement-ref.adoc).

Previously only `blank`, `empty`, `sp`, `vbar`, `deg`, and `plus` were defined. This adds the rest: `nbsp`, `zwsp`, `wj`, `apos`, `quot`, `lsquo`, `rsquo`, `ldquo`, `rdquo`, `brvbar`, `amp`, `lt`, `gt`, `startsb`, `endsb`, `caret`, `asterisk`, `tilde`, `backslash`, `backtick`, `two-colons`, `two-semicolons`, `cpp`, `cxx`, and `pp`.

## Details

- **Grouping & ordering** — In `built_in_attrs.rs`, the character replacement attributes are now collected into one group, defined in the same order they appear on the reference page. The other predefined attributes (`toc`, `sectids`, …) are kept in a separate group. A small `char_replacement` helper removes the per-attribute boilerplate.
- **Values follow Asciidoctor** — Replacement values match Ruby Asciidoctor's `INTRINSIC_ATTRIBUTES` table, verified against `asciidoctor` 2.0.23. Note that the page's "Replacement text" column is illustrative: `cpp`/`cxx` actually store `C&#43;&#43;` (not a literal `C++`) so the `+` characters aren't subject to further substitution. `cxx` is not defined by Asciidoctor 2.0.23 but is listed on the spec page, so it is implemented here as an equivalent of `cpp`.
- **Spec coverage** — Adds `character_replacement_ref.rs`, which tracks `character-replacement-ref.adoc` (which previously had zero coverage). It verifies every attribute resolves to its documented value and that an attribute reference renders verbatim.

## Testing

- `cargo test -p asciidoc-parser --lib` — all pass
- `cargo +nightly fmt --check`, `cargo clippy --all-targets` — clean
- `cd sdd && cargo run` — `character-replacement-ref.adoc` now fully covered (no uncovered lines)
- Replacement values cross-checked against `asciidoctor` 2.0.23

🤖 Generated with [Claude Code](https://claude.com/claude-code)