### PR TITLE
feat: Add support for checklists (task lists)

### DIFF
--- a/parser/src/blocks/list.rs
+++ b/parser/src/blocks/list.rs
@@ -25,6 +25,7 @@ pub struct ListBlock<'src> {
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
+    is_checklist: bool,
 }
 
 impl<'src> ListBlock<'src> {
@@ -192,6 +193,15 @@ impl<'src> ListBlock<'src> {
             parser.close_callout_list();
         }
 
+        // An unordered list is a checklist (i.e. task list) when at least one of
+        // its items has checkbox syntax. This mirrors Asciidoctor, which sets the
+        // `checklist` option on the list once any item carries a checkbox.
+        let is_checklist = type_ == ListType::Unordered
+            && items.iter().any(|item| {
+                item.as_list_item()
+                    .is_some_and(|li| li.checkbox().is_some())
+            });
+
         Some(MatchedItem {
             item: Self {
                 type_,
@@ -206,6 +216,7 @@ impl<'src> ListBlock<'src> {
                 anchor: metadata.anchor,
                 anchor_reftext: metadata.anchor_reftext,
                 attrlist: metadata.attrlist.clone(),
+                is_checklist,
             },
             after: next_item_source,
         })
@@ -214,6 +225,17 @@ impl<'src> ListBlock<'src> {
     /// Returns the type of this list.
     pub fn type_(&self) -> ListType {
         self.type_
+    }
+
+    /// Returns `true` if this list is a checklist (i.e. task list).
+    ///
+    /// An unordered list becomes a checklist when at least one of its items
+    /// uses checkbox syntax (`[ ]`, `[x]`, or `[*]`). See
+    /// [`ListItem::checkbox`].
+    ///
+    /// [`ListItem::checkbox`]: crate::blocks::ListItem::checkbox
+    pub fn is_checklist(&self) -> bool {
+        self.is_checklist
     }
 
     /// Returns the style class for this list based on the marker length.
@@ -304,6 +326,7 @@ impl std::fmt::Debug for ListBlock<'_> {
             .field("anchor", &self.anchor)
             .field("anchor_reftext", &self.anchor_reftext)
             .field("attrlist", &self.attrlist)
+            .field("is_checklist", &self.is_checklist)
             .finish()
     }
 }
@@ -567,7 +590,7 @@ mod tests {
 
         assert_eq!(
             format!("{:#?}", list.item),
-            "ListBlock {\n    type_: ListType::Unordered,\n    items: &[\n        Block::ListItem(\n            ListItem {\n                marker: ListItemMarker::Hyphen(\n                    Span {\n                        data: \"-\",\n                        line: 1,\n                        col: 1,\n                        offset: 0,\n                    },\n                ),\n                blocks: &[\n                    Block::Simple(\n                        SimpleBlock {\n                            content: Content {\n                                original: Span {\n                                    data: \"blah\",\n                                    line: 1,\n                                    col: 3,\n                                    offset: 2,\n                                },\n                                rendered: \"blah\",\n                            },\n                            source: Span {\n                                data: \"blah\",\n                                line: 1,\n                                col: 3,\n                                offset: 2,\n                            },\n                            style: SimpleBlockStyle::Paragraph,\n                            title_source: None,\n                            title: None,\n                            caption: None,\n                            number: None,\n                            anchor: None,\n                            anchor_reftext: None,\n                            attrlist: None,\n                        },\n                    ),\n                ],\n                source: Span {\n                    data: \"- blah\",\n                    line: 1,\n                    col: 1,\n                    offset: 0,\n                },\n                anchor: None,\n                anchor_reftext: None,\n                attrlist: None,\n            },\n        ),\n    ],\n    source: Span {\n        data: \"- blah\",\n        line: 1,\n        col: 1,\n        offset: 0,\n    },\n    title_source: None,\n    title: None,\n    anchor: None,\n    anchor_reftext: None,\n    attrlist: None,\n}"
+            "ListBlock {\n    type_: ListType::Unordered,\n    items: &[\n        Block::ListItem(\n            ListItem {\n                marker: ListItemMarker::Hyphen(\n                    Span {\n                        data: \"-\",\n                        line: 1,\n                        col: 1,\n                        offset: 0,\n                    },\n                ),\n                blocks: &[\n                    Block::Simple(\n                        SimpleBlock {\n                            content: Content {\n                                original: Span {\n                                    data: \"blah\",\n                                    line: 1,\n                                    col: 3,\n                                    offset: 2,\n                                },\n                                rendered: \"blah\",\n                            },\n                            source: Span {\n                                data: \"blah\",\n                                line: 1,\n                                col: 3,\n                                offset: 2,\n                            },\n                            style: SimpleBlockStyle::Paragraph,\n                            title_source: None,\n                            title: None,\n                            caption: None,\n                            number: None,\n                            anchor: None,\n                            anchor_reftext: None,\n                            attrlist: None,\n                        },\n                    ),\n                ],\n                source: Span {\n                    data: \"- blah\",\n                    line: 1,\n                    col: 1,\n                    offset: 0,\n                },\n                anchor: None,\n                anchor_reftext: None,\n                attrlist: None,\n                checkbox: None,\n            },\n        ),\n    ],\n    source: Span {\n        data: \"- blah\",\n        line: 1,\n        col: 1,\n        offset: 0,\n    },\n    title_source: None,\n    title: None,\n    anchor: None,\n    anchor_reftext: None,\n    attrlist: None,\n    is_checklist: false,\n}"
         );
 
         assert_eq!(

--- a/parser/src/blocks/list_item.rs
+++ b/parser/src/blocks/list_item.rs
@@ -29,6 +29,7 @@ pub struct ListItem<'src> {
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
+    checkbox: Option<bool>,
 }
 
 impl<'src> ListItem<'src> {
@@ -52,6 +53,38 @@ impl<'src> ListItem<'src> {
 
         let mut blocks: Vec<Block<'src>> = vec![];
 
+        // Detect checklist (i.e. task list) syntax on unordered list items. When
+        // the principal text begins with `[ ] `, `[x] `, or `[*] ` (the closing
+        // bracket immediately followed by a single space character), the item is
+        // a checklist item. `[ ]` is unchecked; `[x]`/`[*]` are checked. The
+        // four-character checkbox marker is then stripped from the principal text.
+        // This mirrors Asciidoctor's `parse_list_item`.
+        let checkbox: Option<bool> = if matches!(
+            marker,
+            ListItemMarker::Hyphen(_) | ListItemMarker::Asterisks(_) | ListItemMarker::Bullet(_)
+        ) {
+            let text = marker_mi.after.data();
+            if text.starts_with("[ ] ") {
+                Some(false)
+            } else if text.starts_with("[x] ") || text.starts_with("[*] ") {
+                Some(true)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        // When a checkbox marker is present, the principal text begins four
+        // characters later (after `[x] `). Any whitespace re-exposed by stripping
+        // the checkbox is discarded so the principal text never starts indented
+        // (which would otherwise be misread as a literal block).
+        let principal_start = if checkbox.is_some() {
+            marker_mi.after.slice_from(4..).discard_whitespace()
+        } else {
+            marker_mi.after
+        };
+
         // Text after list item marker is always a simple block with no metadata.
         let no_metadata = BlockMetadata {
             title_source: None,
@@ -59,8 +92,8 @@ impl<'src> ListItem<'src> {
             anchor: None,
             anchor_reftext: None,
             attrlist: None,
-            source: marker_mi.after,
-            block_start: marker_mi.after,
+            source: principal_start,
+            block_start: principal_start,
         };
 
         // For description lists, the content after the marker can be empty.
@@ -455,6 +488,7 @@ impl<'src> ListItem<'src> {
                 anchor: metadata.anchor,
                 anchor_reftext: metadata.anchor_reftext,
                 attrlist: metadata.attrlist.clone(),
+                checkbox,
             },
             after: next,
         })
@@ -463,6 +497,17 @@ impl<'src> ListItem<'src> {
     /// Returns the list item marker that was used for this item.
     pub fn list_item_marker(&self) -> ListItemMarker<'src> {
         self.marker.clone()
+    }
+
+    /// Returns the checklist (i.e. task list) state of this item.
+    ///
+    /// An unordered list item whose principal text begins with a checkbox
+    /// marker (`[ ] `, `[x] `, or `[*] `) is a checklist item. The returned
+    /// value is `Some(true)` for a checked item (`[x]`/`[*]`), `Some(false)`
+    /// for an unchecked item (`[ ]`), or `None` if the item is not a checklist
+    /// item.
+    pub fn checkbox(&self) -> Option<bool> {
+        self.checkbox
     }
 }
 
@@ -524,6 +569,7 @@ impl std::fmt::Debug for ListItem<'_> {
             .field("anchor", &self.anchor)
             .field("anchor_reftext", &self.anchor_reftext)
             .field("attrlist", &self.attrlist)
+            .field("checkbox", &self.checkbox)
             .finish()
     }
 }
@@ -670,7 +716,7 @@ mod tests {
 
         assert_eq!(
             format!("{:#?}", li.item),
-            "ListItem {\n    marker: ListItemMarker::Hyphen(\n        Span {\n            data: \"-\",\n            line: 1,\n            col: 1,\n            offset: 0,\n        },\n    ),\n    blocks: &[\n        Block::Simple(\n            SimpleBlock {\n                content: Content {\n                    original: Span {\n                        data: \"blah\",\n                        line: 1,\n                        col: 3,\n                        offset: 2,\n                    },\n                    rendered: \"blah\",\n                },\n                source: Span {\n                    data: \"blah\",\n                    line: 1,\n                    col: 3,\n                    offset: 2,\n                },\n                style: SimpleBlockStyle::Paragraph,\n                title_source: None,\n                title: None,\n                caption: None,\n                number: None,\n                anchor: None,\n                anchor_reftext: None,\n                attrlist: None,\n            },\n        ),\n    ],\n    source: Span {\n        data: \"- blah\",\n        line: 1,\n        col: 1,\n        offset: 0,\n    },\n    anchor: None,\n    anchor_reftext: None,\n    attrlist: None,\n}"
+            "ListItem {\n    marker: ListItemMarker::Hyphen(\n        Span {\n            data: \"-\",\n            line: 1,\n            col: 1,\n            offset: 0,\n        },\n    ),\n    blocks: &[\n        Block::Simple(\n            SimpleBlock {\n                content: Content {\n                    original: Span {\n                        data: \"blah\",\n                        line: 1,\n                        col: 3,\n                        offset: 2,\n                    },\n                    rendered: \"blah\",\n                },\n                source: Span {\n                    data: \"blah\",\n                    line: 1,\n                    col: 3,\n                    offset: 2,\n                },\n                style: SimpleBlockStyle::Paragraph,\n                title_source: None,\n                title: None,\n                caption: None,\n                number: None,\n                anchor: None,\n                anchor_reftext: None,\n                attrlist: None,\n            },\n        ),\n    ],\n    source: Span {\n        data: \"- blah\",\n        line: 1,\n        col: 1,\n        offset: 0,\n    },\n    anchor: None,\n    anchor_reftext: None,\n    attrlist: None,\n    checkbox: None,\n}"
         );
     }
 

--- a/parser/src/tests/asciidoc_lang/lists/checklist.rs
+++ b/parser/src/tests/asciidoc_lang/lists/checklist.rs
@@ -1,0 +1,161 @@
+use crate::{blocks::Block, tests::prelude::*};
+
+track_file!("docs/modules/lists/pages/checklist.adoc");
+
+non_normative!(
+    r#"
+= Checklists
+
+List items can be marked complete using checklists.
+
+"#
+);
+
+/// Returns the first block of `doc` as a [`ListBlock`], panicking if it is not
+/// a list.
+///
+/// [`ListBlock`]: crate::blocks::ListBlock
+fn first_list<'a>(doc: &'a crate::Document<'a>) -> &'a crate::blocks::ListBlock<'a> {
+    match doc.nested_blocks().next() {
+        Some(Block::List(list)) => list,
+        other => panic!("expected a list block, got {other:?}"),
+    }
+}
+
+#[test]
+fn checklist_syntax() {
+    verifies!(
+        r#"
+Checklists (i.e., task lists) are unordered lists that have items marked as checked (`[*]` or `[x]`) or unchecked (`[ ]`).
+Here's an example:
+
+.Checklist syntax
+[#ex-syntax]
+----
+include::example$checklist.adoc[tag=check]
+----
+
+The result of <<ex-syntax>> is displayed below.
+
+include::example$checklist.adoc[tag=check]
+
+TIP: Not all items in the list have to be checklist items, as <<ex-syntax>> shows.
+
+"#
+    );
+
+    // The example referenced above (`example$checklist.adoc[tag=check]`).
+    let doc = Parser::default()
+        .parse("* [*] checked\n* [x] also checked\n* [ ] not checked\n* normal list item\n");
+
+    let checklist = first_list(&doc);
+    assert!(checklist.is_checklist());
+
+    // `[*]` and `[x]` are checked; `[ ]` is unchecked; an item with no checkbox
+    // syntax (the TIP: not every item has to be a checklist item) carries no
+    // checkbox state.
+    let items: Vec<_> = checklist.nested_blocks().collect();
+    assert_eq!(items[0].as_list_item().unwrap().checkbox(), Some(true));
+    assert_eq!(items[1].as_list_item().unwrap().checkbox(), Some(true));
+    assert_eq!(items[2].as_list_item().unwrap().checkbox(), Some(false));
+    assert_eq!(items[3].as_list_item().unwrap().checkbox(), None);
+
+    // The checklist renders with the `checklist` class, and each checkbox is
+    // used in place of the item's bullet (a check mark for checked items, a
+    // ballot box for unchecked ones).
+    assert_css(&doc, ".ulist.checklist", 1);
+    assert_xpath(
+        &doc,
+        "(/*[@class=\"ulist checklist\"]/ul/li)[1]/p[text()=\"\u{2713} checked\"]",
+        1,
+    );
+    assert_xpath(
+        &doc,
+        "(/*[@class=\"ulist checklist\"]/ul/li)[3]/p[text()=\"\u{274f} not checked\"]",
+        1,
+    );
+    assert_xpath(
+        &doc,
+        "(/*[@class=\"ulist checklist\"]/ul/li)[4]/p[text()=\"normal list item\"]",
+        1,
+    );
+}
+
+// The HTML rendering details below describe Asciidoctor's HTML5 converter
+// output (the precise `data-item-complete` markup, and the `disabled` mark for
+// static output). The interactive behavior is exercised by
+// `interactive_checklist` below; the static-vs-interactive HTML specifics are a
+// converter concern.
+non_normative!(
+    r#"
+When checklists are converted to HTML, the checkbox markup is transformed into an HTML checkbox with the appropriate checked state.
+The `data-item-complete` attribute on the checkbox is set to 1 if the item is checked, 0 if not.
+The checkbox is used in place of the item's bullet.
+
+Since HTML generated from AsciiDoc is typically static, the checkbox is set as disabled to make it appear as a simple mark.
+If you want to make the checkbox interactive (i.e., clickable), add the `interactive` option to the checklist (shown here using the shorthand syntax for the xref:attributes:options.adoc[]):
+
+"#
+);
+
+#[test]
+fn interactive_checklist() {
+    verifies!(
+        r#"
+.Checklist with interactive checkboxes
+[#ex-interactive]
+----
+include::example$checklist.adoc[tag=check-int]
+----
+
+The result of <<ex-interactive>> is displayed below.
+
+include::example$checklist.adoc[tag=check-int]
+
+"#
+    );
+
+    // The example referenced above (`example$checklist.adoc[tag=check-int]`).
+    let doc = Parser::default().parse(
+        "[%interactive]\n* [*] checked\n* [x] also checked\n* [ ] not checked\n* normal list item\n",
+    );
+
+    let checklist = first_list(&doc);
+    assert!(checklist.is_checklist());
+    assert!(checklist.has_option("interactive"));
+
+    // Each checklist item renders an interactive `<input type="checkbox">`. The
+    // `data-item-complete` attribute is 1 (with `checked`) for checked items and
+    // 0 for unchecked ones; no checkbox is disabled.
+    assert_css(&doc, ".ulist.checklist", 1);
+    assert_css(&doc, ".ulist.checklist li input[type=\"checkbox\"]", 3);
+    assert_css(
+        &doc,
+        ".ulist.checklist li input[type=\"checkbox\"][checked]",
+        2,
+    );
+    assert_css(
+        &doc,
+        ".ulist.checklist li input[type=\"checkbox\"][disabled]",
+        0,
+    );
+}
+
+// The remainder of the page is an authoring comment block (`////` … `////`)
+// describing a possible font-based-icon example. Comment blocks are not part of
+// the rendered output, so this is non-normative.
+non_normative!(
+    r#"
+////
+This example doesn't seem quite right since nothing about it indicates font based icons.
+
+As a bonus, if you enable font-based icons, the checkbox markup (in non-interactive lists) is transformed into a font-based icon!
+
+.Checklist with font-based checkboxes
+[source]
+----
+include::{partialsdir}/ex-ulist.adoc[tag=check-icon]
+----
+////
+"#
+);

--- a/parser/src/tests/asciidoc_lang/lists/mod.rs
+++ b/parser/src/tests/asciidoc_lang/lists/mod.rs
@@ -1,3 +1,4 @@
+mod checklist;
 mod continuation;
 mod description;
 mod horizontal;

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -5136,54 +5136,128 @@ mod callout_lists {
 }
 
 mod checklists {
-    // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/481):
-    // Enable these tests when checklists are implemented.
-    use crate::tests::prelude::*;
+    use crate::{
+        blocks::{Block, ListType},
+        tests::prelude::*,
+    };
+
+    /// Returns the first block of `doc` as a [`ListBlock`], panicking if it is
+    /// not a list.
+    ///
+    /// [`ListBlock`]: crate::blocks::ListBlock
+    fn first_list<'a>(doc: &'a crate::Document<'a>) -> &'a crate::blocks::ListBlock<'a> {
+        match doc.nested_blocks().next() {
+            Some(Block::List(list)) => list,
+            other => panic!("expected a list block, got {other:?}"),
+        }
+    }
 
     #[test]
-    #[ignore]
     fn should_create_checklist_if_at_least_one_item_has_checkbox_syntax() {
-        let _doc = Parser::default()
+        let doc = Parser::default()
             .parse("- [ ] todo\n- [x] done\n- [ ] another todo\n- [*] another done\n- plain\n");
-        todo!("document_from_string test");
-    }
 
-    #[test]
-    #[ignore]
-    fn entry_is_not_a_checklist_item_if_the_closing_bracket_is_not_immediately_followed_by_the_space_character()
-     {
-        let _doc = Parser::default()
-            .parse("- [ ]    todo\n- [x] \t done\n- [ ]\t  another todo\n- [x]\t  another done\n");
-        todo!("document_from_string test");
-    }
+        let checklist = first_list(&doc);
+        assert!(checklist.is_checklist());
 
-    #[test]
-    #[ignore]
-    fn should_create_checklist_with_font_icons_if_at_least_one_item_has_checkbox_syntax_and_icons_attribute_is_font()
-     {
-        let _doc = Parser::default().parse("- [ ] todo\n- [x] done\n- plain\n");
-        todo!("assert_css: '.ulist.checklist', output, 1");
-        todo!("assert_css: '.ulist.checklist li i.fa-check-square-o', output, 1");
-        todo!("assert_css: '.ulist.checklist li i.fa-square-o', output, 1");
-        todo!(
-            "assert_xpath: '(/*[@class=\"ulist checklist\"]/ul/li)[3]/p[text()=\"plain\"]', output, 1"
+        let items: Vec<_> = checklist.nested_blocks().collect();
+        assert_eq!(items[0].as_list_item().unwrap().checkbox(), Some(false));
+        assert_eq!(items[1].as_list_item().unwrap().checkbox(), Some(true));
+        assert_eq!(items[4].as_list_item().unwrap().checkbox(), None);
+
+        assert_css(&doc, ".ulist.checklist", 1);
+        assert_xpath(
+            &doc,
+            "(/*[@class=\"ulist checklist\"]/ul/li)[1]/p[text()=\"\u{274f} todo\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "(/*[@class=\"ulist checklist\"]/ul/li)[2]/p[text()=\"\u{2713} done\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "(/*[@class=\"ulist checklist\"]/ul/li)[3]/p[text()=\"\u{274f} another todo\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "(/*[@class=\"ulist checklist\"]/ul/li)[4]/p[text()=\"\u{2713} another done\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "(/*[@class=\"ulist checklist\"]/ul/li)[5]/p[text()=\"plain\"]",
+            1,
         );
     }
 
     #[test]
-    #[ignore]
-    fn should_create_interactive_checklist_if_interactive_option_is_set_even_with_icons_attribute_is_font()
+    fn entry_is_not_a_checklist_item_if_the_closing_bracket_is_not_immediately_followed_by_the_space_character()
      {
-        let _doc =
-            Parser::default().parse(":icons: font\n\n[%interactive]\n- [ ] todo\n- [x] done\n");
-        todo!("document_from_string test");
+        let doc = Parser::default()
+            .parse("- [ ]    todo\n- [x] \t done\n- [ ]\t  another todo\n- [x]\t  another done\n");
+
+        let checklist = first_list(&doc);
+        assert!(checklist.is_checklist());
+
+        let items: Vec<_> = checklist.nested_blocks().collect();
+        assert_eq!(items[0].as_list_item().unwrap().checkbox(), Some(false));
+        assert_eq!(items[1].as_list_item().unwrap().checkbox(), Some(true));
+        assert_eq!(items[2].as_list_item().unwrap().checkbox(), None);
+        assert_eq!(items[3].as_list_item().unwrap().checkbox(), None);
     }
 
     #[test]
-    #[ignore]
+    fn should_create_checklist_with_font_icons_if_at_least_one_item_has_checkbox_syntax_and_icons_attribute_is_font()
+     {
+        let doc = Parser::default().parse(":icons: font\n\n- [ ] todo\n- [x] done\n- plain\n");
+
+        assert_css(&doc, ".ulist.checklist", 1);
+        assert_css(&doc, ".ulist.checklist li i.fa-check-square-o", 1);
+        assert_css(&doc, ".ulist.checklist li i.fa-square-o", 1);
+        assert_xpath(
+            &doc,
+            "(/*[@class=\"ulist checklist\"]/ul/li)[3]/p[text()=\"plain\"]",
+            1,
+        );
+    }
+
+    #[test]
+    fn should_create_interactive_checklist_if_interactive_option_is_set_even_with_icons_attribute_is_font()
+     {
+        let doc =
+            Parser::default().parse(":icons: font\n\n[%interactive]\n- [ ] todo\n- [x] done\n");
+
+        let checklist = first_list(&doc);
+        assert!(checklist.is_checklist());
+        assert!(checklist.has_option("interactive"));
+
+        assert_css(&doc, ".ulist.checklist", 1);
+        assert_css(&doc, ".ulist.checklist li input[type=\"checkbox\"]", 2);
+        assert_css(
+            &doc,
+            ".ulist.checklist li input[type=\"checkbox\"][disabled]",
+            0,
+        );
+        assert_css(
+            &doc,
+            ".ulist.checklist li input[type=\"checkbox\"][checked]",
+            1,
+        );
+    }
+
+    #[test]
     fn should_not_create_checklist_if_checkbox_on_item_is_followed_by_a_tab() {
-        let _doc = Parser::default().parse("- [ ]\ttodo\n");
-        todo!("document_from_string test");
+        for checkbox in ["[ ]", "[x]", "[*]"] {
+            let input = format!("- {checkbox}\ttodo\n");
+            let doc = Parser::default().parse(&input);
+
+            let list = first_list(&doc);
+            assert_eq!(list.type_(), ListType::Unordered);
+            assert!(!list.is_checklist());
+        }
     }
 }
 

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -5259,6 +5259,38 @@ mod checklists {
             assert!(!list.is_checklist());
         }
     }
+
+    // Not a direct port: this guards the rendering path where a checklist item
+    // has a continuation block. The checkbox marker must stay on the principal
+    // paragraph, and the continuation paragraph must still be wrapped in
+    // div.paragraph (as for an ordinary list item).
+    #[test]
+    fn checklist_item_with_continuation_block() {
+        let doc = Parser::default().parse("* [x] done\n+\ncontinuation paragraph\n\n* [ ] todo\n");
+
+        let checklist = first_list(&doc);
+        assert!(checklist.is_checklist());
+
+        // First item: principal paragraph carries the check-mark marker, and the
+        // continuation paragraph is wrapped in div.paragraph.
+        assert_xpath(
+            &doc,
+            "(/*[@class=\"ulist checklist\"]/ul/li)[1]/p[text()=\"\u{2713} done\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "(/*[@class=\"ulist checklist\"]/ul/li)[1]/div[@class=\"paragraph\"]/p[text()=\"continuation paragraph\"]",
+            1,
+        );
+
+        // Second item: unchecked marker, no continuation.
+        assert_xpath(
+            &doc,
+            "(/*[@class=\"ulist checklist\"]/ul/li)[2]/p[text()=\"\u{274f} todo\"]",
+            1,
+        );
+    }
 }
 
 mod lists_model {

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -820,6 +820,17 @@ fn list_block_to_node<'a>(list: &'a ListBlock<'a>) -> VirtualNode {
 
     let mut list_element = VirtualNode::new(list_tag);
 
+    // A checklist (i.e. task list) renders its `<ul>` with the `checklist`
+    // class. How each checked/unchecked item's marker is drawn depends on
+    // whether the list is interactive and on the document's `icons` mode
+    // (resolved below, matching Asciidoctor's `convert_ulist`).
+    let is_checklist = list.is_checklist();
+    let interactive = is_checklist && list.has_option("interactive");
+    let icons_font = ICONS_MODE.with(|m| m.get()) == IconsMode::Font;
+    if is_checklist {
+        list_element = list_element.with_class("checklist");
+    }
+
     // For ordered lists, add style class to the list element based on marker
     // length, but only if no explicit style is declared.
     if list.type_() == ListType::Ordered
@@ -965,6 +976,10 @@ fn list_block_to_node<'a>(list: &'a ListBlock<'a>) -> VirtualNode {
                     }
                 }
             }
+        } else if is_checklist && let Block::ListItem(list_item) = item {
+            list_element
+                .children
+                .push(checklist_item_to_node(list_item, interactive, icons_font));
         } else {
             list_element.children.push(item.to_virtual_dom());
         }
@@ -972,6 +987,12 @@ fn list_block_to_node<'a>(list: &'a ListBlock<'a>) -> VirtualNode {
 
     // Wrap the list in a div container (matching Asciidoctor's HTML structure).
     let mut wrapper = VirtualNode::new("div").with_class(base_class);
+
+    // A checklist's wrapper carries the `checklist` class right after the base
+    // `ulist` class (matching Asciidoctor's `div class="ulist checklist"`).
+    if is_checklist {
+        wrapper = wrapper.with_class("checklist");
+    }
 
     // For ordered and callout lists, add style class to the wrapper based on
     // marker length, but only if no explicit style is declared.
@@ -1116,6 +1137,135 @@ fn list_item_to_node<'a>(item: &'a ListItem<'a>) -> VirtualNode {
     }
 
     node
+}
+
+/// Renders a checklist (i.e. task list) item, matching Asciidoctor's
+/// `convert_ulist` for a list carrying the `checklist` option.
+///
+/// This is like [`list_item_to_node`], except the principal paragraph of a
+/// checklist item is prefixed with a checkbox marker. The marker form depends
+/// on the list's options and the document's `icons` mode: an `<input>` checkbox
+/// for an interactive list, a Font Awesome `<i>` icon when `icons=font`, or a
+/// plain check-mark/ballot-box glyph otherwise. Items without checkbox syntax
+/// (e.g. a plain bullet mixed into a checklist) render with no marker prefix.
+fn checklist_item_to_node<'a>(
+    item: &'a ListItem<'a>,
+    interactive: bool,
+    icons_font: bool,
+) -> VirtualNode {
+    let mut node = VirtualNode::new("li");
+
+    for role in item.roles() {
+        node = node.with_class(role);
+    }
+
+    if let Some(id) = item.id() {
+        node = node.with_id(id);
+    }
+
+    let nested = item.nested_blocks().collect::<Vec<_>>();
+    let has_multiple_blocks = nested.len() > 1;
+
+    for (index, child) in nested.iter().enumerate() {
+        let child_vdom = child.to_virtual_dom();
+
+        // The principal paragraph (the first block) carries the checkbox marker
+        // when this item has checkbox syntax.
+        if index == 0
+            && let Some(checked) = item.checkbox()
+        {
+            node.children.push(prepend_checklist_marker(
+                child_vdom,
+                checked,
+                interactive,
+                icons_font,
+            ));
+            continue;
+        }
+
+        // Wrap continuation paragraphs in div.paragraph, exactly as
+        // `list_item_to_node` does.
+        if has_multiple_blocks
+            && index > 0
+            && child_vdom.tag == "p"
+            && child_vdom.classes.is_empty()
+        {
+            let wrapper = VirtualNode::new("div")
+                .with_class("paragraph")
+                .with_child(child_vdom);
+            node.children.push(wrapper);
+        } else {
+            node.children.push(child_vdom);
+        }
+    }
+
+    node
+}
+
+/// Prepends a checkbox marker to a checklist item's principal paragraph.
+///
+/// The paragraph's existing content (text or inline child nodes) is preserved
+/// and the marker nodes are inserted ahead of it. Because `text()` queries read
+/// either a node's direct text or its children's text (but not both), any
+/// direct text on the paragraph is first demoted to a leading text child so the
+/// marker can sit before it.
+fn prepend_checklist_marker(
+    mut p: VirtualNode,
+    checked: bool,
+    interactive: bool,
+    icons_font: bool,
+) -> VirtualNode {
+    let mut children = checklist_marker_nodes(checked, interactive, icons_font);
+
+    // Demote any direct text to a leading child so it survives alongside the
+    // marker nodes (already entity-decoded, so it is set directly).
+    if let Some(text) = p.text.take() {
+        let mut text_node = VirtualNode::new("text");
+        text_node.text = Some(text);
+        children.push(text_node);
+    }
+
+    children.append(&mut p.children);
+    p.children = children;
+    p
+}
+
+/// Builds the marker nodes for a checklist item's checkbox.
+///
+/// Mirrors Asciidoctor's `convert_ulist`: an interactive list uses an `<input>`
+/// checkbox (with `data-item-complete` and, when checked, the `checked`
+/// attribute); `icons=font` uses a Font Awesome `<i>` icon; otherwise a plain
+/// check-mark (`U+2713`) or ballot box (`U+274F`) glyph is used. Each form is
+/// followed by a single space, matching the spacing in Asciidoctor's output.
+fn checklist_marker_nodes(checked: bool, interactive: bool, icons_font: bool) -> Vec<VirtualNode> {
+    let space = || {
+        let mut node = VirtualNode::new("text");
+        node.text = Some(" ".to_string());
+        node
+    };
+
+    if interactive {
+        let mut input = VirtualNode::new("input")
+            .with_attribute("type", "checkbox")
+            .with_attribute("data-item-complete", if checked { "1" } else { "0" });
+        if checked {
+            input = input.with_attribute("checked", "");
+        }
+        vec![input, space()]
+    } else if icons_font {
+        let icon = VirtualNode::new("i")
+            .with_class("fa")
+            .with_class(if checked {
+                "fa-check-square-o"
+            } else {
+                "fa-square-o"
+            });
+        vec![icon, space()]
+    } else {
+        let mut glyph = VirtualNode::new("text");
+        glyph.text = Some(if checked { "\u{2713} " } else { "\u{274f} " }.to_string());
+        vec![glyph]
+    }
 }
 
 fn section_to_node<'a>(section: &'a SectionBlock<'a>) -> VirtualNode {

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -1142,67 +1142,35 @@ fn list_item_to_node<'a>(item: &'a ListItem<'a>) -> VirtualNode {
 /// Renders a checklist (i.e. task list) item, matching Asciidoctor's
 /// `convert_ulist` for a list carrying the `checklist` option.
 ///
-/// This is like [`list_item_to_node`], except the principal paragraph of a
-/// checklist item is prefixed with a checkbox marker. The marker form depends
-/// on the list's options and the document's `icons` mode: an `<input>` checkbox
-/// for an interactive list, a Font Awesome `<i>` icon when `icons=font`, or a
-/// plain check-mark/ballot-box glyph otherwise. Items without checkbox syntax
-/// (e.g. a plain bullet mixed into a checklist) render with no marker prefix.
+/// The `<li>` (roles, id, principal paragraph, and any continuation blocks) is
+/// built exactly as for an ordinary item by [`list_item_to_node`]; the only
+/// difference is that a checklist item's principal paragraph is prefixed with a
+/// checkbox marker. The marker form depends on the list's options and the
+/// document's `icons` mode: an `<input>` checkbox for an interactive list, a
+/// Font Awesome `<i>` icon when `icons=font`, or a plain check-mark/ballot-box
+/// glyph otherwise. Items without checkbox syntax (e.g. a plain bullet mixed
+/// into a checklist) render with no marker prefix.
 fn checklist_item_to_node<'a>(
     item: &'a ListItem<'a>,
     interactive: bool,
     icons_font: bool,
 ) -> VirtualNode {
-    let mut node = VirtualNode::new("li");
+    let mut node = list_item_to_node(item);
 
-    for role in item.roles() {
-        node = node.with_class(role);
-    }
-
-    if let Some(id) = item.id() {
-        node = node.with_id(id);
-    }
-
-    let nested = item.nested_blocks().collect::<Vec<_>>();
-    let has_multiple_blocks = nested.len() > 1;
-
-    for (index, child) in nested.iter().enumerate() {
-        let child_vdom = child.to_virtual_dom();
-
-        // The principal paragraph (the first block) carries the checkbox marker
-        // when this item has checkbox syntax.
-        if index == 0
-            && let Some(checked) = item.checkbox()
-        {
-            node.children.push(prepend_checklist_marker(
-                child_vdom,
-                checked,
-                interactive,
-                icons_font,
-            ));
-            continue;
-        }
-
-        // Wrap continuation paragraphs in div.paragraph, exactly as
-        // `list_item_to_node` does.
-        if has_multiple_blocks
-            && index > 0
-            && child_vdom.tag == "p"
-            && child_vdom.classes.is_empty()
-        {
-            let wrapper = VirtualNode::new("div")
-                .with_class("paragraph")
-                .with_child(child_vdom);
-            node.children.push(wrapper);
-        } else {
-            node.children.push(child_vdom);
-        }
+    // The principal paragraph is always the first child (continuation blocks, if
+    // any, follow it). Prefix it with the checkbox marker when this item has
+    // checkbox syntax.
+    if let Some(checked) = item.checkbox()
+        && let Some(principal) = node.children.first_mut()
+    {
+        prepend_checklist_marker(principal, checked, interactive, icons_font);
     }
 
     node
 }
 
-/// Prepends a checkbox marker to a checklist item's principal paragraph.
+/// Prepends a checkbox marker to a checklist item's principal paragraph,
+/// in place.
 ///
 /// The paragraph's existing content (text or inline child nodes) is preserved
 /// and the marker nodes are inserted ahead of it. Because `text()` queries read
@@ -1210,11 +1178,11 @@ fn checklist_item_to_node<'a>(
 /// direct text on the paragraph is first demoted to a leading text child so the
 /// marker can sit before it.
 fn prepend_checklist_marker(
-    mut p: VirtualNode,
+    p: &mut VirtualNode,
     checked: bool,
     interactive: bool,
     icons_font: bool,
-) -> VirtualNode {
+) {
     let mut children = checklist_marker_nodes(checked, interactive, icons_font);
 
     // Demote any direct text to a leading child so it survives alongside the
@@ -1227,7 +1195,6 @@ fn prepend_checklist_marker(
 
     children.append(&mut p.children);
     p.children = children;
-    p
 }
 
 /// Builds the marker nodes for a checklist item's checkbox.


### PR DESCRIPTION
## Summary

Implements checklist (task list) support for unordered lists, covering all features on `docs/modules/lists/pages/checklist.adoc`.

An unordered list item whose principal text begins with `[ ] `, `[x] `, or `[*] ` (the closing bracket immediately followed by a single space character) is a checklist item:

- `[x]` / `[*]` → checked
- `[ ]` → unchecked
- the four-character checkbox marker is stripped from the principal text
- a list becomes a checklist once **any** item carries a checkbox
- a tab after the bracket (e.g. `- [ ]\ttodo`) is **not** a checklist item, matching Asciidoctor

This mirrors Asciidoctor's `parse_list_item` / `convert_ulist`.

## Model API

- `ListItem::checkbox() -> Option<bool>` — per-item checkbox state (`Some(true)` checked, `Some(false)` unchecked, `None` not a checklist item)
- `ListBlock::is_checklist() -> bool` — whether the list is a checklist

## Rendering (test virtual DOM)

The renderer emits `div.ulist.checklist` / `ul.checklist` and replaces the item bullet with the appropriate marker:

- **interactive** (`[%interactive]`): `<input type="checkbox" data-item-complete="…">` (with `checked` for checked items)
- **`icons=font`**: a Font Awesome `<i class="fa fa-check-square-o">` / `fa-square-o` icon
- **default**: a check-mark (`✓`, U+2713) or ballot-box (`❏`, U+274F) glyph

## Tests

- Enables the five previously-`#[ignore]`d checklist tests ported from Asciidoctor's suite (these carried the `TO DO (#481)` marker).
- Adds line-by-line spec coverage at `parser/src/tests/asciidoc_lang/lists/checklist.rs` (the checklist page is now 100% covered per the `sdd` tool).

All 2429 parser tests pass; `cargo clippy` (deny-warnings) and `cargo +nightly fmt`/`doc` are clean.

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)