### PR TITLE
chore: Cover final line of paragraphs spec page

### DIFF
--- a/parser/src/tests/asciidoc_lang/blocks/paragraphs.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/paragraphs.rs
@@ -35,6 +35,7 @@ The result of <<ex-paragraph>> is displayed below.
 ====
 include::example$paragraph.adoc[tag=para]
 ====
+
 "#
     );
 
@@ -149,7 +150,6 @@ Another way to solve the problem is to write the paragraph as a literal paragrap
  [.rolename]*main text*footnote:[The footnote.]
 ----
 
-The normal style often comes in handy when you want to prevent the parser from matching beginning-of-line syntax.
 "#
     );
 
@@ -360,3 +360,9 @@ The normal style often comes in handy when you want to prevent the parser from m
         }
     );
 }
+
+non_normative!(
+    r#"
+The normal style often comes in handy when you want to prevent the parser from matching beginning-of-line syntax.
+"#
+);


### PR DESCRIPTION
## What changed

Added a non-normative SDD block to cover the last line of `docs/modules/blocks/pages/paragraphs.adoc` (line 47):

> The normal style often comes in handy when you want to prevent the parser from matching beginning-of-line syntax.

That sentence is editorial commentary rather than a testable rule, so it now lives in its own module-level `non_normative!` block instead of inside the `block_attribute_line_conflict` `verifies!` block.

While doing this I also restored a missing trailing blank line on the `create_a_paragraph` `verifies!` block.

## Why

The line was reported as uncovered (`0`) by the SDD coverage tool. The root cause was an alignment bug: the tool walks the spec file and the test's `verifies!`/`non_normative!` content in strict line-by-line lockstep. The `create_a_paragraph` block was missing the trailing blank line that absorbs the empty spec line between the two sections (line 25). That one-line shift silently misaligned everything from line 26 onward and pushed the final line off the end of the following block.

With the blank restored and the concluding sentence split into its own `non_normative!` block, the entire page is now covered — `cd sdd && cargo run` reports lines 9–45 as covered with no `0` entries and no flagged final line.

## Notes for reviewer

- Both tests in the file still pass (`cargo test -p asciidoc-parser --lib blocks::paragraphs`).
- No behavioral/parser changes — this is spec-coverage bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)