### PR TITLE
feat: Implement counter attribute references

### DIFF
--- a/parser/src/blocks/caption.rs
+++ b/parser/src/blocks/caption.rs
@@ -43,13 +43,21 @@ pub(crate) fn caption_attribute_name(context: &str) -> Option<&'static str> {
 /// The `prefix` is the text prepended to the block's title (e.g. `"Example 1.
 /// "`, including the trailing separator and space). The `number` is the bare
 /// counter value (e.g. `1`); it is `None` when an explicit caption override is
-/// in effect, since overrides are not numbered.
+/// in effect (overrides are not numbered) and also when an auto-numbered
+/// block's context counter holds a non-integer value (see [`Caption::number`]).
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct Caption {
     /// The caption prefix prepended to the title (e.g. `"Example 1. "`).
     pub(crate) prefix: String,
 
-    /// The bare counter value, or `None` for an explicit (unnumbered) caption.
+    /// The bare counter value, or `None` when the block is not numbered.
+    ///
+    /// This is `None` for an explicit (unnumbered) caption override. Because a
+    /// context's caption number is the document attribute `<context>-number`
+    /// (shared with `{counter:<context>-number}`), it is *also* `None` for an
+    /// auto-numbered block when that attribute has been set to a non-integer
+    /// value (e.g. `:table-number: A`): the prefix still shows the value, but
+    /// there is no bare integer to expose here.
     pub(crate) number: Option<usize>,
 }
 
@@ -158,10 +166,13 @@ pub(crate) fn assign_caption(
     // receives no caption and no number.
     match parser.attribute_value(attr_name) {
         InterpretedValue::Value(label) if !label.is_empty() => {
-            let number = parser.increment_counter(&format!("{context}-number"));
+            // The caption number is the counter named `<context>-number`, shared
+            // with any `{counter:<context>-number}` reference in the document.
+            let value = parser.counter(&format!("{context}-number"), None);
+            let prefix = format!("{label} {value}. ");
             Some(Caption {
-                prefix: format!("{label} {number}. "),
-                number: Some(number),
+                prefix,
+                number: value.parse::<usize>().ok(),
             })
         }
         _ => None,

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -464,8 +464,11 @@ fn apply_quotes(content: &mut Content<'_>, parser: &Parser) {
 }
 
 static ATTRIBUTE_REFERENCE: LazyLock<Regex> = LazyLock::new(|| {
+    // Either a `counter`/`counter2` directive (group 1) with its `name[:seed]`
+    // expression (group 2), or a plain attribute name (group 3). This mirrors
+    // the `counter2?:` branch of Asciidoctor's `AttributeReferenceRx`.
     #[allow(clippy::unwrap_used)]
-    Regex::new(r#"\\?\{([A-Za-z0-9_][A-Za-z0-9_-]*)\}"#).unwrap()
+    Regex::new(r#"\\?\{(?:(counter2?):([^{}]+)|([A-Za-z0-9_][A-Za-z0-9_-]*))\}"#).unwrap()
 });
 
 /// How the processor handles a reference to a missing attribute, controlled by
@@ -527,7 +530,34 @@ struct AttributeReplacer<'p> {
 impl Replacer for AttributeReplacer<'_> {
     fn replace_append(&mut self, caps: &Captures<'_>, dest: &mut String) {
         let escaped = caps[0].starts_with('\\');
-        let attr_name = &caps[1];
+
+        // A `counter`/`counter2` directive resolves (and advances) a counter
+        // rather than looking up an existing attribute.
+        if let Some(directive) = caps.get(1) {
+            if escaped {
+                // An escaped counter reference is emitted literally (without the
+                // backslash) and does not advance the counter.
+                dest.push_str(&caps[0][1..]);
+                return;
+            }
+
+            // Group 2 always participates when group 1 does (same alternation
+            // branch). The expression is `name` or `name:seed`.
+            let mut parts = caps[2].splitn(2, ':');
+            let name = parts.next().unwrap_or_default();
+            let seed = parts.next();
+
+            let value = self.parser.counter(name, seed);
+
+            // `counter` displays the new value; `counter2` advances silently.
+            if directive.as_str() == "counter" {
+                dest.push_str(&value);
+            }
+            return;
+        }
+
+        // Otherwise this is a plain attribute reference (group 3).
+        let attr_name = &caps[3];
 
         if !self.parser.has_attribute(attr_name) {
             // An escaped reference (e.g. `\{id}`) to an attribute that isn't set
@@ -1334,6 +1364,39 @@ mod tests {
             assert_eq!(
                 content.rendered,
                 CowStr::Boxed("bl{sp}ah".to_string().into_boxed_str())
+            );
+        }
+
+        #[test]
+        fn counter_directive_displays_and_advances() {
+            let mut content = Content::from(crate::Span::new("{counter:n}-{counter:n}"));
+            let p = Parser::default();
+            SubstitutionStep::AttributeReferences.apply(&mut content, &p, None);
+            assert_eq!(
+                content.rendered,
+                CowStr::Boxed("1-2".to_string().into_boxed_str())
+            );
+        }
+
+        #[test]
+        fn counter2_directive_advances_silently() {
+            let mut content = Content::from(crate::Span::new("{counter2:n}{counter:n}"));
+            let p = Parser::default();
+            SubstitutionStep::AttributeReferences.apply(&mut content, &p, None);
+            assert_eq!(
+                content.rendered,
+                CowStr::Boxed("2".to_string().into_boxed_str())
+            );
+        }
+
+        #[test]
+        fn escaped_counter_directive_is_literal_and_does_not_advance() {
+            let mut content = Content::from(crate::Span::new("\\{counter:n} {counter:n}"));
+            let p = Parser::default();
+            SubstitutionStep::AttributeReferences.apply(&mut content, &p, None);
+            assert_eq!(
+                content.rendered,
+                CowStr::Boxed("{counter:n} 1".to_string().into_boxed_str())
             );
         }
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -67,15 +67,25 @@ pub struct Parser {
     /// child sections as a normal section or appendix.)
     pub(crate) topmost_section_type: SectionType,
 
-    /// Per-context counters for captioned blocks, keyed by counter name (e.g.
-    /// `example-number`, `table-number`).
+    /// Live values of [counter] attributes, keyed by counter name (e.g.
+    /// `index`, `example-number`, `table-number`).
     ///
-    /// Each captionable block context (example, table, …) maintains an
-    /// independent, document-wide sequence. A counter is incremented each time
-    /// a block of that context receives an automatically numbered caption
-    /// (e.g. "Example 1.", "Table 1."). This mirrors Asciidoctor's
-    /// per-context `Document#counters`.
-    pub(crate) counters: HashMap<String, usize>,
+    /// A counter is a specialized document attribute: its value is *also* the
+    /// value of the document attribute of the same name. Counters are resolved
+    /// (and advanced) deep inside the attribute-reference substitution step,
+    /// where only a shared `&Parser` is available, so the new value is recorded
+    /// here through a [`RefCell`] and read back as an attribute by
+    /// [`attribute_value()`]. An explicit attribute assignment to a counter's
+    /// name supersedes this overlay (and is what allows `:!name:` to reset a
+    /// counter), so every attribute setter clears the matching entry.
+    ///
+    /// Captioned blocks (example, table, …) are numbered with this same
+    /// mechanism: each context's caption number is the counter named
+    /// `<context>-number`, mirroring Asciidoctor's `Document#counter`.
+    ///
+    /// [counter]: https://docs.asciidoctor.org/asciidoc/latest/attributes/counters/
+    /// [`attribute_value()`]: Self::attribute_value
+    pub(crate) counter_values: RefCell<HashMap<String, String>>,
 
     /// Canonical names of attributes that are locked against modification from
     /// the document body for the current scope.
@@ -172,7 +182,7 @@ impl Default for Parser {
             },
             sectnumlevels: 3,
             topmost_section_type: SectionType::Normal,
-            counters: HashMap::new(),
+            counter_values: RefCell::new(HashMap::new()),
             locked_attribute_names: HashSet::new(),
             nested_document_depth: 0,
             callouts: RefCell::new(CalloutCatalog::default()),
@@ -256,8 +266,8 @@ impl Parser {
         // Reset section numbering for each new document.
         self.last_section_number = SectionNumber::default();
 
-        // Reset captioned-block numbering for each new document.
-        self.counters.clear();
+        // Reset counter (and captioned-block) numbering for each new document.
+        self.counter_values.borrow_mut().clear();
 
         Document::parse(&preprocessed_source, source_map, self)
     }
@@ -287,6 +297,13 @@ impl Parser {
     ///
     /// [document attribute]: https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes/
     pub fn attribute_value<N: AsRef<str>>(&self, name: N) -> InterpretedValue {
+        // A counter's current value lives in the overlay and supersedes any
+        // earlier value of the attribute of the same name (see
+        // [`counter_values`](Self::counter_values)).
+        if let Some(value) = self.counter_values.borrow().get(name.as_ref()) {
+            return InterpretedValue::Value(value.clone());
+        }
+
         self.attribute_values
             .get(name.as_ref())
             .map(|av| av.value.clone())
@@ -306,7 +323,8 @@ impl Parser {
     ///
     /// [document attribute]: https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes/
     pub fn has_attribute<N: AsRef<str>>(&self, name: N) -> bool {
-        self.attribute_values.contains_key(name.as_ref())
+        self.counter_values.borrow().contains_key(name.as_ref())
+            || self.attribute_values.contains_key(name.as_ref())
     }
 
     /// Returns `true` if the parser has a [document attribute] by this name
@@ -315,6 +333,11 @@ impl Parser {
     /// [document attribute]: https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes/
     /// [unset]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unset-attributes/
     pub fn is_attribute_set<N: AsRef<str>>(&self, name: N) -> bool {
+        // A counter always holds a concrete (set) value.
+        if self.counter_values.borrow().contains_key(name.as_ref()) {
+            return true;
+        }
+
         self.attribute_values
             .get(name.as_ref())
             .map(|a| a.value != InterpretedValue::Unset)
@@ -670,6 +693,10 @@ impl Parser {
             value,
         };
 
+        // An explicit assignment supersedes (and resets) any counter of the same
+        // name.
+        self.counter_values.borrow_mut().remove(&attr_name);
+
         let is_doctype = attr_name == "doctype";
         self.attribute_values.insert(attr_name, attribute_value);
         if is_doctype {
@@ -694,6 +721,7 @@ impl Parser {
             value: InterpretedValue::Value(value.as_ref().to_owned()),
         };
 
+        self.counter_values.borrow_mut().remove(&attr_name);
         self.attribute_values.insert(attr_name, attribute_value);
     }
 
@@ -733,6 +761,10 @@ impl Parser {
             value: attr.value().clone(),
         };
 
+        // An explicit assignment supersedes (and resets) any counter of the same
+        // name. This is what lets `:!name:` reset a counter.
+        self.counter_values.borrow_mut().remove(&attr_name);
+
         let is_doctype = attr_name == "doctype";
         self.attribute_values.insert(attr_name, attribute_value);
         if is_doctype {
@@ -758,18 +790,124 @@ impl Parser {
         }
     }
 
-    /// Increments the document-wide counter named `name` and returns its new
-    /// value.
+    /// Resolves a [counter] of the given `name`, advancing it to the next value
+    /// in its sequence and returning that value.
     ///
-    /// Captioned blocks are numbered in document order within their context,
-    /// but only those that actually receive an automatically numbered caption
-    /// consume a number. This mirrors Asciidoctor's
-    /// `Document#increment_and_store_counter`.
-    pub(crate) fn increment_counter(&mut self, name: &str) -> usize {
-        let counter = self.counters.entry(name.to_string()).or_insert(0);
-        *counter += 1;
-        *counter
+    /// A counter is a specialized document attribute: its value is stored as
+    /// (and read back from) the attribute of the same name, so a later
+    /// `{name}` reference shows the current value and an attribute assignment
+    /// such as `:!name:` resets it. Each resolution advances the counter:
+    ///
+    /// * an integer value is incremented (`1` -> `2`);
+    /// * any other value is advanced like Ruby's `String#succ` (`a` -> `b`, `z`
+    ///   -> `aa`, `Az` -> `Ba`), matching Asciidoctor.
+    ///
+    /// `seed` (from the `{counter:name:seed}` form) supplies the first value,
+    /// but only when the counter is currently unset; otherwise it is ignored.
+    /// With no seed the sequence starts at `1`.
+    ///
+    /// This mirrors Asciidoctor's `Document#counter`.
+    ///
+    /// [counter]: https://docs.asciidoctor.org/asciidoc/latest/attributes/counters/
+    pub(crate) fn counter(&self, name: &str, seed: Option<&str>) -> String {
+        let next = match self.attribute_value(name) {
+            InterpretedValue::Value(current) if !current.is_empty() => next_counter_value(&current),
+            _ => match seed {
+                Some(seed) if !seed.is_empty() => seed.to_string(),
+                _ => "1".to_string(),
+            },
+        };
+
+        self.counter_values
+            .borrow_mut()
+            .insert(name.to_string(), next.clone());
+
+        next
     }
+}
+
+/// Advances a counter value to the next value in its sequence, mirroring
+/// Asciidoctor's `Helpers.nextval`.
+///
+/// A canonical integer string (one that round-trips through integer parsing,
+/// e.g. `7` but not `07` or `+7`) is incremented numerically. Anything else is
+/// advanced with [`string_succ`].
+fn next_counter_value(current: &str) -> String {
+    if let Ok(n) = current.parse::<i64>()
+        && n.to_string() == current
+    {
+        // `saturating_add` keeps a counter that has somehow reached `i64::MAX`
+        // pinned there rather than panicking (debug) or wrapping (release).
+        return n.saturating_add(1).to_string();
+    }
+
+    string_succ(current)
+}
+
+/// Returns the successor of a string, mirroring Ruby's `String#succ` for the
+/// ASCII cases that AsciiDoc counters can produce.
+///
+/// The right-most alphanumeric character is incremented within its own class
+/// (digits, lowercase letters, uppercase letters), carrying leftward on
+/// wrap-around (`9` -> `0`, `z` -> `a`, `Z` -> `A`) and prepending a fresh
+/// leading character (`1`, `a`, or `A`) when the carry runs off the front
+/// (`z` -> `aa`, `Zz` -> `AAa`). A string with no alphanumeric characters has
+/// the code point of its last character incremented.
+fn string_succ(current: &str) -> String {
+    let chars: Vec<char> = current.chars().collect();
+
+    // Without an alphanumeric to carry through, Ruby increments the code point
+    // of the final character.
+    if !chars.iter().any(char::is_ascii_alphanumeric) {
+        let mut chars = chars;
+        if let Some(last) = chars.last_mut() {
+            *last = char::from_u32(*last as u32 + 1).unwrap_or(*last);
+        }
+        return chars.into_iter().collect();
+    }
+
+    // Walk right to left. `carrying` stays true while we are still looking for
+    // (or carrying through) the alphanumeric run: trailing non-alphanumeric
+    // characters are passed over unchanged, then the right-most alphanumeric is
+    // incremented within its class and any wrap-around carries leftward to the
+    // next alphanumeric. When the carry runs off the front, a fresh leading
+    // character of the same class is prepended (`z` -> `aa`, `9` -> `10`).
+    let mut out_rev: Vec<char> = Vec::with_capacity(chars.len() + 1);
+    let mut carrying = true;
+    let mut lead = '1';
+
+    for &c in chars.iter().rev() {
+        if carrying && c.is_ascii_alphanumeric() {
+            // Increment within the character's class, carrying on wrap-around.
+            // The arms are exhaustive over ASCII alphanumerics, so the catch-all
+            // can only be `Z` (the one value not matched above).
+            let (next, carry) = match c {
+                '0'..='8' | 'a'..='y' | 'A'..='Y' => ((c as u8 + 1) as char, false),
+                '9' => ('0', true),
+                'z' => ('a', true),
+                _ => ('A', true),
+            };
+            out_rev.push(next);
+            carrying = carry;
+            // On a carry, remember the class of leading character to prepend if
+            // the carry runs off the front; `next` is `0`, `a`, or `A` here.
+            lead = match next {
+                '0' => '1',
+                'a' => 'a',
+                _ => 'A',
+            };
+        } else {
+            // Either the carry is spent, or this is a trailing non-alphanumeric
+            // we pass over while still searching for the run to increment.
+            out_rev.push(c);
+        }
+    }
+
+    if carrying {
+        out_rev.push(lead);
+    }
+
+    out_rev.into_iter().rev().collect()
 }
 
 fn remap_attr_name<N: AsRef<str>>(raw_attr_name: N) -> String {
@@ -1083,6 +1221,89 @@ mod tests {
                 parser.attribute_value("backend-html5-doctype-article"),
                 InterpretedValue::Unset
             );
+        }
+    }
+
+    mod counter {
+        use super::super::next_counter_value;
+        use crate::{document::InterpretedValue, tests::prelude::*};
+
+        #[test]
+        fn next_counter_value_integer() {
+            assert_eq!(next_counter_value("1"), "2");
+            assert_eq!(next_counter_value("9"), "10");
+            assert_eq!(next_counter_value("0"), "1");
+            assert_eq!(next_counter_value("-1"), "0");
+        }
+
+        #[test]
+        fn next_counter_value_non_canonical_integer_is_advanced_as_a_string() {
+            // A leading zero (or sign) does not round-trip through integer
+            // parsing, so it is advanced like a string instead.
+            assert_eq!(next_counter_value("07"), "08");
+            assert_eq!(next_counter_value("+5"), "+6");
+            // A leading-zero value still carries digit-to-digit like a string.
+            assert_eq!(next_counter_value("09"), "10");
+            assert_eq!(next_counter_value("099"), "100");
+        }
+
+        #[test]
+        fn next_counter_value_saturates_at_i64_max() {
+            // A counter pinned at `i64::MAX` stays there rather than panicking
+            // (debug) or wrapping (release).
+            let max = i64::MAX.to_string();
+            assert_eq!(next_counter_value(&max), max);
+        }
+
+        #[test]
+        fn next_counter_value_characters() {
+            assert_eq!(next_counter_value("a"), "b");
+            assert_eq!(next_counter_value("A"), "B");
+            assert_eq!(next_counter_value("z"), "aa");
+            assert_eq!(next_counter_value("Z"), "AA");
+            assert_eq!(next_counter_value("az"), "ba");
+            assert_eq!(next_counter_value("zz"), "aaa");
+            assert_eq!(next_counter_value("Zz"), "AAa");
+        }
+
+        #[test]
+        fn next_counter_value_trailing_non_alphanumeric() {
+            // The right-most alphanumeric is incremented; trailing punctuation is
+            // left in place.
+            assert_eq!(next_counter_value("a)"), "b)");
+        }
+
+        #[test]
+        fn next_counter_value_no_alphanumeric() {
+            // With nothing alphanumeric to carry, the final code point advances.
+            assert_eq!(next_counter_value("{"), "|");
+        }
+
+        #[test]
+        fn counter_defaults_to_one() {
+            let p = Parser::default();
+            assert_eq!(p.counter("x", None), "1");
+            assert_eq!(p.counter("x", None), "2");
+            assert_eq!(
+                p.attribute_value("x"),
+                InterpretedValue::Value("2".to_string())
+            );
+            assert!(p.has_attribute("x"));
+            assert!(p.is_attribute_set("x"));
+        }
+
+        #[test]
+        fn counter_seed_used_only_while_unset() {
+            let p = Parser::default();
+            assert_eq!(p.counter("c", Some("A")), "A");
+            // Once set, a later seed is ignored.
+            assert_eq!(p.counter("c", Some("Q")), "B");
+        }
+
+        #[test]
+        fn counter_empty_seed_falls_back_to_one() {
+            let p = Parser::default();
+            assert_eq!(p.counter("c", Some("")), "1");
         }
     }
 }

--- a/parser/src/tests/asciidoc_lang/attributes/counters.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/counters.rs
@@ -1,0 +1,267 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/attributes/pages/counters.adoc");
+
+/// Renders `input` and returns the rendered content of each of its top-level
+/// blocks, in document order. A counter example is self-contained (it resets
+/// the counter with a leading attribute entry), so this is enough to observe
+/// the sequence it produces.
+fn rendered_blocks(input: &str) -> Vec<String> {
+    let doc = Parser::default().parse(input);
+    doc.nested_blocks()
+        .filter_map(|b| b.rendered_content().map(str::to_string))
+        .collect()
+}
+
+non_normative!(
+    r#"
+= Counters
+// document attributes and counters are NOT the same thing, but modifying a document attribute with the same name as the counter modifies the counter at the same time.
+
+Counters are used to store and display ad-hoc sequences of numbers or Latin characters.
+
+WARNING: Counters are a poorly defined feature in AsciiDoc and should be avoided if possible.
+If you do use counters, you should only used them for the most rudimentary use cases, such as making a sequence in a list, table column, or prose.
+You should *not* use counters to build IDs (i.e., references) or reference text.
+Using counters across the boundaries of a reference will very likely result in unexpected behavior.
+
+"#
+);
+
+#[test]
+fn declare_and_display_a_counter() {
+    verifies!(
+        r#"
+A counter is implemented as a specialized document attribute.
+You declare and display a counter using an attribute reference, where the attribute name is prefixed with `counter:` (e.g., `+{counter:name}+`).
+Since counters are attributes, counter names follow the same rules as xref:names-and-values.adoc#user-defined[attribute names].
+The most important rule to note is that letters in counter names _must be lowercase_.
+
+The counter value is incremented and displayed every time the `counter:` attribute reference is resolved.
+The term [.term]*increment* means to advance the attribute value to the next value in the sequence.
+If the counter value is an integer, add 1.
+If the counter value is a character, move to the next letter in the Latin alphabet (e.g., a -> b).
+The default start value of a counter is 1.
+
+To create a sequence starting at 1, use the simple form `+{counter:name}+` as shown here:
+
+[source]
+The salad calls for {counter:seq1}) apples, {counter:seq1}) oranges and {counter:seq1}) pears.
+
+Here's the resulting output:
+
+====
+:!seq1:
+The salad calls for {counter:seq1}) apples, {counter:seq1}) oranges and {counter:seq1}) pears.
+====
+
+"#
+    );
+
+    assert_eq!(
+        rendered_blocks(
+            ":!seq1:\nThe salad calls for {counter:seq1}) apples, {counter:seq1}) oranges and {counter:seq1}) pears."
+        ),
+        vec!["The salad calls for 1) apples, 2) oranges and 3) pears.".to_string()]
+    );
+}
+
+#[test]
+fn use_a_counter_in_a_section_title() {
+    verifies!(
+        r#"
+If you want to use a counter value in a section title, you should define it first using an attribute reference.
+
+----
+:seq1: {counter:seq1}
+== Section {seq1}
+
+The sequence in this section is {seq1}.
+
+:seq1: {counter:seq1}
+== Section {seq1}
+
+The sequence in this section is {seq1}.
+----
+
+Here's the resulting output:
+
+====
+:!seq1:
+
+:seq1: {counter:seq1}
+[discrete]
+== Section {seq1}
+
+The sequence in this section is {seq1}.
+
+:seq1: {counter:seq1}
+[discrete]
+== Section {seq1}
+
+The sequence in this section is {seq1}.
+====
+
+"#
+    );
+
+    let doc = Parser::default().parse(
+        ":!seq1:\n\n:seq1: {counter:seq1}\n[discrete]\n== Section {seq1}\n\nThe sequence in this section is {seq1}.\n\n:seq1: {counter:seq1}\n[discrete]\n== Section {seq1}\n\nThe sequence in this section is {seq1}.",
+    );
+
+    assert_xpath(&doc, "//h2[text()=\"Section 1\"]", 1);
+    assert_xpath(&doc, "//h2[text()=\"Section 2\"]", 1);
+    assert_output_contains(&doc, "The sequence in this section is 1.");
+    assert_output_contains(&doc, "The sequence in this section is 2.");
+}
+
+#[test]
+fn counter2_increments_without_displaying() {
+    verifies!(
+        r#"
+To increment the counter without displaying it (i.e., to skip an item in the sequence), use the `counter2` prefix instead:
+
+[source]
+{counter2:seq1}
+
+WARNING: A `counter2` attribute reference on a line by itself will produce an empty paragraph.
+You'll need to adjoin it to the nearest content to avoid this side effect.
+
+"#
+    );
+
+    // A `counter2` reference advances the counter but renders nothing, so a
+    // reference on a line by itself yields an (empty) paragraph; a later plain
+    // reference shows the value it advanced to.
+    assert_eq!(
+        rendered_blocks("{counter2:seq1}\n\n{seq1}"),
+        vec![String::new(), "1".to_string()]
+    );
+}
+
+#[test]
+fn display_the_current_value_without_incrementing() {
+    verifies!(
+        r#"
+To display the current value of the counter without incrementing it, reference the counter name as you would any other attribute:
+
+[source]
+{counter2:pnum}This is paragraph {pnum}.
+
+"#
+    );
+
+    // `counter2:pnum` advances `pnum` to 1 without displaying it; the plain
+    // `{pnum}` reference then displays the current value without advancing it.
+    assert_eq!(
+        rendered_blocks("{counter2:pnum}This is paragraph {pnum}."),
+        vec!["This is paragraph 1.".to_string()]
+    );
+}
+
+#[test]
+fn create_a_character_sequence_or_custom_start_value() {
+    verifies!(
+        r#"
+To create a character sequence, or start a number sequence with a value other than 1, specify a start value by appending it to the first use of the counter:
+
+[source]
+Dessert calls for {counter:seq1:A}) mangoes, {counter:seq1}) grapes and {counter:seq1}) cherries.
+
+CAUTION: Character sequences either run from a,b,c,...x,y,z,{,|... or A,B,C,...,X,Y,Z,[,... depending on the start value.
+Therefore, they aren't really useful for more than 26 items.
+
+"#
+    );
+
+    assert_eq!(
+        rendered_blocks(
+            "Dessert calls for {counter:seq1:A}) mangoes, {counter:seq1}) grapes and {counter:seq1}) cherries."
+        ),
+        vec!["Dessert calls for A) mangoes, B) grapes and C) cherries.".to_string()]
+    );
+}
+
+#[test]
+fn reset_a_counter_by_unsetting_the_attribute() {
+    verifies!(
+        r#"
+The start value of a counter is only recognized if the counter is _unset_ at that point in the document.
+Otherwise, the start value is ignored.
+
+To reset a counter attribute, unset the corresponding attribute using an attribute entry.
+The attribute entry must be adjacent to a block or else it is ignored.
+
+[source]
+----
+The salad calls for {counter:seq1:1}) apples, {counter:seq1}) oranges and {counter:seq1}) pears.
+
+:!seq1:
+Dessert calls for {counter:seq1:A}) mangoes, {counter:seq1}) grapes and {counter:seq1}) cherries.
+----
+
+This gives:
+
+====
+:!seq1:
+The salad calls for {counter:seq1:1}) apples, {counter:seq1}) oranges and {counter:seq1}) pears.
+
+:!seq1:
+Dessert calls for {counter:seq1:A}) mangoes, {counter:seq1}) grapes and {counter:seq1}) cherries.
+====
+
+"#
+    );
+
+    assert_eq!(
+        rendered_blocks(
+            ":!seq1:\nThe salad calls for {counter:seq1:1}) apples, {counter:seq1}) oranges and {counter:seq1}) pears.\n\n:!seq1:\nDessert calls for {counter:seq1:A}) mangoes, {counter:seq1}) grapes and {counter:seq1}) cherries."
+        ),
+        vec![
+            "The salad calls for 1) apples, 2) oranges and 3) pears.".to_string(),
+            "Dessert calls for A) mangoes, B) grapes and C) cherries.".to_string(),
+        ]
+    );
+
+    // The start value is ignored once the counter is set: re-seeding `seq1`
+    // with a different value mid-sequence has no effect.
+    assert_eq!(
+        rendered_blocks("{counter:seq1:5} {counter:seq1:9} {counter:seq1:9}"),
+        vec!["5 6 7".to_string()]
+    );
+}
+
+#[test]
+fn use_a_counter_for_part_numbers_in_a_table() {
+    verifies!(
+        r#"
+Here's a full example that shows how to use a counter for part numbers in a table.
+
+[source]
+----
+include::example$counter.adoc[tag=base]
+----
+
+Here's the output of that table:
+
+====
+include::example$counter.adoc[tag=base]
+====
+"#
+    );
+
+    // The body of `example$counter.adoc` (tag `base`), inlined here so the test
+    // does not depend on include resolution.
+    let doc = Parser::default().parse(
+        ".Parts{counter2:index:0}\n|===\n|Part Id |Description\n\n|PX-{counter:index}\n|Description of PX-{index}\n\n|PX-{counter:index}\n|Description of PX-{index}\n|===",
+    );
+
+    // The table itself is numbered with the document-wide `table-number`
+    // counter, while the per-part `index` counter is seeded to 0 (without being
+    // displayed) by the title and then advances 1, 2 across the rows.
+    assert_xpath(&doc, "//caption[text()=\"Table 1. Parts\"]", 1);
+    assert_xpath(&doc, "//p[text()=\"PX-1\"]", 1);
+    assert_xpath(&doc, "//p[text()=\"Description of PX-1\"]", 1);
+    assert_xpath(&doc, "//p[text()=\"PX-2\"]", 1);
+    assert_xpath(&doc, "//p[text()=\"Description of PX-2\"]", 1);
+}

--- a/parser/src/tests/asciidoc_lang/attributes/mod.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/mod.rs
@@ -4,6 +4,7 @@ mod attribute_entry_substitutions;
 mod boolean_attributes;
 mod built_in_attributes;
 mod character_replacement_ref;
+mod counters;
 mod custom_attributes;
 mod document_attributes;
 mod element_attributes;

--- a/parser/src/tests/asciidoc_lang/tables/customize_title_label.rs
+++ b/parser/src/tests/asciidoc_lang/tables/customize_title_label.rs
@@ -225,12 +225,12 @@ If you want the caption of the table to only consist of the caption label, use t
 "#
     );
 
-    // Reproducing this example requires two features the parser does not yet
-    // support: setting a block's title through a `title` attribute, and the
-    // `{counter:table-number}` counter reference. The example is tracked here
-    // but not yet exercised.
+    // The `{counter:table-number}` counter reference is now supported, but this
+    // form additionally requires setting a block's title through a `title`
+    // attribute (`title=...` in the attribute list), which the parser does not
+    // yet support. The example is tracked here but not yet exercised.
     //
-    // TODO: Promote to `verifies!` once counter support lands.
+    // TODO: Promote to `verifies!` once the `title` block attribute lands.
     // https://github.com/asciidoc-rs/asciidoc-parser/issues/514
     to_do_verifies!(
         r#"
@@ -244,7 +244,7 @@ include::example$table.adoc[tag=b-col-h]
     );
 
     if false {
-        todo!("block title attribute and counter:table-number support");
+        todo!("block title attribute support");
     }
 }
 
@@ -257,12 +257,7 @@ Alternately, you can write is as follows:
 "#
     );
 
-    // Reproducing this example requires `{counter:table-number}` counter
-    // support, which is not yet implemented.
-    //
-    // TODO: Promote to `verifies!` once counter support lands.
-    // https://github.com/asciidoc-rs/asciidoc-parser/issues/514
-    to_do_verifies!(
+    verifies!(
         r#"
 [source]
 ----
@@ -273,7 +268,15 @@ include::example$table.adoc[tag=b-col-h]
 "#
     );
 
-    if false {
-        todo!("counter:table-number support");
-    }
+    // Here the title is supplied normally (`.{empty}`, which resolves to an
+    // empty title), so only counter support — now available — is needed. The
+    // `caption` value resolves `{table-caption}` to its default ("Table") and
+    // `{counter:table-number}` to the table's number, yielding "Table 1".
+    // (`example$table.adoc[tag=b-col-h]` is inlined here to avoid depending on
+    // include resolution.)
+    let doc = Parser::default().parse(
+        ".{empty}\n[caption=\"{table-caption} {counter:table-number}\"]\n[%header,cols=2*]\n|===\n|Name of Column 1\n|Name of Column 2\n\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|===",
+    );
+
+    assert_xpath(&doc, "//caption[text()=\"Table 1\"]", 1);
 }


### PR DESCRIPTION
Implements the `counter` feature page (`docs/modules/attributes/pages/counters.adoc`) and unblocks work that was waiting on counters.

## What's implemented

The `counter`/`counter2` attribute-reference directives:

- **`{counter:name}`** — resolves and displays a counter, advancing it on each resolution. Integer values increment (`1` → `2`); other values advance like Ruby's `String#succ` (`a` → `b`, `z` → `aa`, `Az` → `Ba`), matching Asciidoctor.
- **`{counter2:name}`** — advances the counter without displaying it (a reference alone on a line therefore yields an empty paragraph, as the spec notes).
- **`{counter:name:seed}`** — supplies the first value, but only while the counter is _unset_; otherwise the seed is ignored.
- Escaped references (`\{counter:name}`) render literally and do not advance the counter.

## Design

A counter is a specialized document attribute: its value is stored as (and read back from) the attribute of the same name, so a later `{name}` reference shows the current value and `:!name:` resets it.

Counters are resolved deep inside the attribute-reference substitution step, where only a shared `&Parser` is available, so the live value is kept in a `RefCell<HashMap<…>>` overlay (the same interior-mutability pattern already used for callouts and substitution warnings) that `attribute_value`/`has_attribute`/`is_attribute_set` consult. Every explicit attribute assignment clears the matching overlay entry, which is what lets an attribute entry (including `:!name:`) reset a counter.

Captioned-block numbering (example, table, …) now flows through this same `Parser::counter` mechanism, so `{counter:table-number}` shares state with automatic table numbering — matching Asciidoctor's `Document#counter`.

## Previously-incomplete work now resolved

- `tables/customize_title_label.rs`: the `.{empty}` + `[caption="{table-caption} {counter:table-number}"]` example is promoted from `to_do_verifies!` to a verified test. The sibling example still depends on unimplemented `title=` block-attribute support; its comment/TODO is updated to reflect that counters are no longer the blocker.

## Tests

- Full line-by-line spec coverage for `counters.adoc` (verified with `cd sdd && cargo run` — no uncovered lines).
- Unit tests for `next_counter_value`/`string_succ` edge cases and `Parser::counter`.
- Directive + escape tests in the substitution-step suite.

All existing tests pass; `cargo clippy --all-targets`, `cargo +nightly fmt --check`, and `cargo +nightly doc` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)