### PR TITLE
feat: Implement docinfo files (head/header/footer resolution)

### DIFF
--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -16,4 +16,6 @@ pub use substitution_group::SubstitutionGroup;
 
 mod substitution_step;
 pub use substitution_step::SubstitutionStep;
-pub(crate) use substitution_step::substitute_attributes_in_macro_target;
+pub(crate) use substitution_step::{
+    substitute_attributes_in_macro_target, substitute_attributes_in_text,
+};

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -673,6 +673,67 @@ pub(crate) fn substitute_attributes_in_macro_target<'src>(
     Some(replaced.into())
 }
 
+/// Applies the attribute-references substitution to free-standing text (such as
+/// the content of a [docinfo file]), honoring the [`attribute-missing`]
+/// document attribute, and returns the substituted result.
+///
+/// Unlike [`apply_attributes`], this operates on owned text that is not part of
+/// the document source. Substitution is performed line by line so that, in
+/// `drop-line` mode, an individual line carrying a missing reference can be
+/// removed without disturbing the lines around it.
+///
+/// Any `warn`-mode warnings it records on `parser` refer to offsets within
+/// `text` (not the document source); callers that do not want such warnings
+/// surfaced should discard them via
+/// [`Parser::truncate_substitution_warnings`](crate::Parser).
+///
+/// [docinfo file]: https://docs.asciidoctor.org/asciidoc/latest/docinfo/
+/// [`attribute-missing`]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unresolved-references/#missing
+pub(crate) fn substitute_attributes_in_text(text: &str, parser: &Parser) -> String {
+    if !text.contains('{') {
+        return text.to_string();
+    }
+
+    let mode = AttributeMissing::from_parser(parser);
+    let source = Span::new(text);
+
+    let mut out = String::with_capacity(text.len());
+    let mut wrote_line = false;
+
+    for line in text.split('\n') {
+        if !line.contains('{') {
+            if wrote_line {
+                out.push('\n');
+            }
+            out.push_str(line);
+            wrote_line = true;
+            continue;
+        }
+
+        let mut replacer = AttributeReplacer {
+            parser,
+            mode,
+            source,
+            missing_on_line: false,
+        };
+
+        let replaced = ATTRIBUTE_REFERENCE.replace_all(line, replacer.by_ref());
+
+        if replacer.missing_on_line && mode == AttributeMissing::DropLine {
+            // Drop the entire line, including its line break.
+            continue;
+        }
+
+        if wrote_line {
+            out.push('\n');
+        }
+        out.push_str(&replaced);
+        wrote_line = true;
+    }
+
+    out
+}
+
 fn apply_character_replacements(
     content: &mut Content<'_>,
     renderer: &dyn InlineSubstitutionRenderer,

--- a/parser/src/document/docinfo.rs
+++ b/parser/src/document/docinfo.rs
@@ -266,6 +266,34 @@ mod tests {
     }
 
     #[test]
+    fn multi_line_content_mixes_references_and_plain_lines() {
+        // A docinfo file whose lines mix attribute references with plain lines
+        // exercises line-by-line substitution and re-joining of the output.
+        let head = head_for(
+            "= Doc\n:name: World\n:docinfo: shared-head\n\nBody.",
+            &[(
+                "docinfo.html",
+                "<p>Hello {name}</p>\n<p>plain line</p>\n<p>{name} again</p>",
+            )],
+        );
+        assert_eq!(
+            head,
+            "<p>Hello World</p>\n<p>plain line</p>\n<p>World again</p>"
+        );
+    }
+
+    #[test]
+    fn drop_line_removes_docinfo_lines_with_missing_references() {
+        // With `attribute-missing=drop-line`, a docinfo line referencing a
+        // missing attribute is dropped while the surrounding lines are kept.
+        let head = head_for(
+            "= Doc\n:attribute-missing: drop-line\n:docinfo: shared-head\n\nBody.",
+            &[("docinfo.html", "keep one\n{nope}\nkeep two")],
+        );
+        assert_eq!(head, "keep one\nkeep two");
+    }
+
+    #[test]
     fn outfilesuffix_falls_back_to_html() {
         // A bare `:outfilesuffix:` (set, no value) is not a usable suffix, so
         // docinfo file names fall back to the `.html` default.

--- a/parser/src/document/docinfo.rs
+++ b/parser/src/document/docinfo.rs
@@ -1,0 +1,278 @@
+//! Resolves a document's [docinfo] content from the `docinfo` family of
+//! attributes and a caller-supplied
+//! [`DocinfoFileHandler`](crate::parser::DocinfoFileHandler).
+//!
+//! [docinfo]: https://docs.asciidoctor.org/asciidoc/latest/docinfo/
+
+// TODO(#277): Docinfo should be disabled or restricted under Asciidoctor's safe
+// modes (e.g. SECURE disables it entirely). This crate has no safe-mode concept
+// yet, so docinfo is always resolved when a handler is present. Track this at
+// https://github.com/asciidoc-rs/asciidoc-parser/issues/277.
+
+use crate::{Parser, content::substitute_attributes_in_text, document::InterpretedValue};
+
+/// Where a [docinfo] file's content is injected into the converted output.
+///
+/// Each location corresponds to a distinct set of docinfo files (differentiated
+/// by name) and a distinct insertion point in the output document.
+///
+/// [docinfo]: https://docs.asciidoctor.org/asciidoc/latest/docinfo/
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum DocinfoLocation {
+    /// Head docinfo: injected into the top of the document (appended to the
+    /// HTML `<head>` element, or the DocBook root `<info>` element).
+    Head,
+
+    /// Header docinfo: injected at the start of the document body (immediately
+    /// before the HTML header `<div>`).
+    Header,
+
+    /// Footer docinfo: injected at the end of the document body (immediately
+    /// after the HTML footer `<div>`).
+    Footer,
+}
+
+impl DocinfoLocation {
+    /// The token used to enable this location in the `docinfo` attribute (e.g.
+    /// the `header` in `private-header`).
+    fn token(self) -> &'static str {
+        match self {
+            Self::Head => "head",
+            Self::Header => "header",
+            Self::Footer => "footer",
+        }
+    }
+
+    /// The infix added to the docinfo file name for this location (`-header` or
+    /// `-footer`; head files have no infix).
+    fn name_infix(self) -> &'static str {
+        match self {
+            Self::Head => "",
+            Self::Header => "-header",
+            Self::Footer => "-footer",
+        }
+    }
+}
+
+/// A document's resolved docinfo content, captured once the document's header
+/// (and body) have been processed and the parser holds the document's final
+/// attribute state.
+///
+/// The content for each location is already concatenated (shared file first,
+/// then private, matching Asciidoctor) and has had `docinfosubs` substitutions
+/// applied. An empty string means no docinfo applies to that location (e.g. no
+/// handler was configured, the `docinfo` attribute did not enable it, or no
+/// matching file was found).
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct Docinfo {
+    head: String,
+    header: String,
+    footer: String,
+}
+
+impl Docinfo {
+    /// Returns the resolved docinfo content for `location` (an empty string
+    /// when none applies).
+    pub(crate) fn content(&self, location: DocinfoLocation) -> &str {
+        match location {
+            DocinfoLocation::Head => &self.head,
+            DocinfoLocation::Header => &self.header,
+            DocinfoLocation::Footer => &self.footer,
+        }
+    }
+
+    /// Resolves a document's docinfo from a parser's current attribute state
+    /// and its configured
+    /// [`DocinfoFileHandler`](crate::parser::DocinfoFileHandler).
+    ///
+    /// Returns empty content when no handler is configured or the `docinfo`
+    /// attribute is unset.
+    pub(crate) fn resolve(parser: &Parser) -> Self {
+        let Some(handler) = parser.docinfo_file_handler.as_ref() else {
+            return Self::default();
+        };
+
+        // The `docinfo` attribute selects which scopes/locations apply. An unset
+        // attribute means no docinfo; an empty value (a bare `:docinfo:`) is
+        // equivalent to `private`.
+        let tokens: Vec<String> = match parser.attribute_value("docinfo") {
+            InterpretedValue::Unset => return Self::default(),
+            InterpretedValue::Set => vec!["private".to_string()],
+            InterpretedValue::Value(v) => v
+                .split(',')
+                .map(|t| t.trim().to_ascii_lowercase())
+                .filter(|t| !t.is_empty())
+                .collect(),
+        };
+
+        if tokens.is_empty() {
+            return Self::default();
+        }
+
+        // Docinfo file names share the output file extension (`outfilesuffix`,
+        // which always begins with a period and defaults to `.html`).
+        let suffix = match parser.attribute_value("outfilesuffix") {
+            InterpretedValue::Value(v) => v,
+            _ => ".html".to_string(),
+        };
+
+        // When `docinfodir` is set, files are searched only there; otherwise the
+        // document directory is searched (the handler owns path resolution).
+        let docinfodir = match parser.attribute_value("docinfodir") {
+            InterpretedValue::Value(v) => Some(v),
+            _ => None,
+        };
+
+        // Private docinfo file names are derived from the document name, so
+        // private scope is only available when a primary file name is known.
+        let docname = parser.docname();
+
+        let apply_attribute_subs = docinfosubs_includes_attributes(parser);
+
+        let resolve_location = |location: DocinfoLocation| -> String {
+            let token = location.token();
+            let infix = location.name_infix();
+
+            let shared_token = format!("shared-{token}");
+            let private_token = format!("private-{token}");
+
+            let shared_enabled = tokens.iter().any(|t| t == "shared" || *t == shared_token);
+            let private_enabled = tokens.iter().any(|t| t == "private" || *t == private_token);
+
+            // Shared content is concatenated before private content, matching
+            // Asciidoctor's output order.
+            let mut parts: Vec<String> = vec![];
+
+            if shared_enabled {
+                let file_name = format!("docinfo{infix}{suffix}");
+                if let Some(content) =
+                    handler.resolve_docinfo(docinfodir.as_deref(), &file_name, parser)
+                {
+                    parts.push(content);
+                }
+            }
+
+            if private_enabled && let Some(docname) = docname.as_deref() {
+                let file_name = format!("{docname}-docinfo{infix}{suffix}");
+                if let Some(content) =
+                    handler.resolve_docinfo(docinfodir.as_deref(), &file_name, parser)
+                {
+                    parts.push(content);
+                }
+            }
+
+            if parts.is_empty() {
+                return String::new();
+            }
+
+            let joined = parts.join("\n");
+
+            if !apply_attribute_subs {
+                return joined;
+            }
+
+            // Attribute substitution may record `warn`-mode warnings whose
+            // offsets refer to the docinfo text, not the document source.
+            // Discard them so they are not reported against the document.
+            let saved = parser.substitution_warnings_len();
+            let substituted = substitute_attributes_in_text(&joined, parser);
+            parser.truncate_substitution_warnings(saved);
+            substituted
+        };
+
+        Self {
+            head: resolve_location(DocinfoLocation::Head),
+            header: resolve_location(DocinfoLocation::Header),
+            footer: resolve_location(DocinfoLocation::Footer),
+        }
+    }
+}
+
+/// Returns whether the `attributes` substitution should be applied to docinfo
+/// content, per the `docinfosubs` attribute.
+///
+/// When `docinfosubs` is unset it has an implied default of `attributes`, so
+/// substitution is applied. When set, substitution is applied only if the
+/// comma-separated list names `attributes`.
+fn docinfosubs_includes_attributes(parser: &Parser) -> bool {
+    match parser.attribute_value("docinfosubs") {
+        InterpretedValue::Unset => true,
+        InterpretedValue::Set => false,
+        InterpretedValue::Value(v) => v.split(',').any(|s| s.trim() == "attributes"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{Parser, document::DocinfoLocation, parser::DocinfoFileHandler};
+
+    /// A minimal handler that resolves docinfo from a fixed file-name map.
+    #[derive(Debug)]
+    struct MapHandler(HashMap<String, String>);
+
+    impl MapHandler {
+        fn new(pairs: &[(&str, &str)]) -> Self {
+            Self(
+                pairs
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            )
+        }
+    }
+
+    impl DocinfoFileHandler for MapHandler {
+        fn resolve_docinfo(
+            &self,
+            _docinfodir: Option<&str>,
+            file_name: &str,
+            _parser: &Parser,
+        ) -> Option<String> {
+            self.0.get(file_name).cloned()
+        }
+    }
+
+    fn head_for(src: &str, files: &[(&str, &str)]) -> String {
+        Parser::default()
+            .with_primary_file_name("mydoc.adoc")
+            .with_docinfo_file_handler(MapHandler::new(files))
+            .parse(src)
+            .docinfo(DocinfoLocation::Head)
+            .to_string()
+    }
+
+    #[test]
+    fn empty_docinfosubs_disables_substitution() {
+        // A bare `:docinfosubs:` (set, but with no value) names no
+        // substitutions, so attribute references are left untouched.
+        let head = head_for(
+            "= Doc\n:license-url: https://example.org\n:docinfo: shared-head\n:docinfosubs:\n\nBody.",
+            &[("docinfo.html", "{license-url}")],
+        );
+        assert_eq!(head, "{license-url}");
+    }
+
+    #[test]
+    fn blank_docinfo_value_resolves_to_no_locations() {
+        // A `docinfo` value made up only of separators yields no tokens, so no
+        // docinfo is applied.
+        let head = head_for(
+            "= Doc\n:docinfo: ,\n\nBody.",
+            &[("docinfo.html", "X"), ("mydoc-docinfo.html", "Y")],
+        );
+        assert_eq!(head, "");
+    }
+
+    #[test]
+    fn outfilesuffix_falls_back_to_html() {
+        // A bare `:outfilesuffix:` (set, no value) is not a usable suffix, so
+        // docinfo file names fall back to the `.html` default.
+        let head = head_for(
+            "= Doc\n:docinfo: shared-head\n:outfilesuffix:\n\nBody.",
+            &[("docinfo.html", "HEAD")],
+        );
+        assert_eq!(head, "HEAD");
+    }
+}

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -8,7 +8,7 @@ use crate::{
     Parser, Span,
     attributes::Attrlist,
     blocks::{Block, ContentModel, IsBlock, Preamble, parse_utils::parse_blocks_until},
-    document::{Catalog, Header, TocConfig, TocMode},
+    document::{Catalog, Docinfo, DocinfoLocation, Header, TocConfig, TocMode},
     internal::debug::DebugSliceReference,
     parser::{
         CatalogResolver, InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning, SourceMap,
@@ -47,6 +47,7 @@ struct InternalDependent<'src> {
     catalog: Catalog,
     show_doctitle: bool,
     toc: TocConfig,
+    docinfo: Docinfo,
 }
 
 self_cell! {
@@ -140,6 +141,10 @@ impl<'src> Document<'src> {
             // still holds the document's resolved attribute state.
             let toc = TocConfig::from_parser(parser);
 
+            // Resolve docinfo from the final attribute state and the parser's
+            // configured docinfo file handler (empty when no handler is set).
+            let docinfo = Docinfo::resolve(parser);
+
             InternalDependent {
                 header,
                 blocks,
@@ -149,6 +154,7 @@ impl<'src> Document<'src> {
                 catalog: parser.take_catalog(),
                 show_doctitle,
                 toc,
+                docinfo,
             }
         });
 
@@ -206,6 +212,28 @@ impl<'src> Document<'src> {
     /// [`toc-class` attribute]: https://docs.asciidoctor.org/asciidoc/latest/toc/
     pub fn toc_class(&self) -> &str {
         &self.internal.borrow_dependent().toc.class
+    }
+
+    /// Return this document's resolved [docinfo] content for `location`.
+    ///
+    /// [Docinfo] is custom content read from external *docinfo files* and
+    /// injected into the head, header, or footer of the converted output. The
+    /// returned string is the concatenation of the applicable shared and
+    /// private docinfo files (shared first, matching Asciidoctor), with
+    /// `docinfosubs` substitutions already applied.
+    ///
+    /// An empty string is returned when no docinfo applies to the location —
+    /// for example when no [`DocinfoFileHandler`] was configured on the parser,
+    /// the `docinfo` attribute did not enable that scope/location, or no
+    /// matching file was found. Docinfo files are resolved through a
+    /// caller-supplied [`DocinfoFileHandler`], since this crate does not read
+    /// from the filesystem itself.
+    ///
+    /// [docinfo]: https://docs.asciidoctor.org/asciidoc/latest/docinfo/
+    /// [Docinfo]: https://docs.asciidoctor.org/asciidoc/latest/docinfo/
+    /// [`DocinfoFileHandler`]: crate::parser::DocinfoFileHandler
+    pub fn docinfo(&self, location: DocinfoLocation) -> &str {
+        self.internal.borrow_dependent().docinfo.content(location)
     }
 
     /// Return an iterator over any warnings found during parsing.

--- a/parser/src/document/mod.rs
+++ b/parser/src/document/mod.rs
@@ -14,6 +14,10 @@ mod catalog;
 pub(crate) use catalog::DuplicateIdError;
 pub use catalog::{Catalog, RefEntry, RefType};
 
+mod docinfo;
+pub(crate) use docinfo::Docinfo;
+pub use docinfo::DocinfoLocation;
+
 mod document;
 pub use document::Document;
 

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -167,6 +167,19 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
         },
     );
 
+    // The file extension of the output file (always begins with a period). It
+    // defaults to `.html` and may be overridden in the header or via the API.
+    // Docinfo file names are built from this suffix so they match the output
+    // file extension.
+    attrs.insert(
+        "outfilesuffix".to_owned(),
+        AttributeValue {
+            allowable_value: AllowableValue::Any,
+            modification_context: ModificationContext::ApiOrHeader,
+            value: InterpretedValue::Value(".html".to_owned()),
+        },
+    );
+
     // The document type defaults to `article` and may be set in the header or
     // via the API. The derived `backend-html5-doctype-{doctype}` attribute is
     // defined (empty) only for the active doctype; it is kept in sync by

--- a/parser/src/parser/docinfo_file_handler.rs
+++ b/parser/src/parser/docinfo_file_handler.rs
@@ -1,0 +1,48 @@
+use std::fmt::Debug;
+
+use crate::Parser;
+
+/// A `DocinfoFileHandler` is responsible for providing the text content of a
+/// [docinfo file] when one is requested while resolving a document's docinfo.
+///
+/// This crate is a parser, not a converter, and never reads from the
+/// filesystem itself. A client of [`Parser`] that wants docinfo files to be
+/// applied must provide a `DocinfoFileHandler` (analogous to
+/// [`IncludeFileHandler`]) that maps a computed docinfo file name to its
+/// content. If no handler is provided, no docinfo content is resolved.
+///
+/// [docinfo file]: https://docs.asciidoctor.org/asciidoc/latest/docinfo/
+/// [`Parser`]: crate::Parser
+/// [`IncludeFileHandler`]: crate::parser::IncludeFileHandler
+pub trait DocinfoFileHandler: Debug {
+    /// Provide the content of a docinfo file, if available.
+    ///
+    /// # Parameters
+    /// - `docinfodir`: The value of the `docinfodir` attribute, if set. When
+    ///   `Some`, docinfo files should be resolved relative to this directory
+    ///   only (a relative value is appended to the document directory; an
+    ///   absolute value is used as-is). When `None`, the implementation should
+    ///   resolve relative to the document directory.
+    /// - `file_name`: The computed docinfo file name to resolve, for example
+    ///   `docinfo-header.html` (shared) or `mydoc-docinfo.html` (private). The
+    ///   parser determines this name from the docinfo scope, location, the
+    ///   document name, and the `outfilesuffix` attribute.
+    /// - `parser`: An implementation may read document attribute values from
+    ///   the [`Parser`] state.
+    ///
+    /// Return the string content of the docinfo file if found. If no file is
+    /// found (or it is not readable), return `None`; the requested location's
+    /// content simply omits this file.
+    ///
+    /// # Encoding
+    /// If a `Some` result is provided, it is a typical Rust [`String`] and
+    /// therefore must be encoded as UTF-8.
+    ///
+    /// [`Parser`]: crate::Parser
+    fn resolve_docinfo(
+        &self,
+        docinfodir: Option<&str>,
+        file_name: &str,
+        parser: &Parser,
+    ) -> Option<String>;
+}

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -7,6 +7,9 @@ pub use attribute_value::{AllowableValue, ModificationContext};
 
 mod built_in_attrs;
 
+mod docinfo_file_handler;
+pub use docinfo_file_handler::DocinfoFileHandler;
+
 mod include_file_handler;
 pub use include_file_handler::IncludeFileHandler;
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -694,7 +694,8 @@ impl Parser {
         let base = primary.rsplit(['/', '\\']).next().unwrap_or(primary);
 
         // Strip a single trailing extension, if present. A leading-dot name
-        // (e.g. `.adoc`) has no base name to keep, so treat it as having none.
+        // (e.g. `.adoc`) is treated as having no extension and is kept whole as
+        // the stem, matching Ruby's `File.basename(".adoc", ".*")`.
         let stem = match base.rfind('.') {
             Some(0) | None => base,
             Some(idx) => &base[..idx],
@@ -1319,6 +1320,18 @@ mod tests {
                     .docname()
                     .as_deref(),
                 Some("README")
+            );
+        }
+
+        #[test]
+        fn none_when_path_has_no_file_component() {
+            // A primary file name that ends in a separator has an empty base
+            // name, which yields no document name.
+            assert_eq!(
+                Parser::default()
+                    .with_primary_file_name("docs/guide/")
+                    .docname(),
+                None
             );
         }
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -9,8 +9,8 @@ use crate::{
     blocks::{SectionNumber, SectionType},
     document::{Attribute, Catalog, InterpretedValue, RefType},
     parser::{
-        AllowableValue, AttributeValue, HtmlSubstitutionRenderer, IncludeFileHandler,
-        InlineSubstitutionRenderer, ModificationContext, PathResolver,
+        AllowableValue, AttributeValue, DocinfoFileHandler, HtmlSubstitutionRenderer,
+        IncludeFileHandler, InlineSubstitutionRenderer, ModificationContext, PathResolver,
         built_in_attrs::{built_in_attrs, built_in_default_values},
         preprocessor::preprocess,
     },
@@ -43,6 +43,10 @@ pub struct Parser {
 
     /// Handler for resolving include:: directives.
     pub(crate) include_file_handler: Option<Rc<dyn IncludeFileHandler>>,
+
+    /// Handler for resolving docinfo files. If absent, no docinfo content is
+    /// resolved.
+    pub(crate) docinfo_file_handler: Option<Rc<dyn DocinfoFileHandler>>,
 
     /// Document catalog for tracking referenceable elements during parsing.
     /// This is created during parsing and transferred to the Document when
@@ -164,6 +168,7 @@ impl Default for Parser {
             primary_file_name: None,
             path_resolver: PathResolver::default(),
             include_file_handler: None,
+            docinfo_file_handler: None,
             catalog: RefCell::new(Catalog::new()),
             last_section_number: SectionNumber::default(),
             last_appendix_section_number: SectionNumber {
@@ -632,6 +637,53 @@ impl Parser {
         self
     }
 
+    /// Sets the [`DocinfoFileHandler`] for this parser.
+    ///
+    /// The docinfo file handler is responsible for providing the content of
+    /// [docinfo files] requested while resolving a document's docinfo (see the
+    /// `docinfo` attribute). If no handler is provided, no docinfo content is
+    /// resolved and [`Document::docinfo`] returns an empty string for every
+    /// location.
+    ///
+    /// [`DocinfoFileHandler`]: crate::parser::DocinfoFileHandler
+    /// [docinfo files]: https://docs.asciidoctor.org/asciidoc/latest/docinfo/
+    /// [`Document::docinfo`]: crate::Document::docinfo
+    pub fn with_docinfo_file_handler<DFH: DocinfoFileHandler + 'static>(
+        mut self,
+        handler: DFH,
+    ) -> Self {
+        self.docinfo_file_handler = Some(Rc::new(handler));
+        self
+    }
+
+    /// Returns the document name (`docname`): the base name of the primary
+    /// file, stripped of its directory and final extension.
+    ///
+    /// This is the `<docname>` used to build private docinfo file names (e.g.
+    /// `mydoc-docinfo.html` for `mydoc.adoc`). Returns `None` when no primary
+    /// file name has been set, in which case private docinfo files cannot be
+    /// resolved.
+    pub(crate) fn docname(&self) -> Option<String> {
+        let primary = self.primary_file_name.as_deref()?;
+
+        // Strip the directory portion (handling both separators, since the
+        // primary file name may have been supplied on either platform).
+        let base = primary.rsplit(['/', '\\']).next().unwrap_or(primary);
+
+        // Strip a single trailing extension, if present. A leading-dot name
+        // (e.g. `.adoc`) has no base name to keep, so treat it as having none.
+        let stem = match base.rfind('.') {
+            Some(0) | None => base,
+            Some(idx) => &base[..idx],
+        };
+
+        if stem.is_empty() {
+            None
+        } else {
+            Some(stem.to_string())
+        }
+    }
+
     /// Called from [`Header::parse()`] to accept or reject an attribute value.
     ///
     /// [`Header::parse()`]: crate::document::Header::parse
@@ -1082,6 +1134,67 @@ mod tests {
             assert_eq!(
                 parser.attribute_value("backend-html5-doctype-article"),
                 InterpretedValue::Unset
+            );
+        }
+    }
+
+    mod docname {
+        use crate::Parser;
+
+        #[test]
+        fn none_without_primary_file_name() {
+            assert_eq!(Parser::default().docname(), None);
+        }
+
+        #[test]
+        fn strips_directory_and_extension() {
+            assert_eq!(
+                Parser::default()
+                    .with_primary_file_name("mydoc.adoc")
+                    .docname()
+                    .as_deref(),
+                Some("mydoc")
+            );
+            assert_eq!(
+                Parser::default()
+                    .with_primary_file_name("docs/guide/mydoc.adoc")
+                    .docname()
+                    .as_deref(),
+                Some("mydoc")
+            );
+            // A Windows-style separator is handled too, since the primary file
+            // name may be supplied on either platform.
+            assert_eq!(
+                Parser::default()
+                    .with_primary_file_name(r"docs\guide\mydoc.adoc")
+                    .docname()
+                    .as_deref(),
+                Some("mydoc")
+            );
+        }
+
+        #[test]
+        fn keeps_name_with_no_extension() {
+            assert_eq!(
+                Parser::default()
+                    .with_primary_file_name("README")
+                    .docname()
+                    .as_deref(),
+                Some("README")
+            );
+        }
+
+        #[test]
+        fn leading_dot_name_is_kept_whole() {
+            // A leading-dot name (e.g. `.adoc`) is treated as a dotfile with no
+            // extension and kept whole, matching Ruby's
+            // `File.basename(".adoc", ".*")`.
+            assert_eq!(
+                Parser::default()
+                    .with_primary_file_name(".adoc")
+                    .docname()
+                    .as_deref(),
+                Some(".adoc")
             );
         }
     }

--- a/parser/src/tests/asciidoc_lang/docinfo/index.rs
+++ b/parser/src/tests/asciidoc_lang/docinfo/index.rs
@@ -1,0 +1,568 @@
+//! Verifies the docinfo specification page, line by line.
+
+#![allow(clippy::unwrap_used)]
+
+use std::{cell::RefCell, rc::Rc};
+
+use crate::{document::DocinfoLocation, parser::DocinfoFileHandler, tests::prelude::*};
+
+track_file!("docs/modules/docinfo/pages/index.adoc");
+
+/// A log of the docinfo files the parser requested: each entry is the
+/// `docinfodir` (if any) and the requested file name.
+type DocinfoRequests = Rc<RefCell<Vec<(Option<String>, String)>>>;
+
+/// A [`DocinfoFileHandler`] backed by a fixed map of file name to content. It
+/// records each request so tests can assert what the parser asked for.
+#[derive(Clone, Debug)]
+struct TestDocinfo {
+    files: Rc<HashMap<String, String>>,
+    requests: DocinfoRequests,
+}
+
+impl TestDocinfo {
+    fn new(files: &[(&str, &str)]) -> Self {
+        Self {
+            files: Rc::new(
+                files
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            ),
+            requests: Rc::new(RefCell::new(vec![])),
+        }
+    }
+}
+
+impl DocinfoFileHandler for TestDocinfo {
+    fn resolve_docinfo(
+        &self,
+        docinfodir: Option<&str>,
+        file_name: &str,
+        _parser: &Parser,
+    ) -> Option<String> {
+        self.requests
+            .borrow_mut()
+            .push((docinfodir.map(|s| s.to_string()), file_name.to_string()));
+        self.files.get(file_name).cloned()
+    }
+}
+
+/// A handler stocked with all six (shared and private) docinfo files for a
+/// document named `mydoc`.
+fn all_six() -> TestDocinfo {
+    TestDocinfo::new(&[
+        ("docinfo.html", "S-HEAD"),
+        ("docinfo-header.html", "S-HEADER"),
+        ("docinfo-footer.html", "S-FOOTER"),
+        ("mydoc-docinfo.html", "P-HEAD"),
+        ("mydoc-docinfo-header.html", "P-HEADER"),
+        ("mydoc-docinfo-footer.html", "P-FOOTER"),
+    ])
+}
+
+/// Parses a minimal `mydoc.adoc` carrying the given header line, with a handler
+/// stocked with every docinfo file.
+fn parse_docinfo(header_line: &str) -> crate::Document<'static> {
+    let src = format!("= Doc\n{header_line}\n\nBody.");
+    Parser::default()
+        .with_primary_file_name("mydoc.adoc")
+        .with_docinfo_file_handler(all_six())
+        .parse(&src)
+}
+
+non_normative!(
+    r#"
+= Docinfo Files
+:url-docbook-info-ref: https://tdg.docbook.org/tdg/5.0/info.html
+:url-docinfo-example: https://github.com/clojure-cookbook/clojure-cookbook/blob/master/book-docinfo.xml
+
+Docinfo is a feature of AsciiDoc that allows you to insert custom content into the head, header, or footer of the output document.
+This custom content is read from files known as docinfo files by the converter.
+Docinfo files are intended as convenient way to supplement the output produced by a converter.
+Examples include injecting auxiliary metadata, stylesheets, and scripting logic not already provided by the converter.
+
+The docinfo feature does not apply to all backends.
+While it works when converting to output formats such as HTML and DocBook, it does not work when converting to PDF using Asciidoctor PDF.
+
+The docinfo feature must be explicitly enabled using the `docinfo` attribute (see <<enable>>).
+Which docinfo files are consumed depends on the value of the `docinfo` attribute as well as the backend.
+
+"#
+);
+
+non_normative!(
+    r#"
+[#head]
+== Head docinfo files
+
+The content of head docinfo files gets injected into the top of the document.
+For HTML, the content is append to the `<head>` element.
+For DocBook, the content is appended to the root `<info>` element.
+
+The docinfo file for HTML output may contain valid elements to populate the HTML `<head>` element, including:
+
+* `<base>`
+* `<link>`
+* `<meta>`
+* `<noscript>`
+* `<script>`
+* `<style>`
+
+CAUTION: Use of the `<title>` element is not recommended as it's already emitted by the converter.
+
+You do not need to include the enclosing `<head>` element as it's assumed to be the envelope.
+
+Here's an example:
+
+.A head docinfo file for HTML output
+[source,html]
+----
+<meta name="keywords" content="open source, documentation">
+<meta name="description" content="The dangerous and thrilling adventures of an open source documentation team.">
+<link rel="stylesheet" href="basejump.css">
+<script src="map.js"></script>
+----
+
+Docinfo files for HTML output must be saved with the `.html` file extension.
+See <<naming>> for more details.
+
+The docinfo file for DocBook 5.0 output may include any of the {url-docbook-info-ref}[<info> element's children^], such as:
+
+* `<address>`
+* `<copyright>`
+* `<edition>`
+* `<keywordset>`
+* `<publisher>`
+* `<subtitle>`
+* `<revhistory>`
+
+The following example shows some of the content a docinfo file for DocBook might contain.
+
+.A docinfo file for DocBook 5.0 output
+[source,xml]
+----
+<author>
+  <personname>
+    <firstname>Karma</firstname>
+    <surname>Chameleon</surname>
+  </personname>
+  <affiliation>
+    <jobtitle>Word SWAT Team Leader</jobtitle>
+  </affiliation>
+</author>
+
+<keywordset>
+  <keyword>open source</keyword>
+  <keyword>documentation</keyword>
+  <keyword>adventure</keyword>
+</keywordset>
+
+<printhistory>
+  <para>April, 2021. Twenty-sixth printing.</para>
+</printhistory>
+----
+
+Docinfo files for DocBook output must be saved with the `.xml` file extension.
+See <<naming>> for more details.
+
+You can find a real-world example of a docinfo file for DocBook in the source of the {url-docinfo-example}[Clojure Cookbook^].
+
+[#header]
+== Header docinfo files
+
+Header docinfo files are differentiated from head docinfo files by the addition of `-header` to the file name.
+In the HTML output, the header content is inserted immediately before the header div (i.e., `<div id="header">`).
+In the DocBook output, the header content is inserted immediately after the opening tag (e.g., `<article>` or `<book>`).
+
+TIP: One possible use of the header docinfo file is to completely replace the default header in the standard stylesheet.
+Just set the attribute `noheader`, then apply a custom header docinfo file.
+
+[#footer]
+== Footer docinfo files
+
+Footer docinfo files are differentiated from head docinfo files by the addition of `-footer` to the file name.
+In the HTML output, the footer content is inserted immediately after the footer div (i.e., `<div id="footer">`).
+In the DocBook output, the footer content is inserted immediately before the ending tag (e.g., `</article>` or `</book>`).
+
+TIP: One possible use of the footer docinfo file is to completely replace the default footer in the standard stylesheet.
+Just set the attribute `nofooter`, then apply a custom footer docinfo file.
+
+// Not here! Good info, but does nothing to clarify the previous paragraphs and could confuse.
+////
+TIP: To change the text in the "Last updated" line in the footer, set the text in the attribute `last-update-label` (for example, `:last-update-label: <your text> Last Updated`). +
+To disable the "Last updated" line in the footer, unassign the attribute `last-update-label` (however, this leaves an empty footer div). +
+To disable the footer completely, set the attribute `nofooter`. Then having a footer docinfo file effectively replaces the default footer with your custom footer.
+////
+
+"#
+);
+
+#[test]
+fn naming_docinfo_files() {
+    verifies!(
+        r#"
+[#naming]
+== Naming docinfo files
+
+The file that gets selected to provide the docinfo depends on which converter is in use (html, docbook, etc) and whether the docinfo scope is configured for a specific document ("`private`") or for all documents in the same directory ("`shared`").
+The file extension of the docinfo file must match the file extension of the output file (as specified by the `outfilesuffix` attribute, a value which always begins with a period (`.`)).
+
+.Docinfo file naming
+[cols="<10,<20,<30,<30"]
+|===
+|Mode |Location |Behavior |Docinfo file name
+
+.3+|Private
+|Head
+|Adds content to `<head>`/`<info>` for <docname>.adoc files.
+|`<docname>-docinfo<outfilesuffix>`
+
+|Header
+|Adds content to start of document for <docname>.adoc files.
+|`<docname>-docinfo-header<outfilesuffix>`
+
+|Footer
+|Adds content to end of document for <docname>.adoc files.
+|`<docname>-docinfo-footer<outfilesuffix>`
+
+.3+|Shared
+|Head
+|Adds content to `<head>`/`<info>` for any document in same directory.
+|`docinfo<outfilesuffix>`
+
+|Header
+|Adds content to start of document for any document in same directory.
+|`docinfo-header<outfilesuffix>`
+
+|Footer
+|Adds content to end of document for any document in same directory.
+|`docinfo-footer<outfilesuffix>`
+|===
+
+"#
+    );
+
+    let handler = TestDocinfo::new(&[
+        ("docinfo.html", "SHARED-HEAD"),
+        ("docinfo-header.html", "SHARED-HEADER"),
+        ("docinfo-footer.html", "SHARED-FOOTER"),
+        ("mydoc-docinfo.html", "PRIVATE-HEAD"),
+        ("mydoc-docinfo-header.html", "PRIVATE-HEADER"),
+        ("mydoc-docinfo-footer.html", "PRIVATE-FOOTER"),
+    ]);
+    let doc = Parser::default()
+        .with_primary_file_name("mydoc.adoc")
+        .with_docinfo_file_handler(handler)
+        .parse("= Doc\n:docinfo: shared,private\n\nBody.");
+
+    // Each location draws from its own private and shared file names, with the
+    // shared content concatenated before the private content.
+    assert_eq!(
+        doc.docinfo(DocinfoLocation::Head),
+        "SHARED-HEAD\nPRIVATE-HEAD"
+    );
+    assert_eq!(
+        doc.docinfo(DocinfoLocation::Header),
+        "SHARED-HEADER\nPRIVATE-HEADER"
+    );
+    assert_eq!(
+        doc.docinfo(DocinfoLocation::Footer),
+        "SHARED-FOOTER\nPRIVATE-FOOTER"
+    );
+
+    // The docinfo file extension follows `outfilesuffix`.
+    let xml = TestDocinfo::new(&[("docinfo.xml", "XML-HEAD")]);
+    let doc = Parser::default()
+        .with_primary_file_name("mydoc.adoc")
+        .with_docinfo_file_handler(xml)
+        .parse("= Doc\n:docinfo: shared-head\n:outfilesuffix: .xml\n\nBody.");
+    assert_eq!(doc.docinfo(DocinfoLocation::Head), "XML-HEAD");
+
+    // A private docinfo file is named for the document; a file named for a
+    // different document is not used.
+    let other = TestDocinfo::new(&[("otherdoc-docinfo.html", "NOPE")]);
+    let doc = Parser::default()
+        .with_primary_file_name("mydoc.adoc")
+        .with_docinfo_file_handler(other)
+        .parse("= Doc\n:docinfo: private-head\n\nBody.");
+    assert_eq!(doc.docinfo(DocinfoLocation::Head), "");
+}
+
+#[test]
+fn enabling_docinfo() {
+    verifies!(
+        r#"
+[#enable]
+== Enabling docinfo
+
+To specify which file(s) you want to apply, set the `docinfo` attribute to any combination of these values:
+
+* `private-head`
+* `private-header`
+* `private-footer`
+* `private` (alias for `private-head,private-header,private-footer`)
+* `shared-head`
+* `shared-header`
+* `shared-footer`
+* `shared` (alias for `shared-head,shared-header,shared-footer`)
+
+Setting `docinfo` with no value is equivalent to setting the value to `private`.
+
+For example:
+
+[source,asciidoc]
+----
+:docinfo: shared,private-footer
+----
+
+This docinfo configuration will apply the shared docinfo head, header and footer files, if they exist, as well as the private footer file, if it exists.
+
+Let's apply this to an example:
+
+You have two AsciiDoc documents, [.path]_adventure.adoc_ and [.path]_insurance.adoc_, saved in the same folder.
+You want to add the same content to the head of both documents when they're converted to HTML.
+
+. Create a docinfo file containing `<head>` elements.
+. Save it as docinfo.html.
+. Set the `docinfo` attribute in [.path]_adventure.adoc_ and [.path]_insurance.adoc_ to `shared`.
+
+You also want to include some additional content, but only to the head of [.path]_adventure.adoc_.
+
+. Create *another* docinfo file containing `<head>` elements.
+. Save it as [.path]_adventure-docinfo.html_.
+. Set the `docinfo` attribute in [.path]_adventure.adoc_ to `shared,private-head`
+
+If other AsciiDoc files are added to the same folder, and `docinfo` is set to `shared` in those files, only the [.path]_docinfo.html_ file will be added when converting those files.
+
+"#
+    );
+
+    // Each scope/location value selects exactly the matching file.
+    let d = parse_docinfo(":docinfo: shared-head");
+    assert_eq!(d.docinfo(DocinfoLocation::Head), "S-HEAD");
+    assert_eq!(d.docinfo(DocinfoLocation::Header), "");
+    assert_eq!(d.docinfo(DocinfoLocation::Footer), "");
+
+    let d = parse_docinfo(":docinfo: private-header");
+    assert_eq!(d.docinfo(DocinfoLocation::Header), "P-HEADER");
+    assert_eq!(d.docinfo(DocinfoLocation::Head), "");
+
+    let d = parse_docinfo(":docinfo: private-footer");
+    assert_eq!(d.docinfo(DocinfoLocation::Footer), "P-FOOTER");
+
+    // `private` is an alias for `private-head,private-header,private-footer`.
+    let d = parse_docinfo(":docinfo: private");
+    assert_eq!(d.docinfo(DocinfoLocation::Head), "P-HEAD");
+    assert_eq!(d.docinfo(DocinfoLocation::Header), "P-HEADER");
+    assert_eq!(d.docinfo(DocinfoLocation::Footer), "P-FOOTER");
+
+    // `shared` is an alias for `shared-head,shared-header,shared-footer`.
+    let d = parse_docinfo(":docinfo: shared");
+    assert_eq!(d.docinfo(DocinfoLocation::Head), "S-HEAD");
+    assert_eq!(d.docinfo(DocinfoLocation::Header), "S-HEADER");
+    assert_eq!(d.docinfo(DocinfoLocation::Footer), "S-FOOTER");
+
+    // Setting `docinfo` with no value is equivalent to setting it to `private`.
+    let d = parse_docinfo(":docinfo:");
+    assert_eq!(d.docinfo(DocinfoLocation::Head), "P-HEAD");
+    assert_eq!(d.docinfo(DocinfoLocation::Header), "P-HEADER");
+    assert_eq!(d.docinfo(DocinfoLocation::Footer), "P-FOOTER");
+
+    // The combined example from the page: the shared head, header, and footer
+    // files plus the private footer file.
+    let d = parse_docinfo(":docinfo: shared,private-footer");
+    assert_eq!(d.docinfo(DocinfoLocation::Head), "S-HEAD");
+    assert_eq!(d.docinfo(DocinfoLocation::Header), "S-HEADER");
+    assert_eq!(d.docinfo(DocinfoLocation::Footer), "S-FOOTER\nP-FOOTER");
+
+    // With no `docinfo` attribute, no docinfo is applied.
+    let d = Parser::default()
+        .with_primary_file_name("mydoc.adoc")
+        .with_docinfo_file_handler(all_six())
+        .parse("= Doc\n\nBody.");
+    assert_eq!(d.docinfo(DocinfoLocation::Head), "");
+
+    // With no docinfo file handler, no docinfo is resolved even when enabled.
+    let d = Parser::default()
+        .with_primary_file_name("mydoc.adoc")
+        .parse("= Doc\n:docinfo: shared\n\nBody.");
+    assert_eq!(d.docinfo(DocinfoLocation::Head), "");
+}
+
+#[test]
+fn locating_docinfo_files() {
+    verifies!(
+        r#"
+[#resolving]
+== Locating docinfo files
+
+By default, docinfo files are searched for in the same directory as the document file (which can be overridden by setting the `:base_dir` API option / `--base-dir` CLI option).
+If you want to load them from another location, set the `docinfodir` attribute to the directory where the files are located.
+If the value of the `docinfodir` attribute is a relative path, that value is appended to the document directory.
+If the value is an absolute path, that value is used as is.
+
+[source,asciidoc]
+----
+:docinfodir: common/meta
+----
+
+Note that if you use this attribute, only the specified folder will be searched; docinfo files in the document directory will no longer be found.
+
+"#
+    );
+
+    // By default no `docinfodir` is set, so the handler is asked with `None`
+    // (it resolves relative to the document directory).
+    let handler = TestDocinfo::new(&[("docinfo.html", "HEAD")]);
+    let doc = Parser::default()
+        .with_primary_file_name("mydoc.adoc")
+        .with_docinfo_file_handler(handler.clone())
+        .parse("= Doc\n:docinfo: shared-head\n\nBody.");
+    assert_eq!(doc.docinfo(DocinfoLocation::Head), "HEAD");
+    assert_eq!(
+        *handler.requests.borrow(),
+        vec![(None, "docinfo.html".to_string())]
+    );
+
+    // Setting `docinfodir` passes the directory through to the handler, which
+    // is then responsible for searching only that folder.
+    let handler = TestDocinfo::new(&[("docinfo.html", "HEAD")]);
+    let doc = Parser::default()
+        .with_primary_file_name("mydoc.adoc")
+        .with_docinfo_file_handler(handler.clone())
+        .parse("= Doc\n:docinfo: shared-head\n:docinfodir: common/meta\n\nBody.");
+    assert_eq!(doc.docinfo(DocinfoLocation::Head), "HEAD");
+    assert_eq!(
+        *handler.requests.borrow(),
+        vec![(Some("common/meta".to_string()), "docinfo.html".to_string())]
+    );
+}
+
+#[test]
+fn attribute_substitution_in_docinfo_files() {
+    verifies!(
+        r#"
+[#attribute-substitution]
+== Attribute substitution in docinfo files
+
+Docinfo files may include attribute references.
+Which substitutions get applied is controlled by the `docinfosubs` attribute, which takes a comma-separated list of substitution names.
+If this attribute is not set, it has an implied default value of `attributes` (i.e., attribute references are resolved).
+
+For example, if you created the following docinfo file:
+
+.Docinfo file (docinfo.xml) containing a revnumber attribute reference
+[source,xml]
+----
+<edition>{revnumber}</edition>
+----
+
+And this source document:
+
+.Source document including a revision number
+[,asciidoc]
+----
+= Document Title
+Author Name
+v1.0, 2020-12-30
+:doctype: book
+:backend: docbook
+:docinfo: shared
+----
+
+Then the converted DocBook output would be:
+
+.Converted DocBook containing the docinfo
+[,xml]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<info>
+<title>Document Title</title>
+<date>2020-12-30</date>
+<author>
+<personname>
+<firstname>Author</firstname>
+<surname>Name</surname>
+</personname>
+</author>
+<authorinitials>AN</authorinitials>
+<revhistory>
+<revision>
+<revnumber>1.0</revnumber>
+<date>2020-12-30</date>
+<authorinitials>AN</authorinitials>
+</revision>
+</revhistory>
+<edition>1.0</edition> <!--.-->
+</info>
+</book>
+----
+<.> The revnumber attribute reference in `docinfo.xml` was replaced by the source document's revision number in the converted output.
+
+Another example is if you want to define the license link tag in the HTML head.
+
+.Docinfo file (docinfo.html) containing a license meta tag
+[,html]
+----
+<link rel="license" href="{license-url}" title="{license-title}">
+----
+
+Now define these attributes in your AsciiDoc source:
+
+.Source document that defines license attributes
+[,asciidoc]
+----
+= Document Title
+:license-url: https://mit-license.org
+:license-title: MIT
+:docinfo: shared
+----
+
+Then the `<head>` tag in the converted HTML would include:
+
+.Rendered license link tag in HTML output
+[,html]
+----
+<link rel="license" href="https://mit-license.org" title="MIT">
+----
+"#
+    );
+
+    // Attribute references in docinfo content are resolved by default
+    // (`docinfosubs` defaults to `attributes`).
+    let handler = TestDocinfo::new(&[("docinfo.html", "<edition>{revnumber}</edition>")]);
+    let doc = Parser::default()
+        .with_primary_file_name("mydoc.adoc")
+        .with_docinfo_file_handler(handler)
+        .parse("= Doc\n:revnumber: 1.0\n:docinfo: shared-head\n\nBody.");
+    assert_eq!(doc.docinfo(DocinfoLocation::Head), "<edition>1.0</edition>");
+
+    // The license link example from the page.
+    let handler = TestDocinfo::new(&[(
+        "docinfo.html",
+        "<link rel=\"license\" href=\"{license-url}\" title=\"{license-title}\">",
+    )]);
+    let doc = Parser::default()
+        .with_primary_file_name("mydoc.adoc")
+        .with_docinfo_file_handler(handler)
+        .parse(
+            "= Doc\n:license-url: https://mit-license.org\n:license-title: MIT\n:docinfo: shared-head\n\nBody.",
+        );
+    assert_eq!(
+        doc.docinfo(DocinfoLocation::Head),
+        "<link rel=\"license\" href=\"https://mit-license.org\" title=\"MIT\">"
+    );
+
+    // `docinfosubs` controls which substitutions apply: a list that omits
+    // `attributes` leaves attribute references untouched.
+    let handler = TestDocinfo::new(&[("docinfo.html", "{license-url}")]);
+    let doc = Parser::default()
+        .with_primary_file_name("mydoc.adoc")
+        .with_docinfo_file_handler(handler)
+        .parse(
+            "= Doc\n:license-url: https://mit-license.org\n:docinfo: shared-head\n:docinfosubs: specialchars\n\nBody.",
+        );
+    assert_eq!(doc.docinfo(DocinfoLocation::Head), "{license-url}");
+}

--- a/parser/src/tests/asciidoc_lang/docinfo/mod.rs
+++ b/parser/src/tests/asciidoc_lang/docinfo/mod.rs
@@ -1,0 +1,1 @@
+mod index;

--- a/parser/src/tests/asciidoc_lang/mod.rs
+++ b/parser/src/tests/asciidoc_lang/mod.rs
@@ -26,6 +26,7 @@
 mod attributes;
 mod blocks;
 mod directives;
+mod docinfo;
 mod document;
 mod lists;
 mod macros;


### PR DESCRIPTION
## Summary

Implements the docinfo specification page (`docs/modules/docinfo/pages/index.adoc`). Because this crate is a parser (not a converter) and never touches the filesystem, docinfo file reading is delegated to a caller-supplied handler — mirroring how `include::` works via `IncludeFileHandler`.

The parser now:
- Parses the `docinfo` attribute (scopes, locations, `private`/`shared` aliases, empty value ⇒ `private`, combined values like `shared,private-footer`).
- Computes docinfo file names per the naming rules, honoring `docinfodir`, the derived `docname`, and the new `outfilesuffix` built-in (default `.html`).
- Reads files through a new `DocinfoFileHandler` trait and applies `docinfosubs` (default `attributes`) substitution to the content.
- Exposes the resolved content via `Document::docinfo(DocinfoLocation)` — shared file concatenated before private, matching Asciidoctor (verified against the locally installed `asciidoctor`).

## Public API

- `parser::DocinfoFileHandler` trait + `Parser::with_docinfo_file_handler(...)`.
- `document::DocinfoLocation` (`Head` / `Header` / `Footer`).
- `Document::docinfo(DocinfoLocation) -> &str`.
- `outfilesuffix` is now a built-in attribute (`.html`).

## Out of scope (documented)

- Safe-mode gating is left as a `TODO` referencing [#277](https://github.com/asciidoc-rs/asciidoc-parser/issues/277); the spec page does not document safe modes.
- Actual HTML/DocBook injection is the downstream converter's job — this crate exposes the resolved content.
- Only the `attributes` substitution is applied for `docinfosubs` (the only one the page demonstrates); other named subs can be added later.

## Testing

- Line-by-line spec coverage for the docinfo page (`parser/src/tests/asciidoc_lang/docinfo/index.rs`), verified with `cd sdd && cargo run` (page fully covered, no gaps).
- Branch-level unit tests for `docname()` and `Docinfo` edge cases.
- `cargo test -p asciidoc-parser` (2458 passing), `cargo clippy --all-targets`, `cargo +nightly fmt --check`, and `cargo +nightly doc` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)