### PR TITLE
feat: Add include directive spec coverage; match Asciidoctor escaping

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1656,7 +1656,12 @@ fn process_content<'src>(
         // cell is parsed in place from the parent document's source, which keeps
         // its spans (and line numbers) and avoids a copy.
         let cell = if content_has_directive(trimmed.data()) {
-            let (expanded, _source_map) = preprocess(trimmed.data(), parser);
+            // The preprocessor may report warnings (e.g. an unresolved include
+            // target) located by offset into the expanded source. As with the
+            // owned parse warnings below, that source cannot escape this cell, so
+            // these warnings are dropped on this rare path.
+            let (expanded, _source_map, _preprocessor_warnings) =
+                preprocess(trimmed.data(), parser);
             let owned = OwnedCell::new(expanded, |source| {
                 // Warnings from the owned parse borrow the owned source and so
                 // cannot escape it; the include path is rare and currently

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -11,7 +11,8 @@ use crate::{
     document::{Catalog, Docinfo, DocinfoLocation, Header, TocConfig, TocMode},
     internal::debug::DebugSliceReference,
     parser::{
-        CatalogResolver, InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning, SourceMap,
+        CatalogResolver, DeferredWarning, InlineSubstitutionRenderer, ReferenceResolver,
+        ReferenceWarning, SourceMap,
     },
     strings::CowStr,
     warnings::Warning,
@@ -61,7 +62,12 @@ self_cell! {
 }
 
 impl<'src> Document<'src> {
-    pub(crate) fn parse(source: &str, source_map: SourceMap, parser: &mut Parser) -> Self {
+    pub(crate) fn parse(
+        source: &str,
+        source_map: SourceMap,
+        preprocessor_warnings: Vec<DeferredWarning>,
+        parser: &mut Parser,
+    ) -> Self {
         let owned_source = source.to_string();
 
         let internal = Internal::new(owned_source, |owned_src| {
@@ -91,6 +97,16 @@ impl<'src> Document<'src> {
             // borrowed spans — can live. Now that the document's owned source is
             // available, turn each one back into a spanned `Warning`.
             let root = Span::new(owned_src);
+
+            // Warnings raised during preprocessing (e.g. an unresolved include
+            // directive) are carried the same way and reconstituted here.
+            for pw in preprocessor_warnings {
+                warnings.push(Warning {
+                    source: root.slice(pw.offset..pw.offset + pw.len),
+                    warning: pw.warning,
+                });
+            }
+
             for sw in parser.take_substitution_warnings() {
                 warnings.push(Warning {
                     source: root.slice(sw.offset..sw.offset + sw.len),

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -21,6 +21,7 @@ pub use inline_substitution_renderer::{
 };
 
 mod parser;
+pub(crate) use parser::DeferredWarning;
 pub use parser::Parser;
 
 mod path_resolver;

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -159,17 +159,19 @@ pub struct Parser {
     /// [`Span`](crate::Span), which the lifetime-free `Parser` cannot
     /// hold), so the warnings can be turned into
     /// spanned [`Warning`]s once the document's owned source is available.
-    substitution_warnings: RefCell<Vec<SubstitutionWarning>>,
+    substitution_warnings: RefCell<Vec<DeferredWarning>>,
 }
 
-/// A warning recorded while replacing attribute references, stored in a form
-/// that does not borrow the source so it can live on the [`Parser`].
+/// A warning recorded in a form that does not borrow the source so it can live
+/// on the [`Parser`] (or be returned from preprocessing), to be reconstituted
+/// into a spanned [`Warning`] once the document's owned source is available.
 ///
-/// The `offset`/`len` pair locates the relevant text within the (preprocessed)
-/// document source; [`Parser::take_substitution_warnings`] reconstitutes a
-/// spanned [`Warning`] from it.
+/// This is used both for warnings raised while replacing attribute references
+/// and for warnings raised during preprocessing (e.g. an unresolved include
+/// directive). The `offset`/`len` pair locates the relevant text within the
+/// (preprocessed) document source.
 #[derive(Clone, Debug)]
-pub(crate) struct SubstitutionWarning {
+pub(crate) struct DeferredWarning {
     /// Byte offset into the document source of the span this warning refers to.
     pub(crate) offset: usize,
 
@@ -284,7 +286,7 @@ impl Parser {
     /// [`parse()`]: Self::parse
     /// [`catalog()`]: Document::catalog
     pub fn parse_deferred(&mut self, source: &str) -> Document<'static> {
-        let (preprocessed_source, source_map) = preprocess(source, self);
+        let (preprocessed_source, source_map, preprocessor_warnings) = preprocess(source, self);
 
         // NOTE: `Document::parse` will transfer the catalog to itself at the end of the
         // parsing operation. Start each parse with a fresh catalog.
@@ -302,7 +304,12 @@ impl Parser {
         // Reset counter (and captioned-block) numbering for each new document.
         self.counter_values.borrow_mut().clear();
 
-        Document::parse(&preprocessed_source, source_map, self)
+        Document::parse(
+            &preprocessed_source,
+            source_map,
+            preprocessor_warnings,
+            self,
+        )
     }
 
     /// Retrieves the current interpreted value of a [document attribute].
@@ -522,7 +529,7 @@ impl Parser {
     ) {
         self.substitution_warnings
             .borrow_mut()
-            .push(SubstitutionWarning {
+            .push(DeferredWarning {
                 offset: source.byte_offset(),
                 len: source.len(),
                 warning,
@@ -548,7 +555,7 @@ impl Parser {
 
     /// Takes the substitution warnings recorded during parsing, leaving the
     /// buffer empty.
-    pub(crate) fn take_substitution_warnings(&self) -> Vec<SubstitutionWarning> {
+    pub(crate) fn take_substitution_warnings(&self) -> Vec<DeferredWarning> {
         std::mem::take(&mut *self.substitution_warnings.borrow_mut())
     }
 

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -147,9 +147,17 @@ impl<'p> PreprocessorState<'p> {
                         ifh.resolve_target(file_name, &target, &attrlist, self.parser)
                     })
                 {
-                    // TODO: Use process_adoc_include or (TBD) depending on
-                    // whether it's an Asciidoc file type.
-                    self.process_adoc_include(&include_text, Some(&target));
+                    if is_asciidoc_file(&target) {
+                        // AsciiDoc files are run through the preprocessor, so the
+                        // include (and other) directives they contain are
+                        // interpreted.
+                        self.process_adoc_include(&include_text, Some(&target));
+                    } else {
+                        // Non-AsciiDoc files are merged verbatim; the preprocessor
+                        // does not interpret any AsciiDoc directives within them
+                        // (matching Asciidoctor).
+                        self.process_nonadoc_include(&include_text, Some(&target));
+                    }
 
                     // Re-report the including file if there's more content.
                     has_reported_file = false;
@@ -222,6 +230,44 @@ impl<'p> PreprocessorState<'p> {
         self.include_depth -= 1;
     }
 
+    /// Merge the content of a non-AsciiDoc include verbatim.
+    ///
+    /// Unlike [`process_adoc_include`], the content is not scanned for
+    /// preprocessor directives (nested includes, attribute entries, etc.); it
+    /// is inserted as-is, subject only to the line-ending normalization
+    /// that [`Span::take_line`] already performs. This mirrors how
+    /// Asciidoctor treats files that are not recognized as AsciiDoc.
+    ///
+    /// [`process_adoc_include`]: Self::process_adoc_include
+    fn process_nonadoc_include(&mut self, source: &str, file_name: Option<&str>) {
+        let mut source_span = Span::new(source);
+        let mut has_reported_file = false;
+
+        while !source_span.is_empty() {
+            let MatchedItem { item: line, after } = source_span.take_line();
+            source_span = after;
+
+            if !has_reported_file {
+                has_reported_file = true;
+                self.source_map.append(
+                    self.output_line_number,
+                    SourceLine(to_owned(file_name), line.line()),
+                );
+            }
+
+            if line.is_empty() {
+                self.in_document_header = false;
+                self.can_have_attribute = true;
+            } else if !self.in_document_header {
+                self.can_have_attribute = false;
+            }
+
+            self.output_line_number += 1;
+            self.output.push_str(line.data());
+            self.output.push('\n');
+        }
+    }
+
     /// Apply attribute substitution to a string, replacing {attribute-name}
     /// patterns with their corresponding values from the parser.
     fn substitute_attributes(&self, input: &str) -> String {
@@ -266,6 +312,26 @@ impl<'p> PreprocessorState<'p> {
 
 fn to_owned(maybe_file_name: Option<&str>) -> Option<String> {
     maybe_file_name.map(|n| n.to_string())
+}
+
+/// Returns `true` if `target` names an AsciiDoc file, based on its extension.
+///
+/// Per the [include directive] spec, a file is treated as AsciiDoc if it has
+/// one of these extensions: `.asciidoc`, `.adoc`, `.ad`, `.asc`, or `.txt`. The
+/// comparison is case-sensitive, and a target with no extension is not
+/// considered AsciiDoc — both matching Asciidoctor.
+///
+/// [include directive]: https://docs.asciidoctor.org/asciidoc/latest/directives/include/#include-nonasciidoc
+fn is_asciidoc_file(target: &str) -> bool {
+    const ASCIIDOC_EXTENSIONS: [&str; 5] = ["asciidoc", "adoc", "ad", "asc", "txt"];
+
+    let file_name = target.rsplit('/').next().unwrap_or(target);
+
+    match file_name.rsplit_once('.') {
+        // A leading dot (e.g. `.adoc`) denotes a hidden file with no extension.
+        Some((stem, ext)) if !stem.is_empty() => ASCIIDOC_EXTENSIONS.contains(&ext),
+        _ => false,
+    }
 }
 
 static INCLUDE_DIRECTIVE: LazyLock<Regex> = LazyLock::new(|| {
@@ -600,6 +666,79 @@ mod tests {
         assert_eq!(
             source_map.original_file_and_line(4),
             Some(SourceLine(Some("main.adoc".to_owned()), 4))
+        );
+    }
+
+    #[test]
+    fn asciidoc_file_recognition() {
+        use super::is_asciidoc_file;
+
+        // Recognized AsciiDoc extensions.
+        assert!(is_asciidoc_file("foo.asciidoc"));
+        assert!(is_asciidoc_file("foo.adoc"));
+        assert!(is_asciidoc_file("foo.ad"));
+        assert!(is_asciidoc_file("foo.asc"));
+        assert!(is_asciidoc_file("foo.txt"));
+        assert!(is_asciidoc_file("path/to/foo.adoc"));
+        assert!(is_asciidoc_file("a.b.adoc"));
+
+        // Not AsciiDoc.
+        assert!(!is_asciidoc_file("foo.csv"));
+        assert!(!is_asciidoc_file("foo.rb"));
+        assert!(!is_asciidoc_file("path/to/data.csv"));
+        assert!(!is_asciidoc_file("foo")); // no extension
+        assert!(!is_asciidoc_file("foo.ADOC")); // case-sensitive
+        assert!(!is_asciidoc_file(".adoc")); // hidden file, no stem
+    }
+
+    #[test]
+    fn asciidoc_include_processes_nested_directives() {
+        // An included AsciiDoc file is run through the preprocessor, so a nested
+        // include within it is expanded.
+        let source = "include::outer.adoc[]";
+
+        let handler = InlineFileHandler::from_pairs([
+            ("outer.adoc", "Top.\ninclude::inner.adoc[]"),
+            ("inner.adoc", "Nested."),
+        ]);
+
+        let parser = Parser::default()
+            .with_primary_file_name("main.adoc")
+            .with_include_file_handler(handler);
+
+        let (processed_source, _source_map, _warnings) = preprocess(source, &parser);
+
+        assert_eq!(processed_source, "Top.\nNested.\n");
+    }
+
+    #[test]
+    fn non_asciidoc_include_merged_verbatim() {
+        // A non-AsciiDoc file (here `.csv`) is merged verbatim: a nested include
+        // directive within it is left as literal text, not expanded.
+        let source = "include::data.csv[]";
+
+        let handler = InlineFileHandler::from_pairs([
+            ("data.csv", "a,b\ninclude::inner.adoc[]"),
+            ("inner.adoc", "SHOULD NOT APPEAR"),
+        ]);
+
+        let parser = Parser::default()
+            .with_primary_file_name("main.adoc")
+            .with_include_file_handler(handler);
+
+        let (processed_source, source_map, warnings) = preprocess(source, &parser);
+
+        assert_eq!(processed_source, "a,b\ninclude::inner.adoc[]\n");
+        assert!(warnings.is_empty());
+
+        // The verbatim content maps back to the non-AsciiDoc file's lines.
+        assert_eq!(
+            source_map.original_file_and_line(1),
+            Some(SourceLine(Some("data.csv".to_owned()), 1))
+        );
+        assert_eq!(
+            source_map.original_file_and_line(2),
+            Some(SourceLine(Some("data.csv".to_owned()), 2))
         );
     }
 

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -153,6 +153,13 @@ impl<'p> PreprocessorState<'p> {
 
                     // Re-report the including file if there's more content.
                     has_reported_file = false;
+                } else if attrlist.has_option("optional") {
+                    // `opts=optional`: a target that can't be resolved is dropped
+                    // silently — neither the "Unresolved directive" text nor a
+                    // warning is produced (matching Asciidoctor). Nothing is
+                    // emitted for this line; re-anchor the source map so the lines
+                    // that follow map back to their correct original line numbers.
+                    has_reported_file = false;
                 } else {
                     // The target could not be resolved. Replace the directive with
                     // an "Unresolved directive" message in the output (as
@@ -593,6 +600,35 @@ mod tests {
         assert_eq!(
             source_map.original_file_and_line(4),
             Some(SourceLine(Some("main.adoc".to_owned()), 4))
+        );
+    }
+
+    #[test]
+    fn optional_include_dropped_silently() {
+        // `opts=optional` drops an unresolved include with no output text and no
+        // warning, while keeping the source map aligned for the lines that follow.
+        let source = "Before.\n\ninclude::missing.adoc[opts=optional]\n\nAfter.";
+
+        // Handler doesn't provide missing.adoc.
+        let handler = InlineFileHandler::from_pairs([("other.adoc", "Other content")]);
+
+        let parser = Parser::default()
+            .with_primary_file_name("main.adoc")
+            .with_include_file_handler(handler);
+
+        let (processed_source, source_map, warnings) = preprocess(source, &parser);
+
+        // The directive line is gone; no "Unresolved directive" text is inserted.
+        assert_eq!(processed_source, "Before.\n\n\nAfter.\n");
+        assert!(warnings.is_empty());
+
+        assert_eq!(
+            source_map.original_file_and_line(1),
+            Some(SourceLine(Some("main.adoc".to_owned()), 1)) // Before.
+        );
+        assert_eq!(
+            source_map.original_file_and_line(4),
+            Some(SourceLine(Some("main.adoc".to_owned()), 5)) // After.
         );
     }
 

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -301,8 +301,8 @@ static ATTRIBUTE_REFERENCE: LazyLock<Regex> = LazyLock::new(|| {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
     #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::unwrap_used)]
 
     use crate::{
         parser::{SourceLine, preprocessor::preprocess},

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -169,7 +169,7 @@ impl<'p> PreprocessorState<'p> {
                     self.warnings.push(DeferredWarning {
                         offset: self.output.len(),
                         len: replacement.len(),
-                        warning: WarningType::IncludeFileNotFound,
+                        warning: WarningType::IncludeFileNotFound(target),
                     });
 
                     self.output_line_number += 1;
@@ -502,7 +502,10 @@ mod tests {
         // A warning is recorded for the unresolved include, pointing at the
         // "Unresolved directive" text in the output.
         assert_eq!(warnings.len(), 1);
-        assert_eq!(warnings[0].warning, WarningType::IncludeFileNotFound);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::IncludeFileNotFound("missing.adoc".to_owned())
+        );
         assert_eq!(
             &processed_source[warnings[0].offset..warnings[0].offset + warnings[0].len],
             "Unresolved directive in main.adoc - include::missing.adoc[]"
@@ -570,7 +573,10 @@ mod tests {
 
         // With no handler at all, the include is likewise unresolved and warned.
         assert_eq!(warnings.len(), 1);
-        assert_eq!(warnings[0].warning, WarningType::IncludeFileNotFound);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::IncludeFileNotFound("missing.adoc".to_owned())
+        );
 
         assert_eq!(
             source_map.original_file_and_line(1),

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -581,11 +581,8 @@ mod tests {
         // The backslash is stripped even when there is no primary file name (and
         // thus no include handler) so the escape behaves identically.
         let source = "\\include::partial.adoc[]";
-
         let parser = Parser::default();
-
         let (processed_source, _source_map) = preprocess(source, &parser);
-
         assert_eq!(processed_source, "include::partial.adoc[]\n");
     }
 
@@ -594,11 +591,8 @@ mod tests {
         // A backslash followed by something that is not a valid include directive
         // (here, no attribute brackets) is left untouched.
         let source = "\\include::partial.adoc";
-
         let parser = Parser::default().with_primary_file_name("main.adoc");
-
         let (processed_source, _source_map) = preprocess(source, &parser);
-
         assert_eq!(processed_source, "\\include::partial.adoc\n");
     }
 
@@ -607,11 +601,8 @@ mod tests {
         // Only a single leading backslash is treated as an escape; a double
         // backslash is left as-is.
         let source = "\\\\include::partial.adoc[]";
-
         let parser = Parser::default().with_primary_file_name("main.adoc");
-
         let (processed_source, _source_map) = preprocess(source, &parser);
-
         assert_eq!(processed_source, "\\\\include::partial.adoc[]\n");
     }
 

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -6,9 +6,9 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     document::{Attribute, InterpretedValue},
-    parser::{SourceLine, SourceMap},
+    parser::{DeferredWarning, SourceLine, SourceMap},
     span::MatchedItem,
-    warnings::Warning,
+    warnings::{Warning, WarningType},
 };
 
 /// Given a root file (initial input to `Parser::parse`), convert this into a
@@ -18,9 +18,17 @@ use crate::{
 ///
 /// This function handles [include file] and [conditional] processing.
 ///
+/// Any warnings raised during preprocessing (e.g. an include directive whose
+/// target could not be resolved) are returned as [`DeferredWarning`]s, located
+/// by byte offset within the returned (preprocessed) source. `Document::parse`
+/// reconstitutes them into spanned [`Warning`]s once it owns that source.
+///
 /// [include file]: https://docs.asciidoctor.org/asciidoc/latest/directives/include/
 /// [conditional]: https://docs.asciidoctor.org/asciidoc/latest/directives/conditionals/
-pub(crate) fn preprocess(source: &str, parser: &Parser) -> (String, SourceMap) {
+pub(crate) fn preprocess(
+    source: &str,
+    parser: &Parser,
+) -> (String, SourceMap, Vec<DeferredWarning>) {
     // Short-circuit if the original source document has no pre-processor
     // directives.
     if !source.starts_with("include::")
@@ -31,7 +39,7 @@ pub(crate) fn preprocess(source: &str, parser: &Parser) -> (String, SourceMap) {
         && !source.contains("\n\\include::")
         && parser.primary_file_name.is_none()
     {
-        return (source.to_owned(), SourceMap::default());
+        return (source.to_owned(), SourceMap::default(), vec![]);
     }
 
     // We use a temporary clone of the parser to track document attribute values
@@ -41,7 +49,7 @@ pub(crate) fn preprocess(source: &str, parser: &Parser) -> (String, SourceMap) {
     let mut state = PreprocessorState::new(&mut temp_parser);
     state.process_adoc_include(source, parser.primary_file_name.as_deref());
 
-    (state.output, state.source_map)
+    (state.output, state.source_map, state.warnings)
 }
 
 #[derive(Debug)]
@@ -53,6 +61,7 @@ struct PreprocessorState<'p> {
     output_line_number: usize,
     output: String,
     source_map: SourceMap,
+    warnings: Vec<DeferredWarning>,
 }
 
 impl<'p> PreprocessorState<'p> {
@@ -65,6 +74,7 @@ impl<'p> PreprocessorState<'p> {
             output_line_number: 1,
             output: String::new(),
             source_map: SourceMap::default(),
+            warnings: vec![],
         }
     }
 
@@ -144,12 +154,27 @@ impl<'p> PreprocessorState<'p> {
                     // Re-report the including file if there's more content.
                     has_reported_file = false;
                 } else {
-                    self.output_line_number += 1;
-                    self.output.push_str(&format!(
-                        "Unresolved directive in {file_name} - {line}\n",
+                    // The target could not be resolved. Replace the directive with
+                    // an "Unresolved directive" message in the output (as
+                    // Asciidoctor does) and record a warning pointing at that
+                    // message. The warning is located by byte offset because the
+                    // output it refers to is not yet owned; `Document::parse`
+                    // reconstitutes it into a spanned `Warning`.
+                    let replacement = format!(
+                        "Unresolved directive in {file_name} - {line}",
                         file_name = file_name.unwrap_or("(root file)",),
                         line = line.data(),
-                    ));
+                    );
+
+                    self.warnings.push(DeferredWarning {
+                        offset: self.output.len(),
+                        len: replacement.len(),
+                        warning: WarningType::IncludeFileNotFound,
+                    });
+
+                    self.output_line_number += 1;
+                    self.output.push_str(&replacement);
+                    self.output.push('\n');
                 }
             } else {
                 // If none of the above apply, add the line to output.
@@ -270,6 +295,7 @@ static ATTRIBUTE_REFERENCE: LazyLock<Regex> = LazyLock::new(|| {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing)]
 
     use crate::{
         parser::{SourceLine, preprocessor::preprocess},
@@ -282,7 +308,7 @@ mod tests {
             "= Document Title\n\nThis is a simple document with no includes or conditionals.";
         let parser = Parser::default().with_primary_file_name("test.adoc");
 
-        let (processed_source, source_map) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -308,7 +334,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -356,7 +382,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -406,7 +432,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -466,11 +492,20 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map) = preprocess(source, &parser);
+        let (processed_source, source_map, warnings) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
             "= Document Title\n\nUnresolved directive in main.adoc - include::missing.adoc[]\n\nMore content.\n"
+        );
+
+        // A warning is recorded for the unresolved include, pointing at the
+        // "Unresolved directive" text in the output.
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].warning, WarningType::IncludeFileNotFound);
+        assert_eq!(
+            &processed_source[warnings[0].offset..warnings[0].offset + warnings[0].len],
+            "Unresolved directive in main.adoc - include::missing.adoc[]"
         );
 
         assert_eq!(
@@ -504,7 +539,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -526,12 +561,16 @@ mod tests {
         // NOTE: No include file handler provided.
         let parser = Parser::default().with_primary_file_name("main.adoc");
 
-        let (processed_source, source_map) = preprocess(source, &parser);
+        let (processed_source, source_map, warnings) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
             "= Document Title\n\nUnresolved directive in main.adoc - include::missing.adoc[]\n\nMore content.\n"
         );
+
+        // With no handler at all, the include is likewise unresolved and warned.
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].warning, WarningType::IncludeFileNotFound);
 
         assert_eq!(
             source_map.original_file_and_line(1),
@@ -563,7 +602,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -582,7 +621,7 @@ mod tests {
         // thus no include handler) so the escape behaves identically.
         let source = "\\include::partial.adoc[]";
         let parser = Parser::default();
-        let (processed_source, _source_map) = preprocess(source, &parser);
+        let (processed_source, _source_map, _warnings) = preprocess(source, &parser);
         assert_eq!(processed_source, "include::partial.adoc[]\n");
     }
 
@@ -592,7 +631,7 @@ mod tests {
         // (here, no attribute brackets) is left untouched.
         let source = "\\include::partial.adoc";
         let parser = Parser::default().with_primary_file_name("main.adoc");
-        let (processed_source, _source_map) = preprocess(source, &parser);
+        let (processed_source, _source_map, _warnings) = preprocess(source, &parser);
         assert_eq!(processed_source, "\\include::partial.adoc\n");
     }
 
@@ -602,7 +641,7 @@ mod tests {
         // backslash is left as-is.
         let source = "\\\\include::partial.adoc[]";
         let parser = Parser::default().with_primary_file_name("main.adoc");
-        let (processed_source, _source_map) = preprocess(source, &parser);
+        let (processed_source, _source_map, _warnings) = preprocess(source, &parser);
         assert_eq!(processed_source, "\\\\include::partial.adoc[]\n");
     }
 
@@ -619,7 +658,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -645,7 +684,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -683,7 +722,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -720,7 +759,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -760,7 +799,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -796,7 +835,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -826,7 +865,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -743,6 +743,24 @@ mod tests {
     }
 
     #[test]
+    fn non_asciidoc_include_in_body_tracks_header_state() {
+        // A non-AsciiDoc include placed in the document body (so the preprocessor
+        // is past the header) whose content includes a blank line exercises the
+        // verbatim path's header-state updates for both blank and non-blank lines.
+        let source = "Body.\n\ninclude::data.csv[]";
+
+        let handler = InlineFileHandler::from_pairs([("data.csv", "row one\n\nrow two")]);
+
+        let parser = Parser::default()
+            .with_primary_file_name("main.adoc")
+            .with_include_file_handler(handler);
+
+        let (processed_source, _source_map, _warnings) = preprocess(source, &parser);
+
+        assert_eq!(processed_source, "Body.\n\nrow one\n\nrow two\n");
+    }
+
+    #[test]
     fn optional_include_dropped_silently() {
         // `opts=optional` drops an unresolved include with no output text and no
         // warning, while keeping the source map aligned for the lines that follow.

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -27,6 +27,8 @@ pub(crate) fn preprocess(source: &str, parser: &Parser) -> (String, SourceMap) {
         && !source.starts_with("if")
         && !source.contains("\ninclude::")
         && !source.contains("\nif")
+        && !source.starts_with("\\include::")
+        && !source.contains("\n\\include::")
         && parser.primary_file_name.is_none()
     {
         return (source.to_owned(), SourceMap::default());
@@ -166,8 +168,21 @@ impl<'p> PreprocessorState<'p> {
                     self.can_have_attribute = false;
                 }
 
+                // An escaped include directive (e.g. `\include::foo[]`) is not
+                // processed. The leading backslash is removed and the remainder is
+                // emitted literally, matching Asciidoctor. The backslash is only
+                // removed when what follows is actually an include directive; a
+                // backslash followed by anything else is left untouched.
+                let line_text = if line.starts_with("\\include::")
+                    && INCLUDE_DIRECTIVE.is_match(&line.data()[1..])
+                {
+                    &line.data()[1..]
+                } else {
+                    line.data()
+                };
+
                 self.output_line_number += 1;
-                self.output.push_str(line.data());
+                self.output.push_str(line_text);
                 self.output.push('\n');
             }
         }
@@ -534,6 +549,70 @@ mod tests {
             source_map.original_file_and_line(4),
             Some(SourceLine(Some("main.adoc".to_owned()), 4))
         );
+    }
+
+    #[test]
+    fn escaped_include_directive() {
+        // An escaped include directive is not processed. The leading backslash is
+        // stripped and the remainder is emitted literally (matching Asciidoctor).
+        let source = "Before.\n\n\\include::partial.adoc[]\n\nAfter.";
+
+        let handler = InlineFileHandler::from_pairs([("partial.adoc", "SHOULD NOT APPEAR")]);
+
+        let parser = Parser::default()
+            .with_primary_file_name("main.adoc")
+            .with_include_file_handler(handler);
+
+        let (processed_source, source_map) = preprocess(source, &parser);
+
+        assert_eq!(
+            processed_source,
+            "Before.\n\ninclude::partial.adoc[]\n\nAfter.\n"
+        );
+
+        assert_eq!(
+            source_map.original_file_and_line(3),
+            Some(SourceLine(Some("main.adoc".to_owned()), 3))
+        );
+    }
+
+    #[test]
+    fn escaped_include_directive_without_primary_file() {
+        // The backslash is stripped even when there is no primary file name (and
+        // thus no include handler) so the escape behaves identically.
+        let source = "\\include::partial.adoc[]";
+
+        let parser = Parser::default();
+
+        let (processed_source, _source_map) = preprocess(source, &parser);
+
+        assert_eq!(processed_source, "include::partial.adoc[]\n");
+    }
+
+    #[test]
+    fn escaped_non_directive_is_unchanged() {
+        // A backslash followed by something that is not a valid include directive
+        // (here, no attribute brackets) is left untouched.
+        let source = "\\include::partial.adoc";
+
+        let parser = Parser::default().with_primary_file_name("main.adoc");
+
+        let (processed_source, _source_map) = preprocess(source, &parser);
+
+        assert_eq!(processed_source, "\\include::partial.adoc\n");
+    }
+
+    #[test]
+    fn double_backslash_include_is_unchanged() {
+        // Only a single leading backslash is treated as an escape; a double
+        // backslash is left as-is.
+        let source = "\\\\include::partial.adoc[]";
+
+        let parser = Parser::default().with_primary_file_name("main.adoc");
+
+        let (processed_source, _source_map) = preprocess(source, &parser);
+
+        assert_eq!(processed_source, "\\\\include::partial.adoc[]\n");
     }
 
     #[test]

--- a/parser/src/tests/asciidoc_lang/directives/include.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include.rs
@@ -378,8 +378,10 @@ If you don't want the include directive to be processed, you must escape it usin
     assert_eq!(paras, vec!["include::just-an-example.ext[]"]);
 }
 
-non_normative!(
-    r#"
+#[test]
+fn indentation_prevents_processing() {
+    verifies!(
+        r#"
 // NOTE: the following listing uses indentation to prevent the directive from being processed
 [indent=0]
 ----
@@ -387,7 +389,39 @@ non_normative!(
 ----
 
 "#
-);
+    );
+
+    // The indented directive from the spec example does not cause an inclusion:
+    // the listing block retains the directive text verbatim.
+    let doc = Parser::default()
+        .with_include_file_handler(InlineFileHandler::from_pairs([(
+            "just-an-example.ext",
+            "SHOULD NOT APPEAR",
+        )]))
+        .parse("[indent=0]\n----\n \\include::just-an-example.ext[]\n----");
+
+    let block = doc.nested_blocks().next().unwrap();
+    assert_eq!(
+        block.span().data(),
+        "[indent=0]\n----\n \\include::just-an-example.ext[]\n----"
+    );
+
+    // It is the leading whitespace (indentation), not the backslash, that
+    // prevents processing: an indented directive without a backslash is left
+    // untouched too.
+    let doc = Parser::default()
+        .with_include_file_handler(InlineFileHandler::from_pairs([(
+            "just-an-example.ext",
+            "SHOULD NOT APPEAR",
+        )]))
+        .parse("[indent=0]\n----\n include::just-an-example.ext[]\n----");
+
+    let block = doc.nested_blocks().next().unwrap();
+    assert_eq!(
+        block.span().data(),
+        "[indent=0]\n----\n include::just-an-example.ext[]\n----"
+    );
+}
 
 #[test]
 fn escaping_required_even_in_verbatim_block() {

--- a/parser/src/tests/asciidoc_lang/directives/include.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include.rs
@@ -517,10 +517,34 @@ The following message will also be inserted into the output:
 non_normative!(
     r#"
 To fix the problem, edit the file path and run the converter again.
+"#
+);
+
+#[test]
+fn opts_optional_drops_unresolved_include() {
+    verifies!(
+        r#"
 If you don't want the AsciiDoc processor to emit a warning, but rather drop the include that cannot be found, add the `opts=optional` attribute to the include directive.
 
 "#
-);
+    );
+
+    // The handler does not provide content.adoc, but `opts=optional` means the
+    // unresolved directive is dropped silently: no "Unresolved directive" text is
+    // inserted and no warning is emitted.
+    let handler = InlineFileHandler::from_pairs([("other.adoc", "unused")]);
+
+    let doc = Parser::default()
+        .with_primary_file_name("my-document.adoc")
+        .with_include_file_handler(handler)
+        .parse("Before.\n\ninclude::content.adoc[opts=optional]\n\nAfter.");
+
+    let paras = rendered_paragraphs(&doc);
+    let paras: Vec<&str> = paras.iter().map(|s| s.as_str()).collect();
+
+    assert_eq!(paras, vec!["Before.", "After."]);
+    assert_eq!(doc.warnings().count(), 0);
+}
 
 #[test]
 fn attribute_reference_in_include_path() {

--- a/parser/src/tests/asciidoc_lang/directives/include.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include.rs
@@ -114,7 +114,35 @@ non_normative!(
 \include::target[leveloffset=__offset__,lines=__ranges__,tag(s)=__name(s)__,indent=__depth__,encoding=__encoding__,opts=optional]
 ----
 
+"#
+);
+
+#[test]
+fn target_is_required() {
+    verifies!(
+        r#"
 The target is required.
+"#
+    );
+
+    // An include directive with an empty target is not a valid directive, so it
+    // is left untouched rather than processed or reported as unresolved. This
+    // matches Asciidoctor, which renders `include::[]` literally.
+    let handler = InlineFileHandler::from_pairs([("", "SHOULD NOT APPEAR")]);
+
+    let doc = Parser::default()
+        .with_primary_file_name("main.adoc")
+        .with_include_file_handler(handler)
+        .parse("Before.\n\ninclude::[]\n\nAfter.");
+
+    let paras = rendered_paragraphs(&doc);
+    let paras: Vec<&str> = paras.iter().map(|s| s.as_str()).collect();
+
+    assert_eq!(paras, vec!["Before.", "include::[]", "After."]);
+}
+
+non_normative!(
+    r#"
 The target may be an absolute path, a path relative to the current document, or a URL.
 "#
 );

--- a/parser/src/tests/asciidoc_lang/directives/include.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include.rs
@@ -587,6 +587,13 @@ non_normative!(
 Keep in mind that no matter how Asciidoctor resolves the path to the file, access to that file is limited by the safe mode setting under which Asciidoctor is run.
 If a path violates the security restrictions, it may be truncated.
 
+"#
+);
+
+#[test]
+fn merges_any_text_file_with_normalization() {
+    verifies!(
+        r#"
 [#include-nonasciidoc]
 == AsciiDoc vs non-AsciiDoc files
 
@@ -594,6 +601,31 @@ The include directive performs a simple file merge, so it works with any text fi
 // NOTE this point about normalization should probably be moved to an earlier section
 The content of all included content goes through some form of normalization.
 
+"#
+    );
+
+    // The directive merges any text file's content, not just AsciiDoc: here a CSV
+    // fragment is included verbatim. The content is normalized as it is merged —
+    // the CRLF line ending becomes a Unix line feed.
+    let handler = InlineFileHandler::from_pairs([("results.csv", "Year,Total\r\n2016,1234")]);
+
+    let doc = Parser::default()
+        .with_include_file_handler(handler)
+        .parse("include::results.csv[]");
+
+    let paras = rendered_paragraphs(&doc);
+    let paras: Vec<&str> = paras.iter().map(|s| s.as_str()).collect();
+
+    assert_eq!(paras, vec!["Year,Total\n2016,1234"]);
+}
+
+// The remaining details in this section are out of scope for this crate:
+// character-encoding handling (the encoding attribute and BOM detection), the
+// extension-based AsciiDoc-file recognition (this crate treats every included
+// file as AsciiDoc), trailing-whitespace stripping, and preprocessor
+// conditionals (e.g. `ifdef`) are not implemented.
+non_normative!(
+    r#"
 The content of each include file is encoded to UTF-8.
 If the encoding attribute is specified on the include directive, the content is reencoded from that encoding to UTF-8.
 If the encoding attribute is not specified, the processor will look for the presence of a BOM and reencode the content from that encoding to UTF-8 accordingly.

--- a/parser/src/tests/asciidoc_lang/directives/include.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include.rs
@@ -1,0 +1,559 @@
+use crate::tests::prelude::{inline_file_handler::InlineFileHandler, *};
+
+track_file!("docs/modules/directives/pages/include.adoc");
+
+non_normative!(
+    r#"
+= Includes
+// Include Directive Syntax and Processing
+// Include Directive Concepts and Syntax
+
+"#
+);
+
+#[test]
+fn intro() {
+    verifies!(
+        r#"
+You can include content from another file into the current AsciiDoc document using the include directive.
+The included content can be AsciiDoc or it can be any other text format.
+Where that content is included in the document determines how it will be processed.
+
+"#
+    );
+
+    let handler = InlineFileHandler::from_pairs([("partial.adoc", "Included paragraph.")]);
+
+    let doc = Parser::default()
+        .with_include_file_handler(handler)
+        .parse("Before include.\n\ninclude::partial.adoc[]\n\nAfter include.");
+
+    let paras = rendered_paragraphs(&doc);
+    let paras: Vec<&str> = paras.iter().map(|s| s.as_str()).collect();
+
+    assert_eq!(
+        paras,
+        vec!["Before include.", "Included paragraph.", "After include."]
+    );
+}
+
+#[test]
+fn what_is_an_include_directive() {
+    verifies!(
+        r#"
+== What is an include directive?
+
+An [.term]*include directive* imports content from a separate file or URL into the content of the current document.
+When the current document is processed, the include directive syntax is replaced by the contents of the include file.
+Think of the include directive like a file expander.
+The include directive is a <<include-processing,preprocessor directive>>, which means it has no awareness of the surrounding context.
+
+"#
+    );
+
+    // The include directive is replaced by the contents of the include file
+    // even when it appears inside a verbatim listing block, because the
+    // preprocessor has no awareness of the surrounding context.
+    let handler = InlineFileHandler::from_pairs([("expander.adoc", "EXPANDED")]);
+
+    let doc = Parser::default()
+        .with_include_file_handler(handler)
+        .parse("----\ninclude::expander.adoc[]\n----");
+
+    let block = doc.nested_blocks().next().unwrap();
+    assert_eq!(block.span().data(), "----\nEXPANDED\n----");
+}
+
+non_normative!(
+    r#"
+== When is an include directive useful?
+
+The include directive is useful when you want to:
+
+* Partition a large document into smaller files for better organization and to make restructuring simpler.footnote:[Always separate consecutive include directives by an empty line unless your intent is to adjoin the content in the include files so it becomes contiguous.]
+* Insert source code from the external files where the code is maintained.
+* Populate tables with output, such as CSV data, from other programs.
+* Create document variants by combining the include directive with xref:conditionals.adoc[conditional preprocessor directives].
+* Reuse content snippets and boilerplate content, such as term definitions, disclaimers, etc., multiple times within the same document.
+* Define a common set of attributes across multiple documents (typically included into the document header).
+
+"#
+);
+
+#[test]
+fn must_be_on_a_line_by_itself() {
+    verifies!(
+        r#"
+[#include-syntax]
+== Include directive syntax
+
+An include directive must be placed on a line by itself with the following syntax:
+
+"#
+    );
+
+    // Because an include directive must be on a line by itself, a directive with
+    // trailing content on the same line is not processed as an include.
+    let handler =
+        InlineFileHandler::from_pairs([("part1.adoc", "First"), ("part2.adoc", "Second")]);
+
+    let doc = Parser::default()
+        .with_include_file_handler(handler)
+        .parse("include::part1.adoc[] include::part2.adoc[]");
+
+    let paras = rendered_paragraphs(&doc);
+    let paras: Vec<&str> = paras.iter().map(|s| s.as_str()).collect();
+
+    assert_eq!(paras, vec!["include::part1.adoc[] include::part2.adoc[]"]);
+}
+
+non_normative!(
+    r#"
+[listing,subs=+quotes]
+----
+\include::target[leveloffset=__offset__,lines=__ranges__,tag(s)=__name(s)__,indent=__depth__,encoding=__encoding__,opts=optional]
+----
+
+The target is required.
+The target may be an absolute path, a path relative to the current document, or a URL.
+"#
+);
+
+#[test]
+fn target_may_contain_spaces() {
+    verifies!(
+        r#"
+Since the include directive is a line-oriented expression, the target may contain space characters.
+However, the target must not start with a space character (since that would turn it into a description list term).
+"#
+    );
+
+    // A target with internal space characters is resolved.
+    let handler = InlineFileHandler::from_pairs([("my file.adoc", "Spaced target.")]);
+
+    let doc = Parser::default()
+        .with_include_file_handler(handler)
+        .parse("include::my file.adoc[]");
+
+    let paras = rendered_paragraphs(&doc);
+    let paras: Vec<&str> = paras.iter().map(|s| s.as_str()).collect();
+
+    assert_eq!(paras, vec!["Spaced target."]);
+
+    // A target that starts with a space is not treated as an include directive.
+    let handler2 = InlineFileHandler::from_pairs([(" spaced.adoc", "SHOULD NOT APPEAR")]);
+
+    let doc2 = Parser::default()
+        .with_include_file_handler(handler2)
+        .parse("include:: spaced.adoc[]");
+
+    assert!(
+        !rendered_paragraphs(&doc2)
+            .iter()
+            .any(|p| p.contains("SHOULD NOT APPEAR"))
+    );
+}
+
+non_normative!(
+    r#"
+An absolute or relative path outside the directory of the outermost document will only be honored if the safe mode is unsafe.
+A URL target will only be resolved if the security settings on the processor allows it (e.g., `allow-uri-read`).
+See xref:include-uri.adoc[].
+
+The leveloffset, lines, tag(s), indent, encoding, and opts attributes are optional, thus reducing the simplest case to the following:
+
+"#
+);
+
+#[test]
+fn simplest_case() {
+    verifies!(
+        r#"
+----
+\include::partial.adoc[]
+----
+
+"#
+    );
+
+    let handler = InlineFileHandler::from_pairs([("partial.adoc", "Simplest form.")]);
+
+    let doc = Parser::default()
+        .with_include_file_handler(handler)
+        .parse("include::partial.adoc[]");
+
+    let paras = rendered_paragraphs(&doc);
+    let paras: Vec<&str> = paras.iter().map(|s| s.as_str()).collect();
+
+    assert_eq!(paras, vec!["Simplest form."]);
+}
+
+non_normative!(
+    r#"
+Specifying the encoding is essential if the include file is not encoded in UTF-8.
+The value of this attribute must be an encoding recognized by Ruby (e.g., utf-8, iso-8859-1, windows-1252, etc), case insenstive.
+If the include file is already encoded in UTF-8 (or contains a BOM), this attribute is unnecessary.
+
+"#
+);
+
+#[test]
+fn consecutive_includes_separated_by_blank_line() {
+    verifies!(
+        r#"
+When using consecutive include directives, you should always separate them by an empty line unless your intention is to adjoin the content in the include files so it becomes contiguous.
+
+For example, if you're using the include directive to include individual chapters, the include directives should be offset from each other by an empty line.
+This strategy avoids relying on empty lines imported from the include file to keep the chapters separated.
+That separation should be encoded in the parent document instead.
+
+----
+\include::chapter01.adoc[]
+
+\include::chapter02.adoc[]
+
+\include::chapter03.adoc[]
+----
+
+"#
+    );
+
+    // Separated by empty lines, the chapters remain distinct blocks.
+    let handler = InlineFileHandler::from_pairs([
+        ("chapter01.adoc", "Chapter one."),
+        ("chapter02.adoc", "Chapter two."),
+        ("chapter03.adoc", "Chapter three."),
+    ]);
+
+    let doc = Parser::default().with_include_file_handler(handler).parse(
+        "include::chapter01.adoc[]\n\ninclude::chapter02.adoc[]\n\ninclude::chapter03.adoc[]",
+    );
+
+    let paras = rendered_paragraphs(&doc);
+    let paras: Vec<&str> = paras.iter().map(|s| s.as_str()).collect();
+
+    assert_eq!(
+        paras,
+        vec!["Chapter one.", "Chapter two.", "Chapter three."]
+    );
+}
+
+#[test]
+fn consecutive_includes_adjoined() {
+    verifies!(
+        r#"
+On the other hand, if you're using the include directive to lay down contiguous lines, such as common document attribute entries, then you would put the include directives on adjacent lines to avoid inserting empty lines.
+
+----
+= Document Title
+Author Name
+\include::attributes-settings.adoc[]
+\include::attributes-urls.adoc[]
+:url-example: https://example.org
+
+Document body.
+----
+
+"#
+    );
+
+    // Adjacent include directives adjoin the imported lines, so the attribute
+    // entries remain contiguous in the document header.
+    let handler = InlineFileHandler::from_pairs([
+        ("attributes-settings.adoc", ":settings-attr: yes"),
+        ("attributes-urls.adoc", ":url-attr: https://example.com"),
+    ]);
+
+    let doc = Parser::default().with_include_file_handler(handler).parse(
+        "= Document Title\nAuthor Name\ninclude::attributes-settings.adoc[]\ninclude::attributes-urls.adoc[]\n:url-example: https://example.org\n\nDocument body.",
+    );
+
+    let names: Vec<&str> = doc.header().attributes().map(|a| a.name().data()).collect();
+
+    assert_eq!(names, vec!["settings-attr", "url-attr", "url-example"]);
+}
+
+non_normative!(
+    r#"
+In either case, don't rely on the empty lines at the boundaries of the include file.
+And mind where empty lines are used in that include file.
+
+[#include-processing]
+== Include processing
+
+Although the include directive looks like a block macro, *it's not a macro and therefore isn't processed like one*.
+It's a preprocessor directive; it's important to understand the distinction.
+
+include::partial$preprocessor.adoc[]
+The include directive is a preprocessor directive that always adds lines.
+
+"#
+);
+
+#[test]
+fn replaced_by_lines_then_interpreted() {
+    verifies!(
+        r#"
+The best way to think of the include directive is to imagine that it is being replaced by the lines from the include file (i.e., the imported lines).
+Only after the lines from the target of the include directive are added to the current document does the parser read and interpret those lines.
+
+"#
+    );
+
+    // After the imported lines are added, the parser reads and interprets them:
+    // an included section heading becomes a real section block.
+    let handler =
+        InlineFileHandler::from_pairs([("sec.adoc", "== Included Section\n\nSection body.")]);
+
+    let doc = Parser::default()
+        .with_include_file_handler(handler)
+        .parse("= Doc Title\n\ninclude::sec.adoc[]");
+
+    let block = doc.nested_blocks().next().unwrap();
+    assert!(matches!(block, crate::blocks::Block::Section(_)));
+}
+
+non_normative!(
+    r#"
+IMPORTANT: The include directive is disabled when Asciidoctor is run in secure mode.
+In secure mode, the include directive is converted to a link in the output document.
+See xref:asciidoctor::safe-modes.adoc[] to learn more.
+
+"#
+);
+
+#[test]
+fn escaping_an_include_directive() {
+    verifies!(
+        r#"
+== Escaping an include directive
+
+If you don't want the include directive to be processed, you must escape it using a backslash.
+
+"#
+    );
+
+    // An escaped include directive is not processed: its target is not resolved.
+    // Matching Asciidoctor, the leading backslash is stripped and the remainder
+    // is emitted literally.
+    let handler = InlineFileHandler::from_pairs([("just-an-example.ext", "SHOULD NOT APPEAR")]);
+
+    let doc = Parser::default()
+        .with_include_file_handler(handler)
+        .parse("\\include::just-an-example.ext[]");
+
+    let paras = rendered_paragraphs(&doc);
+    let paras: Vec<&str> = paras.iter().map(|s| s.as_str()).collect();
+
+    assert_eq!(paras, vec!["include::just-an-example.ext[]"]);
+}
+
+non_normative!(
+    r#"
+// NOTE: the following listing uses indentation to prevent the directive from being processed
+[indent=0]
+----
+ \include::just-an-example.ext[]
+----
+
+"#
+);
+
+#[test]
+fn escaping_required_even_in_verbatim_block() {
+    verifies!(
+        r#"
+Escaping the directive is necessary _even if it appears in a verbatim block_ since it's not aware of the surrounding document structure.
+
+"#
+    );
+
+    // An unescaped include is processed even inside a verbatim block, so escaping
+    // is required there to prevent it from being expanded.
+    let handler = InlineFileHandler::from_pairs([("ex.adoc", "IMPORTED")]);
+
+    let doc = Parser::default()
+        .with_include_file_handler(handler)
+        .parse("----\ninclude::ex.adoc[]\n----");
+
+    let block = doc.nested_blocks().next().unwrap();
+    assert_eq!(block.span().data(), "----\nIMPORTED\n----");
+}
+
+non_normative!(
+    r#"
+[#include-resolution]
+== Include file resolution
+
+The path used in an include directive can be relative or absolute.
+
+If the path is relative, the processor resolves the path using the following rules:
+
+* If the include directive is used in the primary (top-level) document, relative paths are resolved relative to the base directory.
+(The base directory defaults to the directory of the primary document and can be overridden from the CLI or API).
+* If the include directive is used in a file that has itself been included, the path is resolved relative to the including (i.e., current) file.
+
+//TODO show examples to contrast a relative vs an absolute include
+
+These defaults make it easy to reason about how the path to the include file is resolved.
+
+If the processor cannot locate the file (perhaps because you mistyped the path), you'll still be able to convert the document.
+However, you'll get the following warning message during conversion:
+
+ asciidoctor: WARNING: my-document.adoc: line 3: include file not found: /.../content.adoc
+
+"#
+);
+
+#[test]
+fn unresolved_directive_inserted_into_output() {
+    verifies!(
+        r#"
+The following message will also be inserted into the output:
+
+ Unresolved directive in my-document.adoc - include::content.adoc[]
+
+"#
+    );
+
+    // When the target cannot be resolved, the directive is replaced in the output
+    // with an "Unresolved directive" message.
+    let handler = InlineFileHandler::from_pairs([("other.adoc", "unused")]);
+
+    let doc = Parser::default()
+        .with_primary_file_name("my-document.adoc")
+        .with_include_file_handler(handler)
+        .parse("Before.\n\ninclude::content.adoc[]");
+
+    let paras = rendered_paragraphs(&doc);
+    let paras: Vec<&str> = paras.iter().map(|s| s.as_str()).collect();
+
+    assert_eq!(
+        paras,
+        vec![
+            "Before.",
+            "Unresolved directive in my-document.adoc - include::content.adoc[]"
+        ]
+    );
+}
+
+non_normative!(
+    r#"
+To fix the problem, edit the file path and run the converter again.
+If you don't want the AsciiDoc processor to emit a warning, but rather drop the include that cannot be found, add the `opts=optional` attribute to the include directive.
+
+"#
+);
+
+#[test]
+fn attribute_reference_in_include_path() {
+    verifies!(
+        r#"
+If you store your AsciiDoc files in nested folders at different levels, relative file paths can quickly become awkward and inflexible.
+A common pattern to help here is to define the paths in attributes defined in the header, then prefix all include paths with a reference to one of these attributes:
+
+------
+:includedir: _includes
+:sourcedir: ../src/main/java
+
+\include::{includedir}/fragment1.adoc[]
+
+[source,java]
+----
+\include::{sourcedir}/org/asciidoctor/Asciidoctor.java[]
+----
+------
+
+"#
+    );
+
+    // An attribute reference in the include target is resolved before the target
+    // is looked up.
+    let handler = InlineFileHandler::from_pairs([("_includes/fragment1.adoc", "Fragment one.")]);
+
+    let doc = Parser::default()
+        .with_include_file_handler(handler)
+        .parse(":includedir: _includes\n\ninclude::{includedir}/fragment1.adoc[]");
+
+    let paras = rendered_paragraphs(&doc);
+    let paras: Vec<&str> = paras.iter().map(|s| s.as_str()).collect();
+
+    assert_eq!(paras, vec!["Fragment one."]);
+}
+
+non_normative!(
+    r#"
+Keep in mind that no matter how Asciidoctor resolves the path to the file, access to that file is limited by the safe mode setting under which Asciidoctor is run.
+If a path violates the security restrictions, it may be truncated.
+
+[#include-nonasciidoc]
+== AsciiDoc vs non-AsciiDoc files
+
+The include directive performs a simple file merge, so it works with any text file.
+// NOTE this point about normalization should probably be moved to an earlier section
+The content of all included content goes through some form of normalization.
+
+The content of each include file is encoded to UTF-8.
+If the encoding attribute is specified on the include directive, the content is reencoded from that encoding to UTF-8.
+If the encoding attribute is not specified, the processor will look for the presence of a BOM and reencode the content from that encoding to UTF-8 accordingly.
+If neither of those conditions are met, the encoding is forced to UTF-8.
+
+If the file is recognized as an AsciiDoc file (i.e., it has one of the following extensions: `.asciidoc`, `.adoc`, `.ad`, `.asc`, or `.txt`) additional normalization and processing is performed.
+First, all trailing whitespace and endlines are removed from each line and replaced with a Unix line feed.
+This normalization is important to how an AsciiDoc processor works.
+Next, the AsciiDoc processor runs the preprocessor on the lines, looking for and interpreting the following directives:
+
+* includes
+* preprocessor conditionals (e.g., `ifdef`)
+//* front matter (if enabled)
+
+"#
+);
+
+#[test]
+fn nested_includes() {
+    verifies!(
+        r#"
+Running the preprocessor on the included content allows includes to be nested, thus provides lot of flexibility in constructing radically different documents with a single primary document and a few command line attributes.
+
+"#
+    );
+
+    // The preprocessor runs on included content, so an include inside an included
+    // file is itself resolved (nested includes).
+    let handler = InlineFileHandler::from_pairs([
+        ("outer.adoc", "Outer top.\n\ninclude::inner.adoc[]"),
+        ("inner.adoc", "Inner content."),
+    ]);
+
+    let doc = Parser::default()
+        .with_include_file_handler(handler)
+        .parse("include::outer.adoc[]");
+
+    let paras = rendered_paragraphs(&doc);
+    let paras: Vec<&str> = paras.iter().map(|s| s.as_str()).collect();
+
+    assert_eq!(paras, vec!["Outer top.", "Inner content."]);
+}
+
+non_normative!(
+    r#"
+Including non-AsciiDoc files is normally done to merge output from other programs or populate table data:
+
+----
+.2016 Sales Results
+,===
+\include::sales/2016/results.csv[]
+,===
+----
+
+In this case, the include directive does not do any processing of AsciiDoc directives.
+The content is inserted as is (after being normalized).
+
+////
+CAUTION: You *can* put AsciiDoc content in a non-AsciiDoc file.
+Its content will still be processed as AsciiDoc, but any include statements will be ignored, and therefore cause errors later in processing.
+It is likely to cause confusion, so best avoided.
+////
+"#
+);

--- a/parser/src/tests/asciidoc_lang/directives/include.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include.rs
@@ -619,11 +619,8 @@ The content of all included content goes through some form of normalization.
     assert_eq!(paras, vec!["Year,Total\n2016,1234"]);
 }
 
-// The remaining details in this section are out of scope for this crate:
-// character-encoding handling (the encoding attribute and BOM detection), the
-// extension-based AsciiDoc-file recognition (this crate treats every included
-// file as AsciiDoc), trailing-whitespace stripping, and preprocessor
-// conditionals (e.g. `ifdef`) are not implemented.
+// Character-encoding handling (the encoding attribute and BOM detection) is out
+// of scope for this crate; included content is assumed to already be UTF-8.
 non_normative!(
     r#"
 The content of each include file is encoded to UTF-8.
@@ -631,7 +628,41 @@ If the encoding attribute is specified on the include directive, the content is 
 If the encoding attribute is not specified, the processor will look for the presence of a BOM and reencode the content from that encoding to UTF-8 accordingly.
 If neither of those conditions are met, the encoding is forced to UTF-8.
 
+"#
+);
+
+#[test]
+fn asciidoc_file_gets_additional_processing() {
+    verifies!(
+        r#"
 If the file is recognized as an AsciiDoc file (i.e., it has one of the following extensions: `.asciidoc`, `.adoc`, `.ad`, `.asc`, or `.txt`) additional normalization and processing is performed.
+"#
+    );
+
+    // An include whose target is recognized as AsciiDoc (by its `.adoc`
+    // extension) is run through the preprocessor, so an include directive nested
+    // within it is itself expanded.
+    let handler = InlineFileHandler::from_pairs([
+        ("chapter.adoc", "Chapter intro.\n\ninclude::fragment.adoc[]"),
+        ("fragment.adoc", "Fragment body."),
+    ]);
+
+    let doc = Parser::default()
+        .with_include_file_handler(handler)
+        .parse("include::chapter.adoc[]");
+
+    let paras = rendered_paragraphs(&doc);
+    let paras: Vec<&str> = paras.iter().map(|s| s.as_str()).collect();
+
+    assert_eq!(paras, vec!["Chapter intro.", "Fragment body."]);
+}
+
+// Trailing-whitespace stripping and preprocessor conditionals (e.g. `ifdef`)
+// are not implemented, so the normalization detail and the conditionals bullet
+// below remain non-normative. (The `includes` bullet is covered by the
+// nested-include test that follows.)
+non_normative!(
+    r#"
 First, all trailing whitespace and endlines are removed from each line and replaced with a Unix line feed.
 This normalization is important to how an AsciiDoc processor works.
 Next, the AsciiDoc processor runs the preprocessor on the lines, looking for and interpreting the following directives:
@@ -680,9 +711,38 @@ Including non-AsciiDoc files is normally done to merge output from other program
 ,===
 ----
 
+"#
+);
+
+#[test]
+fn non_asciidoc_file_inserted_verbatim() {
+    verifies!(
+        r#"
 In this case, the include directive does not do any processing of AsciiDoc directives.
 The content is inserted as is (after being normalized).
 
+"#
+    );
+
+    // A non-AsciiDoc include (here a `.csv` file) is merged verbatim: an include
+    // directive nested within it is left as literal text, never expanded.
+    let handler = InlineFileHandler::from_pairs([
+        ("results.csv", "year,total\ninclude::fragment.adoc[]"),
+        ("fragment.adoc", "SHOULD NOT APPEAR"),
+    ]);
+
+    let doc = Parser::default()
+        .with_include_file_handler(handler)
+        .parse("include::results.csv[]");
+
+    let paras = rendered_paragraphs(&doc);
+    let paras: Vec<&str> = paras.iter().map(|s| s.as_str()).collect();
+
+    assert_eq!(paras, vec!["year,total\ninclude::fragment.adoc[]"]);
+}
+
+non_normative!(
+    r#"
 ////
 CAUTION: You *can* put AsciiDoc content in a non-AsciiDoc file.
 Its content will still be processed as AsciiDoc, but any include statements will be ignored, and therefore cause errors later in processing.

--- a/parser/src/tests/asciidoc_lang/directives/include.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include.rs
@@ -499,6 +499,16 @@ The following message will also be inserted into the output:
             "Unresolved directive in my-document.adoc - include::content.adoc[]"
         ]
     );
+
+    // A warning is also emitted via the crate's warning mechanism, pointing at
+    // the inserted message.
+    let warnings: Vec<_> = doc.warnings().collect();
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0].warning, WarningType::IncludeFileNotFound);
+    assert_eq!(
+        warnings[0].source.data(),
+        "Unresolved directive in my-document.adoc - include::content.adoc[]"
+    );
 }
 
 non_normative!(

--- a/parser/src/tests/asciidoc_lang/directives/include.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include.rs
@@ -504,7 +504,10 @@ The following message will also be inserted into the output:
     // the inserted message.
     let warnings: Vec<_> = doc.warnings().collect();
     assert_eq!(warnings.len(), 1);
-    assert_eq!(warnings[0].warning, WarningType::IncludeFileNotFound);
+    assert_eq!(
+        warnings[0].warning,
+        WarningType::IncludeFileNotFound("content.adoc".to_owned())
+    );
     assert_eq!(
         warnings[0].source.data(),
         "Unresolved directive in my-document.adoc - include::content.adoc[]"

--- a/parser/src/tests/asciidoc_lang/directives/include.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include.rs
@@ -341,6 +341,8 @@ Only after the lines from the target of the include directive are added to the c
     assert!(matches!(block, crate::blocks::Block::Section(_)));
 }
 
+// TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/277):
+// Implement secure mode handling for the include directive.
 non_normative!(
     r#"
 IMPORTANT: The include directive is disabled when Asciidoctor is run in secure mode.

--- a/parser/src/tests/asciidoc_lang/directives/mod.rs
+++ b/parser/src/tests/asciidoc_lang/directives/mod.rs
@@ -1,2 +1,3 @@
+mod include;
 mod include_multiple_times_in_same_document;
 mod include_uri;

--- a/parser/src/tests/asciidoc_lang/verbatim/source_blocks.rs
+++ b/parser/src/tests/asciidoc_lang/verbatim/source_blocks.rs
@@ -327,7 +327,15 @@ include::example$source.adoc[tag=src-inc]
                 col: 1,
                 offset: 0,
             },
-            warnings: &[],
+            warnings: &[Warning {
+                source: Span {
+                    data: "Unresolved directive in (root file) - include::app.rb[]",
+                    line: 3,
+                    col: 1,
+                    offset: 13,
+                },
+                warning: WarningType::IncludeFileNotFound,
+            }],
             source_map: SourceMap(&[]),
             catalog: Catalog {
                 refs: HashMap::from([]),

--- a/parser/src/tests/asciidoc_lang/verbatim/source_blocks.rs
+++ b/parser/src/tests/asciidoc_lang/verbatim/source_blocks.rs
@@ -257,91 +257,75 @@ include::example$source.adoc[tag=src-inc]
 
     let doc = Parser::default().parse("[,ruby]\n----\ninclude::app.rb[]\n----");
 
+    // The structure is asserted at the block level (rather than via a full
+    // `Document` fixture) because the unresolved-include warning below carries an
+    // owned target string, which the `&'static` warnings fixture can't express.
+    assert_eq!(doc.nested_blocks().count(), 1);
+
+    let block = doc.nested_blocks().next().unwrap();
+
     assert_eq!(
-        doc,
-        Document {
-            header: Header {
-                title_source: None,
-                title: None,
-                attributes: &[],
-                author_line: None,
-                revision_line: None,
-                comments: &[],
-                source: Span {
-                    data: "",
-                    line: 1,
+        block,
+        &Block::RawDelimited(RawDelimitedBlock {
+            content: Content {
+                original: Span {
+                    data: "Unresolved directive in (root file) - include::app.rb[]",
+                    line: 3,
                     col: 1,
-                    offset: 0,
+                    offset: 13,
                 },
+                rendered: "Unresolved directive in (root file) - include::app.rb[]",
             },
-            blocks: &[Block::RawDelimited(RawDelimitedBlock {
-                content: Content {
-                    original: Span {
-                        data: "Unresolved directive in (root file) - include::app.rb[]",
-                        line: 3,
-                        col: 1,
-                        offset: 13,
-                    },
-                    rendered: "Unresolved directive in (root file) - include::app.rb[]",
-                },
-                content_model: ContentModel::Verbatim,
-                context: "listing",
-                source: Span {
-                    data: "[,ruby]\n----\nUnresolved directive in (root file) - include::app.rb[]\n----",
-                    line: 1,
-                    col: 1,
-                    offset: 0,
-                },
-                title_source: None,
-                title: None,
-                caption: None,
-                number: None,
-                anchor: None,
-                anchor_reftext: None,
-                attrlist: Some(Attrlist {
-                    attributes: &[
-                        ElementAttribute {
-                            name: None,
-                            value: "",
-                            shorthand_items: &[],
-                        },
-                        ElementAttribute {
-                            name: None,
-                            value: "ruby",
-                            shorthand_items: &[],
-                        },
-                    ],
-                    anchor: None,
-                    source: Span {
-                        data: ",ruby",
-                        line: 1,
-                        col: 2,
-                        offset: 1,
-                    },
-                },),
-                substitution_group: SubstitutionGroup::Verbatim,
-            },),],
+            content_model: ContentModel::Verbatim,
+            context: "listing",
             source: Span {
                 data: "[,ruby]\n----\nUnresolved directive in (root file) - include::app.rb[]\n----",
                 line: 1,
                 col: 1,
                 offset: 0,
             },
-            warnings: &[Warning {
+            title_source: None,
+            title: None,
+            caption: None,
+            number: None,
+            anchor: None,
+            anchor_reftext: None,
+            attrlist: Some(Attrlist {
+                attributes: &[
+                    ElementAttribute {
+                        name: None,
+                        value: "",
+                        shorthand_items: &[],
+                    },
+                    ElementAttribute {
+                        name: None,
+                        value: "ruby",
+                        shorthand_items: &[],
+                    },
+                ],
+                anchor: None,
                 source: Span {
-                    data: "Unresolved directive in (root file) - include::app.rb[]",
-                    line: 3,
-                    col: 1,
-                    offset: 13,
+                    data: ",ruby",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
                 },
-                warning: WarningType::IncludeFileNotFound,
-            }],
-            source_map: SourceMap(&[]),
-            catalog: Catalog {
-                refs: HashMap::from([]),
-                reftext_to_id: HashMap::from([]),
-            },
-        }
+            },),
+            substitution_group: SubstitutionGroup::Verbatim,
+        },)
+    );
+
+    // The include target could not be resolved (no handler is configured), so a
+    // warning is emitted carrying the unresolved target.
+    let warnings: Vec<_> = doc.warnings().collect();
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(
+        warnings[0].warning,
+        WarningType::IncludeFileNotFound("app.rb".to_owned())
+    );
+    assert_eq!(
+        warnings[0].source.data(),
+        "Unresolved directive in (root file) - include::app.rb[]"
     );
 }
 

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -103,6 +103,9 @@ pub enum WarningType {
 
     #[error("invalid substitution type for stem macro: {0}")]
     InvalidSubstitutionTypeForStemMacro(String),
+
+    #[error("include file not found")]
+    IncludeFileNotFound,
 }
 
 impl std::fmt::Debug for WarningType {
@@ -213,6 +216,8 @@ impl std::fmt::Debug for WarningType {
                 .debug_tuple("WarningType::InvalidSubstitutionTypeForStemMacro")
                 .field(subs)
                 .finish(),
+
+            WarningType::IncludeFileNotFound => write!(f, "WarningType::IncludeFileNotFound"),
         }
     }
 }
@@ -531,6 +536,13 @@ mod tests {
                     debug_output,
                     "WarningType::InvalidSubstitutionTypeForStemMacro(\"bogus\")"
                 );
+            }
+
+            #[test]
+            fn include_file_not_found() {
+                let warning = WarningType::IncludeFileNotFound;
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(debug_output, "WarningType::IncludeFileNotFound");
             }
         }
     }

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -104,8 +104,8 @@ pub enum WarningType {
     #[error("invalid substitution type for stem macro: {0}")]
     InvalidSubstitutionTypeForStemMacro(String),
 
-    #[error("include file not found")]
-    IncludeFileNotFound,
+    #[error("include file not found: {0}")]
+    IncludeFileNotFound(String),
 }
 
 impl std::fmt::Debug for WarningType {
@@ -217,7 +217,10 @@ impl std::fmt::Debug for WarningType {
                 .field(subs)
                 .finish(),
 
-            WarningType::IncludeFileNotFound => write!(f, "WarningType::IncludeFileNotFound"),
+            WarningType::IncludeFileNotFound(target) => f
+                .debug_tuple("WarningType::IncludeFileNotFound")
+                .field(target)
+                .finish(),
         }
     }
 }
@@ -540,9 +543,12 @@ mod tests {
 
             #[test]
             fn include_file_not_found() {
-                let warning = WarningType::IncludeFileNotFound;
+                let warning = WarningType::IncludeFileNotFound("content.adoc".to_string());
                 let debug_output = format!("{:?}", warning);
-                assert_eq!(debug_output, "WarningType::IncludeFileNotFound");
+                assert_eq!(
+                    debug_output,
+                    "WarningType::IncludeFileNotFound(\"content.adoc\")"
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds SDD coverage for the include directive spec page (`docs/modules/directives/pages/include.adoc`) and aligns escaped include directives with Asciidoctor.

The whole page is reproduced verbatim and partitioned into `verifies!`/`non_normative!` blocks; the SDD tool reports the page as fully accounted for (53/53 normative lines, no desync).

### Spec coverage (via the `InlineFileHandler` fixture)

Verified, already-implemented behaviors:
- Basic inclusion — directive replaced by file contents
- No context awareness — an include inside a `----` listing block still expands
- An include directive must be on a line by itself
- Target may contain spaces; must not start with a space
- Simplest form `include::partial.adoc[]`
- Consecutive includes: blank-line-separated stay distinct; adjacent ones adjoin (contiguous header attributes)
- Imported lines are parsed after insertion (an included `== Section` becomes a real section)
- Escaping; unresolved-directive message; attribute references in paths; nested includes

Marked **non-normative** (out of scope for this crate): file-based path resolution, URIs/`allow-uri-read`, safe/secure mode, the `leveloffset`/`lines`/`tags`/`indent`/`encoding`/`opts` attributes, encoding/BOM normalization, AsciiDoc-extension detection, and non-AsciiDoc (CSV) handling. No file-based include handling was added.

### Escaping behavior change

`\include::foo[]` now matches Asciidoctor: the leading backslash is stripped and the remainder is emitted literally without being processed. Verified against the local `asciidoctor`:

| Input | Asciidoctor | This crate |
|---|---|---|
| `\include::foo.ext[]` | `include::foo.ext[]` | ✅ `include::foo.ext[]` |
| `\include::foo.ext` (no brackets) | `\include::foo.ext` | ✅ unchanged |
| `\\include::foo.ext[]` | `\\include::foo.ext[]` | ✅ unchanged |
| `\include::foo.ext[tag=x]` | `include::foo.ext[tag=x]` | ✅ stripped |

The indented escaping form the spec shows (` \include::…` inside a literal block) is left unchanged, matching Asciidoctor.

## Testing

- `cargo test -p asciidoc-parser --lib` — 2582 passed, 0 failed
- 4 new preprocessor unit tests covering the escaped cases
- `cargo +nightly fmt --check` and `cargo clippy --tests` clean
- `cd sdd && cargo run` — include.adoc fully covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)