### PR TITLE
feat: Implement appendix caption/label (appendix-caption)

### DIFF
--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -9,7 +9,7 @@ use crate::{
         Block, ContentModel, IsBlock, metadata::BlockMetadata, parse_utils::parse_blocks_until,
     },
     content::{Content, SubstitutionGroup},
-    document::RefType,
+    document::{InterpretedValue, RefType},
     internal::debug::DebugSliceReference,
     span::MatchedItem,
     strings::CowStr,
@@ -33,6 +33,7 @@ pub struct SectionBlock<'src> {
     attrlist: Option<Attrlist<'src>>,
     section_type: SectionType,
     section_id: Option<String>,
+    caption: Option<String>,
     section_number: Option<SectionNumber>,
 }
 
@@ -74,12 +75,31 @@ impl<'src> SectionBlock<'src> {
 
         // Assign section number BEFORE parsing child blocks so that sections are
         // numbered in document order (parent before children).
-        let section_number =
-            if parser.is_attribute_set("sectnums") && level <= parser.sectnumlevels && !discrete {
-                Some(parser.assign_section_number(level))
-            } else {
-                None
-            };
+        //
+        // Appendix sections are lettered (A, B, ...) independently of `sectnums`
+        // because their title prefix is governed by the `appendix-caption`
+        // attribute (see the "Appendix label" section of the spec). An appendix
+        // root — the section that directly carries the `appendix` style —
+        // therefore always advances the appendix counter so it (and the numbering
+        // of any subsection) can derive its letter, even when `sectnums` is unset.
+        let sectnums_active =
+            parser.is_attribute_set("sectnums") && level <= parser.sectnumlevels && !discrete;
+
+        let is_appendix_root = !discrete && level == 1 && section_type == SectionType::Appendix;
+
+        let (section_number, caption) = if is_appendix_root {
+            parser
+                .last_appendix_section_number
+                .assign_next_number(level);
+            let number = parser.last_appendix_section_number.clone();
+            let caption = appendix_caption(parser, &number);
+            let section_number = if sectnums_active { Some(number) } else { None };
+            (section_number, Some(caption))
+        } else if sectnums_active {
+            (Some(parser.assign_section_number(level)), None)
+        } else {
+            (None, None)
+        };
 
         let mut most_recent_level = level;
 
@@ -150,6 +170,7 @@ impl<'src> SectionBlock<'src> {
                 attrlist: metadata.attrlist.clone(),
                 section_type,
                 section_id,
+                caption,
                 section_number,
             },
             after: blocks.after,
@@ -199,6 +220,21 @@ impl<'src> SectionBlock<'src> {
     }
 }
 
+/// Builds the appendix title prefix (caption) for an appendix root section.
+///
+/// The prefix combines the `appendix-caption` label (which defaults to
+/// "`Appendix`"), the appendix letter (A, B, ...), and a separator. When
+/// `appendix-caption` is set, the prefix is `"<label> <letter>: "`; when it is
+/// unset (or empty), the label is dropped, leaving `"<letter>. "`. This mirrors
+/// Ruby Asciidoctor.
+fn appendix_caption(parser: &Parser, number: &SectionNumber) -> String {
+    let letter = number.to_string();
+    match parser.attribute_value("appendix-caption") {
+        InterpretedValue::Value(label) if !label.is_empty() => format!("{label} {letter}: "),
+        _ => format!("{letter}. "),
+    }
+}
+
 impl<'src> IsBlock<'src> for SectionBlock<'src> {
     fn content_model(&self) -> ContentModel {
         ContentModel::Compound
@@ -241,6 +277,10 @@ impl<'src> IsBlock<'src> for SectionBlock<'src> {
         self.attrlist.as_ref()
     }
 
+    fn caption(&self) -> Option<&str> {
+        self.caption.as_deref()
+    }
+
     fn id(&'src self) -> Option<&'src str> {
         // First try the default implementation (explicit IDs from anchor or attrlist)
         self.anchor()
@@ -271,6 +311,7 @@ impl std::fmt::Debug for SectionBlock<'_> {
             .field("attrlist", &self.attrlist)
             .field("section_type", &self.section_type)
             .field("section_id", &self.section_id)
+            .field("caption", &self.caption)
             .field("section_number", &self.section_number)
             .finish()
     }
@@ -663,6 +704,7 @@ mod tests {
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_section_title"),
+                    caption: None,
                     section_number: None,
                 }
             );
@@ -755,6 +797,7 @@ mod tests {
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_section_title"),
+                    caption: None,
                     section_number: None,
                 }
             );
@@ -870,6 +913,7 @@ mod tests {
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_section_title"),
+                    caption: None,
                     section_number: None,
                 }
             );
@@ -985,6 +1029,7 @@ mod tests {
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_section_title"),
+                    caption: None,
                     section_number: None,
                 }
             );
@@ -1127,6 +1172,7 @@ mod tests {
                             attrlist: None,
                             section_type: SectionType::Normal,
                             section_id: Some("_section_2"),
+                            caption: None,
                             section_number: None,
                         })
                     ],
@@ -1143,6 +1189,7 @@ mod tests {
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_section_title"),
+                    caption: None,
                     section_number: None,
                 }
             );
@@ -1235,6 +1282,7 @@ mod tests {
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_section_title"),
+                    caption: None,
                     section_number: None,
                 }
             );
@@ -1327,6 +1375,7 @@ mod tests {
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_section_title"),
+                    caption: None,
                     section_number: None,
                 }
             );
@@ -1586,6 +1635,7 @@ mod tests {
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_section_title"),
+                    caption: None,
                     section_number: None,
                 }
             );
@@ -1678,6 +1728,7 @@ mod tests {
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_section_title"),
+                    caption: None,
                     section_number: None,
                 }
             );
@@ -1793,6 +1844,7 @@ mod tests {
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_section_title"),
+                    caption: None,
                     section_number: None,
                 }
             );
@@ -1908,6 +1960,7 @@ mod tests {
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_section_title"),
+                    caption: None,
                     section_number: None,
                 }
             );
@@ -2050,6 +2103,7 @@ mod tests {
                             attrlist: None,
                             section_type: SectionType::Normal,
                             section_id: Some("_section_2"),
+                            caption: None,
                             section_number: None,
                         })
                     ],
@@ -2066,6 +2120,7 @@ mod tests {
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_section_title"),
+                    caption: None,
                     section_number: None,
                 }
             );
@@ -2158,6 +2213,7 @@ mod tests {
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_section_title"),
+                    caption: None,
                     section_number: None,
                 }
             );
@@ -2250,6 +2306,7 @@ mod tests {
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_section_title"),
+                    caption: None,
                     section_number: None,
                 }
             );
@@ -2910,6 +2967,7 @@ mod tests {
     section_id: Some(
         "_section_title",
     ),
+    caption: None,
     section_number: None,
 }"#
         );

--- a/parser/src/blocks/tests/mod.rs
+++ b/parser/src/blocks/tests/mod.rs
@@ -379,6 +379,7 @@ mod error_cases {
                 attrlist: None,
                 section_type: SectionType::Normal,
                 section_id: Some("_section_title"),
+                caption: None,
                 section_number: None,
             }
         );
@@ -580,6 +581,7 @@ mod error_cases {
                 },),
                 section_type: SectionType::Normal,
                 section_id: Some("_section_title_except_it_isnt"),
+                caption: None,
                 section_number: None,
             },)
         );

--- a/parser/src/blocks/tests/section.rs
+++ b/parser/src/blocks/tests/section.rs
@@ -128,6 +128,7 @@ fn simplest_section_block() {
             attrlist: None,
             section_type: SectionType::Normal,
             section_id: Some("_section_title"),
+            caption: None,
             section_number: None,
         })
     );
@@ -219,6 +220,7 @@ fn has_child_block() {
             attrlist: None,
             section_type: SectionType::Normal,
             section_id: Some("_section_title"),
+            caption: None,
             section_number: None,
         })
     );
@@ -351,6 +353,7 @@ fn title() {
             attrlist: None,
             section_type: SectionType::Normal,
             section_id: Some("_section_title"),
+            caption: None,
             section_number: None,
         })
     );
@@ -516,6 +519,7 @@ fn warn_child_attrlist_has_extra_comma() {
             attrlist: None,
             section_type: SectionType::Normal,
             section_id: Some("_section_title"),
+            caption: None,
             section_number: None,
         })
     );

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -1167,6 +1167,7 @@ mod tests {
                         attrlist: None,
                         section_type: SectionType::Normal,
                         section_id: Some("_section_title"),
+                        caption: None,
                         section_number: None,
                     },)
                 ],

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -157,6 +157,15 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
         },
     );
 
+    attrs.insert(
+        "appendix-caption".to_owned(),
+        AttributeValue {
+            allowable_value: AllowableValue::Any,
+            modification_context: ModificationContext::Anywhere,
+            value: InterpretedValue::Set,
+        },
+    );
+
     // TO DO: Replace ./images with value of imagesdir if that is non-default.
     attrs.insert(
         "iconsdir".to_owned(),
@@ -196,6 +205,7 @@ fn build_built_in_default_values() -> HashMap<String, String> {
 
     defaults.insert("example-caption".to_owned(), "Example".to_owned());
     defaults.insert("table-caption".to_owned(), "Table".to_owned());
+    defaults.insert("appendix-caption".to_owned(), "Appendix".to_owned());
     defaults.insert("iconsdir".to_owned(), "./images/icons".to_owned());
     defaults.insert("sectnums".to_owned(), "all".to_owned());
     defaults.insert("toc".to_owned(), "auto".to_owned());

--- a/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
@@ -198,6 +198,7 @@ Here's an example that shows how to set an ID on a section using this shorthand 
                 },),
                 section_type: SectionType::Normal,
                 section_id: None,
+                caption: None,
                 section_number: None,
             },)
         );
@@ -267,6 +268,7 @@ Here's an example that shows how to set an ID on an appendix section using this 
                 },),
                 section_type: SectionType::Appendix,
                 section_id: None,
+                caption: Some("Appendix A: "),
                 section_number: None,
             },)
         );

--- a/parser/src/tests/asciidoc_lang/blocks/discrete_headings.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/discrete_headings.rs
@@ -139,6 +139,7 @@ Discrete headings can be used where sections are not permitted.
                         },),
                         section_type: SectionType::Discrete,
                         section_id: Some("_discrete_heading",),
+                        caption: None,
                         section_number: None,
                     },),
                     Block::Simple(SimpleBlock {
@@ -302,6 +303,7 @@ DocBook refers to a discrete heading as a bridgehead, or free-floating heading.
                         },),
                         section_type: SectionType::Discrete,
                         section_id: Some("_float_heading",),
+                        caption: None,
                         section_number: None,
                     },),
                     Block::Simple(SimpleBlock {

--- a/parser/src/tests/asciidoc_lang/blocks/preamble_and_lead.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/preamble_and_lead.rs
@@ -164,6 +164,7 @@ include::example$preamble.adoc[]
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_certain_peril",),
+                    caption: None,
                     section_number: None,
                 },),
             ],

--- a/parser/src/tests/asciidoc_lang/directives/include_multiple_times_in_same_document.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include_multiple_times_in_same_document.rs
@@ -209,6 +209,7 @@ The single quotes around the variable name in the assignment are required to for
                         },),
                         section_type: SectionType::Normal,
                         section_id: None,
+                        caption: None,
                         section_number: None,
                     },),],
                     source: Span {
@@ -224,6 +225,7 @@ The single quotes around the variable name in the assignment are required to for
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_operation"),
+                    caption: None,
                     section_number: None,
                 },),
                 Block::Section(SectionBlock {
@@ -299,6 +301,7 @@ The single quotes around the variable name in the assignment are required to for
                         },),
                         section_type: SectionType::Normal,
                         section_id: None,
+                        caption: None,
                         section_number: None,
                     },),],
                     source: Span {
@@ -314,6 +317,7 @@ The single quotes around the variable name in the assignment are required to for
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_maintenance"),
+                    caption: None,
                     section_number: None,
                 },),
             ],

--- a/parser/src/tests/asciidoc_lang/document/compound_author_name.rs
+++ b/parser/src/tests/asciidoc_lang/document/compound_author_name.rs
@@ -469,6 +469,7 @@ image::author-attribute-with-compound-name.png[Compound author name displayed in
                 attrlist: None,
                 section_type: SectionType::Normal,
                 section_id: Some("_about_mara_moss_wirribi"),
+                caption: None,
                 section_number: None,
             },),],
             source: Span {

--- a/parser/src/tests/asciidoc_lang/document/reference_author_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/document/reference_author_attributes.rs
@@ -211,6 +211,7 @@ image::reference-author.png[Reference the built-in attributes for an author,role
                 attrlist: None,
                 section_type: SectionType::Normal,
                 section_id: Some("_about_kismet_r_lee"),
+                caption: None,
                 section_number: None,
             },),],
             source: Span {

--- a/parser/src/tests/asciidoc_lang/document/reference_revision_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/document/reference_revision_attributes.rs
@@ -144,6 +144,7 @@ image::reference-revision-line.png["Revision line and rendered revision referenc
                 attrlist: None,
                 section_type: SectionType::Normal,
                 section_id: Some("_colophon"),
+                caption: None,
                 section_number: None,
             },),],
             source: Span {
@@ -354,6 +355,7 @@ If you don't want the default version label to be displayed in the byline, xref:
                 attrlist: None,
                 section_type: SectionType::Normal,
                 section_id: Some("_colophon"),
+                caption: None,
                 section_number: None,
             },),],
             source: Span {

--- a/parser/src/tests/asciidoc_lang/sections/appendix.rs
+++ b/parser/src/tests/asciidoc_lang/sections/appendix.rs
@@ -35,8 +35,12 @@ include::example$appendix.adoc[tag=appx-article-out]
 "#
     );
 
-    // NOTE: Removed `appendix-caption` and `toc` flags because those aren't
-    // supported (yet?).
+    // NOTE: Removed the `:appendix-caption: Exhibit` and `:toc:` header
+    // attributes from the example. The `appendix-caption` attribute is now
+    // honored (it defaults to "`Appendix`", so the appendix sections below carry
+    // "Appendix A: " / "Appendix B: " captions), but `toc` rendering is still not
+    // supported. A custom `appendix-caption` value is exercised separately in
+    // `appendix_label` below.
     let doc = Parser::default().parse("= Article Title\n:sectnums:\n\n== Section\n\n=== Subsection\n\n[appendix]\n== First Appendix\n\n=== First Subsection\n\n=== Second Subsection\n\n[appendix]\n== Second Appendix");
 
     assert_eq!(
@@ -113,6 +117,7 @@ include::example$appendix.adoc[tag=appx-article-out]
                         attrlist: None,
                         section_type: SectionType::Normal,
                         section_id: Some("_subsection",),
+                        caption: None,
                         section_number: Some(SectionNumber {
                             section_type: SectionType::Normal,
                             components: &[1, 1,],
@@ -131,6 +136,7 @@ include::example$appendix.adoc[tag=appx-article-out]
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_section",),
+                    caption: None,
                     section_number: Some(SectionNumber {
                         section_type: SectionType::Normal,
                         components: &[1,],
@@ -173,6 +179,7 @@ include::example$appendix.adoc[tag=appx-article-out]
                             attrlist: None,
                             section_type: SectionType::Appendix,
                             section_id: Some("_first_subsection",),
+                            caption: None,
                             section_number: Some(SectionNumber {
                                 section_type: SectionType::Appendix,
                                 components: &[1, 1,],
@@ -203,6 +210,7 @@ include::example$appendix.adoc[tag=appx-article-out]
                             attrlist: None,
                             section_type: SectionType::Appendix,
                             section_id: Some("_second_subsection",),
+                            caption: None,
                             section_number: Some(SectionNumber {
                                 section_type: SectionType::Appendix,
                                 components: &[1, 2,],
@@ -235,6 +243,7 @@ include::example$appendix.adoc[tag=appx-article-out]
                     },),
                     section_type: SectionType::Appendix,
                     section_id: Some("_first_appendix",),
+                    caption: Some("Appendix A: ",),
                     section_number: Some(SectionNumber {
                         section_type: SectionType::Appendix,
                         components: &[1,],
@@ -278,6 +287,7 @@ include::example$appendix.adoc[tag=appx-article-out]
                     },),
                     section_type: SectionType::Appendix,
                     section_id: Some("_second_appendix",),
+                    caption: Some("Appendix B: ",),
                     section_number: Some(SectionNumber {
                         section_type: SectionType::Appendix,
                         components: &[2,],
@@ -379,4 +389,86 @@ include::example$appendix.adoc[tag=appx-book-out]
 "#
 );
 
-// TO DO: Adapt the appendix label portion. Not sure how to handle this yet.
+#[test]
+fn appendix_label() {
+    verifies!(
+        r#"
+[#caption]
+== Appendix label
+
+When rendered, the titles of sections marked as `appendix` will include:
+
+* A label, taken from the value of the `appendix-caption` attribute, which defaults to "`Appendix`"
+* A letter that represents the order of the appendix within the sequence of appendices (A, B, ...)
+* A colon
+* The section title
+
+For example:
+
+ Appendix A: Data Access Matrix
+
+"#
+    );
+
+    // The label is exposed as the section's caption (the prefix a converter
+    // prepends to the section title). With the default `appendix-caption`, the
+    // first appendix is labeled "Appendix A: " and appendices are lettered in
+    // document order. This holds even without `sectnums`, because appendix
+    // labels are controlled by `appendix-caption`, not section numbering.
+    let doc = Parser::default()
+        .parse("= Title\n\n[appendix]\n== Data Access Matrix\n\n[appendix]\n== Error Codes");
+
+    let captions: Vec<Option<&str>> = doc.nested_blocks().map(|b| b.caption()).collect();
+    assert_eq!(captions, vec![Some("Appendix A: "), Some("Appendix B: ")]);
+
+    // The rendered title combines the caption (label + letter + colon) with the
+    // section title, e.g. "Appendix A: Data Access Matrix".
+    let first = doc.nested_blocks().next().unwrap();
+    if let crate::blocks::Block::Section(section) = first {
+        assert_eq!(
+            format!("{}{}", section.caption().unwrap(), section.section_title()),
+            "Appendix A: Data Access Matrix"
+        );
+    } else {
+        panic!("expected the first block to be a section");
+    }
+
+    verifies!(
+        r#"
+The prefix can be modified by setting the `appendix-caption` attribute and overriding the default value with a custom value.
+
+[source]
+----
+:appendix-caption: Exhibit
+----
+
+"#
+    );
+
+    let doc = Parser::default().parse(
+        ":appendix-caption: Exhibit\n\n[appendix]\n== Data Access Matrix\n\n[appendix]\n== Error Codes",
+    );
+
+    let captions: Vec<Option<&str>> = doc.nested_blocks().map(|b| b.caption()).collect();
+    assert_eq!(captions, vec![Some("Exhibit A: "), Some("Exhibit B: ")]);
+
+    verifies!(
+        r#"
+Unset the attribute to remove the prefix.
+
+[source]
+----
+:appendix-caption!:
+----
+"#
+    );
+
+    // Unsetting `appendix-caption` removes the label, but the appendix is still
+    // lettered: the prefix collapses to "<letter>. " (matching Ruby Asciidoctor).
+    let doc = Parser::default().parse(
+        ":appendix-caption!:\n\n[appendix]\n== Data Access Matrix\n\n[appendix]\n== Error Codes",
+    );
+
+    let captions: Vec<Option<&str>> = doc.nested_blocks().map(|b| b.caption()).collect();
+    assert_eq!(captions, vec![Some("A. "), Some("B. ")]);
+}

--- a/parser/src/tests/asciidoc_lang/sections/auto_ids.rs
+++ b/parser/src/tests/asciidoc_lang/sections/auto_ids.rs
@@ -323,6 +323,7 @@ The AsciiDoc processor builds an ID from the title using the following order of 
                         attrlist: None,
                         section_type: SectionType::Normal,
                         section_id: Some("_duplicate_title",),
+                        caption: None,
                         section_number: None,
                     },),
                     Block::Section(SectionBlock {
@@ -374,6 +375,7 @@ The AsciiDoc processor builds an ID from the title using the following order of 
                         attrlist: None,
                         section_type: SectionType::Normal,
                         section_id: Some("_duplicate_title-2",),
+                        caption: None,
                         section_number: None,
                     },),
                 ],
@@ -565,6 +567,7 @@ By doing so, you can disable ID generation for only certain sections and discret
                         attrlist: None,
                         section_type: SectionType::Normal,
                         section_id: Some("_id_generation_on"),
+                        caption: None,
                         section_number: None,
                     },),
                     Block::Section(SectionBlock {
@@ -607,6 +610,7 @@ By doing so, you can disable ID generation for only certain sections and discret
                         attrlist: None,
                         section_type: SectionType::Normal,
                         section_id: None,
+                        caption: None,
                         section_number: None,
                     },),
                     Block::Section(SectionBlock {
@@ -634,6 +638,7 @@ By doing so, you can disable ID generation for only certain sections and discret
                         attrlist: None,
                         section_type: SectionType::Normal,
                         section_id: Some("_id_generation_on_again",),
+                        caption: None,
                         section_number: None,
                     },),
                 ],

--- a/parser/src/tests/asciidoc_lang/sections/custom_ids.rs
+++ b/parser/src/tests/asciidoc_lang/sections/custom_ids.rs
@@ -87,6 +87,7 @@ include::example$section.adoc[tag=with-anchor-shorthand]
                 },),
                 section_type: SectionType::Normal,
                 section_id: None,
+                caption: None,
                 section_number: None,
             },),],
             source: Span {
@@ -191,6 +192,7 @@ include::example$section.adoc[tag=with-anchor-and-reftext-shorthand]
                 },),
                 section_type: SectionType::Normal,
                 section_id: None,
+                caption: None,
                 section_number: None,
             },),],
             source: Span {
@@ -290,6 +292,7 @@ IMPORTANT: The value of the reftext attribute must be quoted if it contains spac
                 },),
                 section_type: SectionType::Normal,
                 section_id: None,
+                caption: None,
                 section_number: None,
             },),],
             source: Span {
@@ -383,6 +386,7 @@ include::example$section.adoc[tag=with-anchor-and-reftext]
                 attrlist: None,
                 section_type: SectionType::Normal,
                 section_id: None,
+                caption: None,
                 section_number: None,
             },),],
             source: Span {
@@ -486,6 +490,7 @@ Here's how to register auxiliary IDs using inline anchors when using an autogene
                 attrlist: None,
                 section_type: SectionType::Normal,
                 section_id: Some("_section_title",),
+                caption: None,
                 section_number: None,
             },),],
             source: Span {
@@ -591,6 +596,7 @@ fn assign_auxiliary_ids_2() {
                 attrlist: None,
                 section_type: SectionType::Normal,
                 section_id: Some("_section_title",),
+                caption: None,
                 section_number: None,
             },),],
             source: Span {
@@ -721,6 +727,7 @@ These additional anchor points don't interfere with the declaration of the prima
                 },),
                 section_type: SectionType::Normal,
                 section_id: None,
+                caption: None,
                 section_number: None,
             },),],
             source: Span {

--- a/parser/src/tests/asciidoc_lang/sections/id_prefix_and_separator.rs
+++ b/parser/src/tests/asciidoc_lang/sections/id_prefix_and_separator.rs
@@ -108,6 +108,7 @@ The value of `idprefix` must begin with a valid ID start character and can have 
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("id_section_title",),
+                    caption: None,
                     section_number: None,
                 },),],
                 source: Span {
@@ -206,6 +207,7 @@ If you want to remove the prefix, set the attribute to an empty value.
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("section_title",),
+                    caption: None,
                     section_number: None,
                 },),],
                 source: Span {
@@ -331,6 +333,7 @@ Unless empty, the value of the `idseparator` must be _exactly one valid ID chara
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_section.title",),
+                    caption: None,
                     section_number: None,
                 },),],
                 source: Span {
@@ -429,6 +432,7 @@ If you don't want to use a separator, set the attribute to an empty value.
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_sectiontitle",),
+                    caption: None,
                     section_number: None,
                 },),],
                 source: Span {

--- a/parser/src/tests/asciidoc_lang/sections/numbers.rs
+++ b/parser/src/tests/asciidoc_lang/sections/numbers.rs
@@ -127,6 +127,7 @@ When `sectnums` is set, level 1 (`==`) through level 3 (`====`) section titles a
                             attrlist: None,
                             section_type: SectionType::Normal,
                             section_id: Some("_level_4",),
+                            caption: None,
                             section_number: None,
                         },),],
                         source: Span {
@@ -142,6 +143,7 @@ When `sectnums` is set, level 1 (`==`) through level 3 (`====`) section titles a
                         attrlist: None,
                         section_type: SectionType::Normal,
                         section_id: Some("_level_3",),
+                        caption: None,
                         section_number: Some(SectionNumber {
                             section_type: SectionType::Normal,
                             components: &[1, 1, 1,],
@@ -160,6 +162,7 @@ When `sectnums` is set, level 1 (`==`) through level 3 (`====`) section titles a
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_level_2",),
+                    caption: None,
                     section_number: Some(SectionNumber {
                         section_type: SectionType::Normal,
                         components: &[1, 1,],
@@ -178,6 +181,7 @@ When `sectnums` is set, level 1 (`==`) through level 3 (`====`) section titles a
                 attrlist: None,
                 section_type: SectionType::Normal,
                 section_id: Some("_level_1",),
+                caption: None,
                 section_number: Some(SectionNumber {
                     section_type: SectionType::Normal,
                     components: &[1,]
@@ -358,6 +362,7 @@ The section number does not increment in regions of the document where section n
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_numbered_section",),
+                    caption: None,
                     section_number: Some(SectionNumber {
                         section_type: SectionType::Normal,
                         components: &[1,]
@@ -388,6 +393,7 @@ The section number does not increment in regions of the document where section n
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_unnumbered_section",),
+                    caption: None,
                     section_number: None,
                 },),
                 Block::Section(SectionBlock {
@@ -441,6 +447,7 @@ The section number does not increment in regions of the document where section n
                         attrlist: None,
                         section_type: SectionType::Normal,
                         section_id: Some("_unnumbered_section-2",),
+                        caption: None,
                         section_number: None,
                     },),],
                     source: Span {
@@ -456,6 +463,7 @@ The section number does not increment in regions of the document where section n
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_unnumbered_section-3",),
+                    caption: None,
                     section_number: None,
                 },),
                 Block::Section(SectionBlock {
@@ -483,6 +491,7 @@ The section number does not increment in regions of the document where section n
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_numbered_section-2",),
+                    caption: None,
                     section_number: Some(SectionNumber {
                         section_type: SectionType::Normal,
                         components: &[2,]
@@ -730,6 +739,7 @@ include::example$section.adoc[tag=sectnuml]
                         attrlist: None,
                         section_type: SectionType::Normal,
                         section_id: Some("_level_4",),
+                        caption: None,
                         section_number: None,
                     },),],
                     source: Span {
@@ -745,6 +755,7 @@ include::example$section.adoc[tag=sectnuml]
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_level_2",),
+                    caption: None,
                     section_number: Some(SectionNumber {
                         section_type: SectionType::Normal,
                         components: &[1, 1,],
@@ -763,6 +774,7 @@ include::example$section.adoc[tag=sectnuml]
                 attrlist: None,
                 section_type: SectionType::Normal,
                 section_id: Some("_level_1",),
+                caption: None,
                 section_number: Some(SectionNumber {
                     section_type: SectionType::Normal,
                     components: &[1,]

--- a/parser/src/tests/asciidoc_lang/sections/titles_and_levels.rs
+++ b/parser/src/tests/asciidoc_lang/sections/titles_and_levels.rs
@@ -147,6 +147,7 @@ include::example$section.adoc[tag=b-base]
                                     attrlist: None,
                                     section_type: SectionType::Normal,
                                     section_id: Some("_level_5_section_title"),
+                                    caption: None,
                                     section_number: None,
                                 },),],
                                 source: Span {
@@ -162,6 +163,7 @@ include::example$section.adoc[tag=b-base]
                                 attrlist: None,
                                 section_type: SectionType::Normal,
                                 section_id: Some("_level_4_section_title"),
+                                caption: None,
                                 section_number: None,
                             },),],
                             source: Span {
@@ -177,6 +179,7 @@ include::example$section.adoc[tag=b-base]
                             attrlist: None,
                             section_type: SectionType::Normal,
                             section_id: Some("_level_3_section_title"),
+                            caption: None,
                             section_number: None,
                         },),],
                         source: Span {
@@ -192,6 +195,7 @@ include::example$section.adoc[tag=b-base]
                         attrlist: None,
                         section_type: SectionType::Normal,
                         section_id: Some("_level_2_section_title"),
+                        caption: None,
                         section_number: None,
                     },),],
                     source: Span {
@@ -207,6 +211,7 @@ include::example$section.adoc[tag=b-base]
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_level_1_section_title"),
+                    caption: None,
                     section_number: None,
                 },),
                 Block::Section(SectionBlock {
@@ -234,6 +239,7 @@ include::example$section.adoc[tag=b-base]
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_another_level_1_section_title"),
+                    caption: None,
                     section_number: None,
                 },),
             ],
@@ -442,6 +448,7 @@ include::example$section.adoc[tag=content]
                         attrlist: None,
                         section_type: SectionType::Normal,
                         section_id: Some("_illegal_nested_section_violates_rule_2"),
+                        caption: None,
                         section_number: None,
                     },),],
                     source: Span {
@@ -457,6 +464,7 @@ include::example$section.adoc[tag=content]
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_first_section"),
+                    caption: None,
                     section_number: None,
                 },),
             ],
@@ -623,6 +631,7 @@ That means the outline of a Markdown document will be converted just fine as an 
                                     attrlist: None,
                                     section_type: SectionType::Normal,
                                     section_id: Some("_level_5_section_title"),
+                                    caption: None,
                                     section_number: None,
                                 },),],
                                 source: Span {
@@ -638,6 +647,7 @@ That means the outline of a Markdown document will be converted just fine as an 
                                 attrlist: None,
                                 section_type: SectionType::Normal,
                                 section_id: Some("_level_4_section_title"),
+                                caption: None,
                                 section_number: None,
                             },),],
                             source: Span {
@@ -653,6 +663,7 @@ That means the outline of a Markdown document will be converted just fine as an 
                             attrlist: None,
                             section_type: SectionType::Normal,
                             section_id: Some("_level_3_section_title"),
+                            caption: None,
                             section_number: None,
                         },),],
                         source: Span {
@@ -668,6 +679,7 @@ That means the outline of a Markdown document will be converted just fine as an 
                         attrlist: None,
                         section_type: SectionType::Normal,
                         section_id: Some("_level_2_section_title"),
+                        caption: None,
                         section_number: None,
                     },),],
                     source: Span {
@@ -683,6 +695,7 @@ That means the outline of a Markdown document will be converted just fine as an 
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_level_1_section_title"),
+                    caption: None,
                     section_number: None,
                 },),
                 Block::Section(SectionBlock {
@@ -710,6 +723,7 @@ That means the outline of a Markdown document will be converted just fine as an 
                     attrlist: None,
                     section_type: SectionType::Normal,
                     section_id: Some("_another_level_1_section_title"),
+                    caption: None,
                     section_number: None,
                 },),
             ],

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -334,6 +334,7 @@ mod bulleted_lists {
                         attrlist: None,
                         section_type: SectionType::Normal,
                         section_id: Some("_lists",),
+                        caption: None,
                         section_number: None,
                     },),],
                     source: Span {

--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -327,6 +327,7 @@ mod normal {
                         attrlist: None,
                         section_type: SectionType::Normal,
                         section_id: Some("_first_section",),
+                        caption: None,
                         section_number: None,
                     },),
                     Block::Section(SectionBlock {
@@ -378,6 +379,7 @@ mod normal {
                         attrlist: None,
                         section_type: SectionType::Normal,
                         section_id: Some("_second_section",),
+                        caption: None,
                         section_number: None,
                     },),
                 ],

--- a/parser/src/tests/fixtures/blocks/section.rs
+++ b/parser/src/tests/fixtures/blocks/section.rs
@@ -26,6 +26,7 @@ pub(crate) struct SectionBlock {
     pub attrlist: Option<Attrlist>,
     pub section_type: SectionType,
     pub section_id: Option<&'static str>,
+    pub caption: Option<&'static str>,
     pub section_number: Option<SectionNumber>,
 }
 
@@ -43,6 +44,7 @@ impl fmt::Debug for SectionBlock {
             .field("attrlist", &self.attrlist)
             .field("section_type", &self.section_type)
             .field("section_id", &self.section_id)
+            .field("caption", &self.caption)
             .field("section_number", &self.section_number)
             .finish()
     }
@@ -145,6 +147,17 @@ fn fixture_eq_observed(fixture: &SectionBlock, observed: &crate::blocks::Section
     if let Some(ref fixture_section_id) = fixture.section_id
         && let Some(ref observed_section_id) = observed.section_id()
         && fixture_section_id != observed_section_id
+    {
+        return false;
+    }
+
+    if fixture.caption.is_some() != observed.caption().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_caption) = fixture.caption
+        && let Some(ref observed_caption) = observed.caption()
+        && fixture_caption != observed_caption
     {
         return false;
     }


### PR DESCRIPTION
## Summary

Implements the **Appendix label** portion of [`docs/modules/sections/pages/appendix.adoc`](docs/modules/sections/pages/appendix.adoc) — the last unimplemented feature on that page. It was previously left as a `TO DO` because the `appendix-caption` attribute wasn't supported.

Appendix root sections now carry a **caption** (the prefix a converter prepends to the section title):

| `appendix-caption` | Caption | Rendered title |
| --- | --- | --- |
| default (`Appendix`) | `Appendix A: ` | `Appendix A: First Appendix` |
| custom (`:appendix-caption: Exhibit`) | `Exhibit A: ` | `Exhibit A: First Appendix` |
| unset (`:appendix-caption!:`) | `A. ` | `A. First Appendix` |

Appendix letters (A, B, …) are assigned in document order **independently of `sectnums`**, matching Ruby Asciidoctor — appendix title prefixes are governed by `appendix-caption`, not section numbering (see also `special-section-numbers.adoc`). Verified against a local `asciidoctor` install for all three caption states, with and without `sectnums`.

## Changes

- **`appendix-caption` built-in attribute** — registered as `Set` with default value `"Appendix"`, mirroring `example-caption`/`table-caption`.
- **`SectionBlock::caption`** — new field, exposed via `IsBlock::caption()` (the same accessor captioned blocks already use), computed for appendix roots during parsing.
- **Spec coverage** — new `appendix_label` test covers the `[#caption]` section; the existing syntax test now asserts the `Appendix A: ` / `Appendix B: ` captions, and the stale "appendix-caption not supported" note is updated. `cd sdd && cargo run` shows the page's lines 39–65 fully covered with no gaps.

The bulk of the touched test files are mechanical `caption: None,` additions to existing `SectionBlock` fixtures.

## Verification

- `cargo test` — 2456 passing, 0 failing
- `cargo clippy --all-targets` — clean
- `cargo +nightly fmt --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo +nightly doc` — clean
- SDD coverage for `appendix.adoc` — complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)