### PR TITLE
feat: Implement predefined document attributes (document-attributes-ref)

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1633,7 +1633,7 @@ fn process_content<'src>(
         // context. Relax their context for the duration of the cell so a body
         // assignment is honored; the snapshot restore reverts it afterward.
         for name in ASCIIDOC_CELL_MODIFIABLE_ATTRIBUTES {
-            if let Some(attr) = parser.attribute_values.get_mut(*name) {
+            if let Some(attr) = Arc::make_mut(&mut parser.attribute_values).get_mut(*name) {
                 attr.modification_context = ModificationContext::Anywhere;
             }
         }
@@ -1647,7 +1647,7 @@ fn process_content<'src>(
         // document starts without a table of contents and may enable its own.
         // Reset the value to unset; the relax loop above already made `toc`
         // modifiable inside the cell, so a cell-body `:toc:` is still honored.
-        if let Some(toc) = parser.attribute_values.get_mut("toc") {
+        if let Some(toc) = Arc::make_mut(&mut parser.attribute_values).get_mut("toc") {
             toc.value = InterpretedValue::Unset;
         }
 

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -75,6 +75,7 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
     attrs.insert("backtick".to_owned(), char_replacement("`"));
     attrs.insert("two-colons".to_owned(), char_replacement("::"));
     attrs.insert("two-semicolons".to_owned(), char_replacement(";;"));
+
     // `cpp` is deprecated in favor of `cxx`; both resolve to the same value.
     attrs.insert("cpp".to_owned(), char_replacement("C&#43;&#43;"));
     attrs.insert("cxx".to_owned(), char_replacement("C&#43;&#43;"));
@@ -109,6 +110,7 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
         modification_context: ctx,
         value,
     };
+
     // Set by default to a concrete `default` value. The value is stored directly
     // (not via [`build_built_in_default_values`]) so that setting the attribute
     // with an empty value overrides it with an empty value, rather than
@@ -118,18 +120,21 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
         modification_context: ctx,
         value: Value(default.to_owned()),
     };
+
     // Set by default to an empty value (a boolean-style switch).
     let empty = |ctx, value| AttributeValue {
         allowable_value: AllowableValue::Empty,
         modification_context: ctx,
         value,
     };
+
     // Not set by default; has an implied value `(default)` when unset.
     let implied = |ctx, default: &'static str| AttributeValue {
         allowable_value: AllowableValue::Implied(default),
         modification_context: ctx,
         value: Unset,
     };
+
     // Not set by default; an empty value is interpreted as `default`
     // (`_empty_[=default]`).
     let effective = |ctx, default: &str| AttributeValue {
@@ -191,11 +196,13 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
     // ### General content and formatting attributes
     attrs.insert("asset-uri-scheme".to_owned(), implied(ApiOrHeader, "https"));
     attrs.insert("docinfo".to_owned(), effective(ApiOrHeader, "private"));
+
     // `docinfosubs` has an implied default of `attributes`, but that default is
     // applied directly where docinfo substitution is resolved (an unset value
     // means "apply attribute substitution"), so it is recorded here only as
     // metadata.
     attrs.insert("docinfosubs".to_owned(), implied(ApiOrHeader, "attributes"));
+
     // The document type defaults to `article` and may be set in the header or
     // via the API. The derived `backend-html5-doctype-{doctype}` attribute
     // (defined below) is kept in sync by `Parser::refresh_doctype_derived_attr`
@@ -206,6 +213,7 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
     );
     attrs.insert("eqnums".to_owned(), effective(ApiOrHeader, "AMS"));
     attrs.insert("media".to_owned(), implied(ApiOrHeader, "screen"));
+
     // The file extension of the output file (always begins with a period),
     // defaulting to `.html`. Docinfo file names are built from this suffix.
     attrs.insert(
@@ -227,6 +235,7 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
     );
     attrs.insert("iconfont-remote".to_owned(), empty(ApiOrHeader, Set));
     attrs.insert("icons".to_owned(), effective(ApiOrHeader, "image"));
+
     // TO DO: Replace ./images/icons with value of imagesdir if that is non-default.
     attrs.insert("iconsdir".to_owned(), set(Anywhere, "./images/icons"));
     attrs.insert("icontype".to_owned(), implied(Anywhere, "png"));

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -185,6 +185,10 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
         "outfilesuffix".to_owned(),
         any(ApiOrHeader, Value(".html".into())),
     );
+
+    // TO DO: `relfilesuffix` should default to the current value of
+    // `outfilesuffix` rather than a hardcoded `.html`; they diverge for
+    // non-HTML backends (e.g. `.xml` for DocBook).
     attrs.insert("relfilesuffix".to_owned(), set(Anywhere, ".html"));
     attrs.insert("webfonts".to_owned(), empty(ApiOrHeader, Set));
 

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -82,144 +82,223 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
 
     // ## Other predefined document attributes
     //
-    // These configure processor behavior rather than performing character
-    // replacement. Order is not significant.
+    // The groups below mirror the catalog in
+    // `docs/modules/attributes/pages/document-attributes-ref.adoc`. Order is not
+    // significant. Default values match Ruby Asciidoctor.
+    //
+    // Modeling of the reference page's notation:
+    //
+    // * Attributes that are *set by default* store [`Set`](InterpretedValue::Set)
+    //   (or a concrete [`Value`](InterpretedValue::Value)). When the page shows a
+    //   bold default value, that value is recorded in
+    //   [`build_built_in_default_values`] so the attribute resolves to it; a bold
+    //   `_empty_` default resolves to an empty value.
+    // * An *implied* value `(x)` (used when the attribute is not set) is recorded
+    //   as [`AllowableValue::Implied`], and an *effective* value `_empty_[=x]` as
+    //   [`AllowableValue::Effective`]. Per the reference page, neither can be
+    //   resolved through an attribute reference, so these attributes are
+    //   [`Unset`](InterpretedValue::Unset) by default and carry no entry in
+    //   [`build_built_in_default_values`]. The `allowable_value` field records the
+    //   documented default but is not otherwise consulted.
+    use InterpretedValue::{Set, Unset, Value};
+    use ModificationContext::{Anywhere, ApiOnly, ApiOrHeader};
 
+    // Holds a fixed value (`allowable_value` is `Any`).
+    let any = |ctx, value| AttributeValue {
+        allowable_value: AllowableValue::Any,
+        modification_context: ctx,
+        value,
+    };
+    // Set by default to a concrete `default` value. The value is stored directly
+    // (not via [`build_built_in_default_values`]) so that setting the attribute
+    // with an empty value overrides it with an empty value, rather than
+    // re-applying the default.
+    let set = |ctx, default: &str| AttributeValue {
+        allowable_value: AllowableValue::Any,
+        modification_context: ctx,
+        value: Value(default.to_owned()),
+    };
+    // Set by default to an empty value (a boolean-style switch).
+    let empty = |ctx, value| AttributeValue {
+        allowable_value: AllowableValue::Empty,
+        modification_context: ctx,
+        value,
+    };
+    // Not set by default; has an implied value `(default)` when unset.
+    let implied = |ctx, default: &'static str| AttributeValue {
+        allowable_value: AllowableValue::Implied(default),
+        modification_context: ctx,
+        value: Unset,
+    };
+    // Not set by default; an empty value is interpreted as `default`
+    // (`_empty_[=default]`).
+    let effective = |ctx, default: &str| AttributeValue {
+        allowable_value: AllowableValue::Effective(Value(default.to_owned())),
+        modification_context: ctx,
+        value: Unset,
+    };
+
+    // ### Compliance attributes
+    attrs.insert("attribute-missing".to_owned(), set(Anywhere, "skip"));
+    attrs.insert("attribute-undefined".to_owned(), set(Anywhere, "drop-line"));
+
+    // ### Localization and numbering attributes
+    attrs.insert("appendix-caption".to_owned(), set(Anywhere, "Appendix"));
+    attrs.insert("appendix-number".to_owned(), implied(Anywhere, "@"));
+    attrs.insert("appendix-refsig".to_owned(), set(Anywhere, "Appendix"));
+    attrs.insert("caution-caption".to_owned(), set(Anywhere, "Caution"));
+    attrs.insert("chapter-number".to_owned(), implied(Anywhere, "0"));
+    attrs.insert("chapter-refsig".to_owned(), set(Anywhere, "Chapter"));
+    attrs.insert("example-caption".to_owned(), set(Anywhere, "Example"));
+    attrs.insert("example-number".to_owned(), implied(Anywhere, "0"));
+    attrs.insert("figure-caption".to_owned(), set(Anywhere, "Figure"));
+    attrs.insert("figure-number".to_owned(), implied(Anywhere, "0"));
+    attrs.insert("footnote-number".to_owned(), implied(Anywhere, "0"));
+    attrs.insert("important-caption".to_owned(), set(Anywhere, "Important"));
+    attrs.insert("lang".to_owned(), implied(ApiOrHeader, "en"));
     attrs.insert(
-        "toc".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::ApiOrHeader,
-            value: InterpretedValue::Unset,
-        },
+        "last-update-label".to_owned(),
+        set(ApiOrHeader, "Last updated"),
     );
-
+    attrs.insert("listing-number".to_owned(), implied(Anywhere, "0"));
+    attrs.insert("manname-title".to_owned(), implied(ApiOrHeader, "Name"));
+    attrs.insert("note-caption".to_owned(), set(Anywhere, "Note"));
+    attrs.insert("part-refsig".to_owned(), set(Anywhere, "Part"));
+    attrs.insert("section-refsig".to_owned(), set(Anywhere, "Section"));
+    attrs.insert("table-caption".to_owned(), set(Anywhere, "Table"));
+    attrs.insert("table-number".to_owned(), implied(Anywhere, "0"));
+    attrs.insert("tip-caption".to_owned(), set(Anywhere, "Tip"));
     attrs.insert(
-        "sectids".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Empty,
-            modification_context: ModificationContext::Anywhere,
-            value: InterpretedValue::Set,
-        },
+        "toc-title".to_owned(),
+        set(ApiOrHeader, "Table of Contents"),
     );
+    attrs.insert("untitled-label".to_owned(), set(ApiOrHeader, "Untitled"));
+    attrs.insert("version-label".to_owned(), set(ApiOrHeader, "Version"));
+    attrs.insert("warning-caption".to_owned(), set(Anywhere, "Warning"));
 
-    attrs.insert(
-        "sectnums".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Empty,
-            modification_context: ModificationContext::Anywhere,
-            value: InterpretedValue::Unset,
-        },
-    );
-
+    // ### Section title and table of contents attributes
+    attrs.insert("idprefix".to_owned(), any(Anywhere, Value("_".into())));
+    attrs.insert("idseparator".to_owned(), any(Anywhere, Value("_".into())));
+    attrs.insert("sectids".to_owned(), empty(Anywhere, Set));
+    attrs.insert("sectnums".to_owned(), empty(Anywhere, Unset));
     attrs.insert(
         "sectnumlevels".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::ApiOrHeader,
-            value: InterpretedValue::Value("3".into()),
-        },
+        any(ApiOrHeader, Value("3".into())),
     );
+    attrs.insert("toc".to_owned(), any(ApiOrHeader, Unset));
+    attrs.insert("toclevels".to_owned(), implied(ApiOrHeader, "2"));
 
-    attrs.insert(
-        "idprefix".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::Anywhere,
-            value: InterpretedValue::Value("_".into()),
-        },
-    );
-
-    attrs.insert(
-        "idseparator".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::Anywhere,
-            value: InterpretedValue::Value("_".into()),
-        },
-    );
-
-    attrs.insert(
-        "example-caption".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::Anywhere,
-            value: InterpretedValue::Set,
-        },
-    );
-
-    attrs.insert(
-        "table-caption".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::Anywhere,
-            value: InterpretedValue::Set,
-        },
-    );
-
-    attrs.insert(
-        "appendix-caption".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::Anywhere,
-            value: InterpretedValue::Set,
-        },
-    );
-
-    // TO DO: Replace ./images with value of imagesdir if that is non-default.
-    attrs.insert(
-        "iconsdir".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::Anywhere,
-            value: InterpretedValue::Set,
-        },
-    );
-
-    // The file extension of the output file (always begins with a period). It
-    // defaults to `.html` and may be overridden in the header or via the API.
-    // Docinfo file names are built from this suffix so they match the output
-    // file extension.
-    attrs.insert(
-        "outfilesuffix".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::ApiOrHeader,
-            value: InterpretedValue::Value(".html".to_owned()),
-        },
-    );
-
+    // ### General content and formatting attributes
+    attrs.insert("asset-uri-scheme".to_owned(), implied(ApiOrHeader, "https"));
+    attrs.insert("docinfo".to_owned(), effective(ApiOrHeader, "private"));
+    // `docinfosubs` has an implied default of `attributes`, but that default is
+    // applied directly where docinfo substitution is resolved (an unset value
+    // means "apply attribute substitution"), so it is recorded here only as
+    // metadata.
+    attrs.insert("docinfosubs".to_owned(), implied(ApiOrHeader, "attributes"));
     // The document type defaults to `article` and may be set in the header or
-    // via the API. The derived `backend-html5-doctype-{doctype}` attribute is
-    // defined (empty) only for the active doctype; it is kept in sync by
-    // `Parser::refresh_doctype_derived_attr` whenever `doctype` changes.
+    // via the API. The derived `backend-html5-doctype-{doctype}` attribute
+    // (defined below) is kept in sync by `Parser::refresh_doctype_derived_attr`
+    // whenever `doctype` changes.
     attrs.insert(
         "doctype".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::ApiOrHeader,
-            value: InterpretedValue::Value("article".to_owned()),
-        },
+        any(ApiOrHeader, Value("article".into())),
+    );
+    attrs.insert("eqnums".to_owned(), effective(ApiOrHeader, "AMS"));
+    attrs.insert("media".to_owned(), implied(ApiOrHeader, "screen"));
+    // The file extension of the output file (always begins with a period),
+    // defaulting to `.html`. Docinfo file names are built from this suffix.
+    attrs.insert(
+        "outfilesuffix".to_owned(),
+        any(ApiOrHeader, Value(".html".into())),
+    );
+    attrs.insert("pagewidth".to_owned(), implied(ApiOrHeader, "425"));
+    attrs.insert("relfilesuffix".to_owned(), set(Anywhere, ".html"));
+    attrs.insert("stem".to_owned(), effective(ApiOrHeader, "asciimath"));
+    attrs.insert("table-frame".to_owned(), implied(Anywhere, "all"));
+    attrs.insert("table-grid".to_owned(), implied(Anywhere, "all"));
+    attrs.insert("table-stripes".to_owned(), implied(Anywhere, "none"));
+    attrs.insert("webfonts".to_owned(), empty(ApiOrHeader, Set));
+
+    // ### Image and icon attributes
+    attrs.insert(
+        "iconfont-name".to_owned(),
+        implied(ApiOrHeader, "font-awesome"),
+    );
+    attrs.insert("iconfont-remote".to_owned(), empty(ApiOrHeader, Set));
+    attrs.insert("icons".to_owned(), effective(ApiOrHeader, "image"));
+    // TO DO: Replace ./images/icons with value of imagesdir if that is non-default.
+    attrs.insert("iconsdir".to_owned(), set(Anywhere, "./images/icons"));
+    attrs.insert("icontype".to_owned(), implied(Anywhere, "png"));
+    attrs.insert("imagesdir".to_owned(), any(Anywhere, Set));
+
+    // ### Source highlighting and formatting attributes
+    attrs.insert("coderay-css".to_owned(), implied(ApiOrHeader, "class"));
+    attrs.insert(
+        "coderay-linenums-mode".to_owned(),
+        implied(Anywhere, "table"),
     );
     attrs.insert(
+        "highlightjs-theme".to_owned(),
+        implied(ApiOrHeader, "github"),
+    );
+    attrs.insert(
+        "prettify-theme".to_owned(),
+        implied(ApiOrHeader, "prettify"),
+    );
+    attrs.insert("prewrap".to_owned(), empty(Anywhere, Set));
+    attrs.insert("pygments-css".to_owned(), implied(ApiOrHeader, "class"));
+    attrs.insert(
+        "pygments-linenums-mode".to_owned(),
+        implied(Anywhere, "table"),
+    );
+    attrs.insert("pygments-style".to_owned(), implied(ApiOrHeader, "default"));
+    attrs.insert("rouge-css".to_owned(), implied(ApiOrHeader, "class"));
+    attrs.insert("rouge-linenums-mode".to_owned(), implied(Anywhere, "table"));
+    attrs.insert("rouge-style".to_owned(), implied(ApiOrHeader, "github"));
+
+    // ### HTML styling attributes
+    attrs.insert("copycss".to_owned(), any(ApiOrHeader, Set));
+    attrs.insert("stylesdir".to_owned(), set(ApiOrHeader, "."));
+    attrs.insert("stylesheet".to_owned(), any(ApiOrHeader, Set));
+    attrs.insert("toc-class".to_owned(), implied(ApiOrHeader, "toc"));
+
+    // ### Manpage attributes
+    attrs.insert(
+        "man-linkstyle".to_owned(),
+        implied(ApiOrHeader, "blue R <>"),
+    );
+
+    // ### Security attributes
+    // `max-attribute-value-size` only has a default value (`4096`) when the safe
+    // mode is SECURE, which is not yet implemented
+    // (<https://github.com/asciidoc-rs/asciidoc-parser/issues/277>), so it is
+    // unset here.
+    attrs.insert("max-attribute-value-size".to_owned(), any(ApiOnly, Unset));
+    attrs.insert("max-include-depth".to_owned(), set(ApiOnly, "64"));
+
+    // Derived doctype attribute (see `doctype` above): defined (empty) only for
+    // the active doctype.
+    attrs.insert(
         "backend-html5-doctype-article".to_owned(),
-        AttributeValue {
-            allowable_value: AllowableValue::Any,
-            modification_context: ModificationContext::Anywhere,
-            value: InterpretedValue::Value(String::new()),
-        },
+        any(Anywhere, Value(String::new())),
     );
 
     attrs
 }
 
 fn build_built_in_default_values() -> HashMap<String, String> {
+    // The value assigned to a built-in attribute when it is *turned on* with an
+    // empty value (e.g. a bare `:toc:` resolves to `auto`). This applies only to
+    // attributes that are not set by default: setting them activates the default.
+    //
+    // Attributes that *are* set by default store their value directly (see the
+    // `set` helper in [`build_built_in_attrs`]), so that setting them with an
+    // empty value overrides them with an empty value rather than re-applying the
+    // default. Implied/effective defaults are recorded on the attribute's
+    // `allowable_value` and are intentionally not resolvable here.
     let mut defaults: HashMap<String, String> = HashMap::new();
 
-    defaults.insert("example-caption".to_owned(), "Example".to_owned());
-    defaults.insert("table-caption".to_owned(), "Table".to_owned());
-    defaults.insert("appendix-caption".to_owned(), "Appendix".to_owned());
-    defaults.insert("iconsdir".to_owned(), "./images/icons".to_owned());
     defaults.insert("sectnums".to_owned(), "all".to_owned());
     defaults.insert("toc".to_owned(), "auto".to_owned());
 

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::LazyLock};
+use std::{
+    collections::HashMap,
+    sync::{Arc, LazyLock},
+};
 
 use crate::{
     document::InterpretedValue,
@@ -6,22 +9,25 @@ use crate::{
 };
 
 /// The built-in attribute table is identical for every parser, so build it
-/// once and hand out cheap clones. Cloning copies the hash table layout
-/// without re-hashing each key, which matters because [`Parser::default`]
-/// (and therefore this function) is called once per parse.
+/// once and share it behind an [`Arc`]. A [`Parser`] holds this shared table
+/// and copies it (via `Arc::make_mut`) only when it first modifies an
+/// attribute, so the (large) built-in table is never deep-cloned just to create
+/// or clone a parser. This matters because [`Parser::default`] (and parser
+/// cloning, e.g. for nested AsciiDoc table cells) happens frequently.
 ///
+/// [`Parser`]: crate::Parser
 /// [`Parser::default`]: crate::Parser::default
-static BUILT_IN_ATTRS: LazyLock<HashMap<String, AttributeValue>> =
-    LazyLock::new(build_built_in_attrs);
+static BUILT_IN_ATTRS: LazyLock<Arc<HashMap<String, AttributeValue>>> =
+    LazyLock::new(|| Arc::new(build_built_in_attrs()));
 
-static BUILT_IN_DEFAULT_VALUES: LazyLock<HashMap<String, String>> =
-    LazyLock::new(build_built_in_default_values);
+static BUILT_IN_DEFAULT_VALUES: LazyLock<Arc<HashMap<String, String>>> =
+    LazyLock::new(|| Arc::new(build_built_in_default_values()));
 
-pub(super) fn built_in_attrs() -> HashMap<String, AttributeValue> {
+pub(super) fn built_in_attrs() -> Arc<HashMap<String, AttributeValue>> {
     BUILT_IN_ATTRS.clone()
 }
 
-pub(super) fn built_in_default_values() -> HashMap<String, String> {
+pub(super) fn built_in_default_values() -> Arc<HashMap<String, String>> {
     BUILT_IN_DEFAULT_VALUES.clone()
 }
 
@@ -87,20 +93,14 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
     // `docs/modules/attributes/pages/document-attributes-ref.adoc`. Order is not
     // significant. Default values match Ruby Asciidoctor.
     //
-    // Modeling of the reference page's notation:
-    //
-    // * Attributes that are *set by default* store [`Set`](InterpretedValue::Set)
-    //   (or a concrete [`Value`](InterpretedValue::Value)). When the page shows a
-    //   bold default value, that value is recorded in
-    //   [`build_built_in_default_values`] so the attribute resolves to it; a bold
-    //   `_empty_` default resolves to an empty value.
-    // * An *implied* value `(x)` (used when the attribute is not set) is recorded
-    //   as [`AllowableValue::Implied`], and an *effective* value `_empty_[=x]` as
-    //   [`AllowableValue::Effective`]. Per the reference page, neither can be
-    //   resolved through an attribute reference, so these attributes are
-    //   [`Unset`](InterpretedValue::Unset) by default and carry no entry in
-    //   [`build_built_in_default_values`]. The `allowable_value` field records the
-    //   documented default but is not otherwise consulted.
+    // Only attributes that are *set by default* are registered here, so they
+    // resolve on a pristine parser. Attributes that are not set by default but
+    // have a default value (the reference page's implied `(x)` and effective
+    // `_empty_[=x]` values, e.g. `lang`, `toclevels`, `icons`) are recorded in
+    // [`build_built_in_default_values`] instead: they stay absent (so an
+    // attribute reference such as `{lang}` is treated as missing), but the
+    // default value is applied when the attribute is later set with an empty
+    // value.
     use InterpretedValue::{Set, Unset, Value};
     use ModificationContext::{Anywhere, ApiOnly, ApiOrHeader};
 
@@ -128,50 +128,26 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
         value,
     };
 
-    // Not set by default; has an implied value `(default)` when unset.
-    let implied = |ctx, default: &'static str| AttributeValue {
-        allowable_value: AllowableValue::Implied(default),
-        modification_context: ctx,
-        value: Unset,
-    };
-
-    // Not set by default; an empty value is interpreted as `default`
-    // (`_empty_[=default]`).
-    let effective = |ctx, default: &str| AttributeValue {
-        allowable_value: AllowableValue::Effective(Value(default.to_owned())),
-        modification_context: ctx,
-        value: Unset,
-    };
-
     // ### Compliance attributes
     attrs.insert("attribute-missing".to_owned(), set(Anywhere, "skip"));
     attrs.insert("attribute-undefined".to_owned(), set(Anywhere, "drop-line"));
 
     // ### Localization and numbering attributes
     attrs.insert("appendix-caption".to_owned(), set(Anywhere, "Appendix"));
-    attrs.insert("appendix-number".to_owned(), implied(Anywhere, "@"));
     attrs.insert("appendix-refsig".to_owned(), set(Anywhere, "Appendix"));
     attrs.insert("caution-caption".to_owned(), set(Anywhere, "Caution"));
-    attrs.insert("chapter-number".to_owned(), implied(Anywhere, "0"));
     attrs.insert("chapter-refsig".to_owned(), set(Anywhere, "Chapter"));
     attrs.insert("example-caption".to_owned(), set(Anywhere, "Example"));
-    attrs.insert("example-number".to_owned(), implied(Anywhere, "0"));
     attrs.insert("figure-caption".to_owned(), set(Anywhere, "Figure"));
-    attrs.insert("figure-number".to_owned(), implied(Anywhere, "0"));
-    attrs.insert("footnote-number".to_owned(), implied(Anywhere, "0"));
     attrs.insert("important-caption".to_owned(), set(Anywhere, "Important"));
-    attrs.insert("lang".to_owned(), implied(ApiOrHeader, "en"));
     attrs.insert(
         "last-update-label".to_owned(),
         set(ApiOrHeader, "Last updated"),
     );
-    attrs.insert("listing-number".to_owned(), implied(Anywhere, "0"));
-    attrs.insert("manname-title".to_owned(), implied(ApiOrHeader, "Name"));
     attrs.insert("note-caption".to_owned(), set(Anywhere, "Note"));
     attrs.insert("part-refsig".to_owned(), set(Anywhere, "Part"));
     attrs.insert("section-refsig".to_owned(), set(Anywhere, "Section"));
     attrs.insert("table-caption".to_owned(), set(Anywhere, "Table"));
-    attrs.insert("table-number".to_owned(), implied(Anywhere, "0"));
     attrs.insert("tip-caption".to_owned(), set(Anywhere, "Tip"));
     attrs.insert(
         "toc-title".to_owned(),
@@ -191,18 +167,9 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
         any(ApiOrHeader, Value("3".into())),
     );
     attrs.insert("toc".to_owned(), any(ApiOrHeader, Unset));
-    attrs.insert("toclevels".to_owned(), implied(ApiOrHeader, "2"));
 
     // ### General content and formatting attributes
-    attrs.insert("asset-uri-scheme".to_owned(), implied(ApiOrHeader, "https"));
-    attrs.insert("docinfo".to_owned(), effective(ApiOrHeader, "private"));
-
-    // `docinfosubs` has an implied default of `attributes`, but that default is
-    // applied directly where docinfo substitution is resolved (an unset value
-    // means "apply attribute substitution"), so it is recorded here only as
-    // metadata.
-    attrs.insert("docinfosubs".to_owned(), implied(ApiOrHeader, "attributes"));
-
+    //
     // The document type defaults to `article` and may be set in the header or
     // via the API. The derived `backend-html5-doctype-{doctype}` attribute
     // (defined below) is kept in sync by `Parser::refresh_doctype_derived_attr`
@@ -211,8 +178,6 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
         "doctype".to_owned(),
         any(ApiOrHeader, Value("article".into())),
     );
-    attrs.insert("eqnums".to_owned(), effective(ApiOrHeader, "AMS"));
-    attrs.insert("media".to_owned(), implied(ApiOrHeader, "screen"));
 
     // The file extension of the output file (always begins with a period),
     // defaulting to `.html`. Docinfo file names are built from this suffix.
@@ -220,70 +185,25 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
         "outfilesuffix".to_owned(),
         any(ApiOrHeader, Value(".html".into())),
     );
-    attrs.insert("pagewidth".to_owned(), implied(ApiOrHeader, "425"));
     attrs.insert("relfilesuffix".to_owned(), set(Anywhere, ".html"));
-    attrs.insert("stem".to_owned(), effective(ApiOrHeader, "asciimath"));
-    attrs.insert("table-frame".to_owned(), implied(Anywhere, "all"));
-    attrs.insert("table-grid".to_owned(), implied(Anywhere, "all"));
-    attrs.insert("table-stripes".to_owned(), implied(Anywhere, "none"));
     attrs.insert("webfonts".to_owned(), empty(ApiOrHeader, Set));
 
     // ### Image and icon attributes
-    attrs.insert(
-        "iconfont-name".to_owned(),
-        implied(ApiOrHeader, "font-awesome"),
-    );
     attrs.insert("iconfont-remote".to_owned(), empty(ApiOrHeader, Set));
-    attrs.insert("icons".to_owned(), effective(ApiOrHeader, "image"));
 
     // TO DO: Replace ./images/icons with value of imagesdir if that is non-default.
     attrs.insert("iconsdir".to_owned(), set(Anywhere, "./images/icons"));
-    attrs.insert("icontype".to_owned(), implied(Anywhere, "png"));
     attrs.insert("imagesdir".to_owned(), any(Anywhere, Set));
 
     // ### Source highlighting and formatting attributes
-    attrs.insert("coderay-css".to_owned(), implied(ApiOrHeader, "class"));
-    attrs.insert(
-        "coderay-linenums-mode".to_owned(),
-        implied(Anywhere, "table"),
-    );
-    attrs.insert(
-        "highlightjs-theme".to_owned(),
-        implied(ApiOrHeader, "github"),
-    );
-    attrs.insert(
-        "prettify-theme".to_owned(),
-        implied(ApiOrHeader, "prettify"),
-    );
     attrs.insert("prewrap".to_owned(), empty(Anywhere, Set));
-    attrs.insert("pygments-css".to_owned(), implied(ApiOrHeader, "class"));
-    attrs.insert(
-        "pygments-linenums-mode".to_owned(),
-        implied(Anywhere, "table"),
-    );
-    attrs.insert("pygments-style".to_owned(), implied(ApiOrHeader, "default"));
-    attrs.insert("rouge-css".to_owned(), implied(ApiOrHeader, "class"));
-    attrs.insert("rouge-linenums-mode".to_owned(), implied(Anywhere, "table"));
-    attrs.insert("rouge-style".to_owned(), implied(ApiOrHeader, "github"));
 
     // ### HTML styling attributes
     attrs.insert("copycss".to_owned(), any(ApiOrHeader, Set));
     attrs.insert("stylesdir".to_owned(), set(ApiOrHeader, "."));
     attrs.insert("stylesheet".to_owned(), any(ApiOrHeader, Set));
-    attrs.insert("toc-class".to_owned(), implied(ApiOrHeader, "toc"));
-
-    // ### Manpage attributes
-    attrs.insert(
-        "man-linkstyle".to_owned(),
-        implied(ApiOrHeader, "blue R <>"),
-    );
 
     // ### Security attributes
-    // `max-attribute-value-size` only has a default value (`4096`) when the safe
-    // mode is SECURE, which is not yet implemented
-    // (<https://github.com/asciidoc-rs/asciidoc-parser/issues/277>), so it is
-    // unset here.
-    attrs.insert("max-attribute-value-size".to_owned(), any(ApiOnly, Unset));
     attrs.insert("max-include-depth".to_owned(), set(ApiOnly, "64"));
 
     // Derived doctype attribute (see `doctype` above): defined (empty) only for
@@ -297,19 +217,74 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
 }
 
 fn build_built_in_default_values() -> HashMap<String, String> {
-    // The value assigned to a built-in attribute when it is *turned on* with an
-    // empty value (e.g. a bare `:toc:` resolves to `auto`). This applies only to
-    // attributes that are not set by default: setting them activates the default.
+    // The value assigned to a built-in attribute when it is set (or turned on)
+    // with an empty value (e.g. a bare `:toc:` resolves to `auto`, and a bare
+    // `:lang:` resolves to `en`).
     //
-    // Attributes that *are* set by default store their value directly (see the
-    // `set` helper in [`build_built_in_attrs`]), so that setting them with an
-    // empty value overrides them with an empty value rather than re-applying the
-    // default. Implied/effective defaults are recorded on the attribute's
-    // `allowable_value` and are intentionally not resolvable here.
+    // This map holds the defaults for attributes that are *not* set by default:
+    // the reference page's "turn-on" attributes (`toc`, `sectnums`) and its
+    // implied `(x)` / effective `_empty_[=x]` values. Because these attributes
+    // are absent from [`build_built_in_attrs`], they are treated as missing when
+    // referenced while unset; their default is applied only once they are
+    // explicitly set. Attributes that *are* set by default store their value
+    // directly in [`build_built_in_attrs`] and do not appear here, so setting
+    // one with an empty value overrides it with an empty value.
+    //
+    // `docinfosubs` is intentionally omitted: its implied default of
+    // `attributes` is handled where docinfo substitution is resolved (an unset
+    // value means "apply attribute substitution"), so a bare `:docinfosubs:`
+    // must remain empty rather than resolving to `attributes`.
     let mut defaults: HashMap<String, String> = HashMap::new();
 
+    // Turn-on attributes (reference page section: section title / TOC).
     defaults.insert("sectnums".to_owned(), "all".to_owned());
     defaults.insert("toc".to_owned(), "auto".to_owned());
+    defaults.insert("toclevels".to_owned(), "2".to_owned());
+
+    // Numbering seeds (localization and numbering attributes).
+    defaults.insert("appendix-number".to_owned(), "@".to_owned());
+    defaults.insert("chapter-number".to_owned(), "0".to_owned());
+    defaults.insert("example-number".to_owned(), "0".to_owned());
+    defaults.insert("figure-number".to_owned(), "0".to_owned());
+    defaults.insert("footnote-number".to_owned(), "0".to_owned());
+    defaults.insert("listing-number".to_owned(), "0".to_owned());
+    defaults.insert("table-number".to_owned(), "0".to_owned());
+    defaults.insert("lang".to_owned(), "en".to_owned());
+    defaults.insert("manname-title".to_owned(), "Name".to_owned());
+
+    // General content and formatting attributes.
+    defaults.insert("asset-uri-scheme".to_owned(), "https".to_owned());
+    defaults.insert("docinfo".to_owned(), "private".to_owned());
+    defaults.insert("eqnums".to_owned(), "AMS".to_owned());
+    defaults.insert("media".to_owned(), "screen".to_owned());
+    defaults.insert("pagewidth".to_owned(), "425".to_owned());
+    defaults.insert("stem".to_owned(), "asciimath".to_owned());
+    defaults.insert("table-frame".to_owned(), "all".to_owned());
+    defaults.insert("table-grid".to_owned(), "all".to_owned());
+    defaults.insert("table-stripes".to_owned(), "none".to_owned());
+
+    // Image and icon attributes.
+    defaults.insert("iconfont-name".to_owned(), "font-awesome".to_owned());
+    defaults.insert("icons".to_owned(), "image".to_owned());
+    defaults.insert("icontype".to_owned(), "png".to_owned());
+
+    // Source highlighting and formatting attributes.
+    defaults.insert("coderay-css".to_owned(), "class".to_owned());
+    defaults.insert("coderay-linenums-mode".to_owned(), "table".to_owned());
+    defaults.insert("highlightjs-theme".to_owned(), "github".to_owned());
+    defaults.insert("prettify-theme".to_owned(), "prettify".to_owned());
+    defaults.insert("pygments-css".to_owned(), "class".to_owned());
+    defaults.insert("pygments-linenums-mode".to_owned(), "table".to_owned());
+    defaults.insert("pygments-style".to_owned(), "default".to_owned());
+    defaults.insert("rouge-css".to_owned(), "class".to_owned());
+    defaults.insert("rouge-linenums-mode".to_owned(), "table".to_owned());
+    defaults.insert("rouge-style".to_owned(), "github".to_owned());
+
+    // HTML styling attributes.
+    defaults.insert("toc-class".to_owned(), "toc".to_owned());
+
+    // Manpage attributes.
+    defaults.insert("man-linkstyle".to_owned(), "blue R <>".to_owned());
 
     defaults
 }

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -660,7 +660,7 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
     fn render_icon(&self, params: &IconRenderParams, dest: &mut String) {
         let src = self.icon_uri(params.target, params.attrlist, params.parser);
 
-        let img = if params.parser.has_attribute("icons") {
+        let img = if params.parser.is_attribute_set("icons") {
             let icons = params.parser.attribute_value("icons");
             if let Some(icons) = icons.as_maybe_str()
                 && icons == "font"
@@ -795,7 +795,7 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
             dest.push_str(&format!(
                 r#"<i class="conum" data-value="{n}"></i><b>({n})</b>"#
             ));
-        } else if parser.has_attribute("icons") {
+        } else if parser.is_attribute_set("icons") {
             let icontype = parser
                 .attribute_value("icontype")
                 .as_maybe_str()

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2,6 +2,7 @@ use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
     rc::Rc,
+    sync::Arc,
 };
 
 use crate::{
@@ -22,10 +23,15 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct Parser {
     /// Attribute values at current state of parsing.
-    pub(crate) attribute_values: HashMap<String, AttributeValue>,
+    ///
+    /// Shared (copy-on-write via [`Arc`]) with the immutable built-in attribute
+    /// table, so creating or cloning a parser does not deep-copy the table; the
+    /// map is only copied the first time this parser modifies an attribute.
+    pub(crate) attribute_values: Arc<HashMap<String, AttributeValue>>,
 
-    /// Default values for attributes if "set."
-    default_attribute_values: HashMap<String, String>,
+    /// Default values for attributes if "set." Immutable after construction and
+    /// shared via [`Arc`] (never copied per parser).
+    default_attribute_values: Arc<HashMap<String, String>>,
 
     /// Specifies how the basic raw text of a simple block will be converted to
     /// the format which will ultimately be presented in the final output.
@@ -375,7 +381,7 @@ impl Parser {
     /// modifiable from the document body so the cell may still set its own
     /// doctype.
     pub(crate) fn force_doctype(&mut self, value: &str) {
-        self.attribute_values.insert(
+        Arc::make_mut(&mut self.attribute_values).insert(
             "doctype".to_string(),
             AttributeValue {
                 allowable_value: AllowableValue::Any,
@@ -391,11 +397,11 @@ impl Parser {
     /// (defined) value. References to any other doctype stay undefined and so
     /// render literally.
     pub(crate) fn refresh_doctype_derived_attr(&mut self) {
-        self.attribute_values
+        Arc::make_mut(&mut self.attribute_values)
             .retain(|name, _| !name.starts_with("backend-html5-doctype-"));
 
         if let InterpretedValue::Value(doctype) = self.attribute_value("doctype") {
-            self.attribute_values.insert(
+            Arc::make_mut(&mut self.attribute_values).insert(
                 format!("backend-html5-doctype-{doctype}"),
                 AttributeValue {
                     allowable_value: AllowableValue::Any,
@@ -437,7 +443,7 @@ impl Parser {
             value: InterpretedValue::Value(value.as_ref().to_string()),
         };
 
-        self.attribute_values
+        Arc::make_mut(&mut self.attribute_values)
             .insert(name.as_ref().to_lowercase(), attribute_value);
 
         self
@@ -610,7 +616,7 @@ impl Parser {
             },
         };
 
-        self.attribute_values
+        Arc::make_mut(&mut self.attribute_values)
             .insert(name.as_ref().to_lowercase(), attribute_value);
 
         self
@@ -751,7 +757,7 @@ impl Parser {
         self.counter_values.borrow_mut().remove(&attr_name);
 
         let is_doctype = attr_name == "doctype";
-        self.attribute_values.insert(attr_name, attribute_value);
+        Arc::make_mut(&mut self.attribute_values).insert(attr_name, attribute_value);
         if is_doctype {
             self.refresh_doctype_derived_attr();
         }
@@ -775,7 +781,7 @@ impl Parser {
         };
 
         self.counter_values.borrow_mut().remove(&attr_name);
-        self.attribute_values.insert(attr_name, attribute_value);
+        Arc::make_mut(&mut self.attribute_values).insert(attr_name, attribute_value);
     }
 
     /// Called while parsing a block (see [`Block::parse_with_outcome()`]) to
@@ -819,7 +825,7 @@ impl Parser {
         self.counter_values.borrow_mut().remove(&attr_name);
 
         let is_doctype = attr_name == "doctype";
-        self.attribute_values.insert(attr_name, attribute_value);
+        Arc::make_mut(&mut self.attribute_values).insert(attr_name, attribute_value);
         if is_doctype {
             self.refresh_doctype_derived_attr();
         }
@@ -1266,7 +1272,7 @@ mod tests {
 
             // With `doctype` unset (no `Value`), a refresh clears any existing
             // derived attribute and defines none.
-            parser.attribute_values.remove("doctype");
+            std::sync::Arc::make_mut(&mut parser.attribute_values).remove("doctype");
             parser.refresh_doctype_derived_attr();
 
             assert_eq!(parser.attribute_value("doctype"), InterpretedValue::Unset);

--- a/parser/src/tests/asciidoc_lang/attributes/document_attributes_ref.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/document_attributes_ref.rs
@@ -1,0 +1,1720 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/attributes/pages/document-attributes-ref.adoc");
+
+// This page is the reference catalog of built-in document attributes. The
+// `verifies!` blocks below pair each attribute table with assertions that a
+// pristine `Parser` exposes the documented defaults: attributes that are set by
+// default resolve to their default value (or an empty value), and attributes
+// that are not set by default are left unset. The intrinsic, document metadata,
+// and manpage tables describe values derived from the environment or document
+// content rather than fixed defaults, so they are recorded as non-normative.
+
+/// A pristine parser resolves `name` to the given set-by-default value.
+fn assert_default(name: &str, expected: &str) {
+    let parser = Parser::default();
+    assert_eq!(
+        parser.attribute_value(name).as_maybe_str(),
+        Some(expected),
+        "`{name}` should be set by default to `{expected}`"
+    );
+}
+
+/// A pristine parser has `name` set by default to an empty value.
+fn assert_set_empty(name: &str) {
+    let parser = Parser::default();
+    assert!(
+        parser.is_attribute_set(name),
+        "`{name}` should be set by default"
+    );
+    assert_eq!(
+        parser.attribute_value(name).as_maybe_str(),
+        None,
+        "`{name}` should be set by default to an empty value"
+    );
+}
+
+/// A pristine parser leaves `name` unset.
+fn assert_not_set_by_default(name: &str) {
+    let parser = Parser::default();
+    assert!(
+        !parser.is_attribute_set(name),
+        "`{name}` should not be set by default"
+    );
+}
+
+non_normative!(
+    r#"
+= Document Attributes Reference
+:page-aliases: document-attributes-reference.adoc
+// TODO use icons or emoji for y and n
+:y: Yes
+:n: No
+:endash: &#8211;
+:url-epoch: https://reproducible-builds.org/specs/source-date-epoch/
+
+Document attributes are used either to configure behavior in the processor or to relay information about the document and its environment.
+This page catalogs all the built-in (i.e., reserved) document attributes in AsciiDoc.
+
+Unless otherwise marked, these attributes can be modified (set or unset) from the API using the `:attributes` option, from the CLI using the `-a` option, or in the document (often in the document header) using an attribute entry.
+
+Use the follow legend to understand the columns and values in the tables on this page.
+
+[horizontal]
+Set By Default:: The attribute is automatically set and assigned a default value by the AsciiDoc processor.
+The default value is indicated in *bold* (e.g., `*skip*`).
+
+Allowable Values:: Allowable values for the attribute.
+Numeric values and values shown in _italic_ are instructional and indicate a value type (e.g., _any_, _empty_, _number_, 1{endash}5, etc.).
++
+* _any_ -- Any value is accepted.
+* _empty_ -- Indicates the attribute doesn't require an explicit value.
+The attribute is simply turned on by being set.
+* _empty_[=`effective`] -- In some cases, an empty value is interpreted by the processor as one of the allowable non-empty values.
+This effective value is prefixed with an equals sign and enclosed in square brackets (e.g., [=`auto`]).
+An attribute reference will resolve to an empty value rather than the effective value.
+* (`implied`) -- Built-in attributes that are not set may have an implied value.
+The implied value is enclosed in parentheses (e.g., (`attributes`)).
+An implied value can't be resolved using an attribute reference.
+
++
+If the attribute doesn't accept _any_ or _empty_, than you must only assign one of the allowable values or specified value type.
+
+Header Only:: The attribute must be set or unset by the end of the document header (i.e., set by the API, CLI, or in the document header).
+Otherwise, the assignment won't have any effect on the document.
+If an attribute is not marked as _Header Only_, it can be set anywhere in the document, assuming the attribute is not locked by the API or CLI.
+However, changing an attribute only affects behavior for content that follows the assignment (in document order).
+
+== Intrinsic attributes
+
+Intrinsic attributes are set automatically by the processor.
+These attributes provide information about the document being processed (e.g., `docfile`), the security mode under which the processor is running (e.g., `safe-mode-name`), and information about the user's environment (e.g., `user-home`).
+
+Many of these attributes are read only, which means they can't be modified (with some exceptions).
+Attributes which are not are marked as modifiable.
+Attributes marked as both modifiable and API/CLI Only can only be set from the API or CLI.
+All other attributes marked as modifiable must be set by the end of the header (i.e., Header Only).
+
+[cols="30m,20,^10,^10,30"]
+|===
+.>|Name .>|Allowable Values .>|Modifiable .>|API/CLI Only .>|Notes
+
+|backend
+|_any_ +
+_ex._ html5
+|{y}
+|{n}
+|The backend used to select and activate the converter that creates the output file.
+Usually named according to the output format (e.g., `html5`)
+
+|backend-<backend>
+|_empty_
+|{n}
+|n/a
+|A convenience attribute for checking which backend is selected.
+<backend> is the value of the `backend` attribute (e.g., `backend-html5`).
+Only one such attribute is set at time.
+
+//|backend-<backend>-doctype-<doctype>
+//|_empty_
+//|{n}
+//|n/a
+//|A convenience attribute for checking the current backend/doctype combination.
+//<backend> is the value of the `backend` attribute and <doctype> is the value of the `doctype` attribute (e.g., `backend-html5-doctype-article`).
+//Only one such attribute is set at time.
+
+|basebackend
+|_any_ +
+_ex._ html
+|{n}
+|n/a
+|The generic backend on which the backend is based.
+Typically derived from the backend value minus trailing numbers (e.g., the basebackend for `docbook5` is `docbook`).
+May also indicate the internal backend employed by the converter (e.g., the basebackend for `pdf` is `html`).
+
+|basebackend-<basebackend>
+|_empty_
+|{n}
+|n/a
+|A convenience attribute for checking which basebackend is active.
+<basebackend> is the value of the `basebackend` attribute (e.g., `basebackend-html`).
+Only one such attribute is set at time.
+
+//|basebackend-<basebackend>-doctype-<doctype>
+//|_empty_
+//|{n}
+//|n/a
+//|A convenience attribute for checking the current basebackend/doctype combination.
+//<basebackend> is the value of the `basebackend` attribute and <doctype> is the value of the `doctype` attribute (e.g., `basebackend-html-doctype-article`).
+//Only one such attribute is set at time.
+
+|docdate
+|_date (ISO)_ +
+_ex._ 2019-01-04
+|{y}
+|{n}
+|Last modified date of the source document.^[<<note-docdatetime,1>>,<<note-sourcedateepoch,2>>]^
+
+|docdatetime
+|_datetime (ISO)_ +
+_ex._ 2019-01-04 19:26:06 UTC
+|{y}
+|{n}
+|Last modified date and time of the source document.^[<<note-docdatetime,1>>,<<note-sourcedateepoch,2>>]^
+
+|docdir
+|_directory path_ +
+_ex._ /home/user/docs
+|If input is a string
+|{y}
+|Full path of the directory that contains the source document.
+Empty if the safe mode is SERVER or SECURE (to conceal the file's location).
+
+|docfile
+|_file path_ +
+_ex._ /home/user/docs/userguide.adoc
+|If input is a string
+|{y}
+|Full path of the source document.
+Truncated to the basename if the safe mode is SERVER or SECURE (to conceal the file's location).
+
+|docfilesuffix
+|_file extension_ +
+_ex._ .adoc
+|If input is a string
+|{y}
+|File extension of the source document, including the leading period.
+
+|docname
+|_file stem basename_ +
+_ex._ userguide
+|If input is a string
+|{y}
+|Root name of the source document (no leading path or file extension).
+
+|doctime
+|_time (ISO)_ +
+_ex._ 19:26:06 UTC
+|{y}
+|{n}
+|Last modified time of the source document.^[<<note-docdatetime,1>>,<<note-sourcedateepoch,2>>]^
+
+|doctype-<doctype>
+|_empty_
+|{n}
+|n/a
+|A convenience attribute for checking the doctype of the document.
+<doctype> is the value of the `doctype` attribute (e.g., `doctype-book`).
+Only one such attribute is set at time.
+
+|docyear
+|_integer_ +
+_ex._ {docyear}
+|{y}
+|{n}
+|Year that the document was last modified.^[<<note-docdatetime,1>>,<<note-sourcedateepoch,2>>]^
+
+|embedded
+|_empty_
+|{n}
+|n/a
+|Only set if content is being converted to an embedded document (i.e., body of document only).
+
+|filetype
+|_any_ +
+_ex._ html
+|If input is a string
+|{y}
+|File extension of the output file name (without leading period).
+
+|filetype-<filetype>
+|_empty_
+|{n}
+|n/a
+|A convenience attribute for checking the filetype of the output.
+<filetype> is the value of the `filetype` attribute (e.g., `filetype-html`).
+Only one such attribute is set at time.
+
+|htmlsyntax
+|`html` +
+`xml`
+|{n}
+|n/a
+|Syntax used when generating the HTML output.
+Controlled by and derived from the backend name (html=html or xhtml=html).
+
+|localdate
+|_date (ISO)_ +
+_ex._ 2019-02-17
+|{y}
+|{n}
+|Date when the document was converted.^[<<note-sourcedateepoch,2>>]^
+
+|localdatetime
+|_datetime (ISO)_ +
+_ex._ 2019-02-17 19:31:05 UTC
+|{y}
+|{n}
+|Date and time when the document was converted.^[<<note-sourcedateepoch,2>>]^
+
+|localtime
+|_time (ISO)_ +
+_ex._ 19:31:05 UTC
+|{y}
+|{n}
+|Time when the document was converted.^[<<note-sourcedateepoch,2>>]^
+
+|localyear
+|_integer_ +
+_ex._ {localyear}
+|{y}
+|{n}
+|Year when the document was converted.^[<<note-sourcedateepoch,2>>]^
+
+|outdir
+|_directory path_ +
+_ex._ /home/user/docs/dist
+|{n}
+|n/a
+|Full path of the output directory.
+(Cannot be referenced in the content.
+Only available to the API once the document is converted).
+
+|outfile
+|_file path_ +
+_ex._ /home/user/docs/dist/userguide.html
+|{n}
+|n/a
+|Full path of the output file.
+(Cannot be referenced in the content.
+Only available to the API once the document is converted).
+
+|outfilesuffix
+|_file extension_ +
+_ex._ .html
+|{y}
+|{n}
+|File extension of the output file (starting with a period) as determined by the backend (`.html` for `html`, `.xml` for `docbook`, etc.).
+
+|safe-mode-level
+|`0` +
+`1` +
+`10` +
+`20`
+|{n}
+|n/a
+|Numeric value of the safe mode setting.
+(0=UNSAFE, 1=SAFE, 10=SERVER, 20=SECURE).
+
+|safe-mode-name
+|`UNSAFE` +
+`SAFE` +
+`SERVER` +
+`SECURE`
+|{n}
+|n/a
+|Textual value of the safe mode setting.
+
+|safe-mode-unsafe
+|_empty_
+|{n}
+|n/a
+|Set if the safe mode is UNSAFE.
+
+|safe-mode-safe
+|_empty_
+|{n}
+|n/a
+|Set if the safe mode is SAFE.
+
+|safe-mode-server
+|_empty_
+|{n}
+|n/a
+|Set if the safe mode is SERVER.
+
+|safe-mode-secure
+|_empty_
+|{n}
+|n/a
+|Set if the safe mode is SECURE.
+
+|user-home
+|_directory path_ +
+_ex._ /home/user
+|{n}
+|n/a
+|Full path of the home directory for the current user.
+Masked as `.` if the safe mode is SERVER or SECURE.
+|===
+[[note-docdatetime]]^[1]^ Only reflects the last modified time of the source document file.
+It does not consider the last modified time of files which are included.
+
+[[note-sourcedateepoch]]^[2]^ If the SOURCE_DATE_EPOCH environment variable is set, the value assigned to this attribute is built from a UTC date object that corresponds to the timestamp (as an integer) stored in that environment variable.
+This override offers one way to make the conversion reproducible.
+See the {url-epoch}[source date epoch specification] for more information about the SOURCE_DATE_EPOCH environment variable.
+Otherwise, the date is expressed in the local time zone, which is reported as a time zone offset (e.g., `-0600`) or UTC if the time zone offset is 0).
+To force the use of UTC, set the `TZ=UTC` environment variable when invoking Asciidoctor.
+
+"#
+);
+
+#[test]
+fn compliance_attributes() {
+    verifies!(
+        r#"
+== Compliance attributes
+
+[cols="30m,20,^10,^10,30"]
+|===
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
+
+|attribute-missing
+|`drop` +
+`drop-line` +
+`*skip*` +
+`warn`
+|{y}
+|{n}
+|Controls how xref:unresolved-references.adoc#missing[missing attribute references] are handled.
+
+|attribute-undefined
+|`drop` +
+`*drop-line*`
+|{y}
+|{n}
+|Controls how xref:unresolved-references.adoc#undefined[attribute unassignments] are handled.
+
+|compat-mode
+|_empty_
+|{n}
+|{n}
+|Controls when the legacy parsing mode is used to parse the document.
+
+|experimental
+|_empty_
+|{n}
+|{y}
+|Enables xref:macros:ui-macros.adoc[] and the xref:macros:keyboard-macro.adoc[].
+
+|reproducible
+|_empty_
+|{n}
+|{y}
+|Prevents last-updated date from being added to HTML footer or DocBook info element.
+Useful for storing the output in a source code control system as it prevents spurious changes every time you convert the document.
+Alternately, you can use the SOURCE_DATE_EPOCH environment variable, which sets the epoch of all source documents and the local datetime to a fixed value.
+
+|skip-front-matter
+|_empty_
+|{n}
+|{y}
+|Consume YAML-style frontmatter at top of document and store it in `front-matter` attribute.
+//<<front-matter-added-for-static-site-generators>>
+|===
+
+"#
+    );
+
+    assert_default("attribute-missing", "skip");
+    assert_default("attribute-undefined", "drop-line");
+
+    for name in [
+        "compat-mode",
+        "experimental",
+        "reproducible",
+        "skip-front-matter",
+    ] {
+        assert_not_set_by_default(name);
+    }
+}
+
+#[test]
+fn localization_and_numbering_attributes() {
+    verifies!(
+        r#"
+[#builtin-attributes-i18n]
+== Localization and numbering attributes
+
+[cols="30m,20,^10,^10,30"]
+|===
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
+
+|appendix-caption
+|_any_ +
+`*Appendix*`
+|{y}
+|{n}
+|Label added before an xref:sections:appendix.adoc[appendix title].
+
+|appendix-number
+|_character_ +
+(`@`)
+|{n}
+|{n}
+|Sets the seed value for the appendix number sequence.^[<<note-number,1>>]^
+
+|appendix-refsig
+|_any_ +
+`*Appendix*`
+|{y}
+|{n}
+|Signifier added to Appendix title cross references.
+
+|caution-caption
+|_any_ +
+`*Caution*`
+|{y}
+|{n}
+|Text used to label CAUTION admonitions when icons aren't enabled.
+
+|chapter-number
+|_number_ +
+(`0`)
+|{n}
+|{n}
+|Sets the seed value for the chapter number sequence.^[<<note-number,1>>]^
+_Book doctype only_.
+
+|chapter-refsig
+|_any_ +
+`*Chapter*`
+|{y}
+|{n}
+|Signifier added to Chapter titles in cross references.
+_Book doctype only_.
+
+|chapter-signifier
+|_any_
+|{n}
+|{n}
+|xref:sections:chapters.adoc[Label added to level 1 section titles (chapters)].
+_Book doctype only_.
+
+|example-caption
+|_any_ +
+`*Example*`
+|{y}
+|{n}
+|Text used to label example blocks.
+
+|example-number
+|_number_ +
+(`0`)
+|{n}
+|{n}
+|Sets the seed value for the example number sequence.^[<<note-number,1>>]^
+
+|figure-caption
+|_any_ +
+`*Figure*`
+|{y}
+|{n}
+|Text used to label images and figures.
+
+|figure-number
+|_number_ +
+(`0`)
+|{n}
+|{n}
+|Sets the seed value for the figure number sequence.^[<<note-number,1>>]^
+
+|footnote-number
+|_number_ +
+(`0`)
+|{n}
+|{n}
+|Sets the seed value for the footnote number sequence.^[<<note-number,1>>]^
+
+|important-caption
+|_any_ +
+`*Important*`
+|{y}
+|{n}
+|Text used to label IMPORTANT admonitions when icons are not enabled.
+
+|lang
+|_BCP 47 language tag_ +
+(`en`)
+|{n}
+|{y}
+|Language tag specified on document element of the output document.
+Refer to https://html.spec.whatwg.org/#the-lang-and-xml:lang-attributes[the lang and xml:lang attributes section^] of the HTML specification to learn about the acceptable values for this attribute.
+
+|last-update-label
+|_any_ +
+`*Last updated*`
+|{y}
+|{y}
+|Text used for “Last updated” label in footer.
+
+|listing-caption
+|_any_
+|{n}
+|{n}
+|Text used to label listing blocks.
+
+|listing-number
+|_number_ +
+(`0`)
+|{n}
+|{n}
+|Sets the seed value for the listing number sequence.^[<<note-number,1>>]^
+
+|manname-title
+|_any_ +
+(`Name`)
+|{n}
+|{y}
+|Label for program name section in the man page.
+
+|nolang
+|_empty_
+|{n}
+|{y}
+|Prevents `lang` attribute from being added to root element of the output document.
+
+|note-caption
+|_any_ +
+`*Note*`
+|{y}
+|{n}
+|Text used to label NOTE admonitions when icons aren't enabled.
+
+|part-refsig
+|_any_ +
+`*Part*`
+|{y}
+|{n}
+|Signifier added to Part titles in cross references.
+_Book doctype only_.
+
+|part-signifier
+|_any_
+|{n}
+|{n}
+|xref:sections:chapters.adoc[Label added to level 0 section titles (parts)].
+_Book doctype only_.
+
+|preface-title
+|_any_
+|{n}
+|{n}
+|Title text for an anonymous preface when `doctype` is `book`.
+
+|section-refsig
+|_any_ +
+`*Section*`
+|{y}
+|{n}
+|Signifier added to title of numbered sections in cross reference text.
+
+|table-caption
+|_any_ +
+`*Table*`
+|{y}
+|{n}
+|Text of label prefixed to table titles.
+
+|table-number
+|_number_ +
+(`0`)
+|{n}
+|{n}
+|Sets the seed value for the table number sequence.^[<<note-number,1>>]^
+
+|tip-caption
+|_any_ +
+`*Tip*`
+|{y}
+|{n}
+|Text used to label TIP admonitions when icons aren't enabled.
+
+|toc-title
+|_any_ +
+`*Table of Contents*`
+|{y}
+|{y}
+|xref:toc:title.adoc[Title for table of contents].
+
+|untitled-label
+|_any_ +
+`*Untitled*`
+|{y}
+|{y}
+|Default document title if document doesn't have a document title.
+
+|version-label
+|_any_ +
+`*Version*`
+|{y}
+|{y}
+|See xref:document:version-label.adoc[].
+
+|warning-caption
+|_any_ +
+`*Warning*`
+|{y}
+|{n}
+|Text used to label WARNING admonitions when icons aren't enabled.
+|===
+
+"#
+    );
+
+    for (name, expected) in [
+        ("appendix-caption", "Appendix"),
+        ("appendix-refsig", "Appendix"),
+        ("caution-caption", "Caution"),
+        ("chapter-refsig", "Chapter"),
+        ("example-caption", "Example"),
+        ("figure-caption", "Figure"),
+        ("important-caption", "Important"),
+        ("last-update-label", "Last updated"),
+        ("note-caption", "Note"),
+        ("part-refsig", "Part"),
+        ("section-refsig", "Section"),
+        ("table-caption", "Table"),
+        ("tip-caption", "Tip"),
+        ("toc-title", "Table of Contents"),
+        ("untitled-label", "Untitled"),
+        ("version-label", "Version"),
+        ("warning-caption", "Warning"),
+    ] {
+        assert_default(name, expected);
+    }
+
+    for name in [
+        "appendix-number",
+        "chapter-number",
+        "chapter-signifier",
+        "example-number",
+        "figure-number",
+        "footnote-number",
+        "lang",
+        "listing-caption",
+        "listing-number",
+        "manname-title",
+        "nolang",
+        "part-signifier",
+        "preface-title",
+        "table-number",
+    ] {
+        assert_not_set_by_default(name);
+    }
+}
+
+non_normative!(
+    r#"
+== Document metadata attributes
+
+[cols="30m,20,^10,^10,30"]
+|===
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
+
+|app-name
+|_any_
+|{n}
+|{y}
+|Adds `application-name` meta element for mobile devices inside HTML document head.
+
+|author
+|_any_
+|Extracted from author info line
+|{y}
+|Can be set automatically via the author info line or explicitly.
+See xref:document:author-information.adoc[].
+
+|authorinitials
+|_any_
+|Extracted from `author` attribute
+|{y}
+|Derived from the author attribute by default.
+See xref:document:author-information.adoc[].
+
+|authors
+|_any_
+|Extracted from author info line
+|{y}
+|Can be set automatically via the author info line or explicitly as a comma-separated value list.
+See xref:document:author-information.adoc[].
+
+|copyright
+|_any_
+|{n}
+|{y}
+|Adds `copyright` meta element in HTML document head.
+
+|doctitle
+|_any_
+|Yes, if document has a doctitle
+|{y}
+|See xref:document:title.adoc#reference-doctitle[doctitle attribute].
+
+|description
+|_any_
+|{n}
+|{y}
+|Adds xref:document:metadata.adoc#description[description] meta element in HTML document head.
+
+|email
+|_any_
+|Extracted from author info line
+|{y}
+|Can be any inline macro, such as a URL.
+See xref:document:author-information.adoc[].
+
+|firstname
+|_any_
+|Extracted from author info line
+|{y}
+|See xref:document:author-information.adoc[].
+
+|front-matter
+|_any_
+|Yes, if front matter is captured
+|n/a
+|If `skip-front-matter` is set via the API or CLI, any YAML-style frontmatter skimmed from the top of the document is stored in this attribute.
+
+|keywords
+|_any_
+|{n}
+|{y}
+|Adds xref:document:metadata.adoc#keywords[keywords] meta element in HTML document head.
+
+|lastname
+|_any_
+|Extracted from author info line
+|{y}
+|See xref:document:author-information.adoc[].
+
+|middlename
+|_any_
+|Extracted from author info line
+|{y}
+|See xref:document:author-information.adoc[].
+
+|orgname
+|_any_
+|{n}
+|{y}
+|Adds `<orgname>` element value to DocBook info element.
+
+|revdate
+|_any_
+|Extracted from revision info line
+|{y}
+|See xref:document:revision-information.adoc[].
+
+|revremark
+|_any_
+|Extracted from revision info line
+|{y}
+|See xref:document:revision-information.adoc[].
+
+|revnumber
+|_any_
+|Extracted from revision info line
+|{y}
+|See xref:document:revision-information.adoc[].
+
+|title
+|_any_
+|{n}
+|{y}
+|Value of `<title>` element in HTML `<head>` or main DocBook `<info>` of output document.
+Used as a fallback when the document title is not specified.
+See xref:document:title.adoc#title-attr[title attribute].
+|===
+
+"#
+);
+
+#[test]
+fn section_title_and_toc_attributes() {
+    verifies!(
+        r#"
+== Section title and table of contents attributes
+
+[cols="30m,20,^10,^10,30"]
+|===
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
+
+|idprefix
+|_valid XML ID start character_ +
+`*_*`
+|{y}
+|{n}
+|Prefix of auto-generated section IDs.
+See xref:sections:id-prefix-and-separator.adoc#prefix[Change the ID prefix].
+
+|idseparator
+|_valid XML ID character_ +
+`*_*`
+|{y}
+|{n}
+|Word separator used in auto-generated section IDs.
+See xref:sections:id-prefix-and-separator.adoc#separator[Change the ID word separator].
+
+|leveloffset
+|{startsb}+-{endsb}0{endash}5
+|{n}
+|{n}
+|Increases or decreases level of headings below assignment.
+A leading + or - makes the value relative.
+//<<include-partitioning>>
+
+|partnums
+|_empty_
+|{n}
+|{n}
+|Enables numbering of parts.
+See xref:sections:part-numbers-and-labels.adoc#partnums[Number book parts].
+_Book doctype only_.
+
+|sectanchors
+|_empty_
+|{n}
+|{n}
+|xref:sections:title-links.adoc#anchor[Adds anchor in front of section title] on mouse cursor hover.
+
+|sectids
+|*_empty_*
+|{y}
+|{n}
+|Generates and assigns an ID to any section that does not have an ID.
+See xref:sections:auto-ids.adoc#disable[Disable automatic ID generation].
+
+|sectlinks
+|_empty_
+|{n}
+|{n}
+|xref:sections:title-links.adoc[Turns section titles into self-referencing links].
+
+|sectnums
+|_empty_ +
+`all`
+|{n}
+|{n}
+|xref:sections:numbers.adoc[Numbers sections] to depth specified by `sectnumlevels`.
+
+|sectnumlevels
+|0{endash}5 +
+(`3`)
+|{n}
+|{n}
+|xref:sections:numbers.adoc#numlevels[Controls depth of section numbering].
+
+|title-separator
+|_any_
+|{n}
+|{y}
+|Character used to xref:document:subtitle.adoc[separate document title and subtitle].
+
+|toc
+|_empty_[=`auto`] +
+`auto` +
+`left` +
+`right` +
+`macro` +
+`preamble`
+|{n}
+|{y}
+|Turns on xref:toc:index.adoc[table of contents] and specifies xref:toc:position.adoc[its location].
+
+|toclevels
+|0{endash}5 +
+(`2`)
+|{n}
+|{y}
+|xref:toc:levels.adoc[Maximum section level to display].
+
+|fragment
+|_empty_
+|{n}
+|{y}
+|Informs parser that document is a fragment and that it shouldn't enforce proper section nesting.
+|===
+
+"#
+    );
+
+    for (name, expected) in [
+        ("idprefix", "_"),
+        ("idseparator", "_"),
+        ("sectnumlevels", "3"),
+    ] {
+        assert_default(name, expected);
+    }
+
+    assert_set_empty("sectids");
+
+    for name in [
+        "leveloffset",
+        "partnums",
+        "sectanchors",
+        "sectlinks",
+        "sectnums",
+        "title-separator",
+        "toc",
+        "toclevels",
+        "fragment",
+    ] {
+        assert_not_set_by_default(name);
+    }
+}
+
+#[test]
+fn general_content_and_formatting_attributes() {
+    verifies!(
+        r#"
+== General content and formatting attributes
+
+[cols="30m,20,^10,^10,30"]
+|===
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
+
+|asset-uri-scheme
+|_empty_ +
+`http` +
+(`https`)
+|{n}
+|{y}
+|Controls protocol used for assets hosted on a CDN.
+
+|cache-uri
+|_empty_
+|{n}
+|{y}
+|Cache content read from URIs.
+//<<caching-uri-content>>
+
+|data-uri
+|_empty_
+|{n}
+|{y}
+|Embed graphics as data-uri elements in HTML elements so file is completely self-contained.
+//<<managing-images>>
+
+|docinfo
+|_empty_[=`private`] +
+`shared` +
+`private` +
+`shared-head` +
+`private-head` +
+`shared-footer` +
+`private-footer`
+|{n}
+|{y}
+|Read input from one or more DocBook info files.
+//<<naming-docinfo-files>>
+
+|docinfodir
+|_directory path_
+|{n}
+|{y}
+|Location of docinfo files.
+Defaults to directory of source file if not specified.
+//<<locating-docinfo-files>>
+
+|docinfosubs
+|_comma-separated substitution names_ +
+(`attributes`)
+|{n}
+|{y}
+|AsciiDoc substitutions that are applied to docinfo content.
+//<<attribute-substitution-in-docinfo-files>>
+
+|doctype
+|`*article*` +
+`book` +
+`inline` +
+`manpage`
+|{y}
+|{y}
+|Output document type.
+//<<document-types>>
+
+|eqnums
+|_empty_[=`AMS`] +
+`AMS` +
+`all` +
+`none`
+|{n}
+|{y}
+|Controls automatic equation numbering on LaTeX blocks in HTML output (MathJax).
+If the value is AMS, only LaTeX content enclosed in an `+\begin{equation}...\end{equation}+` container will be numbered.
+If the value is all, then all LaTeX blocks will be numbered.
+See https://docs.mathjax.org/en/v2.5-latest/tex.html#automatic-equation-numbering[equation numbering in MathJax].
+
+|hardbreaks-option
+|_empty_
+|{n}
+|{n}
+|xref:blocks:hard-line-breaks.adoc#per-document[Preserve hard line breaks].
+
+|hide-uri-scheme
+|_empty_
+|{n}
+|{n}
+|xref:macros:links.adoc#hide-uri-scheme[Hides URI scheme] for raw links.
+
+|media
+|`prepress` +
+`print` +
+(`screen`)
+|{n}
+|{y}
+|Specifies media type of output and enables behavior specific to that media type.
+_PDF converter only_.
+
+|nofooter
+|_empty_
+|{n}
+|{y}
+|Turns off footer.
+//<<footer-docinfo-files>>
+
+|nofootnotes
+|_empty_
+|{n}
+|{y}
+|Turns off footnotes.
+//<<user-footnotes>>
+
+|noheader
+|_empty_
+|{n}
+|{y}
+|Turns off header.
+//<<doc-header>>
+
+|notitle
+|_empty_
+|{n}
+|{y}
+|xref:document:title.adoc#hide-or-show[Hides the doctitle in an embedded document].
+Mutually exclusive with the `showtitle` attribute.
+
+|outfilesuffix
+|*_file extension_* +
+_ex._ .html
+|{y}
+|{y}
+|File extension of output file, including dot (`.`), such as `.html`.
+// <<navigating-between-source-files>>
+
+|pagewidth
+|_integer_ +
+(`425`)
+|{n}
+|{y}
+|Page width used to calculate the absolute width of tables in the DocBook output.
+
+|relfileprefix
+|_empty_ +
+_path segment_
+|{n}
+|{n}
+|The path prefix to add to relative xrefs.
+//<<navigating-between-source-files>>
+
+|relfilesuffix
+|*_file extension_* +
+_path segment_ +
+_ex._ .html
+|{y}
+|{n}
+|The path suffix (e.g., file extension) to add to relative xrefs.
+Defaults to the value of the `outfilesuffix` attribute.
+(Preferred over modifying outfilesuffix).
+//|<<navigating-between-source-files>>
+
+|show-link-uri
+|_empty_
+|{n}
+|{n}
+|Prints the URI of a link after the link text.
+_PDF converter only_.
+
+|showtitle
+|_empty_
+|{n}
+|{y}
+|xref:document:title.adoc#hide-or-show[Displays the doctitle in an embedded document].
+Mutually exclusive with the `notitle` attribute.
+
+|stem
+|`_empty_`[=`asciimath`] +
+`asciimath` +
+`latexmath`
+|{n}
+|{y}
+|Enables xref:stem:index.adoc[mathematics processing and interpreter].
+
+|table-frame
+|(`all`) +
+`ends` +
+`sides` +
+`none`
+|{n}
+|{n}
+|Controls default value for `frame` attribute on tables.
+
+|table-grid
+|(`all`) +
+`cols` +
+`rows` +
+`none`
+|{n}
+|{n}
+|Controls default value for `grid` attribute on tables.
+
+|table-stripes
+|(`none`) +
+`even` +
+`odd` +
+`hover` +
+`all`
+|{n}
+|{n}
+|Controls default value for `stripes` attribute on tables.
+
+|tabsize
+|_integer_ (≥ 0)
+|{n}
+|{n}
+|Converts tabs to spaces in verbatim content blocks (e.g., listing, literal).
+
+|webfonts
+|*_empty_*
+|{y}
+|{y}
+|Control whether webfonts are loaded when using the default stylesheet.
+When set to empty, uses the default font collection from Google Fonts.
+A non-empty value replaces the `family` query string parameter in the Google Fonts URL.
+
+|xrefstyle
+|`full` +
+`short` +
+`basic`
+|{n}
+|{n}
+|xref:macros:xref-text-and-style.adoc#cross-reference-styles[Formatting style to apply to cross reference text].
+|===
+
+"#
+    );
+
+    for (name, expected) in [
+        ("doctype", "article"),
+        ("outfilesuffix", ".html"),
+        ("relfilesuffix", ".html"),
+    ] {
+        assert_default(name, expected);
+    }
+
+    assert_set_empty("webfonts");
+
+    for name in [
+        "asset-uri-scheme",
+        "cache-uri",
+        "data-uri",
+        "docinfo",
+        "docinfodir",
+        "docinfosubs",
+        "eqnums",
+        "hardbreaks-option",
+        "hide-uri-scheme",
+        "media",
+        "nofooter",
+        "nofootnotes",
+        "noheader",
+        "notitle",
+        "pagewidth",
+        "relfileprefix",
+        "show-link-uri",
+        "showtitle",
+        "stem",
+        "table-frame",
+        "table-grid",
+        "table-stripes",
+        "tabsize",
+        "xrefstyle",
+    ] {
+        assert_not_set_by_default(name);
+    }
+}
+
+#[test]
+fn image_and_icon_attributes() {
+    verifies!(
+        r#"
+== Image and icon attributes
+
+[cols="30m,20,^10,^10,30"]
+|===
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
+
+|iconfont-cdn
+|_url_ +
+(default CDN URL)
+|{n}
+|{y}
+|If not specified, uses the cdnjs.com service.
+Overrides CDN used to link to the Font Awesome stylesheet.
+
+|iconfont-name
+|_any_ +
+(`font-awesome`)
+|{n}
+|{y}
+|Overrides the name of the icon font stylesheet.
+//<<icons>>
+
+|iconfont-remote
+|*_empty_*
+|{y}
+|{y}
+|Allows use of a CDN for resolving the icon font.
+Only relevant used when value of `icons` attribute is `font`.
+
+|icons
+|_empty_[=`image`] +
+`image` +
+`font`
+|{n}
+|{y}
+|Chooses xref:macros:icons.adoc#icons-attribute[images or font icons] instead of text for admonitions.
+Any other value is assumed to be an icontype and sets the value to empty (image-based icons).
+
+|iconsdir
+|_directory path_ +
+_url_ +
+_ex._ ./images/icons
+|{y}
+|{n}
+|Location of non-font-based image icons.
+Defaults to the _icons_ folder under `imagesdir` if `imagesdir` is specified and `iconsdir` is not specified.
+
+|icontype
+|`jpg` +
+(`png`) +
+`gif` +
+`svg`
+|{n}
+|{n}
+|File type for image icons.
+Only relevant when using image-based icons.
+
+|imagesdir
+|*_empty_* +
+_directory path_ +
+_url_
+|{y}
+|{n}
+|Location of image files.
+|===
+
+"#
+    );
+
+    assert_default("iconsdir", "./images/icons");
+
+    assert_set_empty("iconfont-remote");
+    assert_set_empty("imagesdir");
+
+    for name in ["iconfont-cdn", "iconfont-name", "icons", "icontype"] {
+        assert_not_set_by_default(name);
+    }
+}
+
+#[test]
+fn source_highlighting_and_formatting_attributes() {
+    verifies!(
+        r#"
+== Source highlighting and formatting attributes
+
+[cols="30m,20,^10,^10,30"]
+|===
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
+
+|coderay-css
+|(`class`) +
+`style`
+|{n}
+|{y}
+|Controls whether CodeRay uses CSS classes or inline styles.
+
+|coderay-linenums-mode
+|`inline` +
+(`table`)
+|{n}
+|{n}
+|Sets how CodeRay inserts line numbers into source listings.
+
+|coderay-unavailable
+|_empty_
+|{n}
+|{y}
+|Instructs processor not to load CodeRay.
+Also set if processor fails to load CodeRay.
+
+|highlightjsdir
+|_directory path_ +
+_url_ +
+(default CDN URL)
+|{n}
+|{y}
+|Location of the highlight.js source code highlighter library.
+
+|highlightjs-theme
+|_highlight.js style name_ +
+(`github`)
+|{n}
+|{y}
+|Name of theme used by highlight.js.
+
+|prettifydir
+|_directory path_ +
+_url_ +
+(default CDN URL)
+|{n}
+|{y}
+|Location of non-CDN prettify source code highlighter library.
+
+|prettify-theme
+|_prettify style name_ +
+(`prettify`)
+|{n}
+|{y}
+|Name of theme used by prettify.
+
+|prewrap
+|*_empty_*
+|{y}
+|{n}
+|xref:asciidoctor:html-backend:verbatim-line-wrap.adoc[Wrap wide code listings].
+
+|pygments-css
+|(`class`) +
+`style`
+|{n}
+|{y}
+|Controls whether Pygments uses CSS classes or inline styles.
+
+|pygments-linenums-mode
+|(`table`) +
+`inline`
+|{n}
+|{n}
+|Sets how Pygments inserts line numbers into source listings.
+
+|pygments-style
+|_Pygments style name_ +
+(`default`)
+|{n}
+|{y}
+|Name of style used by Pygments.
+
+|pygments-unavailable
+|_empty_
+|{n}
+|{y}
+|Instructs processor not to load Pygments.
+Also set if processor fails to load Pygments.
+
+|rouge-css
+|(`class`) +
+`style`
+|{n}
+|{y}
+|Controls whether Rouge uses CSS classes or inline styles.
+
+|rouge-linenums-mode
+|`inline` +
+(`table`)
+|{n}
+|{n}
+|Sets how Rouge inserts line numbers into source listings.
+_`inline` not yet supported by Asciidoctor._
+See https://github.com/asciidoctor/asciidoctor/issues/3641[asciidoctor#3641].
+
+|rouge-style
+|_Rouge style name_ +
+(`github`)
+|{n}
+|{y}
+|Name of style used by Rouge.
+
+|rouge-unavailable
+|_empty_
+|{n}
+|{y}
+|Instructs processor not to load Rouge.
+Also set if processor fails to load Rouge.
+
+|source-highlighter
+|`coderay` +
+`highlight.js` +
+`pygments` +
+`rouge`
+|{n}
+|{y}
+|xref:verbatim:source-highlighter.adoc[Specifies source code highlighter].
+Any other value is permitted, but must be supported by a custom syntax highlighter adapter.
+
+|source-indent
+|_integer_
+|{n}
+|{n}
+|Normalize block indentation in source code listings.
+//<<normalize-block-indentation>>
+
+|source-language
+|_source code language name_
+|{n}
+|{n}
+|xref:verbatim:source-highlighter.adoc[Default language for source code blocks].
+
+|source-linenums-option
+|_empty_
+|{n}
+|{n}
+|Turns on line numbers for source code listings.
+|===
+
+"#
+    );
+
+    assert_set_empty("prewrap");
+
+    for name in [
+        "coderay-css",
+        "coderay-linenums-mode",
+        "coderay-unavailable",
+        "highlightjsdir",
+        "highlightjs-theme",
+        "prettifydir",
+        "prettify-theme",
+        "pygments-css",
+        "pygments-linenums-mode",
+        "pygments-style",
+        "pygments-unavailable",
+        "rouge-css",
+        "rouge-linenums-mode",
+        "rouge-style",
+        "rouge-unavailable",
+        "source-highlighter",
+        "source-indent",
+        "source-language",
+        "source-linenums-option",
+    ] {
+        assert_not_set_by_default(name);
+    }
+}
+
+#[test]
+fn html_styling_attributes() {
+    verifies!(
+        r#"
+== HTML styling attributes
+
+[cols="30m,20,^10,^10,30"]
+|===
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
+
+|copycss
+|*_empty_* +
+_file path_
+|{y}
+|{y}
+|Copy CSS files to output.
+Only relevant when the `linkcss` attribute is set and the output is a standalone HTML file.
+//<<applying-a-theme>>
+
+|css-signature
+|_valid XML ID_
+|{n}
+|{y}
+|Assign value to `id` attribute of HTML `<body>` element.
+*Preferred approach is to assign an ID to document title*.
+
+|linkcss
+|_empty_
+|{n}
+|{y}
+|Links to stylesheet instead of embedding it.
+Can't be unset in SECURE mode.
+//<<styling-the-html-with-css>>
+
+|max-width
+|CSS length (e.g. 55em, 12cm, etc)
+|{n}
+|{y}
+|Constrains maximum width of document body.
+*Not recommended.
+Use CSS stylesheet instead.*
+
+|stylesdir
+|_directory path_ +
+_url_ +
+`*.*`
+|{y}
+|{y}
+|Location of CSS stylesheets.
+//<<creating-a-theme>>
+
+|stylesheet
+|*_empty_* +
+_file path_
+|{y}
+|{y}
+|CSS stylesheet file name.
+An empty value tells the converter to use the default stylesheet.
+//<<applying-a-theme>>
+
+|toc-class
+|_valid CSS class name_ +
+(`*toc*`) or (`*toc2*`) if toc=left
+|{n}
+|{y}
+|CSS class on the table of contents container.
+//<<user-toc>>
+|===
+
+"#
+    );
+
+    assert_default("stylesdir", ".");
+
+    assert_set_empty("copycss");
+    assert_set_empty("stylesheet");
+
+    for name in ["css-signature", "linkcss", "max-width", "toc-class"] {
+        assert_not_set_by_default(name);
+    }
+}
+
+non_normative!(
+    r#"
+== Manpage attributes
+
+The attribute in this section are only relevant when using the manpage doctype and/or backend.
+
+[cols="30m,20,^10,^10,30"]
+|===
+.>|Name .>|Allowable Values .>|Set By Default .>|Header Only .>|Notes
+
+|mantitle
+|_any_
+|Based on content.
+|{y}
+|Metadata for man page output.
+//<<man-pages>>
+
+|manvolnum
+|_any_
+|Based on content.
+|{y}
+|Metadata for man page output.
+//<<man-pages>>
+
+|manname
+|_any_
+|Based on content.
+|{y}
+|Metadata for man page output.
+//<<man-pages>>
+
+|manpurpose
+|_any_
+|Based on content
+|{y}
+|Metadata for man page output.
+//<<man-pages>>
+
+|man-linkstyle
+|_link format pattern_ +
+(`blue R <>`)
+|{n}
+|{y}
+|Link style in man page output.
+//<<man-pages>>
+
+|mansource
+|_any_
+|{n}
+|{y}
+|Source (e.g., application and version) the man page describes.
+//<<man-pages>>
+
+|manmanual
+|_any_
+|{n}
+|{y}
+|Manual name displayed in the man page footer.
+//<<man-pages>>
+|===
+
+"#
+);
+
+#[test]
+fn security_attributes() {
+    verifies!(
+        r#"
+== Security attributes
+
+Since these attributes deal with security, they can only be set from the API or CLI.
+
+[cols="30m,20,^10,^10,30"]
+|===
+.>|Name .>|Allowable Values .>|Set By Default .>|API/CLI Only .>|Notes
+
+|allow-uri-read
+|_empty_
+|{n}
+|{y}
+|Allows data to be read from URLs.
+//<<include-uri>>
+
+|max-attribute-value-size
+|_integer_ (≥ 0) +
+`*4096*`
+|If safe mode is SECURE
+|{y}
+|Limits maximum size (in bytes) of a resolved attribute value.
+Default value is only set in SECURE mode.
+Since attributes can reference attributes, it's possible to create an output document disproportionately larger than the input document without this limit in place.
+
+|max-include-depth
+|_integer_ (≥ 0) +
+`*64*`
+|{y}
+|{y}
+|Curtail infinite include loops and to limit the opportunity to exploit nested includes to compound the size of the output document.
+//<<include-directive>>
+|===
+
+"#
+    );
+
+    assert_default("max-include-depth", "64");
+
+    // `max-attribute-value-size` is only assigned its `4096` default in SECURE
+    // mode, which is not yet implemented, so it is unset here.
+    for name in ["allow-uri-read", "max-attribute-value-size"] {
+        assert_not_set_by_default(name);
+    }
+}
+
+non_normative!(
+    r#"
+[[note-number]]^[1]^ The `-number` attributes are created and managed automatically by the AsciiDoc processor for numbered blocks.
+They are only used if the corresponding `-caption` attribute is set (e.g., `listing-caption`) and the block has a title.
+In Asciidoctor, setting the `-number` attributes will influence the next number used for subsequent numbered blocks of that type.
+However, you should not rely on this behavior as it is subject to change in future revisions of the language.
+// end::table[]
+"#
+);

--- a/parser/src/tests/asciidoc_lang/attributes/mod.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/mod.rs
@@ -7,6 +7,7 @@ mod character_replacement_ref;
 mod counters;
 mod custom_attributes;
 mod document_attributes;
+mod document_attributes_ref;
 mod element_attributes;
 mod id;
 mod inline_attribute_entries;


### PR DESCRIPTION
## Summary

Implements default values for the predefined document attributes cataloged in [`document-attributes-ref.adoc`](docs/modules/attributes/pages/document-attributes-ref.adoc), and adds full spec coverage for that page (which previously had **zero** coverage). This follows the same pattern as [#568](https://github.com/asciidoc-rs/asciidoc-parser/pull/568) (the character-replacement reference): record every documented default and reproduce the page verbatim for line-by-line coverage.

## Built-in attributes

`built_in_attrs.rs` now registers every attribute on the page that documents a default, grouped to mirror the reference page. Values match Ruby Asciidoctor, and the page's notation is modeled faithfully:

- **Set by default** attributes store a concrete `Value` (e.g. `note-caption` → `Note`, `idprefix` → `_`, `max-include-depth` → `64`) or `Set` for a bold `_empty_` default (e.g. `imagesdir`, `webfonts`, `prewrap`). The value is stored directly (not via the default-values map) so that setting the attribute with an *empty* value overrides it with empty rather than re-applying the default — which is what the existing `:toc-title:` → empty test relies on.
- **Implied** values `(x)` are recorded as `AllowableValue::Implied`, and **effective** values `_empty_[=x]` as `AllowableValue::Effective`. Per the page, neither is resolvable through an attribute reference, so these stay `Unset` by default with no default-values entry (this also keeps `docinfosubs`'s existing "bare `:docinfosubs:` disables substitution" semantics intact).
- The default-values map is reduced to the two genuine "turn-on applies a default" cases: `toc` (`auto`) and `sectnums` (`all`).

Intrinsic, document-metadata, and manpage attributes are derived from the environment or document content (no fixed defaults), so they are not given static values.

## Icon detection fix

Registering `icons` (previously unregistered) exposed that the inline image and callout renderers gated icon rendering on `has_attribute("icons")`, which is true for *any* registered built-in. Both sites now use `is_attribute_set("icons")`, matching Asciidoctor's `attr? 'icons'` (icons render only when the attribute is actually set).

## Spec coverage

Adds `document_attributes_ref.rs`, reproducing the page verbatim. The eight attribute tables with fixed defaults are `verifies!` blocks backed by assertions that a pristine `Parser` exposes each documented default (or leaves the attribute unset); the intrinsic, metadata, and manpage tables are non-normative.

## Testing

- `cargo test -p asciidoc-parser --lib` — 2497 pass, 0 fail
- `cargo +nightly fmt --check`, `cargo clippy --all-targets` — clean
- `cargo +nightly doc --no-deps` — clean
- `cd sdd && cargo run` — `document-attributes-ref.adoc` fully covered (0 uncovered lines; 796 verified lines match exactly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)