### PR TITLE
chore: Repoint title-attribute TODO from #514 to #578

### DIFF
--- a/parser/src/tests/asciidoc_lang/tables/customize_title_label.rs
+++ b/parser/src/tests/asciidoc_lang/tables/customize_title_label.rs
@@ -231,7 +231,7 @@ If you want the caption of the table to only consist of the caption label, use t
     // yet support. The example is tracked here but not yet exercised.
     //
     // TODO: Promote to `verifies!` once the `title` block attribute lands.
-    // https://github.com/asciidoc-rs/asciidoc-parser/issues/514
+    // https://github.com/asciidoc-rs/asciidoc-parser/issues/578
     to_do_verifies!(
         r#"
 [source]


### PR DESCRIPTION
Counter attribute references (#514) were fully implemented in #569, but the issue was never auto-closed because the PR didn't include a `Closes #514` line.

While confirming #514 is safe to close, I found one lingering reference in `parser/src/tests/asciidoc_lang/tables/customize_title_label.rs`. Its `to_do_verifies!` block is no longer blocked on counters — it's blocked on the separate `title=` block-attribute feature — but its TODO comment still pointed at #514.

This repoints that comment at the new tracking issue #578 (`Implement title= block attribute`), so closing #514 won't leave a dangling reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)