### PR TITLE
chore: Close SDD coverage gap in text/index.adoc

### DIFF
--- a/parser/src/tests/asciidoc_lang/text/index.rs
+++ b/parser/src/tests/asciidoc_lang/text/index.rs
@@ -72,6 +72,7 @@ This stuff is *strong*!
 As you can see, the constrained pair offers a more succinct markup at the tradeoff of having more limited (constrained) use.
 However, it should suffice in most cases, so the abbreviated markup is a benefit.
 You can think of a constrained pair as being a weaker markup hint than an unconstrained pair.
+
 "#
         );
 


### PR DESCRIPTION
## What changed

Added the trailing blank line to the `constrained_formatting_pair` `verifies!` block in `parser/src/tests/asciidoc_lang/text/index.rs`.

## Why

The SDD spec-coverage tool reported `docs/modules/text/pages/index.adoc` line 125 (`////`) as uncovered. The tool matches the reconstructed `verifies!`/`non_normative!` block content against the adoc source in strict line-by-line lockstep.

The blank line at adoc line 54 — separating the *Constrained formatting pair* and *Unconstrained formatting pair* sections — was represented in neither the constrained block (no trailing blank) nor the unconstrained block (no leading blank). That dropped line shifted the entire reconstruction by one from line 54 onward:

- The unconstrained section (lines 55–70) silently failed to register as covered.
- The reconstruction ran out one line early, so line 125 was reported uncovered (`0`).

## Fix

Adding the blank line as the **trailing** line of the constrained block — per the project convention that a blank line between two blocks belongs to the block it follows — realigns the reconstruction. Lines 55–70 now register as covered and no uncovered lines remain for this file.

## Verification

- `cd sdd && cargo run` — no `0`-coverage lines remain for `text/pages/index.adoc`.
- `cargo test -p asciidoc-parser asciidoc_lang::text::index` — both tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)