### PR TITLE
feat: Implement index terms (user-index)

### DIFF
--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -7,7 +7,11 @@ use crate::{
     Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     content::{Content, content::XrefSegment},
-    parser::{IconRenderParams, ImageRenderParams, LinkRenderParams, LinkRenderType},
+    internal::{LookaheadReplacer, LookaheadResult, replace_with_lookahead},
+    parser::{
+        IconRenderParams, ImageRenderParams, IndexTermRenderParams, LinkRenderParams,
+        LinkRenderType,
+    },
 };
 
 pub(super) fn apply_macros(content: &mut Content<'_>, parser: &Parser) {
@@ -54,14 +58,19 @@ pub(super) fn apply_macros(content: &mut Content<'_>, parser: &Parser) {
         }
     }
 
-    /*
+    let found_macroish_short = found_macroish && text.contains(":[");
+
     if (text.contains("((") && text.contains("))"))
         || (found_macroish_short && text.contains("dexterm"))
     {
-        todo!("Index term macro");
-        // Port Ruby Asciidoctor's implementation from lines 439..536.
+        let replacer = InlineIndextermReplacer(parser);
+
+        if let Cow::Owned(new_result) =
+            replace_with_lookahead(&INLINE_INDEXTERM, content.rendered(), replacer)
+        {
+            content.rendered = new_result.into();
+        }
     }
-    */
 
     if found_colon && text.contains("://") {
         let replacer = InlineLinkReplacer(parser);
@@ -232,6 +241,193 @@ fn basename(path: &str) -> String {
 
 fn normalize_text_lf_escaped_bracket(text: &str) -> String {
     text.replace("\n", " ").replace("\\]", "]")
+}
+
+/// Matches an [index term] inline macro, in either the macro form
+/// (`indexterm:[…]` / `indexterm2:[…]`) or the shorthand form
+/// (`(((primary, secondary, tertiary)))` / `((primary))`).
+///
+/// The shorthand alternative captures the text between the outermost `((` and
+/// `))`. Asciidoctor anchors the closing `))` with a `(?!\))` look-ahead so
+/// that the *last* pair in a run of parentheses closes the term; Rust's regex
+/// engine has no look-ahead, so [`InlineIndextermReplacer`] re-creates that
+/// behavior by absorbing any trailing `)` that follow the matched `))`.
+///
+/// [index term]: https://docs.asciidoctor.org/asciidoc/latest/sections/user-index/
+static INLINE_INDEXTERM: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(
+        r#"(?xs)                         # extended mode; dot matches newline
+        \\?                              # optional escaping backslash
+        (?:
+            (indexterm2?):\[ (.*?[^\\]) \]   # (1) macro name, (2) macro argument
+          |
+            \(\( (.+?) \)\)                  # (3) shorthand enclosed text
+        )
+        "#,
+    )
+    .unwrap()
+});
+
+#[derive(Debug)]
+struct InlineIndextermReplacer<'p>(&'p Parser);
+
+impl LookaheadReplacer for InlineIndextermReplacer<'_> {
+    fn replace_append(
+        &mut self,
+        caps: &Captures<'_>,
+        dest: &mut String,
+        after: &str,
+    ) -> LookaheadResult {
+        // Adapted from Asciidoctor#sub_macros (the `InlineIndextermMacroRx`
+        // branch), found in
+        // https://github.com/asciidoctor/asciidoctor/blob/main/lib/asciidoctor/substitutors.rb.
+
+        let parser = self.0;
+
+        // Macro form: `indexterm:[…]` (concealed) or `indexterm2:[…]` (flow).
+        if let Some(name) = caps.get(1) {
+            // Honor the escape: emit the macro text without the backslash.
+            if caps[0].starts_with('\\') {
+                dest.push_str(&caps[0][1..]);
+                return LookaheadResult::Continue;
+            }
+
+            if name.as_str() == "indexterm2" {
+                // A flow index term renders its primary term inline. When the
+                // argument carries an attribute list (it contains `=`), the
+                // first positional attribute is the primary term.
+                let arg = normalize_index_text(&caps[2], true);
+                let term = if arg.contains('=') {
+                    Attrlist::parse(Span::new(&arg), parser, AttrlistContext::Inline)
+                        .item
+                        .item
+                        .nth_attribute(1)
+                        .map(|a| a.value().to_string())
+                        .unwrap_or(arg)
+                } else {
+                    arg
+                };
+
+                parser.renderer.render_index_term(
+                    &IndexTermRenderParams {
+                        visible_term: Some(&term),
+                    },
+                    dest,
+                );
+            } else {
+                // A concealed index term produces no inline output.
+                parser
+                    .renderer
+                    .render_index_term(&IndexTermRenderParams { visible_term: None }, dest);
+            }
+
+            return LookaheadResult::Continue;
+        }
+
+        // Shorthand form: `((…))` / `(((…)))`.
+        //
+        // Absorb any `)` that immediately follow the matched `))` so that the
+        // closing pair is the last in the run, mirroring Asciidoctor's
+        // `(?!\))` look-ahead. Those extra characters are part of this logical
+        // match, so they are skipped (rather than re-scanned) once consumed.
+        let extra = after.bytes().take_while(|b| *b == b')').count();
+        let advance = if extra > 0 {
+            LookaheadResult::SkipAheadAndRetry(caps[0].len() + extra)
+        } else {
+            LookaheadResult::Continue
+        };
+
+        let mut encl_text = String::with_capacity(caps[3].len() + extra);
+        encl_text.push_str(&caps[3]);
+        for _ in 0..extra {
+            encl_text.push(')');
+        }
+
+        let escaped = caps[0].starts_with('\\');
+
+        // Strip the enclosing parentheses (if any) to decide whether the term
+        // is concealed or visible, and which literal parentheses to preserve in
+        // the flow of text. `before`/`trailing` carry literal parentheses that
+        // are adjacent to (but not part of) the index term.
+        let (inner, visible, before, trailing): (&str, bool, &str, &str) = if escaped {
+            if encl_text.starts_with('(') && encl_text.ends_with(')') {
+                // An escaped concealed term still processes a nested flow term.
+                (&encl_text[1..encl_text.len() - 1], true, "(", ")")
+            } else {
+                // Honor the escape: emit the enclosed text verbatim (the full
+                // match, including any absorbed parens, minus the backslash).
+                dest.push_str(&caps[0][1..]);
+                for _ in 0..extra {
+                    dest.push(')');
+                }
+                return advance;
+            }
+        } else if let Some(without_open) = encl_text.strip_prefix('(') {
+            if let Some(inner) = without_open.strip_suffix(')') {
+                // `(((concealed)))`
+                (inner, false, "", "")
+            } else {
+                (without_open, true, "(", "")
+            }
+        } else if let Some(inner) = encl_text.strip_suffix(')') {
+            (inner, true, "", ")")
+        } else {
+            // `((visible))`
+            (&encl_text[..], true, "", "")
+        };
+
+        dest.push_str(before);
+
+        if visible {
+            let term = strip_see_and_seealso(&normalize_index_text(inner, false));
+            parser.renderer.render_index_term(
+                &IndexTermRenderParams {
+                    visible_term: Some(&term),
+                },
+                dest,
+            );
+        } else {
+            parser
+                .renderer
+                .render_index_term(&IndexTermRenderParams { visible_term: None }, dest);
+        }
+
+        dest.push_str(trailing);
+
+        advance
+    }
+}
+
+/// Normalizes the text of an index term: trims surrounding whitespace and
+/// collapses embedded newlines to spaces (Asciidoctor compacts a multi-line
+/// term onto a single line). When `unescape_brackets` is set (the macro forms),
+/// an escaped closing square bracket (`\]`) is also unescaped.
+fn normalize_index_text(text: &str, unescape_brackets: bool) -> String {
+    let normalized = text.trim().replace('\n', " ");
+    if unescape_brackets {
+        normalized.replace("\\]", "]")
+    } else {
+        normalized
+    }
+}
+
+/// Strips a trailing `see` (` >> …`) or `see-also` (` &> …`) clause from a
+/// visible index term, leaving only the primary term to display in the flow of
+/// text. By the time macros are processed, the special-characters substitution
+/// has already turned `>` into `&gt;` and `&` into `&amp;`, so the separators
+/// appear here as ` &gt;&gt; ` and ` &amp;&gt; `.
+fn strip_see_and_seealso(term: &str) -> String {
+    // Cheap guard mirroring Asciidoctor's `term.include? ';&'`.
+    if term.contains(";&") {
+        if let Some((primary, _see)) = term.split_once(" &gt;&gt; ") {
+            return primary.to_string();
+        }
+        if let Some((primary, _see_also)) = term.split_once(" &amp;&gt; ") {
+            return primary.to_string();
+        }
+    }
+    term.to_string()
 }
 
 static INLINE_LINK: LazyLock<Regex> = LazyLock::new(|| {

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -166,6 +166,22 @@ pub trait InlineSubstitutionRenderer: Debug {
     ///
     /// [callout]: https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/
     fn render_callout(&self, params: &CalloutRenderParams, dest: &mut String);
+
+    /// Renders an [index term].
+    ///
+    /// A *flow* (visible) index term ([`IndexTermRenderParams::visible_term`]
+    /// is `Some`) appears in the flow of text, so the renderer should write
+    /// the term text to `dest`. A *concealed* index term ([`visible_term`]
+    /// is `None`) does not appear in the rendered text, so the renderer
+    /// should typically write nothing.
+    ///
+    /// Note that the built-in HTML5 converter never builds an index catalog;
+    /// index terms only contribute markup in output formats (such as DocBook or
+    /// PDF) that generate an index.
+    ///
+    /// [index term]: https://docs.asciidoctor.org/asciidoc/latest/sections/user-index/
+    /// [`visible_term`]: IndexTermRenderParams::visible_term
+    fn render_index_term(&self, params: &IndexTermRenderParams, dest: &mut String);
 }
 
 /// Specifies which special character is being replaced in a call to
@@ -396,6 +412,18 @@ pub struct XrefRenderParams<'a> {
 
     /// The resolved destination, or `None` if the reference is unresolved.
     pub resolved: Option<&'a ResolvedReference>,
+}
+
+/// Provides parameters for rendering an [index term].
+///
+/// [index term]: https://docs.asciidoctor.org/asciidoc/latest/sections/user-index/
+#[derive(Clone, Debug)]
+pub struct IndexTermRenderParams<'a> {
+    /// For a *flow* (visible) index term (`((term))` or `indexterm2:[term]`),
+    /// the already-substituted primary term text to display in the flow of
+    /// text. `None` for a *concealed* index term (`(((p, s, t)))` or
+    /// `indexterm:[p, s, t]`), which produces no visible output.
+    pub visible_term: Option<&'a str>,
 }
 
 /// Implementation of [`InlineSubstitutionRenderer`] that renders substitutions
@@ -836,6 +864,15 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
                     dest.push_str(&format!(r#"<b class="conum">({n})</b>"#));
                 }
             }
+        }
+    }
+
+    fn render_index_term(&self, params: &IndexTermRenderParams, dest: &mut String) {
+        // The HTML5 converter does not generate an index, so a concealed index
+        // term produces no output and a flow index term renders only its
+        // (already-substituted) visible term text.
+        if let Some(term) = params.visible_term {
+            dest.push_str(term);
         }
     }
 }

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -16,8 +16,8 @@ pub use include_file_handler::IncludeFileHandler;
 mod inline_substitution_renderer;
 pub use inline_substitution_renderer::{
     CalloutGuard, CalloutRenderParams, CharacterReplacementType, HtmlSubstitutionRenderer,
-    IconRenderParams, ImageRenderParams, InlineSubstitutionRenderer, LinkRenderParams,
-    LinkRenderType, QuoteScope, QuoteType, SpecialCharacter, XrefRenderParams,
+    IconRenderParams, ImageRenderParams, IndexTermRenderParams, InlineSubstitutionRenderer,
+    LinkRenderParams, LinkRenderType, QuoteScope, QuoteType, SpecialCharacter, XrefRenderParams,
 };
 
 mod parser;

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1192,6 +1192,17 @@ mod tests {
         fn render_callout(&self, params: &crate::parser::CalloutRenderParams, dest: &mut String) {
             dest.push_str(&format!("[CALLOUT:{}]", params.number));
         }
+
+        fn render_index_term(
+            &self,
+            params: &crate::parser::IndexTermRenderParams,
+            dest: &mut String,
+        ) {
+            match params.visible_term {
+                Some(term) => dest.push_str(&format!("[INDEXTERM:{term}]")),
+                None => dest.push_str("[INDEXTERM]"),
+            }
+        }
     }
 
     #[test]

--- a/parser/src/tests/asciidoc_lang/sections/mod.rs
+++ b/parser/src/tests/asciidoc_lang/sections/mod.rs
@@ -18,3 +18,4 @@ mod special_section_titles;
 mod styles;
 mod title_links;
 mod titles_and_levels;
+mod user_index;

--- a/parser/src/tests/asciidoc_lang/sections/user_index.rs
+++ b/parser/src/tests/asciidoc_lang/sections/user_index.rs
@@ -1,0 +1,310 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/sections/pages/user-index.adoc");
+
+non_normative!(
+    r#"
+= Index
+:page-aliases: index.adoc
+
+You can mark index terms explicitly in AsciiDoc content.
+Index terms form a controlled vocabulary that can be used to navigate the document by keyword starting from an index.
+
+"#
+);
+
+#[test]
+fn index_catalog() {
+    non_normative!(
+        r#"
+== Index catalog
+
+NOTE: Although index terms are always processed, only Asciidoctor PDF and the DocBook toolchain support creating an index catalog automatically.
+The built-in HTML5 converter in Asciidoctor does not generate an index.
+
+"#
+    );
+
+    verifies!(
+        r#"
+To create an index, define a level 1 section (`==`) marked with the style `index` at the end of your document.
+(In a multipart book, the index can be the last level 0 section (`=`)).
+
+[source]
+----
+[index]
+== Index
+----
+
+"#
+    );
+
+    // A level 1 section marked with the `index` style carries that style, which
+    // a converter that generates an index uses as the seed section. (The level 0
+    // multipart-book form is not modeled by this single-document crate.)
+    let doc = Parser::default().parse("[index]\n== Index\n");
+    let section = doc.nested_blocks().next().unwrap();
+    assert_eq!(section.declared_style(), Some("index"));
+    assert_eq!(section.raw_context().as_ref(), "section");
+
+    non_normative!(
+        r#"
+Both Asciidoctor PDF and the DocBook toolchain will automatically populate an index into this seed section.
+
+The index will consist of term entries that link to (or otherwise cite) the location of each marked index term.
+You learn how to mark an index term in the next section.
+
+"#
+    );
+}
+
+#[test]
+fn index_terms() {
+    non_normative!(
+        r#"
+== Index terms
+
+Every index term, as well as every occurrence of that index term, must be explicitly marked in the AsciiDoc document.
+It's not enough just to mark the first occurrence of an index term if you want every occurrence to appear in the index.
+Instead, each occurrence you want to be cited in the index must be marked explicitly.
+
+There are two types of index terms in AsciiDoc:
+
+"#
+    );
+
+    verifies!(
+        r#"
+flow index term:: `\indexterm2:[<primary>]` +
+`+((<primary>))+`
++
+An index term that appears in the flow of text (i.e., a visible term) and in the index.
+This type of index term can only be used to define a primary entry and is case sensitive.
+If you want the entry to appear in the index using a different case, use an adjacent concealed index term, such as `+(((term)))Term+`.
+
+"#
+    );
+
+    // A flow index term appears as a visible term in the flow of text. Both the
+    // `indexterm2:[…]` macro form and the `((…))` shorthand render the primary
+    // term inline.
+    let doc = Parser::default().parse("indexterm2:[Lancelot] was a knight.");
+    assert_eq!(rendered_paragraphs(&doc), &["Lancelot was a knight."]);
+
+    let doc = Parser::default().parse("The ((Arthur)) was king.");
+    assert_eq!(rendered_paragraphs(&doc), &["The Arthur was king."]);
+
+    verifies!(
+        r#"
+concealed index term:: `\indexterm:[<primary>, <secondary>, <tertiary>]` +
+`+(((<primary>, <secondary>, <tertiary>)))+`
++
+A group of index terms that appear only in the index.
+This type of index term can be used to define a primary entry as well as optional secondary and tertiary entries.
+
+"#
+    );
+
+    // A concealed index term appears only in the index, never in the flow of
+    // text, so both the `indexterm:[…]` macro form and the `(((…)))` shorthand
+    // render as nothing.
+    let doc = Parser::default().parse("indexterm:[knight, Knight of the Round Table, Lancelot]");
+    assert_eq!(rendered_paragraphs(&doc), &[""]);
+
+    let doc = Parser::default().parse("Excalibur(((Sword, Broadsword, Excalibur))).");
+    assert_eq!(rendered_paragraphs(&doc), &["Excalibur."]);
+
+    non_normative!(
+        r#"
+Here's an example that shows the two forms in use.
+
+"#
+    );
+
+    verifies!(
+        r#"
+[source]
+----
+The Lady of the Lake, her arm clad in the purest shimmering samite,
+held aloft Excalibur from the bosom of the water,
+signifying by divine providence that I, ((Arthur)), <.>
+was to carry Excalibur(((Sword, Broadsword, Excalibur))). <.>
+That is why I am your king. Shut up! Will you shut up?!
+Burn her anyway! I'm not a witch.
+Look, my liege! We found them.
+
+indexterm2:[Lancelot] was one of the Knights of the Round Table. <.>
+indexterm:[knight, Knight of the Round Table, Lancelot] <.>
+----
+"#
+    );
+
+    // The callout markers (`<.>`) above are annotations on the listing, not part
+    // of the marked-up content. Parsing the equivalent content, the visible
+    // (flow) terms remain inline while the concealed terms disappear.
+    let doc = Parser::default().parse(
+        "signifying by divine providence that I, ((Arthur)),\nwas to carry Excalibur(((Sword, Broadsword, Excalibur))).",
+    );
+    assert_eq!(
+        rendered_paragraphs(&doc),
+        &["signifying by divine providence that I, Arthur,\nwas to carry Excalibur."]
+    );
+
+    verifies!(
+        r#"
+<.> The double parenthesis form adds a primary index term and includes the term in the generated output.
+<.> The triple parenthesis form allows for an optional second and third index term and _does not_ include the terms in the generated output (i.e., concealed index term).
+<.> The inline macro `\indexterm2:[primary]` is equivalent to the double parenthesis form.
+<.> The inline macro `\indexterm:[primary, secondary, tertiary]` is equivalent to the triple parenthesis form.
+
+"#
+    );
+
+    // The macro form and the parenthesis form are equivalent: `indexterm2:[…]`
+    // matches `((…))` (visible) and `indexterm:[…]` matches `(((…)))`
+    // (concealed).
+    let macro_visible = Parser::default().parse("indexterm2:[Lancelot].");
+    let shorthand_visible = Parser::default().parse("((Lancelot)).");
+    assert_eq!(
+        rendered_paragraphs(&macro_visible),
+        rendered_paragraphs(&shorthand_visible)
+    );
+
+    let macro_concealed = Parser::default().parse("Knights.indexterm:[knight, Lancelot]");
+    let shorthand_concealed = Parser::default().parse("Knights.(((knight, Lancelot)))");
+    assert_eq!(
+        rendered_paragraphs(&macro_concealed),
+        rendered_paragraphs(&shorthand_concealed)
+    );
+
+    verifies!(
+        r#"
+If you're defining a concealed index term (i.e., the `indexterm` macro), and one of the terms contains a comma, you must surround that segment in double quotes so the comma is treated as content.
+For example:
+
+[source]
+----
+I, King Arthur.
+indexterm:[knight, "Arthur, King"]
+----
+
+"#
+    );
+
+    // A comma inside a double-quoted term segment is treated as content, so the
+    // concealed term parses cleanly and contributes nothing to the flow of text.
+    let doc = Parser::default().parse("I, King Arthur.\nindexterm:[knight, \"Arthur, King\"]");
+    assert_eq!(rendered_paragraphs(&doc), &["I, King Arthur.\n"]);
+
+    verifies!(
+        r#"
+or
+
+[source]
+----
+I, King Arthur.
+(((knight, "Arthur, King")))
+----
+
+"#
+    );
+
+    // The shorthand concealed form quotes commas the same way.
+    let doc = Parser::default().parse("I, King Arthur.\n(((knight, \"Arthur, King\")))");
+    assert_eq!(rendered_paragraphs(&doc), &["I, King Arthur.\n"]);
+
+    non_normative!(
+        r#"
+//Follow https://github.com/asciidoctor/asciidoctor/issues/450[Asciidoctor issue #450] to track the progress of this feature.
+
+"#
+    );
+}
+
+#[test]
+fn placement_of_hidden_index_terms() {
+    verifies!(
+        r#"
+== Placement of hidden index terms
+
+Hidden index entries should be directly adjacent to the paragraph content to which they apply.
+<<ex-hidden-terms-correct>> shows where to place hidden index terms for a paragraph.
+
+.Correct
+[#ex-hidden-terms-correct]
+----
+=== Create a new Git repository
+
+(((Repository, create)))
+(((Create Git repository)))
+To create a new git repository,
+----
+
+"#
+    );
+
+    // When the hidden (concealed) terms are directly adjacent to the paragraph
+    // they belong to, they are absorbed into that single paragraph (they render
+    // as nothing), so the section contains exactly one paragraph.
+    let doc = Parser::default().parse(
+        "=== Create a new Git repository\n\n(((Repository, create)))\n(((Create Git repository)))\nTo create a new git repository,\n",
+    );
+    let section = doc.nested_blocks().next().unwrap();
+    let paragraphs = rendered_paragraphs(&doc);
+    assert_eq!(section.nested_blocks().count(), 1);
+    assert_eq!(paragraphs, &["\n\nTo create a new git repository,"]);
+
+    verifies!(
+        r#"
+If the terms are offset from the paragraph content by an empty line, it will cause an empty paragraph to be created in the parsed document, thus leaving extra space in the generated output.
+<<ex-hidden-terms-incorrect-1>> and <<ex-hidden-terms-incorrect-2>> show where you should not place hidden index terms for a paragraph.
+
+.Incorrect
+[#ex-hidden-terms-incorrect-1]
+----
+=== Create a new Git repository
+
+(((Repository, create)))
+(((Create Git repository)))
+
+To create a new git repository,
+----
+
+"#
+    );
+
+    // An empty line between the terms and the paragraph splits them into two
+    // blocks: an (empty) paragraph holding only the now-invisible terms, and the
+    // real paragraph.
+    let doc = Parser::default().parse(
+        "=== Create a new Git repository\n\n(((Repository, create)))\n(((Create Git repository)))\n\nTo create a new git repository,\n",
+    );
+    let section = doc.nested_blocks().next().unwrap();
+    assert_eq!(section.nested_blocks().count(), 2);
+    assert_eq!(
+        rendered_paragraphs(&doc),
+        &["\n", "To create a new git repository,"]
+    );
+
+    verifies!(
+        r#"
+.Also incorrect
+[#ex-hidden-terms-incorrect-2]
+----
+=== Create a new Git repository
+(((Repository, create)))
+(((Create Git repository)))
+
+To create a new git repository,
+----
+"#
+    );
+
+    // Likewise, terms stacked directly under the section title but separated
+    // from the paragraph by an empty line form their own empty paragraph.
+    let doc = Parser::default().parse(
+        "=== Create a new Git repository\n(((Repository, create)))\n(((Create Git repository)))\n\nTo create a new git repository,\n",
+    );
+    let section = doc.nested_blocks().next().unwrap();
+    assert_eq!(section.nested_blocks().count(), 2);
+}

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -3741,6 +3741,228 @@ mod macros {
         );
     }
 
+    mod index_terms {
+        //! Ported from Asciidoctor's `substitutions_test.rs` index-term cases.
+        //!
+        //! These were previously stubbed (un-ported Ruby) because index terms
+        //! weren't implemented. The crate targets HTML5 output, which never
+        //! builds an index catalog, so the original `catalog[:indexterms]`
+        //! assertions (commented out even in Ruby) and the DocBook-only
+        //! `see`/`see-also` cases are intentionally omitted. What remains is
+        //! the inline rendering each macro produces: a concealed term
+        //! (`indexterm:[…]` / `(((…)))`) disappears, and a flow term
+        //! (`indexterm2:[…]` / `((…))`) leaves its primary term in the text.
+
+        use crate::tests::prelude::*;
+
+        const SENTENCE: &str = "The tiger (Panthera tigris) is the largest cat species.";
+
+        #[test]
+        fn concealed_macro_with_primary_term() {
+            // 'a single-line index term macro with a primary term should be
+            // registered as an index reference'
+            for macro_ in ["indexterm:[Tigers]", "(((Tigers)))"] {
+                let doc = Parser::default().parse(&format!("{SENTENCE}\n{macro_}"));
+                assert_eq!(rendered_paragraphs(&doc), &[format!("{SENTENCE}\n")]);
+            }
+        }
+
+        #[test]
+        fn concealed_macro_with_primary_and_secondary_terms() {
+            // 'a single-line index term macro with primary and secondary terms ...'
+            for macro_ in ["indexterm:[Big cats, Tigers]", "(((Big cats, Tigers)))"] {
+                let doc = Parser::default().parse(&format!("{SENTENCE}\n{macro_}"));
+                assert_eq!(rendered_paragraphs(&doc), &[format!("{SENTENCE}\n")]);
+            }
+        }
+
+        #[test]
+        fn concealed_macro_with_primary_secondary_and_tertiary_terms() {
+            // 'a single-line index term macro with primary, secondary and
+            // tertiary terms ...'
+            for macro_ in [
+                "indexterm:[Big cats,Tigers , Panthera tigris]",
+                "(((Big cats,Tigers , Panthera tigris)))",
+            ] {
+                let doc = Parser::default().parse(&format!("{SENTENCE}\n{macro_}"));
+                assert_eq!(rendered_paragraphs(&doc), &[format!("{SENTENCE}\n")]);
+            }
+        }
+
+        #[test]
+        fn multiline_concealed_macro_is_compacted() {
+            // 'a multi-line index term macro should be compacted and registered ...'
+            for macro_ in ["indexterm:[Panthera\ntigris]", "(((Panthera\ntigris)))"] {
+                let doc = Parser::default().parse(&format!("{SENTENCE}\n{macro_}"));
+                assert_eq!(rendered_paragraphs(&doc), &[format!("{SENTENCE}\n")]);
+            }
+        }
+
+        #[test]
+        fn escape_concealed_term_when_second_bracket_escaped() {
+            // 'should escape concealed index term if second bracket is preceded
+            // by a backslash'
+            let doc = Parser::default()
+                .parse("National Institute of Science and Technology (\\((NIST)))");
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &["National Institute of Science and Technology (((NIST)))"]
+            );
+        }
+
+        #[test]
+        fn escape_only_enclosing_brackets() {
+            // 'should only escape enclosing brackets if concealed index term is
+            // preceded by a backslash'
+            let doc = Parser::default()
+                .parse("National Institute of Science and Technology \\(((NIST)))");
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &["National Institute of Science and Technology (NIST)"]
+            );
+        }
+
+        #[test]
+        fn does_not_split_terms_on_commas_inside_quotes() {
+            // 'should not split index terms on commas inside of quoted terms'
+            // The quoted comma keeps the term intact; the concealed term renders
+            // nothing, so only the leading sentence remains.
+            let macro_form =
+                "Tigers are big, scary cats.\nindexterm:[Tigers, \"[Big\\],\nscary cats\"]";
+            let shorthand = "Tigers are big, scary cats.\n(((Tigers, \"[Big],\nscary cats\")))";
+            for input in [macro_form, shorthand] {
+                let doc = Parser::default().parse(input);
+                assert_eq!(
+                    rendered_paragraphs(&doc),
+                    &["Tigers are big, scary cats.\n"]
+                );
+            }
+        }
+
+        #[test]
+        fn normal_substitutions_applied_to_concealed_macro() {
+            // 'normal substitutions are performed on an index term macro'
+            // The concealed term renders nothing regardless of inner formatting.
+            for macro_ in ["indexterm:[*Tigers*]", "(((*Tigers*)))"] {
+                let doc = Parser::default().parse(&format!("{SENTENCE}\n{macro_}"));
+                assert_eq!(rendered_paragraphs(&doc), &[format!("{SENTENCE}\n")]);
+            }
+        }
+
+        #[test]
+        fn registers_multiple_concealed_macros() {
+            // 'registers multiple index term macros'
+            let doc =
+                Parser::default().parse(&format!("{SENTENCE}\n(((Tigers)))\n(((Animals,Cats)))"));
+            assert_eq!(rendered_paragraphs(&doc), &[format!("{SENTENCE}\n\n")]);
+        }
+
+        #[test]
+        fn concealed_term_may_contain_round_brackets() {
+            // 'an index term macro with round bracket syntax may contain round
+            // brackets in term'
+            let doc =
+                Parser::default().parse(&format!("{SENTENCE}\n(((Tiger (Panthera tigris))))"));
+            assert_eq!(rendered_paragraphs(&doc), &[format!("{SENTENCE}\n")]);
+        }
+
+        #[test]
+        fn shorthand_does_not_consume_trailing_round_bracket() {
+            // HTML5 analogue of the DocBook-only test 'visible shorthand index
+            // term macro should not consume trailing round bracket'.
+            let doc = Parser::default().parse("(text with ((index term)))");
+            assert_eq!(rendered_paragraphs(&doc), &["(text with index term)"]);
+        }
+
+        #[test]
+        fn shorthand_does_not_consume_leading_round_bracket() {
+            // HTML5 analogue of 'visible shorthand index term macro should not
+            // consume leading round bracket'.
+            let doc = Parser::default().parse("(((index term)) for text)");
+            assert_eq!(rendered_paragraphs(&doc), &["(index term for text)"]);
+        }
+
+        #[test]
+        fn concealed_term_may_contain_square_brackets() {
+            // 'an index term macro with square bracket syntax may contain square
+            // brackets in term'
+            let doc = Parser::default().parse(&format!(
+                "{SENTENCE}\nindexterm:[Tiger [Panthera tigris\\]]"
+            ));
+            assert_eq!(rendered_paragraphs(&doc), &[format!("{SENTENCE}\n")]);
+        }
+
+        #[test]
+        fn flow_macro_retains_term_inline() {
+            // 'a single-line index term 2 macro should be registered ... and
+            // retain term inline'
+            for input in [
+                "The indexterm2:[tiger] (Panthera tigris) is the largest cat species.",
+                "The ((tiger)) (Panthera tigris) is the largest cat species.",
+            ] {
+                let doc = Parser::default().parse(input);
+                assert_eq!(rendered_paragraphs(&doc), &[SENTENCE.to_string()]);
+            }
+        }
+
+        #[test]
+        fn multiline_flow_macro_is_compacted() {
+            // 'a multi-line index term 2 macro should be compacted ... and retain
+            // term inline'
+            let expected = "The panthera tigris is the largest cat species.";
+            for input in [
+                "The indexterm2:[ panthera\ntigris ] is the largest cat species.",
+                "The (( panthera\ntigris )) is the largest cat species.",
+            ] {
+                let doc = Parser::default().parse(input);
+                assert_eq!(rendered_paragraphs(&doc), &[expected.to_string()]);
+            }
+        }
+
+        #[test]
+        fn registers_multiple_flow_macros() {
+            // 'registers multiple index term 2 macros'
+            let doc = Parser::default()
+                .parse("The ((tiger)) (Panthera tigris) is the largest ((cat)) species.");
+            assert_eq!(rendered_paragraphs(&doc), &[SENTENCE.to_string()]);
+        }
+
+        #[test]
+        fn escape_visible_term() {
+            // 'should escape visible index term if preceded by a backslash'
+            let doc = Parser::default()
+                .parse("The \\((tiger)) (Panthera tigris) is the largest \\((cat)) species.");
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &["The ((tiger)) (Panthera tigris) is the largest ((cat)) species."]
+            );
+        }
+
+        #[test]
+        fn normal_substitutions_applied_to_flow_macro() {
+            // 'normal substitutions are performed on an index term 2 macro'
+            let doc = Parser::default()
+                .parse("The ((*tiger*)) (Panthera tigris) is the largest cat species.");
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &["The <strong>tiger</strong> (Panthera tigris) is the largest cat species."]
+            );
+        }
+
+        #[test]
+        fn flow_and_concealed_shorthand_do_not_interfere() {
+            // 'index term 2 macro with round bracket syntex should not interfer
+            // with index term macro with round bracket syntax'
+            let doc = Parser::default().parse(
+                "The ((panthera tigris)) is the largest cat species.\n(((Big cats,Tigers)))",
+            );
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &["The panthera tigris is the largest cat species.\n"]
+            );
+        }
+    }
+
     #[ignore]
     #[test]
     fn todo_migrate_from_ruby_2() {
@@ -4049,325 +4271,6 @@ mod macros {
             assert_equal %w(1 1 2), footnote_refs.map(&:text)
             assert_equal 3, footnote_defs.length
             assert_equal ['1. second footnote', '1. first footnote', '2. third footnote'], footnote_defs.map(&:text).map(&:strip)
-        end
-
-        test 'a single-line index term macro with a primary term should be registered as an index reference' do
-            sentence = "The tiger (Panthera tigris) is the largest cat species.\n"
-            macros = ['indexterm:[Tigers]', '(((Tigers)))']
-            macros.each do |macro|
-            para = block_from_string "#{sentence}#{macro}"
-            output = para.sub_macros para.source
-            assert_equal sentence, output
-            #assert_equal 1, para.document.catalog[:indexterms].size
-            #assert_equal ['Tigers'], para.document.catalog[:indexterms].first
-            end
-        end
-
-        test 'a single-line index term macro with primary and secondary terms should be registered as an index reference' do
-            sentence = "The tiger (Panthera tigris) is the largest cat species.\n"
-            macros = ['indexterm:[Big cats, Tigers]', '(((Big cats, Tigers)))']
-            macros.each do |macro|
-            para = block_from_string "#{sentence}#{macro}"
-            output = para.sub_macros para.source
-            assert_equal sentence, output
-            #assert_equal 1, para.document.catalog[:indexterms].size
-            #assert_equal ['Big cats', 'Tigers'], para.document.catalog[:indexterms].first
-            end
-        end
-
-        test 'a single-line index term macro with primary, secondary and tertiary terms should be registered as an index reference' do
-            sentence = "The tiger (Panthera tigris) is the largest cat species.\n"
-            macros = ['indexterm:[Big cats,Tigers , Panthera tigris]', '(((Big cats,Tigers , Panthera tigris)))']
-            macros.each do |macro|
-            para = block_from_string "#{sentence}#{macro}"
-            output = para.sub_macros para.source
-            assert_equal sentence, output
-            #assert_equal 1, para.document.catalog[:indexterms].size
-            #assert_equal ['Big cats', 'Tigers', 'Panthera tigris'], para.document.catalog[:indexterms].first
-            end
-        end
-
-        test 'a multi-line index term macro should be compacted and registered as an index reference' do
-            sentence = "The tiger (Panthera tigris) is the largest cat species.\n"
-            macros = ["indexterm:[Panthera\ntigris]", "(((Panthera\ntigris)))"]
-            macros.each do |macro|
-            para = block_from_string "#{sentence}#{macro}"
-            output = para.sub_macros para.source
-            assert_equal sentence, output
-            #assert_equal 1, para.document.catalog[:indexterms].size
-            #assert_equal ['Panthera tigris'], para.document.catalog[:indexterms].first
-            end
-        end
-
-        test 'should escape concealed index term if second bracket is preceded by a backslash' do
-            input = %[National Institute of Science and Technology (#{BACKSLASH}((NIST)))]
-            doc = document_from_string input, standalone: false
-            output = doc.convert
-            assert_xpath '//p[text()="National Institute of Science and Technology (((NIST)))"]', output, 1
-            #assert doc.catalog[:indexterms].empty?
-        end
-
-        test 'should only escape enclosing brackets if concealed index term is preceded by a backslash' do
-            input = %[National Institute of Science and Technology #{BACKSLASH}(((NIST)))]
-            doc = document_from_string input, standalone: false
-            output = doc.convert
-            assert_xpath '//p[text()="National Institute of Science and Technology (NIST)"]', output, 1
-            #term = doc.catalog[:indexterms].first
-            #assert_equal 1, term.size
-            #assert_equal 'NIST', term.first
-        end
-
-        test 'should not split index terms on commas inside of quoted terms' do
-            inputs = []
-            inputs.push <<~'EOS'
-            Tigers are big, scary cats.
-            indexterm:[Tigers, "[Big\],
-            scary cats"]
-            EOS
-            inputs.push <<~'EOS'
-            Tigers are big, scary cats.
-            (((Tigers, "[Big],
-            scary cats")))
-            EOS
-
-            inputs.each do |input|
-            para = block_from_string input
-            output = para.sub_macros para.source
-            assert_equal input.lines.first, output
-            #assert_equal 1, para.document.catalog[:indexterms].size
-            #terms = para.document.catalog[:indexterms].first
-            #assert_equal 2, terms.size
-            #assert_equal 'Tigers', terms.first
-            #assert_equal '[Big], scary cats', terms.last
-            end
-        end
-
-        test 'normal substitutions are performed on an index term macro' do
-            sentence = "The tiger (Panthera tigris) is the largest cat species.\n"
-            macros = ['indexterm:[*Tigers*]', '(((*Tigers*)))']
-            macros.each do |macro|
-            para = block_from_string "#{sentence}#{macro}"
-            output = para.apply_subs para.source
-            assert_equal sentence, output
-            #assert_equal 1, para.document.catalog[:indexterms].size
-            #assert_equal ['<strong>Tigers</strong>'], para.document.catalog[:indexterms].first
-            end
-        end
-
-        test 'registers multiple index term macros' do
-            sentence = 'The tiger (Panthera tigris) is the largest cat species.'
-            macros = "(((Tigers)))\n(((Animals,Cats)))"
-            para = block_from_string "#{sentence}\n#{macros}"
-            output = para.sub_macros para.source
-            assert_equal sentence, output.rstrip
-            #assert_equal 2, para.document.catalog[:indexterms].size
-            #assert_equal ['Tigers'], para.document.catalog[:indexterms][0]
-            #assert_equal ['Animals', 'Cats'], para.document.catalog[:indexterms][1]
-        end
-
-        test 'an index term macro with round bracket syntax may contain round brackets in term' do
-            sentence = "The tiger (Panthera tigris) is the largest cat species.\n"
-            macro = '(((Tiger (Panthera tigris))))'
-            para = block_from_string "#{sentence}#{macro}"
-            output = para.sub_macros para.source
-            assert_equal sentence, output
-            #assert_equal 1, para.document.catalog[:indexterms].size
-            #assert_equal ['Tiger (Panthera tigris)'], para.document.catalog[:indexterms].first
-        end
-
-        test 'visible shorthand index term macro should not consume trailing round bracket' do
-            input = '(text with ((index term)))'
-            expected = <<~'EOS'.chop
-            (text with <indexterm>
-            <primary>index term</primary>
-            </indexterm>index term)
-            EOS
-            #expected_term = ['index term']
-            para = block_from_string input, backend: :docbook
-            output = para.sub_macros para.source
-            assert_equal expected, output
-            #indexterms_table = para.document.catalog[:indexterms]
-            #assert_equal 1, indexterms_table.size
-            #assert_equal expected_term, indexterms_table[0]
-        end
-
-        test 'visible shorthand index term macro should not consume leading round bracket' do
-            input = '(((index term)) for text)'
-            expected = <<~'EOS'.chop
-            (<indexterm>
-            <primary>index term</primary>
-            </indexterm>index term for text)
-            EOS
-            #expected_term = ['index term']
-            para = block_from_string input, backend: :docbook
-            output = para.sub_macros para.source
-            assert_equal expected, output
-            #indexterms_table = para.document.catalog[:indexterms]
-            #assert_equal 1, indexterms_table.size
-            #assert_equal expected_term, indexterms_table[0]
-        end
-
-        test 'an index term macro with square bracket syntax may contain square brackets in term' do
-            sentence = "The tiger (Panthera tigris) is the largest cat species.\n"
-            macro = 'indexterm:[Tiger [Panthera tigris\\]]'
-            para = block_from_string "#{sentence}#{macro}"
-            output = para.sub_macros para.source
-            assert_equal sentence, output
-            #assert_equal 1, para.document.catalog[:indexterms].size
-            #assert_equal ['Tiger [Panthera tigris]'], para.document.catalog[:indexterms].first
-        end
-
-        test 'a single-line index term 2 macro should be registered as an index reference and retain term inline' do
-            sentence = 'The tiger (Panthera tigris) is the largest cat species.'
-            macros = ['The indexterm2:[tiger] (Panthera tigris) is the largest cat species.', 'The ((tiger)) (Panthera tigris) is the largest cat species.']
-            macros.each do |macro|
-            para = block_from_string macro
-            output = para.sub_macros para.source
-            assert_equal sentence, output
-            #assert_equal 1, para.document.catalog[:indexterms].size
-            #assert_equal ['tiger'], para.document.catalog[:indexterms].first
-            end
-        end
-
-        test 'a multi-line index term 2 macro should be compacted and registered as an index reference and retain term inline' do
-            sentence = 'The panthera tigris is the largest cat species.'
-            macros = ["The indexterm2:[ panthera\ntigris ] is the largest cat species.", "The (( panthera\ntigris )) is the largest cat species."]
-            macros.each do |macro|
-            para = block_from_string macro
-            output = para.sub_macros para.source
-            assert_equal sentence, output
-            #assert_equal 1, para.document.catalog[:indexterms].size
-            #assert_equal ['panthera tigris'], para.document.catalog[:indexterms].first
-            end
-        end
-
-        test 'registers multiple index term 2 macros' do
-            sentence = 'The ((tiger)) (Panthera tigris) is the largest ((cat)) species.'
-            para = block_from_string sentence
-            output = para.sub_macros para.source
-            assert_equal 'The tiger (Panthera tigris) is the largest cat species.', output
-            #assert_equal 2, para.document.catalog[:indexterms].size
-            #assert_equal ['tiger'], para.document.catalog[:indexterms][0]
-            #assert_equal ['cat'], para.document.catalog[:indexterms][1]
-        end
-
-        test 'should escape visible index term if preceded by a backslash' do
-            sentence = "The #{BACKSLASH}((tiger)) (Panthera tigris) is the largest #{BACKSLASH}((cat)) species."
-            para = block_from_string sentence
-            output = para.sub_macros para.source
-            assert_equal 'The ((tiger)) (Panthera tigris) is the largest ((cat)) species.', output
-            #assert para.document.catalog[:indexterms].empty?
-        end
-
-        test 'normal substitutions are performed on an index term 2 macro' do
-            sentence = 'The ((*tiger*)) (Panthera tigris) is the largest cat species.'
-            para = block_from_string sentence
-            output = para.apply_subs para.source
-            assert_equal 'The <strong>tiger</strong> (Panthera tigris) is the largest cat species.', output
-            #assert_equal 1, para.document.catalog[:indexterms].size
-            #assert_equal ['<strong>tiger</strong>'], para.document.catalog[:indexterms].first
-        end
-
-        test 'index term 2 macro with round bracket syntex should not interfer with index term macro with round bracket syntax' do
-            sentence = "The ((panthera tigris)) is the largest cat species.\n(((Big cats,Tigers)))"
-            para = block_from_string sentence
-            output = para.sub_macros para.source
-            assert_equal "The panthera tigris is the largest cat species.\n", output
-            #terms = para.document.catalog[:indexterms]
-            #assert_equal 2, terms.size
-            #assert_equal ['panthera tigris'], terms[0]
-            #assert_equal ['Big cats', 'Tigers'], terms[1]
-        end
-
-        test 'should parse visible shorthand index term with see and seealso' do
-            sentence = '((Flash >> HTML 5)) has been supplanted by ((HTML 5 &> CSS 3 &> SVG)).'
-            output = convert_string_to_embedded sentence, backend: 'docbook'
-            indexterm_flash = <<~'EOS'.chop
-            <indexterm>
-            <primary>Flash</primary>
-            <see>HTML 5</see>
-            </indexterm>
-            EOS
-            indexterm_html5 = <<~'EOS'.chop
-            <indexterm>
-            <primary>HTML 5</primary>
-            <seealso>CSS 3</seealso>
-            <seealso>SVG</seealso>
-            </indexterm>
-            EOS
-            assert_includes output, indexterm_flash
-            assert_includes output, indexterm_html5
-        end
-
-        test 'should parse concealed shorthand index term with see and seealso' do
-            sentence = 'Flash(((Flash >> HTML 5))) has been supplanted by HTML 5(((HTML 5 &> CSS 3 &> SVG))).'
-            output = convert_string_to_embedded sentence, backend: 'docbook'
-            indexterm_flash = <<~'EOS'.chop
-            <indexterm>
-            <primary>Flash</primary>
-            <see>HTML 5</see>
-            </indexterm>
-            EOS
-            indexterm_html5 = <<~'EOS'.chop
-            <indexterm>
-            <primary>HTML 5</primary>
-            <seealso>CSS 3</seealso>
-            <seealso>SVG</seealso>
-            </indexterm>
-            EOS
-            assert_includes output, indexterm_flash
-            assert_includes output, indexterm_html5
-        end
-
-        test 'should parse visible index term macro with see and seealso' do
-            sentence = 'indexterm2:[Flash,see=HTML 5] has been supplanted by indexterm2:[HTML 5,see-also="CSS 3, SVG"].'
-            output = convert_string_to_embedded sentence, backend: 'docbook'
-            indexterm_flash = <<~'EOS'.chop
-            <indexterm>
-            <primary>Flash</primary>
-            <see>HTML 5</see>
-            </indexterm>
-            EOS
-            indexterm_html5 = <<~'EOS'.chop
-            <indexterm>
-            <primary>HTML 5</primary>
-            <seealso>CSS 3</seealso>
-            <seealso>SVG</seealso>
-            </indexterm>
-            EOS
-            assert_includes output, indexterm_flash
-            assert_includes output, indexterm_html5
-        end
-
-        test 'should parse concealed index term macro with see and seealso' do
-            sentence = 'Flashindexterm:[Flash,see=HTML 5] has been supplanted by HTML 5indexterm:[HTML 5,see-also="CSS 3, SVG"].'
-            output = convert_string_to_embedded sentence, backend: 'docbook'
-            indexterm_flash = <<~'EOS'.chop
-            <indexterm>
-            <primary>Flash</primary>
-            <see>HTML 5</see>
-            </indexterm>
-            EOS
-            indexterm_html5 = <<~'EOS'.chop
-            <indexterm>
-            <primary>HTML 5</primary>
-            <seealso>CSS 3</seealso>
-            <seealso>SVG</seealso>
-            </indexterm>
-            EOS
-            assert_includes output, indexterm_flash
-            assert_includes output, indexterm_html5
-        end
-
-        test 'should honor secondary and tertiary index terms when primary index term is quoted and contains equals sign' do
-            sentence = 'Assigning variables.'
-            expected = %(#{sentence}<indexterm><primary>name=value</primary><secondary>variable</secondary><tertiary>assignment</tertiary></indexterm>)
-            macros = ['indexterm:["name=value",variable,assignment]', '(((name=value,variable,assignment)))']
-            macros.each do |macro|
-            para = block_from_string %(#{sentence}#{macro}), backend: 'docbook'
-            output = (para.sub_macros para.source).tr ?\n, ''
-            assert_equal expected, output
-            end
         end
 
         context 'Button macro' do

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -3961,6 +3961,63 @@ mod macros {
                 &["The panthera tigris is the largest cat species.\n"]
             );
         }
+
+        #[test]
+        fn flow_shorthand_strips_see_and_seealso() {
+            // The DocBook-only `see`/`see-also` structure is not modeled, but
+            // Asciidoctor strips the `see` (` >> `) and `see-also` (` &> `)
+            // clauses from a *visible* term's inline text regardless of backend,
+            // leaving only the primary term in the flow of text.
+            let doc =
+                Parser::default().parse("((Flash >> HTML 5)) and ((HTML 5 &> CSS 3 &> SVG)) done.");
+            assert_eq!(rendered_paragraphs(&doc), &["Flash and HTML 5 done."]);
+        }
+
+        #[test]
+        fn flow_macro_strips_see_and_seealso_attributes() {
+            // For the macro form, `see`/`see-also` are named attributes, so the
+            // visible inline text is just the first positional attribute.
+            let doc = Parser::default().parse(
+                "indexterm2:[Flash,see=HTML 5] and indexterm2:[HTML 5,see-also=\"CSS 3, SVG\"] done.",
+            );
+            assert_eq!(rendered_paragraphs(&doc), &["Flash and HTML 5 done."]);
+        }
+
+        #[test]
+        fn flow_term_with_entities_but_no_see_clause_is_preserved() {
+            // A visible term may contain `>`/`&` (rendered as entities) without
+            // forming a `see`/`see-also` clause; the whole term is then kept.
+            let doc = Parser::default().parse("A ((tom >& jerry)) term.");
+            assert_eq!(rendered_paragraphs(&doc), &["A tom &gt;&amp; jerry term."]);
+        }
+
+        #[test]
+        fn flow_macro_without_positional_term_falls_back_to_argument() {
+            // When the argument carries only named attributes (no positional
+            // primary term), Asciidoctor displays the raw argument text.
+            let doc = Parser::default().parse("Only named indexterm2:[see=HTML 5] here.");
+            assert_eq!(rendered_paragraphs(&doc), &["Only named see=HTML 5 here."]);
+        }
+
+        #[test]
+        fn escape_macro_forms() {
+            // A backslash before either macro form is honored: the macro is
+            // emitted literally (without the backslash) and not interpreted.
+            let doc =
+                Parser::default().parse("A \\indexterm:[Tigers] and \\indexterm2:[Lancelot] here.");
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &["A indexterm:[Tigers] and indexterm2:[Lancelot] here."]
+            );
+        }
+
+        #[test]
+        fn empty_macro_argument_is_passed_through() {
+            // A truly empty argument does not match the macro (Asciidoctor
+            // requires at least one character), so it is emitted verbatim.
+            let doc = Parser::default().parse("an indexterm:[] here");
+            assert_eq!(rendered_paragraphs(&doc), &["an indexterm:[] here"]);
+        }
     }
 
     #[ignore]


### PR DESCRIPTION
Implements all features described on the **Index** spec page (`docs/modules/sections/pages/user-index.adoc`).

## What's implemented

- **Flow (visible) index terms** — `indexterm2:[<primary>]` and the `((<primary>))` shorthand render their primary term inline.
- **Concealed index terms** — `indexterm:[<primary>, <secondary>, <tertiary>]` and the `(((…)))` shorthand render nothing (the HTML5 converter builds no index catalog, matching Asciidoctor).
- **`[index]` seed section** — confirmed a level-1 section with the `index` style parses and preserves that style for a downstream index-generating converter.

Behavior matches Ruby Asciidoctor's HTML5 output, including:
- backslash escaping (`\indexterm:[…]`, `\((…))`, and the `(\((…)))` / `\(((…)))` enclosing-bracket cases);
- comma-quoting of term segments (`indexterm:[knight, "Arthur, King"]`);
- multi-line term compaction;
- the `((` vs `(((` parenthesis-run disambiguation (emulating Asciidoctor's `(?!\))` look-ahead, which the Rust regex engine lacks);
- stripping `see` (`>>`) / `see-also` (`&>`) clauses from visible terms.

## Implementation notes

- New `InlineSubstitutionRenderer::render_index_term` hook (+ `IndexTermRenderParams`), implemented for the HTML5 renderer and the test renderer. Concealed terms emit nothing; flow terms emit the already-substituted primary term. This keeps the door open for an index-building converter (DocBook/PDF) without registering an index catalog here, consistent with the spec note that the HTML5 converter doesn't generate an index.
- Replaces the long-standing `todo!("Index term macro")` stub in `content/macros.rs`.

## Tests

- New verbatim spec-coverage test `sections/user_index.rs` covering the entire Index page (the SDD coverage tool reports **no uncovered lines**).
- Ported the previously-stubbed index-term tests out of the `todo_migrate_from_ruby_2` blob into a real `macros::index_terms` module (DocBook-only `see`/`see-also` cases and the commented-out `catalog[:indexterms]` assertions omitted, as the crate targets HTML5).
- Full suite: **2587 passing**, `cargo clippy` / `cargo +nightly fmt --check` / `cargo +nightly doc` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)