### PR TITLE
feat: Implement STEM (stem/asciimath/latexmath) inline and block support (#261)

### DIFF
--- a/parser/src/blocks/context.rs
+++ b/parser/src/blocks/context.rs
@@ -21,6 +21,7 @@ pub(crate) fn is_built_in_context(context: &str) -> bool {
             | "quote"
             | "section"
             | "sidebar"
+            | "stem"
             | "table"
             | "table_cell"
             | "thematic_break"

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -2,7 +2,7 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::Attrlist,
     blocks::{ContentModel, IsBlock, metadata::BlockMetadata},
-    content::{Content, SubstitutionGroup},
+    content::{Content, SubstitutionGroup, SubstitutionStep},
     span::MatchedItem,
     strings::CowStr,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -99,7 +99,7 @@ impl<'src> RawDelimitedBlock<'src> {
                     "literal",
                     SubstitutionGroup::Verbatim,
                 ),
-                "++++" => (ContentModel::Raw, "pass", SubstitutionGroup::Pass),
+                "++++" => pass_or_stem_block_type(metadata.attrlist.as_ref()),
                 _ => {
                     return None;
                 }
@@ -214,6 +214,27 @@ fn open_block_verbatim_masquerade(
             SubstitutionGroup::Verbatim,
         )),
         _ => None,
+    }
+}
+
+/// Resolve the content model, context, and substitution group for a passthrough
+/// (`++++`) delimited block.
+///
+/// A passthrough block normally has the `pass` context and applies no
+/// substitutions. When it carries a STEM style (`stem`, `asciimath`, or
+/// `latexmath`), it instead becomes a `stem` block: a raw block whose
+/// expression has only the special characters substitution applied (the
+/// notation's math delimiters are added by the converter at render time).
+fn pass_or_stem_block_type(
+    attrlist: Option<&Attrlist<'_>>,
+) -> (ContentModel, &'static str, SubstitutionGroup) {
+    match attrlist.and_then(|a| a.block_style()) {
+        Some("stem") | Some("asciimath") | Some("latexmath") => (
+            ContentModel::Raw,
+            "stem",
+            SubstitutionGroup::Custom(vec![SubstitutionStep::SpecialCharacters]),
+        ),
+        _ => (ContentModel::Raw, "pass", SubstitutionGroup::Pass),
     }
 }
 
@@ -1372,6 +1393,75 @@ mod tests {
                     rendered: "line1  \n+++++\nline2",
                 }
             );
+        }
+    }
+
+    mod stem {
+        use crate::{blocks::ContentModel, content::SubstitutionStep, tests::prelude::*};
+
+        /// A `[stem]` passthrough block becomes a `stem` block whose expression
+        /// has only the special characters substitution applied. The notation's
+        /// math delimiters are added by the converter at render time, so they do
+        /// not appear in the parsed content.
+        #[test]
+        fn stem_style_block() {
+            let doc = Parser::default().parse("[stem]\n++++\na < b\n++++");
+            let block = doc.nested_blocks().next().unwrap();
+
+            assert_eq!(block.content_model(), ContentModel::Raw);
+            assert_eq!(block.raw_context().as_ref(), "stem");
+            assert_eq!(block.resolved_context().as_ref(), "stem");
+            assert_eq!(block.declared_style(), Some("stem"));
+            assert_eq!(block.rendered_content(), Some("a &lt; b"));
+            assert_eq!(
+                block.substitution_group(),
+                SubstitutionGroup::Custom(vec![SubstitutionStep::SpecialCharacters])
+            );
+            assert!(doc.warnings().next().is_none());
+        }
+
+        #[test]
+        fn asciimath_style_block() {
+            let doc = Parser::default().parse("[asciimath]\n++++\nx^2\n++++");
+            let block = doc.nested_blocks().next().unwrap();
+
+            assert_eq!(block.raw_context().as_ref(), "stem");
+            assert_eq!(block.declared_style(), Some("asciimath"));
+            assert_eq!(block.rendered_content(), Some("x^2"));
+        }
+
+        #[test]
+        fn latexmath_style_block() {
+            let doc = Parser::default().parse("[latexmath]\n++++\nC = \\alpha\n++++");
+            let block = doc.nested_blocks().next().unwrap();
+
+            assert_eq!(block.raw_context().as_ref(), "stem");
+            assert_eq!(block.declared_style(), Some("latexmath"));
+            assert_eq!(block.rendered_content(), Some(r"C = \alpha"));
+        }
+
+        /// Without a STEM style, a `++++` block remains a `pass` block with no
+        /// substitutions applied.
+        #[test]
+        fn unstyled_block_is_still_pass() {
+            let doc = Parser::default().parse("++++\na < b\n++++");
+            let block = doc.nested_blocks().next().unwrap();
+
+            assert_eq!(block.raw_context().as_ref(), "pass");
+            assert_eq!(block.rendered_content(), Some("a < b"));
+            assert_eq!(block.substitution_group(), SubstitutionGroup::Pass);
+        }
+
+        /// An explicit `subs` attribute still overrides a STEM block's default
+        /// substitution group.
+        #[test]
+        fn subs_attribute_overrides_stem_default() {
+            let doc = Parser::default().parse("[stem,subs=none]\n++++\na < b\n++++");
+            let block = doc.nested_blocks().next().unwrap();
+
+            assert_eq!(block.raw_context().as_ref(), "stem");
+            assert_eq!(block.rendered_content(), Some("a < b"));
+            assert_eq!(block.substitution_group(), SubstitutionGroup::None);
         }
     }
 

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -2,7 +2,7 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::Attrlist,
     blocks::{ContentModel, IsBlock, metadata::BlockMetadata},
-    content::{Content, SubstitutionGroup, SubstitutionStep},
+    content::{Content, SubstitutionGroup},
     span::MatchedItem,
     strings::CowStr,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -229,11 +229,9 @@ fn pass_or_stem_block_type(
     attrlist: Option<&Attrlist<'_>>,
 ) -> (ContentModel, &'static str, SubstitutionGroup) {
     match attrlist.and_then(|a| a.block_style()) {
-        Some("stem") | Some("asciimath") | Some("latexmath") => (
-            ContentModel::Raw,
-            "stem",
-            SubstitutionGroup::Custom(vec![SubstitutionStep::SpecialCharacters]),
-        ),
+        Some("stem") | Some("asciimath") | Some("latexmath") => {
+            (ContentModel::Raw, "stem", SubstitutionGroup::stem())
+        }
         _ => (ContentModel::Raw, "pass", SubstitutionGroup::Pass),
     }
 }
@@ -1401,8 +1399,8 @@ mod tests {
 
         /// A `[stem]` passthrough block becomes a `stem` block whose expression
         /// has only the special characters substitution applied. The notation's
-        /// math delimiters are added by the converter at render time, so they do
-        /// not appear in the parsed content.
+        /// math delimiters are added by the converter at render time, so they
+        /// do not appear in the parsed content.
         #[test]
         fn stem_style_block() {
             let doc = Parser::default().parse("[stem]\n++++\na < b\n++++");

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -230,7 +230,7 @@ fn pass_or_stem_block_type(
 ) -> (ContentModel, &'static str, SubstitutionGroup) {
     match attrlist.and_then(|a| a.block_style()) {
         Some("stem") | Some("asciimath") | Some("latexmath") => {
-            (ContentModel::Raw, "stem", SubstitutionGroup::stem())
+            (ContentModel::Raw, "stem", SubstitutionGroup::Stem)
         }
         _ => (ContentModel::Raw, "pass", SubstitutionGroup::Pass),
     }
@@ -1395,7 +1395,7 @@ mod tests {
     }
 
     mod stem {
-        use crate::{blocks::ContentModel, content::SubstitutionStep, tests::prelude::*};
+        use crate::{blocks::ContentModel, tests::prelude::*};
 
         /// A `[stem]` passthrough block becomes a `stem` block whose expression
         /// has only the special characters substitution applied. The notation's
@@ -1411,10 +1411,7 @@ mod tests {
             assert_eq!(block.resolved_context().as_ref(), "stem");
             assert_eq!(block.declared_style(), Some("stem"));
             assert_eq!(block.rendered_content(), Some("a &lt; b"));
-            assert_eq!(
-                block.substitution_group(),
-                SubstitutionGroup::Custom(vec![SubstitutionStep::SpecialCharacters])
-            );
+            assert_eq!(block.substitution_group(), SubstitutionGroup::Stem);
             assert!(doc.warnings().next().is_none());
         }
 

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -5,8 +5,9 @@ use regex::{Captures, Regex, Replacer};
 use crate::{
     Parser, Span,
     attributes::{Attrlist, AttrlistContext},
-    content::{Content, SubstitutionGroup},
+    content::{Content, SubstitutionGroup, SubstitutionStep},
     parser::{QuoteScope, QuoteType},
+    warnings::WarningType,
 };
 
 /// Saves the content of one passthrough (`+++` or similarly bracketed) passage
@@ -25,7 +26,7 @@ pub(crate) struct Passthrough {
 pub(crate) struct Passthroughs(pub(crate) Vec<Passthrough>);
 
 impl Passthroughs {
-    pub(crate) fn extract_from(content: &mut Content<'_>) -> Self {
+    pub(crate) fn extract_from(content: &mut Content<'_>, parser: &Parser) -> Self {
         let mut passthroughs = Self(vec![]);
 
         // TRANSLATION GUIDE:
@@ -55,9 +56,26 @@ impl Passthroughs {
             }
         }
 
-        // TO DO (#261): When implementing STEM macros, look for the block that starts
-        // with `text.gsub InlineStemMacroRx do` in Ruby Asciidoctor's substitutors.rb
-        // file.
+        // Inline STEM macros (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`) are
+        // implicit passthroughs. They are extracted last so that any earlier
+        // passthrough placeholders nested inside a STEM expression are preserved
+        // and recursively restored. (Mirrors the `text.gsub InlineStemMacroRx`
+        // block in Ruby Asciidoctor's substitutors.rb.)
+        {
+            let text = content.rendered.as_ref();
+            if text.contains(':') && (text.contains("stem:") || text.contains("math:")) {
+                let original = content.original();
+                let replacer = InlineStemMacroReplacer {
+                    passthroughs: &mut passthroughs,
+                    parser,
+                    source: original,
+                };
+
+                if let Cow::Owned(new_result) = INLINE_STEM_MACRO.replace_all(text, replacer) {
+                    content.rendered = new_result.into();
+                }
+            }
+        }
 
         passthroughs
     }
@@ -430,6 +448,111 @@ impl Replacer for InlinePassReplacer<'_> {
     }
 }
 
+/// Matches a STEM inline macro (`stem`, and its alternatives `asciimath` and
+/// `latexmath`), which may span multiple lines.
+///
+/// ## Examples
+///
+/// * `stem:[x^2]`
+/// * `asciimath:[x != 0]`
+/// * `latexmath:[\sqrt{4} = 2]`
+///
+/// The content group requires at least one character whose final character is
+/// not a backslash, so an empty macro (e.g. `stem:[]`) is not recognized.
+static INLINE_STEM_MACRO: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(
+        r#"(?xs)
+            (\\?)                          # Group 1: optional escape
+            (stem|latexmath|asciimath)     # Group 2: notation
+            :
+            ([a-z]+(?:,[a-z-]+)*)?         # Group 3: optional substitution list
+            \[
+                (.*?[^\\])                 # Group 4: expression (last char not a backslash)
+            \]
+        "#,
+    )
+    .unwrap()
+});
+
+#[derive(Debug)]
+struct InlineStemMacroReplacer<'p> {
+    passthroughs: &'p mut Passthroughs,
+    parser: &'p Parser,
+    source: Span<'p>,
+}
+
+impl Replacer for InlineStemMacroReplacer<'_> {
+    fn replace_append(&mut self, caps: &Captures<'_>, dest: &mut String) {
+        // Honor the escape: drop the leading backslash and emit the macro
+        // literally.
+        if caps.get(1).is_some_and(|m| !m.as_str().is_empty()) {
+            dest.push_str(&caps[0][1..]);
+            return;
+        }
+
+        let type_ = match &caps[2] {
+            "latexmath" => QuoteType::LatexMath,
+            "asciimath" => QuoteType::AsciiMath,
+            // `stem`: the notation is resolved from the `stem` document
+            // attribute (defaulting to AsciiMath).
+            _ => stem_notation(self.parser),
+        };
+
+        // Unescape any escaped closing brackets in the expression.
+        let mut content = caps[4].to_string();
+        if content.contains("\\]") {
+            content = content.replace("\\]", "]");
+        }
+
+        // Drop legacy enclosing `$…$` around latexmath content (for backwards
+        // compatibility with AsciiDoc.py).
+        if type_ == QuoteType::LatexMath
+            && content.len() >= 2
+            && content.starts_with('$')
+            && content.ends_with('$')
+        {
+            content = content[1..content.len() - 1].to_string();
+        }
+
+        // Resolve the substitution group. When no explicit substitution list is
+        // given, HTML output applies only the special characters substitution.
+        let subs = match caps.get(3).map(|m| m.as_str()) {
+            None => SubstitutionGroup::Custom(vec![SubstitutionStep::SpecialCharacters]),
+            Some(subs_list) => match SubstitutionGroup::from_custom_string(None, subs_list) {
+                Some(group) => group,
+                None => {
+                    self.parser.record_substitution_warning(
+                        self.source,
+                        WarningType::InvalidSubstitutionTypeForStemMacro(subs_list.to_string()),
+                    );
+                    SubstitutionGroup::None
+                }
+            },
+        };
+
+        self.passthroughs.push(
+            Passthrough {
+                text: content,
+                subs,
+                type_: Some(type_),
+                attrlist: None,
+            },
+            dest,
+        );
+    }
+}
+
+/// Resolves the STEM notation to apply for a bare `stem` macro or block from the
+/// `stem` document attribute. Any value other than `latexmath`, `latex`, or
+/// `tex` (including an unset, empty, or unrecognized value) maps to AsciiMath.
+fn stem_notation(parser: &Parser) -> QuoteType {
+    match parser.attribute_value("stem").as_maybe_str() {
+        Some("latexmath") | Some("latex") | Some("tex") => QuoteType::LatexMath,
+        _ => QuoteType::AsciiMath,
+    }
+}
+
 #[derive(Debug)]
 struct PassthroughRestoreReplacer<'p>(&'p Passthroughs, &'p Parser);
 
@@ -537,7 +660,8 @@ mod tests {
     fn adds_warning_text_for_unresolved_passthrough_id() {
         let mut content =
             crate::content::Content::from(crate::Span::new("pass:q,a[*<{backend}>*]"));
-        let pt = Passthroughs::extract_from(&mut content);
+        let parser_for_extract = Parser::default();
+        let pt = Passthroughs::extract_from(&mut content, &parser_for_extract);
 
         assert_eq!(
             content,

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -518,7 +518,7 @@ impl Replacer for InlineStemMacroReplacer<'_> {
         // Resolve the substitution group. When no explicit substitution list is
         // given, HTML output applies only the special characters substitution.
         let subs = match caps.get(3).map(|m| m.as_str()) {
-            None => SubstitutionGroup::stem(),
+            None => SubstitutionGroup::Stem,
             Some(subs_list) => match SubstitutionGroup::from_custom_string(None, subs_list) {
                 Some(group) => group,
                 None => {

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -5,7 +5,7 @@ use regex::{Captures, Regex, Replacer};
 use crate::{
     Parser, Span,
     attributes::{Attrlist, AttrlistContext},
-    content::{Content, SubstitutionGroup, SubstitutionStep},
+    content::{Content, SubstitutionGroup},
     parser::{QuoteScope, QuoteType},
     warnings::WarningType,
 };
@@ -518,7 +518,7 @@ impl Replacer for InlineStemMacroReplacer<'_> {
         // Resolve the substitution group. When no explicit substitution list is
         // given, HTML output applies only the special characters substitution.
         let subs = match caps.get(3).map(|m| m.as_str()) {
-            None => SubstitutionGroup::Custom(vec![SubstitutionStep::SpecialCharacters]),
+            None => SubstitutionGroup::stem(),
             Some(subs_list) => match SubstitutionGroup::from_custom_string(None, subs_list) {
                 Some(group) => group,
                 None => {
@@ -543,8 +543,8 @@ impl Replacer for InlineStemMacroReplacer<'_> {
     }
 }
 
-/// Resolves the STEM notation to apply for a bare `stem` macro or block from the
-/// `stem` document attribute. Any value other than `latexmath`, `latex`, or
+/// Resolves the STEM notation to apply for a bare `stem` macro or block from
+/// the `stem` document attribute. Any value other than `latexmath`, `latex`, or
 /// `tex` (including an unset, empty, or unrecognized value) maps to AsciiMath.
 fn stem_notation(parser: &Parser) -> QuoteType {
     match parser.attribute_value("stem").as_maybe_str() {

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -176,7 +176,7 @@ impl SubstitutionGroup {
 
         let passthroughs: Option<Passthroughs> =
             if steps.contains(&SubstitutionStep::Macros) || self == &Self::Header {
-                Some(Passthroughs::extract_from(content))
+                Some(Passthroughs::extract_from(content, parser))
             } else {
                 None
             };

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -54,6 +54,12 @@ pub enum SubstitutionGroup {
     /// these values.
     AttributeEntryValue,
 
+    /// The STEM substitution group is applied to STEM (`stem`, `asciimath`, and
+    /// `latexmath`) content when no explicit substitution list is given. Only
+    /// the special characters substitution is applied (Asciidoctor's basic subs
+    /// for HTML output). Used by both the inline STEM macro and the STEM block.
+    Stem,
+
     /// You can customize the substitutions applied to the content of an inline
     /// pass macro by specifying one or more substitution values. Multiple
     /// values must be separated by commas and may not contain any spaces. The
@@ -67,14 +73,6 @@ pub enum SubstitutionGroup {
 }
 
 impl SubstitutionGroup {
-    /// The substitution group applied to STEM (`stem`, `asciimath`, and
-    /// `latexmath`) content when no explicit substitution list is given: only
-    /// the special characters substitution (Asciidoctor's basic subs for HTML
-    /// output). Used by both the inline STEM macro and the STEM block.
-    pub(crate) fn stem() -> Self {
-        Self::Custom(vec![SubstitutionStep::SpecialCharacters])
-    }
-
     /// Parse the custom substitution group syntax defined in [Custom
     /// substitutions].
     ///
@@ -249,6 +247,8 @@ impl SubstitutionGroup {
                 SubstitutionStep::Callouts,
             ],
 
+            Self::Stem => &[SubstitutionStep::SpecialCharacters],
+
             Self::Pass | Self::None => &[],
 
             Self::Custom(steps) => steps,
@@ -261,13 +261,19 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     mod stem {
-        use crate::{content::SubstitutionStep, tests::prelude::*};
+        use crate::{content::Content, strings::CowStr, tests::prelude::*};
 
         #[test]
-        fn is_special_characters_only() {
+        fn applies_special_characters_only() {
+            // The `Stem` group applies only the special characters substitution:
+            // `<` is escaped, but quotes (`*bold*`) and attribute references
+            // (`{color}`) are left untouched.
+            let mut content = Content::from(crate::Span::new("*a* < {color}"));
+            let p = Parser::default();
+            SubstitutionGroup::Stem.apply(&mut content, &p, None);
             assert_eq!(
-                SubstitutionGroup::stem(),
-                SubstitutionGroup::Custom(vec![SubstitutionStep::SpecialCharacters])
+                content.rendered,
+                CowStr::Boxed("*a* &lt; {color}".to_string().into_boxed_str())
             );
         }
     }

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -67,6 +67,14 @@ pub enum SubstitutionGroup {
 }
 
 impl SubstitutionGroup {
+    /// The substitution group applied to STEM (`stem`, `asciimath`, and
+    /// `latexmath`) content when no explicit substitution list is given: only
+    /// the special characters substitution (Asciidoctor's basic subs for HTML
+    /// output). Used by both the inline STEM macro and the STEM block.
+    pub(crate) fn stem() -> Self {
+        Self::Custom(vec![SubstitutionStep::SpecialCharacters])
+    }
+
     /// Parse the custom substitution group syntax defined in [Custom
     /// substitutions].
     ///
@@ -251,6 +259,18 @@ impl SubstitutionGroup {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
+
+    mod stem {
+        use crate::{content::SubstitutionStep, tests::prelude::*};
+
+        #[test]
+        fn is_special_characters_only() {
+            assert_eq!(
+                SubstitutionGroup::stem(),
+                SubstitutionGroup::Custom(vec![SubstitutionStep::SpecialCharacters])
+            );
+        }
+    }
 
     mod from_custom_string {
         use crate::{

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -213,6 +213,13 @@ pub enum QuoteType {
 
     /// Surrounds a block of text that may need a `<span>` or similar tag.
     Unquoted,
+
+    /// Inline AsciiMath expression, surrounded by AsciiMath math delimiters.
+    AsciiMath,
+
+    /// Inline LaTeX math expression, surrounded by LaTeX inline math
+    /// delimiters.
+    LatexMath,
 }
 
 /// Specifies whether the block is aligned to word boundaries or not.
@@ -485,6 +492,18 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
                 } else {
                     wrap_body_in_html_tag(attrlist.as_ref(), "span", id, roles, body, dest);
                 }
+            }
+
+            QuoteType::AsciiMath => {
+                dest.push_str(r"\$");
+                dest.push_str(body);
+                dest.push_str(r"\$");
+            }
+
+            QuoteType::LatexMath => {
+                dest.push_str(r"\(");
+                dest.push_str(body);
+                dest.push_str(r"\)");
             }
         }
     }

--- a/parser/src/tests/asciidoc_lang/mod.rs
+++ b/parser/src/tests/asciidoc_lang/mod.rs
@@ -32,6 +32,7 @@ mod macros;
 mod pass;
 mod root;
 mod sections;
+mod stem;
 mod subs;
 mod tables;
 mod text;

--- a/parser/src/tests/asciidoc_lang/stem/index.rs
+++ b/parser/src/tests/asciidoc_lang/stem/index.rs
@@ -144,7 +144,7 @@ All such syntax is passed through to the STEM processor as is.
 }
 
 mod block_stem_content {
-    use crate::{blocks::ContentModel, content::SubstitutionStep, tests::prelude::*};
+    use crate::{blocks::ContentModel, tests::prelude::*};
 
     #[test]
     fn block_stem_syntax() {
@@ -187,10 +187,7 @@ The AsciiDoc processor handles that for you automatically!
         assert_eq!(block.raw_context().as_ref(), "stem");
         assert_eq!(block.declared_style(), Some("stem"));
         assert_eq!(block.rendered_content(), Some("sqrt(4) = 2"));
-        assert_eq!(
-            block.substitution_group(),
-            SubstitutionGroup::Custom(vec![SubstitutionStep::SpecialCharacters])
-        );
+        assert_eq!(block.substitution_group(), SubstitutionGroup::Stem);
     }
 }
 

--- a/parser/src/tests/asciidoc_lang/stem/index.rs
+++ b/parser/src/tests/asciidoc_lang/stem/index.rs
@@ -1,0 +1,478 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/stem/pages/index.adoc");
+
+non_normative!(
+    r#"
+= Equations and Formulas (STEM)
+:page-aliases: stem.adoc
+:stem: asciimath
+:url-mathjax: https://www.mathjax.org
+:url-asciimath: https://docs.mathjax.org/en/latest/input/asciimath.html
+:url-latexmath: https://docs.mathjax.org/en/latest/input/tex/index.html
+:url-mathjax-docs: https://meta.math.stackexchange.com/questions/5020/mathjax-basic-tutorial-and-quick-reference
+
+If you need to include Science, Technology, Engineering and Math (STEM) expressions in your document, the AsciiDoc language supports embedding math-mode macros from {url-latexmath}[LaTeX] and/or {url-asciimath}[AsciiMath] notation as block or inline elements.
+These elements act as passthroughs to preserve the expressions as entered.
+The expressions are then passed on to the converter to be processed and rendered for display using a STEM provider (e.g., MathJax).
+
+== Activating STEM support
+
+To activate equation and formula support, set the `stem` attribute in the document's header (or by passing the attribute to the command line or API).
+
+.Setting the stem attribute
+[source]
+----
+include::example$stem.adoc[tag=base-co]
+----
+<.> The default notation value, `asciimath`, is assigned implicitly.
+
+By default, AsciiDoc's stem integration assumes all equations are AsciiMath if not specified explicitly.
+The HTML converter supports STEM content written in {url-asciimath}[AsciiMath^] and {url-latexmath}[TeX and LaTeX^] math notation.
+The DocBook converter only processes AsciiMath notation, leaving LaTeX to be processed by a separate tool in the DocBook toolchain.
+
+If you want to use the LaTeX notation by default, assign `latexmath` to the stem attribute.
+
+.Assigning an alternative notation to the stem attribute
+[source]
+----
+include::example$stem.adoc[tag=base-alt]
+----
+
+TIP: You can use both notations in the same document.
+The value of the `stem` attribute merely sets the default notation.
+To set the notation explicitly for a given block or inline span, just use `asciimath` or `latexmath` in place of `stem` as explained in <<mixing-notations>>.
+
+Stem content can be displayed inline with other content or as discrete blocks.
+No substitutions are applied to the content within a stem macro or block.
+
+"#
+);
+
+mod inline_stem_content {
+    use crate::{blocks::Block, tests::prelude::*};
+
+    #[test]
+    fn inline_stem_macro() {
+        verifies!(
+            r#"
+[#inline]
+== Inline STEM content
+
+The best way to mark up an inline formula is to use the `stem` macro.
+The text between the square brackets of the inline stem macro acts as an implicit passthrough.
+
+.Inline stem macro syntax
+[source#ex-inline]
+----
+include::example$stem.adoc[tag=in-co]
+----
+<.> The inline stem macro contains only one colon (`:`).
+<.> Place the expression within the square brackets (`[ ]`) of the macro.
+
+The result of <<ex-inline>> is displayed below.
+
+====
+include::example$stem.adoc[tag=in]
+====
+
+If the inline stem equation contains a right square bracket, you must escape this character using a backslash.
+
+.Inline stem macro with a right square bracket
+[source#ex-square-bracket]
+----
+include::example$stem.adoc[tag=in-sb]
+----
+
+The result of <<ex-square-bracket>> is displayed below.
+
+====
+include::example$stem.adoc[tag=in-sb]
+====
+
+Since the inline stem macro is an implicit passthrough, the closing square bracket it the only character you have to escape.
+You don't have to worry about escaping other AsciiDoc syntax, such as attribute references.
+All such syntax is passed through to the STEM processor as is.
+
+"#
+        );
+
+        // Examples from `example$stem.adoc[tag=in]`, rendered with the default
+        // `asciimath` notation. The expression is preserved verbatim and
+        // surrounded by the AsciiMath inline delimiters.
+        let mut parser = Parser::default().with_intrinsic_attribute(
+            "stem",
+            "asciimath",
+            ModificationContext::Anywhere,
+        );
+
+        let doc =
+            parser.parse("stem:[sqrt(4) = 2]\n\nWater (stem:[H_2O]) is a critical component.");
+
+        let mut blocks = doc.nested_blocks();
+
+        let block1 = blocks.next().unwrap();
+        let Block::Simple(sb1) = block1 else {
+            panic!("Unexpected block type: {block1:?}");
+        };
+        assert_eq!(sb1.content().rendered(), r"\$sqrt(4) = 2\$");
+
+        let block2 = blocks.next().unwrap();
+        let Block::Simple(sb2) = block2 else {
+            panic!("Unexpected block type: {block2:?}");
+        };
+        assert_eq!(
+            sb2.content().rendered(),
+            r"Water (\$H_2O\$) is a critical component."
+        );
+        assert!(blocks.next().is_none());
+
+        // The closing square bracket is escaped with a backslash
+        // (`example$stem.adoc[tag=in-sb]`); no other AsciiDoc syntax needs
+        // escaping inside the passthrough.
+        let doc = parser.parse(r"A matrix can be written as stem:[[[a,b\],[c,d\]\]((n),(k))].");
+
+        let block = doc.nested_blocks().next().unwrap();
+        let Block::Simple(sb) = block else {
+            panic!("Unexpected block type: {block:?}");
+        };
+        assert_eq!(
+            sb.content().rendered(),
+            r"A matrix can be written as \$[[a,b],[c,d]]((n),(k))\$."
+        );
+    }
+}
+
+mod block_stem_content {
+    use crate::{blocks::ContentModel, content::SubstitutionStep, tests::prelude::*};
+
+    #[test]
+    fn block_stem_syntax() {
+        verifies!(
+            r#"
+[#block]
+== Block STEM content
+
+Block formulas are marked up by assigning the `stem` style to a delimited passthrough block.
+
+.Delimited stem block syntax
+[source#ex-block]
+----
+include::example$stem.adoc[tag=bl-co]
+----
+<.> Assign the stem style to the passthrough block.
+<.> A passthrough block is delimited by a line of four consecutive plus signs (`pass:[++++]`).
+
+The result <<ex-block>> is rendered beautifully in the browser thanks to MathJax!
+
+====
+include::example$stem.adoc[tag=bl]
+====
+
+TIP: You don't need to add special delimiters around the expression as the {url-mathjax-docs}[MathJax documentation^] suggests.
+The AsciiDoc processor handles that for you automatically!
+
+"#
+        );
+
+        // Example from `example$stem.adoc[tag=bl]`. The `stem` style turns the
+        // passthrough block into a `stem` block whose expression has only the
+        // special characters substitution applied; the math delimiters are
+        // added by the converter at render time.
+        let doc = Parser::default().parse("[stem]\n++++\nsqrt(4) = 2\n++++");
+
+        let block = doc.nested_blocks().next().unwrap();
+
+        assert_eq!(block.content_model(), ContentModel::Raw);
+        assert_eq!(block.raw_context().as_ref(), "stem");
+        assert_eq!(block.declared_style(), Some("stem"));
+        assert_eq!(block.rendered_content(), Some("sqrt(4) = 2"));
+        assert_eq!(
+            block.substitution_group(),
+            SubstitutionGroup::Custom(vec![SubstitutionStep::SpecialCharacters])
+        );
+    }
+}
+
+// The newline-handling rules for AsciiMath and LaTeX blocks describe the
+// behavior of the STEM provider (MathJax) and the converter at render time, not
+// the parser. They are therefore non-normative for this crate, which preserves
+// the block content verbatim and defers rendering to a downstream converter.
+non_normative!(
+    r#"
+=== Newlines in AsciiMath blocks
+
+Newlines in an AsciiMath block are only preserved in certain circumstances.
+The following examples illustrate how newlines are handled.
+
+[%collapsible]
+.Single newline not preserved
+====
+[listing]
+----
+x
+y
+----
+====
+
+[%collapsible]
+.Single newline preserved if escaped
+====
+[listing]
+----
+x\
+y
+----
+====
+
+[%collapsible]
+.Sequential newlines preserved if escaped
+====
+[listing]
+----
+x\
+\
+y
+----
+====
+
+[%collapsible]
+.Paragraph break preserved
+====
+[listing]
+----
+x
+
+y
+----
+====
+
+[%collapsible]
+.Sequential newlines between paragraph break preserved
+====
+[listing]
+----
+x
+
+
+y
+----
+====
+
+The first preserved newline splits the expression into two.
+Subsequent newlines get translated into a `<br>` element.
+
+=== Newlines in LaTeX blocks
+
+Newlines in a LaTeX block are only preserved in certain circumstances.
+The following examples illustrate how newlines are handled.
+
+[%collapsible]
+.Single newline not preserved
+====
+[listing]
+----
+x
+y
+----
+====
+
+[%collapsible]
+.Single newline preserved if escaped
+====
+[listing]
+----
+x\\
+y
+----
+====
+
+[%collapsible]
+.Sequential newlines preserved if escaped and prefixed by null character
+====
+[listing]
+----
+x\\
+~\\
+y
+----
+====
+
+[%collapsible]
+.Paragraph break not preserved
+====
+[listing]
+----
+x
+
+y
+----
+====
+
+[%collapsible]
+.Paragraph break preserved if separated by newline spacer
+====
+[listing]
+----
+x
+\\[1em]
+y
+----
+====
+
+The first preserved newline splits the expression into two.
+Subsequent newlines get translated into a `<br>` element.
+
+"#
+);
+
+mod mixing_stem_notations {
+    use crate::{blocks::Block, tests::prelude::*};
+
+    #[test]
+    fn mixing_notations() {
+        verifies!(
+            r#"
+[#mixing-notations]
+== Mixing STEM notations
+
+You can use multiple notations for STEM content within the same document by using the notation's name instead of the keyword `stem`.
+
+For example, if you want to write an inline equation using the LaTeX notation, name the macro `latexmath`.
+
+.Inline latexmath macro syntax
+[source#ex-latexmath]
+----
+include::example$stem.adoc[tag=multi-l]
+----
+
+The result of <<ex-latexmath>> is displayed below.
+
+====
+include::example$stem.adoc[tag=multi-l]
+====
+
+The name that maps to the notation you want to use can also be applied to block STEM content.
+
+.Using both asciimath and latexmath notations in a single document
+[source]
+----
+include::example$stem.adoc[tag=multi-a]
+----
+
+Here's how the body of this example will be shown:
+
+=====
+include::example$stem.adoc[tag=multi-a-render]
+=====
+
+"#
+        );
+
+        // Inline `latexmath` macro (`example$stem.adoc[tag=multi-l]`): naming the
+        // macro after the notation surrounds the expression with LaTeX inline
+        // delimiters regardless of the document's default `stem` notation.
+        let doc = Parser::default().parse(r"latexmath:[C = \alpha + \beta Y^{\gamma} + \epsilon]");
+
+        let block = doc.nested_blocks().next().unwrap();
+        let Block::Simple(sb) = block else {
+            panic!("Unexpected block type: {block:?}");
+        };
+        assert_eq!(
+            sb.content().rendered(),
+            r"\(C = \alpha + \beta Y^{\gamma} + \epsilon\)"
+        );
+
+        // The notation name applied to block content (`tag=multi-a`): both the
+        // `latexmath` and `asciimath` styles produce `stem` blocks that carry
+        // their notation as the block style.
+        let doc = Parser::default()
+            .parse("[latexmath]\n++++\nx = y\n++++\n\n[asciimath]\n++++\nsqrt(4) = 2\n++++");
+
+        let mut blocks = doc.nested_blocks();
+
+        let block1 = blocks.next().unwrap();
+        assert_eq!(block1.raw_context().as_ref(), "stem");
+        assert_eq!(block1.declared_style(), Some("latexmath"));
+
+        let block2 = blocks.next().unwrap();
+        assert_eq!(block2.raw_context().as_ref(), "stem");
+        assert_eq!(block2.declared_style(), Some("asciimath"));
+    }
+}
+
+// Equation numbering (the `eqnums` attribute) and equation references (`\label`
+// and `\eqref`) are interpreted by the STEM provider (MathJax) at render time.
+// The parser passes the expressions through verbatim, so these sections are
+// non-normative for this crate.
+non_normative!(
+    r#"
+== Equation numbering
+
+When writing expresions in LaTeX, you can configure the STEM processor to add numbers to block equations.
+To do so, set the `eqnums` attribute on the document to empty (or `AMS`).
+Let's look at an example.
+
+[source]
+----
+= Document Title
+:stem: latexmath
+:eqnums:
+
+[stem]
+++++
+\begin{equation}
+x = y^2
+\end{equation}
+++++
+----
+
+The automatic numbering is only applied when the expression is contained within an `\{equation}` container (in fact, to all such containers in a stem block).
+
+If you want all expressions to be numbered, even those not designated as an equation, set the value of the `eqnums` attribute to `all`.
+Let's look at an example.
+
+[source]
+----
+= Document Title
+:stem: latexmath
+:eqnums: all
+
+[stem]
+++++
+x = y^2
+++++
+----
+
+In this case, the `\{equation}` container is not required.
+
+== Reference equations
+
+When writing expresions in LaTeX, you can reference an equation in a stem block using an inline stem macro.
+First, you need to add a label (aka ID) to the (ideally numbered) equation in a stem block using `\label` .
+
+[source]
+----
+= Document Title
+:stem: latexmath
+:eqnums:
+
+[stem]
+++++
+\begin{equation}
+\label{hypotenuse}
+c = \sqrt{a^2 + b^2}
+\end{equation}
+++++
+----
+
+Next, we reference that equation using `\eqref`.
+
+[source]
+----
+We can calculate the hypotenuse using stem:[\eqref{hypotenuse}].
+----
+
+You can also use `\eqref` within any LaTeX stem block.
+"#
+);

--- a/parser/src/tests/asciidoc_lang/stem/mod.rs
+++ b/parser/src/tests/asciidoc_lang/stem/mod.rs
@@ -1,0 +1,1 @@
+mod index;

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -4593,7 +4593,7 @@ mod passthroughs {
         let mut content =
             crate::content::Content::from(crate::Span::new("+++<code>inline code</code>+++"));
 
-        let pt = Passthroughs::extract_from(&mut content);
+        let pt = Passthroughs::extract_from(&mut content, &Parser::default());
 
         assert_eq!(
             content,
@@ -4625,7 +4625,7 @@ mod passthroughs {
         let mut content =
             crate::content::Content::from(crate::Span::new("[role]+++<code>inline code</code>+++"));
 
-        let pt = Passthroughs::extract_from(&mut content);
+        let pt = Passthroughs::extract_from(&mut content, &Parser::default());
 
         assert_eq!(
             content,
@@ -4656,7 +4656,7 @@ mod passthroughs {
         let mut content =
             crate::content::Content::from(crate::Span::new("+++<code>inline\ncode</code>+++"));
 
-        let pt = Passthroughs::extract_from(&mut content);
+        let pt = Passthroughs::extract_from(&mut content, &Parser::default());
 
         assert_eq!(
             content,
@@ -4687,7 +4687,7 @@ mod passthroughs {
         let mut content =
             crate::content::Content::from(crate::Span::new("$$<code>{code}</code>$$"));
 
-        let pt = Passthroughs::extract_from(&mut content);
+        let pt = Passthroughs::extract_from(&mut content, &Parser::default());
 
         assert_eq!(
             content,
@@ -4718,7 +4718,7 @@ mod passthroughs {
         let mut content =
             crate::content::Content::from(crate::Span::new("++<code>{code}</code>++"));
 
-        let pt = Passthroughs::extract_from(&mut content);
+        let pt = Passthroughs::extract_from(&mut content, &Parser::default());
 
         assert_eq!(
             content,
@@ -4904,7 +4904,7 @@ mod passthroughs {
         let mut content =
             crate::content::Content::from(crate::Span::new("$$<code>\n{code}\n</code>$$"));
 
-        let pt = Passthroughs::extract_from(&mut content);
+        let pt = Passthroughs::extract_from(&mut content, &Parser::default());
 
         assert_eq!(
             content,
@@ -4936,7 +4936,7 @@ mod passthroughs {
             "pass:specialcharacters,quotes[<code>['code'\\]</code>]",
         ));
 
-        let pt = Passthroughs::extract_from(&mut content);
+        let pt = Passthroughs::extract_from(&mut content, &Parser::default());
 
         assert_eq!(
             content,
@@ -4971,7 +4971,7 @@ mod passthroughs {
             "pass:specialcharacters,quotes[<code>['more\ncode'\\]</code>]",
         ));
 
-        let pt = Passthroughs::extract_from(&mut content);
+        let pt = Passthroughs::extract_from(&mut content, &Parser::default());
 
         assert_eq!(
             content,
@@ -5050,7 +5050,7 @@ mod passthroughs {
         let mut content =
             crate::content::Content::from(crate::Span::new("pass:q,a[*<{backend}>*]"));
 
-        let pt = Passthroughs::extract_from(&mut content);
+        let pt = Passthroughs::extract_from(&mut content, &Parser::default());
 
         assert_eq!(
             content,
@@ -5107,7 +5107,7 @@ mod passthroughs {
     fn inline_pass_macro_supports_incremental_subs() {
         // TO DO: Restore this test once macro substitutions are implemented.
         let mut content = crate::content::Content::from(crate::Span::new("pass:n,-a[<{backend}>]"));
-        let pt = Passthroughs::extract_from(&mut content);
+        let pt = Passthroughs::extract_from(&mut content, &Parser::default());
 
         assert_eq!(
             content,
@@ -5165,7 +5165,7 @@ mod passthroughs {
     #[test]
     fn should_not_recognize_pass_macro_with_invalid_substitution_list_1() {
         let mut content = crate::content::Content::from(crate::Span::new("pass:,[foobar]"));
-        let pt = Passthroughs::extract_from(&mut content);
+        let pt = Passthroughs::extract_from(&mut content, &Parser::default());
 
         assert_eq!(
             content,
@@ -5186,7 +5186,7 @@ mod passthroughs {
     #[test]
     fn should_not_recognize_pass_macro_with_invalid_substitution_list_2() {
         let mut content = crate::content::Content::from(crate::Span::new("pass:42[foobar]"));
-        let pt = Passthroughs::extract_from(&mut content);
+        let pt = Passthroughs::extract_from(&mut content, &Parser::default());
 
         assert_eq!(
             content,
@@ -5207,7 +5207,7 @@ mod passthroughs {
     #[test]
     fn should_not_recognize_pass_macro_with_invalid_substitution_list_3() {
         let mut content = crate::content::Content::from(crate::Span::new("pass:a,[foobar]"));
-        let pt = Passthroughs::extract_from(&mut content);
+        let pt = Passthroughs::extract_from(&mut content, &Parser::default());
 
         assert_eq!(
             content,
@@ -5500,7 +5500,7 @@ mod passthroughs {
             "$$[(] <'basic form'> <'logical operator'> <'basic form'> [)]$$",
         ));
 
-        let pt = Passthroughs::extract_from(&mut content);
+        let pt = Passthroughs::extract_from(&mut content, &Parser::default());
 
         assert_eq!(
             content,
@@ -5532,7 +5532,7 @@ mod passthroughs {
             r#"pass:specialcharacters[[(\] <'basic form'> <'logical operator'> <'basic form'> [)\]]"#,
         ));
 
-        let pt = Passthroughs::extract_from(&mut content);
+        let pt = Passthroughs::extract_from(&mut content, &Parser::default());
 
         assert_eq!(
             content,
@@ -5990,11 +5990,227 @@ mod passthroughs {
     }
 
     mod math_macros {
-        #[ignore]
+        use crate::tests::prelude::*;
+
+        /// Assert that the first block of `input` (parsed with `parser`) has the
+        /// given rendered content (the equivalent of Asciidoctor's
+        /// `para.content`) and that no warnings were raised.
+        fn assert_content(parser: Parser, input: &str, expected: &str) {
+            let mut parser = parser;
+            let doc = parser.parse(input);
+            assert_eq!(
+                doc.nested_blocks().next().unwrap().rendered_content(),
+                Some(expected),
+                "input = {input:?}"
+            );
+            assert!(doc.warnings().next().is_none(), "input = {input:?}");
+        }
+
         #[test]
-        fn not_implemented() {
-            todo!("Review Ruby Asciidoctor test suite for `context 'Math macros'`");
-            // See https://github.com/asciidoc-rs/asciidoc-parser/issues/261.
+        fn should_passthrough_text_in_asciimath_macro_and_surround_with_asciimath_delimiters() {
+            assert_content(
+                Parser::default(),
+                "asciimath:[x/x={(1,if x!=0),(text{undefined},if x=0):}]",
+                r"\$x/x={(1,if x!=0),(text{undefined},if x=0):}\$",
+            );
+        }
+
+        #[test]
+        fn should_not_recognize_asciimath_macro_with_no_content() {
+            assert_content(Parser::default(), "asciimath:[]", "asciimath:[]");
+        }
+
+        #[test]
+        fn should_perform_specialcharacters_subs_on_asciimath_macro_content_in_html_backend_by_default()
+         {
+            assert_content(Parser::default(), "asciimath:[a < b]", r"\$a &lt; b\$");
+        }
+
+        #[test]
+        fn should_honor_explicit_subslist_on_asciimath_macro() {
+            let p = Parser::default().with_intrinsic_attribute(
+                "expr",
+                "x != 0",
+                ModificationContext::Anywhere,
+            );
+            assert_content(p, "asciimath:attributes[{expr}]", r"\$x != 0\$");
+        }
+
+        #[test]
+        fn should_passthrough_text_in_latexmath_macro_and_surround_with_latex_math_delimiters() {
+            assert_content(
+                Parser::default(),
+                r"latexmath:[C = \alpha + \beta Y^{\gamma} + \epsilon]",
+                r"\(C = \alpha + \beta Y^{\gamma} + \epsilon\)",
+            );
+        }
+
+        #[test]
+        fn should_strip_legacy_latex_math_delimiters_around_latexmath_content_if_present() {
+            assert_content(
+                Parser::default(),
+                r"latexmath:[$C = \alpha + \beta Y^{\gamma} + \epsilon$]",
+                r"\(C = \alpha + \beta Y^{\gamma} + \epsilon\)",
+            );
+        }
+
+        #[test]
+        fn should_not_recognize_latexmath_macro_with_no_content() {
+            assert_content(Parser::default(), "latexmath:[]", "latexmath:[]");
+        }
+
+        #[test]
+        fn should_unescape_escaped_square_bracket_in_equation() {
+            assert_content(
+                Parser::default(),
+                r"latexmath:[\sqrt[3\]{x}]",
+                r"\(\sqrt[3]{x}\)",
+            );
+        }
+
+        #[test]
+        fn should_perform_specialcharacters_subs_on_latexmath_macro_in_html_backend_by_default() {
+            assert_content(Parser::default(), "latexmath:[a < b]", r"\(a &lt; b\)");
+        }
+
+        #[test]
+        fn should_honor_explicit_subslist_on_latexmath_macro() {
+            let p = Parser::default().with_intrinsic_attribute(
+                "expr",
+                r"\sqrt{4} = 2",
+                ModificationContext::Anywhere,
+            );
+            assert_content(p, "latexmath:attributes[{expr}]", r"\(\sqrt{4} = 2\)");
+        }
+
+        #[test]
+        fn should_passthrough_math_macro_inside_another_passthrough() {
+            assert_content(
+                Parser::default(),
+                "the text [x-]`asciimath:[x = y]` should be passed through as `literal` text",
+                "the text <code>asciimath:[x = y]</code> should be passed through as <code>literal</code> text",
+            );
+
+            assert_content(
+                Parser::default(),
+                "the text `+asciimath:[x = y]+` should be passed through as `literal` text",
+                "the text <code>asciimath:[x = y]</code> should be passed through as <code>literal</code> text",
+            );
+        }
+
+        #[test]
+        fn should_not_recognize_stem_macro_with_no_content() {
+            assert_content(Parser::default(), "stem:[]", "stem:[]");
+        }
+
+        #[test]
+        fn should_passthrough_text_in_stem_macro_and_surround_with_asciimath_delimiters_by_default()
+        {
+            for stem in ["__unset__", "", "asciimath", "bogus"] {
+                let mut p = Parser::default();
+                if stem != "__unset__" {
+                    p = p.with_intrinsic_attribute("stem", stem, ModificationContext::Anywhere);
+                }
+                assert_content(
+                    p,
+                    "stem:[x/x={(1,if x!=0),(text{undefined},if x=0):}]",
+                    r"\$x/x={(1,if x!=0),(text{undefined},if x=0):}\$",
+                );
+            }
+        }
+
+        #[test]
+        fn should_passthrough_text_in_stem_macro_and_surround_with_latex_math_delimiters() {
+            for stem in ["latexmath", "latex", "tex"] {
+                let p = Parser::default().with_intrinsic_attribute(
+                    "stem",
+                    stem,
+                    ModificationContext::Anywhere,
+                );
+                assert_content(
+                    p,
+                    r"stem:[C = \alpha + \beta Y^{\gamma} + \epsilon]",
+                    r"\(C = \alpha + \beta Y^{\gamma} + \epsilon\)",
+                );
+            }
+        }
+
+        #[test]
+        fn should_apply_substitutions_specified_on_stem_macro() {
+            for input in [
+                "stem:c,a[sqrt(x) <=> {solve-for-x}]",
+                "stem:n,-r[sqrt(x) <=> {solve-for-x}]",
+            ] {
+                let p = Parser::default()
+                    .with_intrinsic_attribute("stem", "asciimath", ModificationContext::Anywhere)
+                    .with_intrinsic_attribute("solve-for-x", "13", ModificationContext::Anywhere);
+                assert_content(p, input, r"\$sqrt(x) &lt;=&gt; 13\$");
+            }
+        }
+
+        #[test]
+        fn should_replace_passthroughs_inside_stem_expression() {
+            for (input, expected) in [
+                ("stem:[+1+]", r"\$1\$"),
+                (r"stem:[+\infty-(+\infty)]", r"\$\infty-(\infty)\$"),
+                (r"stem:[+++\infty-(+\infty)++]", r"\$+\infty-(+\infty)\$"),
+            ] {
+                let p = Parser::default().with_intrinsic_attribute(
+                    "stem",
+                    "",
+                    ModificationContext::Anywhere,
+                );
+                assert_content(p, input, expected);
+            }
+        }
+
+        #[test]
+        fn should_allow_passthrough_inside_stem_expression_to_be_escaped() {
+            for (input, expected) in [
+                (r"stem:[\+] and stem:[+]", r"\$+\$ and \$+\$"),
+                (r"stem:[\+1+]", r"\$+1+\$"),
+            ] {
+                let p = Parser::default().with_intrinsic_attribute(
+                    "stem",
+                    "",
+                    ModificationContext::Anywhere,
+                );
+                assert_content(p, input, expected);
+            }
+        }
+
+        #[test]
+        fn should_not_recognize_stem_macro_with_invalid_substitution_list() {
+            for subs in [",", "42", "a,"] {
+                let p = Parser::default().with_intrinsic_attribute(
+                    "stem",
+                    "asciimath",
+                    ModificationContext::Anywhere,
+                );
+                let input = format!("stem:{subs}[x^2]");
+                assert_content(p, &input, &input);
+            }
+        }
+
+        #[test]
+        fn should_warn_if_substitutions_on_stem_macro_are_invalid() {
+            let mut p = Parser::default().with_intrinsic_attribute(
+                "stem",
+                "asciimath",
+                ModificationContext::Anywhere,
+            );
+            let doc = p.parse("stem:bogus[x^2]");
+            assert_eq!(
+                doc.nested_blocks().next().unwrap().rendered_content(),
+                Some(r"\$x^2\$")
+            );
+
+            let warnings: Vec<_> = doc.warnings().collect();
+            assert_eq!(warnings.len(), 1);
+            assert_eq!(
+                warnings[0].warning,
+                WarningType::InvalidSubstitutionTypeForStemMacro("bogus".to_string())
+            );
         }
     }
 }

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -5992,8 +5992,8 @@ mod passthroughs {
     mod math_macros {
         use crate::tests::prelude::*;
 
-        /// Assert that the first block of `input` (parsed with `parser`) has the
-        /// given rendered content (the equivalent of Asciidoctor's
+        /// Assert that the first block of `input` (parsed with `parser`) has
+        /// the given rendered content (the equivalent of Asciidoctor's
         /// `para.content`) and that no warnings were raised.
         fn assert_content(parser: Parser, input: &str, expected: &str) {
             let mut parser = parser;
@@ -6210,6 +6210,17 @@ mod passthroughs {
             assert_eq!(
                 warnings[0].warning,
                 WarningType::InvalidSubstitutionTypeForStemMacro("bogus".to_string())
+            );
+        }
+
+        #[test]
+        fn should_not_process_escaped_stem_macro() {
+            // A leading backslash escapes the entire macro: the backslash is
+            // dropped and the macro text is emitted verbatim.
+            assert_content(
+                Parser::default(),
+                r"The \stem:[x^2] macro is escaped.",
+                "The stem:[x^2] macro is escaped.",
             );
         }
     }

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -100,6 +100,9 @@ pub enum WarningType {
 
     #[error("skipping reference to missing attribute: {0}")]
     SkippingReferenceToMissingAttribute(String),
+
+    #[error("invalid substitution type for stem macro: {0}")]
+    InvalidSubstitutionTypeForStemMacro(String),
 }
 
 impl std::fmt::Debug for WarningType {
@@ -204,6 +207,11 @@ impl std::fmt::Debug for WarningType {
             WarningType::SkippingReferenceToMissingAttribute(name) => f
                 .debug_tuple("WarningType::SkippingReferenceToMissingAttribute")
                 .field(name)
+                .finish(),
+
+            WarningType::InvalidSubstitutionTypeForStemMacro(subs) => f
+                .debug_tuple("WarningType::InvalidSubstitutionTypeForStemMacro")
+                .field(subs)
                 .finish(),
         }
     }
@@ -512,6 +520,16 @@ mod tests {
                 assert_eq!(
                     debug_output,
                     "WarningType::SkippingReferenceToMissingAttribute(\"name\")"
+                );
+            }
+
+            #[test]
+            fn invalid_substitution_type_for_stem_macro() {
+                let warning = WarningType::InvalidSubstitutionTypeForStemMacro("bogus".to_string());
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(
+                    debug_output,
+                    "WarningType::InvalidSubstitutionTypeForStemMacro(\"bogus\")"
                 );
             }
         }


### PR DESCRIPTION
## Summary

Implements STEM (Science, Technology, Engineering, Math) support per [docs/modules/stem/pages/index.adoc](docs/modules/stem/pages/index.adoc), resolving [#261](https://github.com/asciidoc-rs/asciidoc-parser/issues/261).

STEM in AsciiDoc is a **passthrough** mechanism: the parser preserves the expression verbatim and surrounds it with the notation's math delimiters; the actual rendering is delegated to a downstream STEM provider (e.g. MathJax). No Rust math engine is involved.

### Inline STEM macros (`stem:[…]`, `asciimath:[…]`, `latexmath:[…]`)
- Extracted as implicit passthroughs (last, so nested passthroughs like `stem:[+1+]` restore recursively).
- AsciiMath → `\$…\$`, inline LaTeX → `\(…\)`, via new `QuoteType::AsciiMath`/`LatexMath`.
- Bare `stem:` resolves notation from the `:stem:` document attribute (default AsciiMath).
- Special-characters subs by default on HTML; explicit subs lists (`stem:c,a[…]`); legacy `$…$` stripping for latexmath; `\]` unescaping; empty macros not recognized; warning on invalid subs (new `WarningType::InvalidSubstitutionTypeForStemMacro`).

### Block STEM (`[stem]`/`[asciimath]`/`[latexmath]` on `++++`)
- Becomes a `stem`-context raw block with special-characters substitutions (delimiters added downstream). Plain `++++` stays `pass`; explicit `subs=` still overrides.

### Out of scope (correctly deferred to the converter/MathJax)
Equation numbering (`eqnums`), `\label`/`\eqref` references, and stem-block newline→`<br>` handling are all render-time concerns handled downstream; the parser passes the expressions through verbatim.

## Tests
- 19 ported Ruby Asciidoctor "Math macros" tests (DocBook omitted per convention) + 5 block-STEM tests + warning Debug test.
- Full SDD spec coverage for the stem page (`track_file!`/`verifies!`/`non_normative!`): **0 uncovered lines, 67 verified** (`cd sdd && cargo run`).
- Full suite green; `clippy` clean; `cargo fmt`; nightly `cargo doc` clean. Outputs cross-checked against the `asciidoctor` CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)