### PR TITLE
feat: Implement footnote inline macro

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1744,6 +1744,15 @@ fn parse_asciidoc_cell_body<'src>(
         (None, content)
     };
 
+    // A nested document keeps its own footnote registry: footnotes defined
+    // inside this cell must not be shared with (or numbered into the list of)
+    // the enclosing document. We swap in a fresh, empty footnote list for the
+    // duration of the cell parse and restore the parent's afterward, discarding
+    // the cell's footnotes (see issue #544). The `footnote-number` counter is a
+    // document-wide attribute and is deliberately *not* reset, so footnote
+    // numbering continues across the cell as Asciidoctor does.
+    let saved_footnotes = parser.take_footnotes();
+
     // Mark that we are inside an AsciiDoc cell (a nested document) for the
     // duration of the parse, so a table found within defaults its cell separator
     // to `!` rather than `|` (matching Asciidoctor's `Document#nested?`).
@@ -1751,6 +1760,8 @@ fn parse_asciidoc_cell_body<'src>(
     let mut maw = parse_blocks_until(body, |_| false, parser);
     parser.nested_document_depth -= 1;
     warnings.append(&mut maw.warnings);
+
+    parser.restore_footnotes(saved_footnotes);
 
     let inline = matches!(
         parser.attribute_value("doctype"),

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -1286,7 +1286,7 @@ impl LookaheadReplacer for InlineFootnoteMacroReplacer<'_, '_> {
                 // A reference to an already-defined footnote: reuse its number.
                 parser.renderer.render_footnote(
                     &FootnoteRenderParams {
-                        index: Some(index),
+                        index: Some(index.as_str()),
                         id: None,
                         is_reference: true,
                         text: "",
@@ -1298,7 +1298,7 @@ impl LookaheadReplacer for InlineFootnoteMacroReplacer<'_, '_> {
                 let index = parser.define_footnote(Some(&id), normalize_footnote_text(&content));
                 parser.renderer.render_footnote(
                     &FootnoteRenderParams {
-                        index: Some(index),
+                        index: Some(index.as_str()),
                         id: Some(&id),
                         is_reference: false,
                         text: "",
@@ -1326,7 +1326,7 @@ impl LookaheadReplacer for InlineFootnoteMacroReplacer<'_, '_> {
             let index = parser.define_footnote(None, normalize_footnote_text(&content));
             parser.renderer.render_footnote(
                 &FootnoteRenderParams {
-                    index: Some(index),
+                    index: Some(index.as_str()),
                     id: None,
                     is_reference: false,
                     text: "",

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -9,9 +9,10 @@ use crate::{
     content::{Content, content::XrefSegment},
     internal::{LookaheadReplacer, LookaheadResult, replace_with_lookahead},
     parser::{
-        IconRenderParams, ImageRenderParams, IndexTermRenderParams, LinkRenderParams,
-        LinkRenderType,
+        FootnoteRenderParams, IconRenderParams, ImageRenderParams, IndexTermRenderParams,
+        LinkRenderParams, LinkRenderType,
     },
+    warnings::WarningType,
 };
 
 pub(super) fn apply_macros(content: &mut Content<'_>, parser: &Parser) {
@@ -105,6 +106,28 @@ pub(super) fn apply_macros(content: &mut Content<'_>, parser: &Parser) {
         }
     }
 
+    // Footnotes (`footnote:[text]`, `footnote:id[text]`, `footnote:id[]`, and
+    // the deprecated `footnoteref:[id,text]` / `footnoteref:[id]`).
+    //
+    // This runs before cross-references are processed because the footnote
+    // *text* is extracted out of the flow of text (only a superscript marker is
+    // left behind), so any macro inside the footnote that has already been
+    // substituted at this point (images, links, anchors, index terms) is
+    // captured as part of the footnote text. Cross-references are deferred and
+    // therefore not yet resolved inside footnote text (see issue #545).
+    if found_macroish && text.contains("tnote") {
+        let replacer = InlineFootnoteMacroReplacer {
+            parser,
+            source: content.original(),
+        };
+
+        if let Cow::Owned(new_result) =
+            replace_with_lookahead(&INLINE_FOOTNOTE_MACRO, content.rendered(), replacer)
+        {
+            content.rendered = new_result.into();
+        }
+    }
+
     // Cross-references (`<<id>>`, `<<id,text>>`, `xref:id[]`, `xref:id[text]`).
     //
     // By the time the macros step runs, the special-characters step has already
@@ -130,13 +153,6 @@ pub(super) fn apply_macros(content: &mut Content<'_>, parser: &Parser) {
 
         content.set_deferred_xrefs(xrefs);
     }
-
-    /*
-    if found_macroish && text.contains("tnote") {
-        todo!("Port footnote macro");
-        // Port Ruby Asciidoctor's implementation from lines 842..884.
-    }
-    */
 }
 
 static INLINE_IMAGE_MACRO: LazyLock<Regex> = LazyLock::new(|| {
@@ -1157,6 +1173,180 @@ impl Replacer for InlineXrefReplacer<'_> {
 
         dest.push_str(&Content::xref_placeholder(index));
     }
+}
+
+/// Matches a [footnote] inline macro, in either the `footnote:` form or the
+/// deprecated `footnoteref:` form.
+///
+/// ## Examples
+///
+/// * `footnote:[text]` — an anonymous footnote
+/// * `footnote:id[text]` — a footnote with an ID, so it can be referenced again
+/// * `footnote:id[]` — a reference to a previously-defined footnote
+/// * `footnoteref:[id,text]` / `footnoteref:[id]` — the deprecated equivalents
+///
+/// Asciidoctor anchors the match with a `(?!</a>)` look-ahead after the closing
+/// bracket so a `footnote:[…]` that forms the text of an already-rendered link
+/// is not matched again; the `regex` crate has no look-ahead, so
+/// [`InlineFootnoteMacroReplacer`] re-creates that guard by inspecting the text
+/// that follows the match.
+///
+/// [footnote]: https://docs.asciidoctor.org/asciidoc/latest/macros/footnote/
+static INLINE_FOOTNOTE_MACRO: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(
+        r#"(?xs)                     # extended mode; dot matches newline
+        \\?                          # optional escaping backslash
+        footnote
+        (?:
+            (ref):                   # (1) the deprecated 'footnoteref:' form
+          |
+            : ([\w-]+)?              # (2) optional id for the 'footnote:id' form
+        )
+        \[
+            (?: | (.*?[^\\]) )       # (3) text: empty, or ends in a non-backslash
+        \]
+        "#,
+    )
+    .unwrap()
+});
+
+#[derive(Debug)]
+struct InlineFootnoteMacroReplacer<'p, 's> {
+    parser: &'p Parser,
+
+    /// The original (pre-substitution) span of the content being rendered, used
+    /// to locate any warning recorded while resolving a footnote.
+    source: Span<'s>,
+}
+
+impl LookaheadReplacer for InlineFootnoteMacroReplacer<'_, '_> {
+    fn replace_append(
+        &mut self,
+        caps: &Captures<'_>,
+        dest: &mut String,
+        after: &str,
+    ) -> LookaheadResult {
+        // Adapted from Asciidoctor#sub_macros (the `InlineFootnoteMacroRx`
+        // branch), found in
+        // https://github.com/asciidoctor/asciidoctor/blob/main/lib/asciidoctor/substitutors.rb.
+
+        // Honor the escape: emit the macro text without the leading backslash.
+        if caps[0].starts_with('\\') {
+            dest.push_str(&caps[0][1..]);
+            return LookaheadResult::Continue;
+        }
+
+        // Re-create Asciidoctor's `(?!</a>)` look-ahead: a closing bracket
+        // immediately followed by `</a>` is not a footnote (it closes an
+        // already-rendered link), so the macro is left untouched.
+        if after.starts_with("</a>") {
+            dest.push_str(&caps[0]);
+            return LookaheadResult::Continue;
+        }
+
+        let parser = self.parser;
+
+        // Resolve the macro into an (id, text) pair. The deprecated
+        // `footnoteref:` form packs both into the bracketed text (`id,text`),
+        // whereas the `footnote:` form takes the id from the macro target.
+        let (id, content): (Option<String>, Option<String>) = if caps.get(1).is_some() {
+            // `footnoteref:` form. With no bracketed text at all it is left
+            // untouched (matching Asciidoctor's `next $&`).
+            let Some(raw) = caps.get(3).map(|m| m.as_str()) else {
+                dest.push_str(&caps[0]);
+                return LookaheadResult::Continue;
+            };
+
+            // The `footnoteref:` macro is deprecated outside compatibility mode.
+            if !parser.is_attribute_set("compat-mode") {
+                parser.record_substitution_warning(
+                    self.source,
+                    WarningType::DeprecatedFootnorefMacro(caps[0].to_string()),
+                );
+            }
+
+            match raw.split_once(',') {
+                Some((id, content)) => (Some(id.to_string()), Some(content.to_string())),
+                None => (Some(raw.to_string()), None),
+            }
+        } else {
+            // `footnote:` form.
+            (
+                caps.get(2).map(|m| m.as_str().to_string()),
+                caps.get(3).map(|m| m.as_str().to_string()),
+            )
+        };
+
+        // `id` and `content` own their data, so each branch renders its marker
+        // before they are dropped (the params borrow them).
+        if let Some(id) = id {
+            if let Some(index) = parser.footnote_index_for_id(&id) {
+                // A reference to an already-defined footnote: reuse its number.
+                parser.renderer.render_footnote(
+                    &FootnoteRenderParams {
+                        index: Some(index),
+                        id: None,
+                        is_reference: true,
+                        text: "",
+                    },
+                    dest,
+                );
+            } else if let Some(content) = content {
+                // A defining occurrence that also carries an ID.
+                let index = parser.define_footnote(Some(&id), normalize_footnote_text(&content));
+                parser.renderer.render_footnote(
+                    &FootnoteRenderParams {
+                        index: Some(index),
+                        id: Some(&id),
+                        is_reference: false,
+                        text: "",
+                    },
+                    dest,
+                );
+            } else {
+                // A reference to an ID that was never defined.
+                parser.record_substitution_warning(
+                    self.source,
+                    WarningType::InvalidFootnoteReference(id.clone()),
+                );
+                parser.renderer.render_footnote(
+                    &FootnoteRenderParams {
+                        index: None,
+                        id: None,
+                        is_reference: true,
+                        text: &id,
+                    },
+                    dest,
+                );
+            }
+        } else if let Some(content) = content {
+            // An anonymous defining occurrence.
+            let index = parser.define_footnote(None, normalize_footnote_text(&content));
+            parser.renderer.render_footnote(
+                &FootnoteRenderParams {
+                    index: Some(index),
+                    id: None,
+                    is_reference: false,
+                    text: "",
+                },
+                dest,
+            );
+        } else {
+            // `footnote:[]` with neither an ID nor text is not a footnote.
+            dest.push_str(&caps[0]);
+        }
+
+        LookaheadResult::Continue
+    }
+}
+
+/// Normalizes the text of a footnote: trims surrounding whitespace, collapses
+/// each embedded newline to a space (Asciidoctor compacts a multi-line footnote
+/// onto a single line), and unescapes an escaped closing square bracket
+/// (`\]` -> `]`). Mirrors Asciidoctor's `normalize_text text, true, true`.
+fn normalize_footnote_text(content: &str) -> String {
+    content.trim().replace('\n', " ").replace("\\]", "]")
 }
 
 static URI_SNIFF: LazyLock<Regex> = LazyLock::new(|| {

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -115,7 +115,7 @@ pub(super) fn apply_macros(content: &mut Content<'_>, parser: &Parser) {
     // substituted at this point (images, links, anchors, index terms) is
     // captured as part of the footnote text. Cross-references, by contrast, are
     // resolved in a later document-level pass, so an `<<id>>` inside a footnote
-    // is not yet resolved in the extracted footnote text.
+    // is not yet resolved in the extracted footnote text (see issue #592).
     if found_macroish && text.contains("tnote") {
         let replacer = InlineFootnoteMacroReplacer {
             parser,

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -113,8 +113,9 @@ pub(super) fn apply_macros(content: &mut Content<'_>, parser: &Parser) {
     // *text* is extracted out of the flow of text (only a superscript marker is
     // left behind), so any macro inside the footnote that has already been
     // substituted at this point (images, links, anchors, index terms) is
-    // captured as part of the footnote text. Cross-references are deferred and
-    // therefore not yet resolved inside footnote text (see issue #545).
+    // captured as part of the footnote text. Cross-references, by contrast, are
+    // resolved in a later document-level pass, so an `<<id>>` inside a footnote
+    // is not yet resolved in the extracted footnote text.
     if found_macroish && text.contains("tnote") {
         let replacer = InlineFootnoteMacroReplacer {
             parser,

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -15,6 +15,15 @@ pub struct Catalog {
 
     /// Reverse lookup cache: reftext -> ID.
     pub(crate) reftext_to_id: HashMap<String, String>,
+
+    /// Footnotes registered (in document order) while substituting inline
+    /// macros. Each entry corresponds to a `footnote:[…]` macro that *defined*
+    /// a footnote; subsequent references to an existing footnote (via a repeated
+    /// ID) reuse an entry rather than adding a new one.
+    ///
+    /// A nested document (an AsciiDoc table cell) keeps its own footnote list:
+    /// footnotes defined inside a cell are *not* shared with the main document.
+    pub(crate) footnotes: Vec<Footnote>,
 }
 
 impl Default for Catalog {
@@ -28,6 +37,7 @@ impl Catalog {
         Self {
             refs: HashMap::new(),
             reftext_to_id: HashMap::new(),
+            footnotes: Vec::new(),
         }
     }
 
@@ -155,6 +165,60 @@ impl Catalog {
     pub fn is_empty(&self) -> bool {
         self.refs.is_empty()
     }
+
+    /// Returns the footnotes registered in this document, in document order.
+    pub fn footnotes(&self) -> &[Footnote] {
+        &self.footnotes
+    }
+
+    /// Registers a newly-defined [`Footnote`].
+    pub(crate) fn register_footnote(&mut self, footnote: Footnote) {
+        self.footnotes.push(footnote);
+    }
+
+    /// Returns the registered footnote with the given ID, if one exists.
+    pub(crate) fn footnote_with_id(&self, id: &str) -> Option<&Footnote> {
+        self.footnotes
+            .iter()
+            .find(|f| f.id.as_deref() == Some(id))
+    }
+
+    /// Removes and returns the current footnote list, leaving an empty list
+    /// behind. Used to give a nested document (an AsciiDoc table cell) its own
+    /// footnote registry so its footnotes are not shared with the enclosing
+    /// document.
+    pub(crate) fn take_footnotes(&mut self) -> Vec<Footnote> {
+        std::mem::take(&mut self.footnotes)
+    }
+
+    /// Restores a previously-[taken](Self::take_footnotes) footnote list,
+    /// discarding any footnotes registered in the meantime.
+    pub(crate) fn restore_footnotes(&mut self, footnotes: Vec<Footnote>) {
+        self.footnotes = footnotes;
+    }
+}
+
+/// A footnote registered while substituting the inline `footnote:[…]` macro.
+///
+/// A footnote is defined at the location of its reference, but its text is
+/// extracted to an item in the document's footnote list. The same footnote can
+/// be referenced from multiple locations by assigning it an ID at the first
+/// occurrence and repeating that ID (with empty text) afterward; only the
+/// defining occurrence produces a `Footnote` entry.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Footnote {
+    /// The footnote's sequential number, assigned in document order. Footnotes
+    /// are numbered consecutively throughout the document via the
+    /// `footnote-number` counter.
+    pub index: i64,
+
+    /// The optional ID assigned to this footnote (the target of the macro, e.g.
+    /// `disclaimer` in `footnote:disclaimer[…]`). `None` for an anonymous
+    /// footnote.
+    pub id: Option<String>,
+
+    /// The already-substituted text of the footnote.
+    pub text: String,
 }
 
 impl std::fmt::Debug for Catalog {
@@ -162,6 +226,7 @@ impl std::fmt::Debug for Catalog {
         f.debug_struct("Catalog")
             .field("refs", &DebugHashMapFrom(&self.refs))
             .field("reftext_to_id", &DebugHashMapFrom(&self.reftext_to_id))
+            .field("footnotes", &self.footnotes)
             .finish()
     }
 }

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -205,10 +205,12 @@ impl Catalog {
 /// defining occurrence produces a `Footnote` entry.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Footnote {
-    /// The footnote's sequential number, assigned in document order. Footnotes
-    /// are numbered consecutively throughout the document via the
-    /// `footnote-number` counter.
-    pub index: i64,
+    /// The footnote's number, assigned in document order via the
+    /// `footnote-number` counter. Normally a consecutive integer (`1`, `2`, …),
+    /// but stored as a string because the counter honors any seed the document
+    /// sets (e.g. `:footnote-number: z` yields `aa`, `ab`, … as Asciidoctor
+    /// does).
+    pub index: String,
 
     /// The optional ID assigned to this footnote (the target of the macro, e.g.
     /// `disclaimer` in `footnote:disclaimer[…]`). `None` for an anonymous

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -18,8 +18,8 @@ pub struct Catalog {
 
     /// Footnotes registered (in document order) while substituting inline
     /// macros. Each entry corresponds to a `footnote:[…]` macro that *defined*
-    /// a footnote; subsequent references to an existing footnote (via a repeated
-    /// ID) reuse an entry rather than adding a new one.
+    /// a footnote; subsequent references to an existing footnote (via a
+    /// repeated ID) reuse an entry rather than adding a new one.
     ///
     /// A nested document (an AsciiDoc table cell) keeps its own footnote list:
     /// footnotes defined inside a cell are *not* shared with the main document.
@@ -178,9 +178,7 @@ impl Catalog {
 
     /// Returns the registered footnote with the given ID, if one exists.
     pub(crate) fn footnote_with_id(&self, id: &str) -> Option<&Footnote> {
-        self.footnotes
-            .iter()
-            .find(|f| f.id.as_deref() == Some(id))
+        self.footnotes.iter().find(|f| f.id.as_deref() == Some(id))
     }
 
     /// Removes and returns the current footnote list, leaving an empty list

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -1341,6 +1341,7 @@ mod tests {
     catalog: Catalog {
         refs: HashMap::from([]),
         reftext_to_id: HashMap::from([]),
+        footnotes: [],
     },
 }"#
         );

--- a/parser/src/document/mod.rs
+++ b/parser/src/document/mod.rs
@@ -12,7 +12,7 @@ pub use author_line::AuthorLine;
 mod catalog;
 #[allow(unused)] // TEMPORARY while building
 pub(crate) use catalog::DuplicateIdError;
-pub use catalog::{Catalog, RefEntry, RefType};
+pub use catalog::{Catalog, Footnote, RefEntry, RefType};
 
 mod docinfo;
 pub(crate) use docinfo::Docinfo;

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -182,6 +182,19 @@ pub trait InlineSubstitutionRenderer: Debug {
     /// [index term]: https://docs.asciidoctor.org/asciidoc/latest/sections/user-index/
     /// [`visible_term`]: IndexTermRenderParams::visible_term
     fn render_index_term(&self, params: &IndexTermRenderParams, dest: &mut String);
+
+    /// Renders the inline reference produced by a [`footnote`] macro.
+    ///
+    /// The footnote's *text* is not rendered here (it is extracted to the
+    /// document's footnote list); this method renders only the superscript
+    /// marker that appears in the flow of text and links to the footnote.
+    ///
+    /// See [`FootnoteRenderParams`] for the three cases the renderer must
+    /// handle (a defining occurrence, a reference to an earlier footnote, and
+    /// an unresolved reference).
+    ///
+    /// [`footnote`]: https://docs.asciidoctor.org/asciidoc/latest/macros/footnote/
+    fn render_footnote(&self, params: &FootnoteRenderParams, dest: &mut String);
 }
 
 /// Specifies which special character is being replaced in a call to
@@ -424,6 +437,39 @@ pub struct IndexTermRenderParams<'a> {
     /// text. `None` for a *concealed* index term (`(((p, s, t)))` or
     /// `indexterm:[p, s, t]`), which produces no visible output.
     pub visible_term: Option<&'a str>,
+}
+
+/// Provides parameters for rendering the inline marker of a [`footnote`] macro.
+///
+/// There are three cases the renderer must distinguish:
+///
+/// * A *defining* occurrence (`index` is `Some`, `is_reference` is `false`):
+///   the footnote introduces new text. The marker carries the footnote number
+///   and, when the footnote was given an ID, an `id` of its own.
+/// * A *reference* to an earlier footnote (`index` is `Some`, `is_reference` is
+///   `true`): a later occurrence (`footnote:id[]`) that reuses an existing
+///   footnote's number.
+/// * An *unresolved* reference (`index` is `None`, `is_reference` is `true`): a
+///   reference whose ID was never defined; the renderer emits a visible
+///   error marker built from [`text`](Self::text).
+///
+/// [`footnote`]: https://docs.asciidoctor.org/asciidoc/latest/macros/footnote/
+#[derive(Clone, Debug)]
+pub struct FootnoteRenderParams<'a> {
+    /// The footnote's sequential number, or `None` for an unresolved reference.
+    pub index: Option<i64>,
+
+    /// The footnote's own ID, used only on a defining occurrence to produce the
+    /// `id="_footnote_<id>"` attribute on the marker.
+    pub id: Option<&'a str>,
+
+    /// `true` when this occurrence references an existing footnote (or fails to
+    /// resolve one); `false` for the defining occurrence.
+    pub is_reference: bool,
+
+    /// For an unresolved reference, the text to show inside the error marker
+    /// (the unresolved ID). Ignored in the other cases.
+    pub text: &'a str,
 }
 
 /// Implementation of [`InlineSubstitutionRenderer`] that renders substitutions
@@ -873,6 +919,39 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
         // (already-substituted) visible term text.
         if let Some(term) = params.visible_term {
             dest.push_str(term);
+        }
+    }
+
+    fn render_footnote(&self, params: &FootnoteRenderParams, dest: &mut String) {
+        match params.index {
+            Some(index) if params.is_reference => {
+                // A reference to an already-defined footnote reuses its number
+                // but gets no anchor of its own.
+                dest.push_str(&format!(
+                    r##"<sup class="footnoteref">[<a class="footnote" href="#_footnotedef_{index}" title="View footnote.">{index}</a>]</sup>"##
+                ));
+            }
+
+            Some(index) => {
+                // A defining occurrence. When the footnote carries an ID, the
+                // marker is given a matching anchor so it can be linked to.
+                let id_attr = params
+                    .id
+                    .map(|id| format!(r#" id="_footnote_{id}""#))
+                    .unwrap_or_default();
+
+                dest.push_str(&format!(
+                    r##"<sup class="footnote"{id_attr}>[<a id="_footnoteref_{index}" class="footnote" href="#_footnotedef_{index}" title="View footnote.">{index}</a>]</sup>"##
+                ));
+            }
+
+            None => {
+                // An unresolved reference: the ID was never defined.
+                dest.push_str(&format!(
+                    r#"<sup class="footnoteref red" title="Unresolved footnote reference.">[{text}]</sup>"#,
+                    text = params.text
+                ));
+            }
         }
     }
 }

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -450,8 +450,8 @@ pub struct IndexTermRenderParams<'a> {
 ///   `true`): a later occurrence (`footnote:id[]`) that reuses an existing
 ///   footnote's number.
 /// * An *unresolved* reference (`index` is `None`, `is_reference` is `true`): a
-///   reference whose ID was never defined; the renderer emits a visible
-///   error marker built from [`text`](Self::text).
+///   reference whose ID was never defined; the renderer emits a visible error
+///   marker built from [`text`](Self::text).
 ///
 /// [`footnote`]: https://docs.asciidoctor.org/asciidoc/latest/macros/footnote/
 #[derive(Clone, Debug)]

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -456,8 +456,10 @@ pub struct IndexTermRenderParams<'a> {
 /// [`footnote`]: https://docs.asciidoctor.org/asciidoc/latest/macros/footnote/
 #[derive(Clone, Debug)]
 pub struct FootnoteRenderParams<'a> {
-    /// The footnote's sequential number, or `None` for an unresolved reference.
-    pub index: Option<i64>,
+    /// The footnote's number, or `None` for an unresolved reference. Normally a
+    /// consecutive integer, but the `footnote-number` counter honors any seed
+    /// the document sets, so it is passed through as text.
+    pub index: Option<&'a str>,
 
     /// The footnote's own ID, used only on a defining occurrence to produce the
     /// `id="_footnote_<id>"` attribute on the marker.

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -15,9 +15,10 @@ pub use include_file_handler::IncludeFileHandler;
 
 mod inline_substitution_renderer;
 pub use inline_substitution_renderer::{
-    CalloutGuard, CalloutRenderParams, CharacterReplacementType, HtmlSubstitutionRenderer,
-    IconRenderParams, ImageRenderParams, IndexTermRenderParams, InlineSubstitutionRenderer,
-    LinkRenderParams, LinkRenderType, QuoteScope, QuoteType, SpecialCharacter, XrefRenderParams,
+    CalloutGuard, CalloutRenderParams, CharacterReplacementType, FootnoteRenderParams,
+    HtmlSubstitutionRenderer, IconRenderParams, ImageRenderParams, IndexTermRenderParams,
+    InlineSubstitutionRenderer, LinkRenderParams, LinkRenderType, QuoteScope, QuoteType,
+    SpecialCharacter, XrefRenderParams,
 };
 
 mod parser;

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1275,8 +1275,8 @@ mod tests {
     fn with_inline_substitution_renderer() {
         let mut parser = Parser::default().with_inline_substitution_renderer(TestRenderer);
 
-        // Parse a simple document with special characters.
-        let doc = parser.parse("Hello & goodbye < world > test");
+        // Parse a simple document with special characters and a footnote.
+        let doc = parser.parse("Hello & goodbye < world > test footnote:[a note]");
 
         // The document should parse successfully.
         assert_eq!(doc.warnings().count(), 0);
@@ -1289,11 +1289,28 @@ mod tests {
         };
 
         // Our custom renderer should show [AMP], [LT], and [GT] instead of HTML
-        // entities.
+        // entities, and a resolved footnote as [FOOTNOTE:<index>].
         assert_eq!(
             simple_block.content().rendered(),
-            "Hello [AMP] goodbye [LT] world [GT] test"
+            "Hello [AMP] goodbye [LT] world [GT] test [FOOTNOTE:1]"
         );
+    }
+
+    #[test]
+    fn custom_renderer_renders_unresolved_footnote() {
+        let mut parser = Parser::default().with_inline_substitution_renderer(TestRenderer);
+
+        // An unresolved footnote reference exercises the renderer's `None`
+        // (no index) branch, which our custom renderer shows as
+        // [FOOTNOTE:<text>].
+        let doc = parser.parse("test.footnote:missing[]");
+
+        let block = doc.nested_blocks().next().unwrap();
+        let Block::Simple(simple_block) = block else {
+            panic!("Expected simple block, got: {block:?}");
+        };
+
+        assert_eq!(simple_block.content().rendered(), "test.[FOOTNOTE:missing]");
     }
 
     mod resolve_show_title {

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -515,13 +515,16 @@ impl Parser {
         self.callouts.borrow_mut().current.clear();
     }
 
-    /// Returns the sequential index of an already-defined footnote with the
-    /// given ID, if one exists in the current document's footnote registry.
+    /// Returns the number of an already-defined footnote with the given ID, if
+    /// one exists in the current document's footnote registry.
     ///
     /// Takes `&self` so it can be called from the macros substitution step,
     /// which only holds a shared reference to the parser.
-    pub(crate) fn footnote_index_for_id(&self, id: &str) -> Option<i64> {
-        self.catalog.borrow().footnote_with_id(id).map(|f| f.index)
+    pub(crate) fn footnote_index_for_id(&self, id: &str) -> Option<String> {
+        self.catalog
+            .borrow()
+            .footnote_with_id(id)
+            .map(|f| f.index.clone())
     }
 
     /// Defines a new footnote, advancing the `footnote-number` counter and
@@ -529,21 +532,20 @@ impl Parser {
     /// number assigned to the footnote.
     ///
     /// Takes `&self` so it can be called from the macros substitution step.
-    pub(crate) fn define_footnote(&self, id: Option<&str>, text: String) -> i64 {
+    pub(crate) fn define_footnote(&self, id: Option<&str>, text: String) -> String {
         // Footnotes are numbered consecutively throughout the document via the
         // `footnote-number` counter, which is seeded to `0` so the first
         // footnote is numbered `1`. The counter is a document-wide attribute, so
         // numbering continues across nested documents (AsciiDoc table cells)
-        // even though the footnote *list* does not.
-        let index = self
-            .counter("footnote-number", None)
-            .parse::<i64>()
-            .unwrap_or(0);
+        // even though the footnote *list* does not. The counter honors any seed
+        // the document sets, so a non-integer seed yields a non-integer number
+        // (matching Asciidoctor); the value is therefore kept as a string.
+        let index = self.counter("footnote-number", None);
 
         self.catalog
             .borrow_mut()
             .register_footnote(crate::document::Footnote {
-                index,
+                index: index.clone(),
                 id: id.map(|s| s.to_owned()),
                 text,
             });

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -508,6 +508,56 @@ impl Parser {
         self.callouts.borrow_mut().current.clear();
     }
 
+    /// Returns the sequential index of an already-defined footnote with the
+    /// given ID, if one exists in the current document's footnote registry.
+    ///
+    /// Takes `&self` so it can be called from the macros substitution step,
+    /// which only holds a shared reference to the parser.
+    pub(crate) fn footnote_index_for_id(&self, id: &str) -> Option<i64> {
+        self.catalog.borrow().footnote_with_id(id).map(|f| f.index)
+    }
+
+    /// Defines a new footnote, advancing the `footnote-number` counter and
+    /// registering the footnote in the current document's registry. Returns the
+    /// number assigned to the footnote.
+    ///
+    /// Takes `&self` so it can be called from the macros substitution step.
+    pub(crate) fn define_footnote(&self, id: Option<&str>, text: String) -> i64 {
+        // Footnotes are numbered consecutively throughout the document via the
+        // `footnote-number` counter, which is seeded to `0` so the first
+        // footnote is numbered `1`. The counter is a document-wide attribute, so
+        // numbering continues across nested documents (AsciiDoc table cells)
+        // even though the footnote *list* does not.
+        let index = self
+            .counter("footnote-number", None)
+            .parse::<i64>()
+            .unwrap_or(0);
+
+        self.catalog.borrow_mut().register_footnote(crate::document::Footnote {
+            index,
+            id: id.map(|s| s.to_owned()),
+            text,
+        });
+
+        index
+    }
+
+    /// Removes and returns the current document's footnote list, leaving an
+    /// empty list behind. Used to give a nested document (an AsciiDoc table
+    /// cell) its own footnote registry; see [`restore_footnotes`].
+    ///
+    /// [`restore_footnotes`]: Self::restore_footnotes
+    pub(crate) fn take_footnotes(&self) -> Vec<crate::document::Footnote> {
+        self.catalog.borrow_mut().take_footnotes()
+    }
+
+    /// Restores a previously-[taken](Self::take_footnotes) footnote list,
+    /// discarding any footnotes registered in the meantime (i.e. those defined
+    /// inside the nested document).
+    pub(crate) fn restore_footnotes(&self, footnotes: Vec<crate::document::Footnote>) {
+        self.catalog.borrow_mut().restore_footnotes(footnotes);
+    }
+
     /// Records a warning produced while replacing attribute references.
     ///
     /// Takes `&self` so it can be called from the attributes substitution step,
@@ -1201,6 +1251,17 @@ mod tests {
             match params.visible_term {
                 Some(term) => dest.push_str(&format!("[INDEXTERM:{term}]")),
                 None => dest.push_str("[INDEXTERM]"),
+            }
+        }
+
+        fn render_footnote(
+            &self,
+            params: &crate::parser::FootnoteRenderParams,
+            dest: &mut String,
+        ) {
+            match params.index {
+                Some(index) => dest.push_str(&format!("[FOOTNOTE:{index}]")),
+                None => dest.push_str(&format!("[FOOTNOTE:{}]", params.text)),
             }
         }
     }

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -533,11 +533,13 @@ impl Parser {
             .parse::<i64>()
             .unwrap_or(0);
 
-        self.catalog.borrow_mut().register_footnote(crate::document::Footnote {
-            index,
-            id: id.map(|s| s.to_owned()),
-            text,
-        });
+        self.catalog
+            .borrow_mut()
+            .register_footnote(crate::document::Footnote {
+                index,
+                id: id.map(|s| s.to_owned()),
+                text,
+            });
 
         index
     }
@@ -1254,11 +1256,7 @@ mod tests {
             }
         }
 
-        fn render_footnote(
-            &self,
-            params: &crate::parser::FootnoteRenderParams,
-            dest: &mut String,
-        ) {
+        fn render_footnote(&self, params: &crate::parser::FootnoteRenderParams, dest: &mut String) {
             match params.index {
                 Some(index) => dest.push_str(&format!("[FOOTNOTE:{index}]")),
                 None => dest.push_str(&format!("[FOOTNOTE:{}]", params.text)),

--- a/parser/src/tests/asciidoc_lang/blocks/paragraphs.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/paragraphs.rs
@@ -156,8 +156,11 @@ Another way to solve the problem is to write the paragraph as a literal paragrap
     // A line that starts with `[` and ends with `]` is consumed as a block
     // attribute line, not as paragraph text. Because no block follows it, the
     // attribute list is left dangling (`MissingBlockAfterTitleOrAttributeList`)
-    // and the intended inline formatting is never applied: the rendered content
-    // is identical to the raw source.
+    // and the intended block role and inline bold formatting are never applied;
+    // the `*main text*` and `.rolename` are left literal. (The trailing
+    // `footnote:[…]` macro is still resolved, as macros are substituted
+    // independently of the disrupted block-attribute match — matching
+    // Asciidoctor.)
     let mut parser = Parser::default();
     assert_eq!(
         parser.parse("[.rolename]*main text*footnote:[The footnote.]"),
@@ -184,7 +187,7 @@ Another way to solve the problem is to write the paragraph as a literal paragrap
                         col: 1,
                         offset: 0,
                     },
-                    rendered: "[.rolename]*main text*footnote:[The footnote.]",
+                    rendered: "[.rolename]*main text*<sup class=\"footnote\">[<a id=\"_footnoteref_1\" class=\"footnote\" href=\"#_footnotedef_1\" title=\"View footnote.\">1</a>]</sup>",
                 },
                 source: Span {
                     data: "[.rolename]*main text*footnote:[The footnote.]",
@@ -260,7 +263,7 @@ Another way to solve the problem is to write the paragraph as a literal paragrap
                         col: 1,
                         offset: 0,
                     },
-                    rendered: "[.rolename]*main text*footnote:[The footnote.]",
+                    rendered: "[.rolename]*main text*<sup class=\"footnote\">[<a id=\"_footnoteref_1\" class=\"footnote\" href=\"#_footnotedef_1\" title=\"View footnote.\">1</a>]</sup>",
                 },
                 source: Span {
                     data: "{empty}[.rolename]*main text*footnote:[The footnote.]",
@@ -318,7 +321,7 @@ Another way to solve the problem is to write the paragraph as a literal paragrap
                         col: 1,
                         offset: 9,
                     },
-                    rendered: "[.rolename]*main text*footnote:[The footnote.]",
+                    rendered: "[.rolename]*main text*<sup class=\"footnote\">[<a id=\"_footnoteref_1\" class=\"footnote\" href=\"#_footnotedef_1\" title=\"View footnote.\">1</a>]</sup>",
                 },
                 source: Span {
                     data: "[normal]\n [.rolename]*main text*footnote:[The footnote.]",

--- a/parser/src/tests/asciidoc_lang/macros/footnote.rs
+++ b/parser/src/tests/asciidoc_lang/macros/footnote.rs
@@ -69,8 +69,10 @@ To make a reference to a previously defined footnote, you specify the ID in the 
     assert_eq!(footnotes[0].text, "Original.");
 }
 
-non_normative!(
-    r#"
+#[test]
+fn footnote_syntax() {
+    verifies!(
+        r#"
 .Footnote syntax
 [source#ex-footnote]
 ----
@@ -85,6 +87,39 @@ The text may span several lines.
 The text between the square brackets should be empty.
 If both the ID and text are specified, and the ID has already been defined by an earlier footnote, the text is ignored.
 
+"#
+    );
+
+    // The `ex-footnote` example (the `base-c` tagged region), rendered without
+    // the source-block callout annotations. It exercises each numbered point
+    // above: an anonymous footnote placed directly after a word, a footnote
+    // that assigns a unique ID (`disclaimer`) so it can be reused, and a
+    // reference to that footnote via its ID with empty text.
+    let doc = Parser::default().parse(
+        "The hail-and-rainbow protocol can be initiated at five levels:\n\n. doublefootnote:[The double hail-and-rainbow level makes my toes tingle.]\n. tertiary\n. supernumerary\n. supermassive\n. apocalyptic\n\nA bold statement!footnote:disclaimer[Opinions are my own.]\n\nAnother outrageous statement.footnote:disclaimer[]",
+    );
+
+    // Two footnotes are defined; the third occurrence only references the
+    // second, so it registers no new footnote.
+    let footnotes = doc.catalog().footnotes();
+    assert_eq!(footnotes.len(), 2);
+    assert_eq!(footnotes[0].index, 1);
+    assert_eq!(footnotes[0].id, None);
+    assert_eq!(
+        footnotes[0].text,
+        "The double hail-and-rainbow level makes my toes tingle."
+    );
+    assert_eq!(footnotes[1].index, 2);
+    assert_eq!(footnotes[1].id.as_deref(), Some("disclaimer"));
+    assert_eq!(footnotes[1].text, "Opinions are my own.");
+
+    // Two defining markers and one reference marker are rendered in the flow.
+    assert_css(&doc, "sup.footnote", 2);
+    assert_css(&doc, "sup.footnoteref", 1);
+}
+
+non_normative!(
+    r#"
 TIP: If you find that having to put the footnote macro directly adjacent to a word makes it difficult to read, you can insert an attribute reference in between that resolves to an empty string (e.g., `+word{empty}footnote:[text]+`).
 
 "#

--- a/parser/src/tests/asciidoc_lang/macros/footnote.rs
+++ b/parser/src/tests/asciidoc_lang/macros/footnote.rs
@@ -44,7 +44,7 @@ To make a reference to a previously defined footnote, you specify the ID in the 
     );
     let footnotes = doc.catalog().footnotes();
     assert_eq!(footnotes.len(), 1);
-    assert_eq!(footnotes[0].index, 1);
+    assert_eq!(footnotes[0].index, "1");
     assert_eq!(footnotes[0].id, None);
     assert_eq!(footnotes[0].text, "The text.");
 
@@ -103,13 +103,13 @@ If both the ID and text are specified, and the ID has already been defined by an
     // second, so it registers no new footnote.
     let footnotes = doc.catalog().footnotes();
     assert_eq!(footnotes.len(), 2);
-    assert_eq!(footnotes[0].index, 1);
+    assert_eq!(footnotes[0].index, "1");
     assert_eq!(footnotes[0].id, None);
     assert_eq!(
         footnotes[0].text,
         "The double hail-and-rainbow level makes my toes tingle."
     );
-    assert_eq!(footnotes[1].index, 2);
+    assert_eq!(footnotes[1].index, "2");
     assert_eq!(footnotes[1].id.as_deref(), Some("disclaimer"));
     assert_eq!(footnotes[1].text, "Opinions are my own.");
 
@@ -157,8 +157,11 @@ The footnotes are numbered consecutively throughout the article.
         .parse("One.footnote:[First.] Two.footnote:[Second.] Three.footnote:[Third.]");
     let footnotes = doc.catalog().footnotes();
     assert_eq!(
-        footnotes.iter().map(|f| f.index).collect::<Vec<_>>(),
-        vec![1, 2, 3]
+        footnotes
+            .iter()
+            .map(|f| f.index.as_str())
+            .collect::<Vec<_>>(),
+        vec!["1", "2", "3"]
     );
 }
 

--- a/parser/src/tests/asciidoc_lang/macros/footnote.rs
+++ b/parser/src/tests/asciidoc_lang/macros/footnote.rs
@@ -186,12 +186,45 @@ The name of the attribute can be as verbose (`fn-disclaimer`) or concise (`fn-1`
 
 Here's the previous example with the footnotes defined in document attributes and inserted using attribute references.
 
+"#
+);
+
+#[test]
+fn externalized_footnote() {
+    verifies!(
+        r#"
 .Externalized footnote
 [source]
 ----
 include::example$footnote.adoc[tag=externalized]
 ----
 
+"#
+    );
+
+    // The `externalized` example. Attribute references are expanded before
+    // footnotes are parsed, so a document attribute whose value is a footnote
+    // macro can be inserted with a plain attribute reference and still produces
+    // a footnote.
+    let doc = Parser::default().parse(
+        ":fn-hail-and-rainbow: footnote:[The double hail-and-rainbow level makes my toes tingle.]\n:fn-disclaimer: footnote:disclaimer[Opinions are my own.]\n\nThe hail-and-rainbow protocol can be initiated at five levels:\n\n. double{fn-hail-and-rainbow}\n. tertiary\n. supernumerary\n. supermassive\n. apocalyptic\n\nA bold statement!{fn-disclaimer}\n\nAnother outrageous statement.{fn-disclaimer}",
+    );
+
+    let footnotes = doc.catalog().footnotes();
+    assert_eq!(footnotes.len(), 2);
+    assert_eq!(footnotes[0].id, None);
+    assert_eq!(
+        footnotes[0].text,
+        "The double hail-and-rainbow level makes my toes tingle."
+    );
+    assert_eq!(footnotes[1].id.as_deref(), Some("disclaimer"));
+    assert_eq!(footnotes[1].text, "Opinions are my own.");
+    assert_css(&doc, "sup.footnote", 2);
+    assert_css(&doc, "sup.footnoteref", 1);
+}
+
+non_normative!(
+    r#"
 Notice you still get the benefit of seeing where the footnote is placed without all the noise.
 And since the footnotes are now defined in the document header, they could be further externalized to an include file.
 
@@ -203,12 +236,41 @@ In order to use text formatting markup in the text of the footnote, you need to 
 
 The following example demonstrates how to configure the substitutions applied to the text of an externalized footnote so that text formatting markup is honored.
 
+"#
+);
+
+#[test]
+fn externalized_footnote_with_text_formatting() {
+    verifies!(
+        r#"
 .Externalized footnote with text formatting
 [source]
 ----
 include::example$footnote.adoc[tag=externalized-format]
 ----
 
+"#
+    );
+
+    // The `externalized-format` example. Wrapping the attribute value in
+    // `pass:c,q[…]` applies the special characters and quotes substitutions to
+    // the footnote text up front, so text formatting markup is honored even
+    // though the value is inserted via an attribute reference.
+    let doc = Parser::default().parse(
+        ":fn-disclaimer: pass:c,q[footnote:disclaimer[Opinions are _mine_, and mine *alone*.]]\n\nA bold statement!{fn-disclaimer}\n\nAnother outrageous statement.{fn-disclaimer}",
+    );
+
+    let footnotes = doc.catalog().footnotes();
+    assert_eq!(footnotes.len(), 1);
+    assert_eq!(footnotes[0].id.as_deref(), Some("disclaimer"));
+    assert_eq!(
+        footnotes[0].text,
+        "Opinions are <em>mine</em>, and mine <strong>alone</strong>."
+    );
+}
+
+non_normative!(
+    r#"
 The `c,q` target on the pass macro instructs the processor to apply the special characters substitution followed by the quotes substitution.
 That means the text formatting in the footnote text will already be applied when the footnote is inserted using an attribute reference.
 

--- a/parser/src/tests/asciidoc_lang/macros/footnote.rs
+++ b/parser/src/tests/asciidoc_lang/macros/footnote.rs
@@ -1,0 +1,190 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/macros/pages/footnote.adoc");
+
+non_normative!(
+    r#"
+= Footnotes
+
+AsciiDoc provides the `footnote` macro for adding footnotes to your document.
+A footnote is a reference to an item in a footnote list.
+The footnote is defined in AsciiDoc at the location of the reference, but the text is extracted to an item in the footnote list.
+You can refer to the same footnote in multiple locations by assigning an ID to the first occurrence and referencing that ID in subsequent occurrences.
+
+NOTE: All AsciiDoc processors, including Asciidoctor, currently implement footnotes as endnotes.
+The placement and numbering of footnotes can be customized using a custom converter.
+
+== Footnote macro syntax
+
+"#
+);
+
+#[test]
+fn macro_syntax() {
+    verifies!(
+        r#"
+You can insert footnotes into your document using the footnote macro.
+The text of the footnote is defined between the square brackets of the footnote macro (`+footnote:[text]+`).
+The footnote macro accepts an optional ID using the target of the macro (`+footnote:id[text]+`).
+Specifying an ID allows you to refer to that same footnote from multiple locations in the document.
+To make a reference to a previously defined footnote, you specify the ID in the target without specifying text (`+footnote:id[]+`).
+
+"#
+    );
+
+    // The text between the square brackets defines the footnote. An inline
+    // marker is left in the flow of text and the text is extracted to the
+    // document's footnote registry.
+    let doc = Parser::default().parse("The footnote.footnote:[The text.]");
+    assert_eq!(
+        rendered_paragraphs(&doc),
+        &[
+            r##"The footnote.<sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>"##
+        ]
+    );
+    let footnotes = doc.catalog().footnotes();
+    assert_eq!(footnotes.len(), 1);
+    assert_eq!(footnotes[0].index, 1);
+    assert_eq!(footnotes[0].id, None);
+    assert_eq!(footnotes[0].text, "The text.");
+
+    // An ID supplied in the macro target lets the same footnote be referenced
+    // again with empty text (`footnote:id[]`); the reference reuses the
+    // original footnote's number and registers no new footnote.
+    let doc = Parser::default().parse("First.footnote:fn1[Shared text.] Again.footnote:fn1[]");
+    assert_eq!(
+        rendered_paragraphs(&doc),
+        &[
+            r##"First.<sup class="footnote" id="_footnote_fn1">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup> Again.<sup class="footnoteref">[<a class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>"##
+        ]
+    );
+    assert_eq!(doc.catalog().footnotes().len(), 1);
+
+    // If both an ID and text are specified but the ID was already defined by an
+    // earlier footnote, the later text is ignored: the reference resolves to
+    // the original footnote.
+    let doc = Parser::default().parse("First.footnote:fn1[Original.] Again.footnote:fn1[Ignored.]");
+    let footnotes = doc.catalog().footnotes();
+    assert_eq!(footnotes.len(), 1);
+    assert_eq!(footnotes[0].text, "Original.");
+}
+
+non_normative!(
+    r#"
+.Footnote syntax
+[source#ex-footnote]
+----
+include::example$footnote.adoc[tag=base-c]
+----
+<.> Insert the footnote macro directly after any punctuation.
+Note that the footnote macro only uses a single colon (`:`).
+<.> Insert the footnote's content within the square brackets (`+[]+`).
+The text may span several lines.
+<.> If you plan to reuse a footnote, specify a unique ID in the target position.
+<.> To reference an existing footnote, you only need to specify the ID of the footnote in the target slot.
+The text between the square brackets should be empty.
+If both the ID and text are specified, and the ID has already been defined by an earlier footnote, the text is ignored.
+
+TIP: If you find that having to put the footnote macro directly adjacent to a word makes it difficult to read, you can insert an attribute reference in between that resolves to an empty string (e.g., `+word{empty}footnote:[text]+`).
+
+"#
+);
+
+#[test]
+fn numbered_consecutively() {
+    verifies!(
+        r#"
+The footnotes are numbered consecutively throughout the article.
+
+"#
+    );
+
+    let doc = Parser::default()
+        .parse("One.footnote:[First.] Two.footnote:[Second.] Three.footnote:[Third.]");
+    let footnotes = doc.catalog().footnotes();
+    assert_eq!(
+        footnotes.iter().map(|f| f.index).collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+}
+
+non_normative!(
+    r#"
+The results of <<ex-footnote>> are displayed below.
+
+[.unstyled]
+|===
+a|
+include::example$footnote.adoc[tag=base-x]
+|===
+
+Just like normal paragraph text, you can use text formatting markup in the text of the footnote.
+
+== Externalizing a footnote
+
+Since footnotes are defined using an inline macro, the footnote content must be inserted alongside the text it's annotating.
+This requirement can make the text harder to read.
+You can solve this problem by externalizing your footnotes using document attributes.
+
+When defining a document attribute that holds a footnote, you can name the document attributes whatever you want.
+A common practice is to name the attribute using the `fn-` prefix.
+The name of the attribute can be as verbose (`fn-disclaimer`) or concise (`fn-1`) as you prefer.
+
+Here's the previous example with the footnotes defined in document attributes and inserted using attribute references.
+
+.Externalized footnote
+[source]
+----
+include::example$footnote.adoc[tag=externalized]
+----
+
+Notice you still get the benefit of seeing where the footnote is placed without all the noise.
+And since the footnotes are now defined in the document header, they could be further externalized to an include file.
+
+This approach works since attribute references are expanded before footnotes are parsed.
+However, this technique does not work if you have text formatting markup in the text of the footnote (e.g., `+*bold*+`).
+That markup will not be interpreted.
+That's because the attributes substitution (which replaces attribute references) is applied _after_ the quotes substitution (which interprets text formatting markup).
+In order to use text formatting markup in the text of the footnote, you need to configure the substitutions on the value of the attribute entry using the `\pass:[]` macro.
+
+The following example demonstrates how to configure the substitutions applied to the text of an externalized footnote so that text formatting markup is honored.
+
+.Externalized footnote with text formatting
+[source]
+----
+include::example$footnote.adoc[tag=externalized-format]
+----
+
+The `c,q` target on the pass macro instructs the processor to apply the special characters substitution followed by the quotes substitution.
+That means the text formatting in the footnote text will already be applied when the footnote is inserted using an attribute reference.
+
+== Footnotes in headings
+
+Footnotes are *not officially supported in headings* (section titles and discrete headings) in pre-spec AsciiDoc.
+While the footnote gets parsed, there's no guarantee that it will work properly and may require workarounds.
+This limitation may be lifted once the AsciiDoc Language is defined by the specification.
+
+If you use a footnote in a heading, you'll likely find that the footnote index is wrong (either not incremented or out of order).
+That's because headings (section titles and discrete headings) get converted out of document order for the purpose of generating IDs, populating up cross references, and eagerly resolving attribute references.
+
+The only way to workaround this limitation is by assigning an explicit ID *and* reftext to any heading that contains a footnote.
+For example:
+
+[source]
+----
+See <<heading>>.
+
+[[heading,Heading]]
+== Headingfootnote:[This is a heading with a footnote]
+----
+
+Assigning an explicit ID and reftext to a heading will prevent the heading from being converted eagerly (thus deferring the footnote substitution) until the heading is rendered.
+
+As a result, the footnote macro in the heading will be processed in document order.
+
+This workaround will also prevent the footnote number from reappearing in the text of an xref.
+
+Even with this workaround, you still have to avoid using attribute references in the heading as those also causes the heading to be converted eagerly (which forces substitutions to be applied).
+If you use an attribute reference in the heading, the footnotes will be processed out of document order.
+"#
+);

--- a/parser/src/tests/asciidoc_lang/macros/footnote.rs
+++ b/parser/src/tests/asciidoc_lang/macros/footnote.rs
@@ -176,6 +176,13 @@ Just like normal paragraph text, you can use text formatting markup in the text 
 
 == Externalizing a footnote
 
+"#
+);
+
+#[test]
+fn externalized_footnote() {
+    verifies!(
+        r#"
 Since footnotes are defined using an inline macro, the footnote content must be inserted alongside the text it's annotating.
 This requirement can make the text harder to read.
 You can solve this problem by externalizing your footnotes using document attributes.
@@ -186,13 +193,6 @@ The name of the attribute can be as verbose (`fn-disclaimer`) or concise (`fn-1`
 
 Here's the previous example with the footnotes defined in document attributes and inserted using attribute references.
 
-"#
-);
-
-#[test]
-fn externalized_footnote() {
-    verifies!(
-        r#"
 .Externalized footnote
 [source]
 ----
@@ -228,6 +228,13 @@ non_normative!(
 Notice you still get the benefit of seeing where the footnote is placed without all the noise.
 And since the footnotes are now defined in the document header, they could be further externalized to an include file.
 
+"#
+);
+
+#[test]
+fn externalized_footnote_with_text_formatting() {
+    verifies!(
+        r#"
 This approach works since attribute references are expanded before footnotes are parsed.
 However, this technique does not work if you have text formatting markup in the text of the footnote (e.g., `+*bold*+`).
 That markup will not be interpreted.
@@ -236,18 +243,14 @@ In order to use text formatting markup in the text of the footnote, you need to 
 
 The following example demonstrates how to configure the substitutions applied to the text of an externalized footnote so that text formatting markup is honored.
 
-"#
-);
-
-#[test]
-fn externalized_footnote_with_text_formatting() {
-    verifies!(
-        r#"
 .Externalized footnote with text formatting
 [source]
 ----
 include::example$footnote.adoc[tag=externalized-format]
 ----
+
+The `c,q` target on the pass macro instructs the processor to apply the special characters substitution followed by the quotes substitution.
+That means the text formatting in the footnote text will already be applied when the footnote is inserted using an attribute reference.
 
 "#
     );
@@ -268,14 +271,6 @@ include::example$footnote.adoc[tag=externalized-format]
         "Opinions are <em>mine</em>, and mine <strong>alone</strong>."
     );
 }
-
-non_normative!(
-    r#"
-The `c,q` target on the pass macro instructs the processor to apply the special characters substitution followed by the quotes substitution.
-That means the text formatting in the footnote text will already be applied when the footnote is inserted using an attribute reference.
-
-"#
-);
 
 // The "Footnotes in headings" section is left non-normative rather than
 // verified: the crate does not yet implement the workaround it describes.

--- a/parser/src/tests/asciidoc_lang/macros/footnote.rs
+++ b/parser/src/tests/asciidoc_lang/macros/footnote.rs
@@ -274,6 +274,17 @@ non_normative!(
 The `c,q` target on the pass macro instructs the processor to apply the special characters substitution followed by the quotes substitution.
 That means the text formatting in the footnote text will already be applied when the footnote is inserted using an attribute reference.
 
+"#
+);
+
+// The "Footnotes in headings" section is left non-normative rather than
+// verified: the crate does not yet implement the workaround it describes.
+// Section titles are not converted eagerly/out of document order, so a footnote
+// placed in a heading still reappears in the reference text of an xref to that
+// heading (Asciidoctor's workaround suppresses it). Tracked by
+// https://github.com/asciidoc-rs/asciidoc-parser/issues/594.
+non_normative!(
+    r#"
 == Footnotes in headings
 
 Footnotes are *not officially supported in headings* (section titles and discrete headings) in pre-spec AsciiDoc.

--- a/parser/src/tests/asciidoc_lang/macros/footnote.rs
+++ b/parser/src/tests/asciidoc_lang/macros/footnote.rs
@@ -118,12 +118,31 @@ If both the ID and text are specified, and the ID has already been defined by an
     assert_css(&doc, "sup.footnoteref", 1);
 }
 
-non_normative!(
-    r#"
+#[test]
+fn empty_attribute_reference_separates_word_from_macro() {
+    verifies!(
+        r#"
 TIP: If you find that having to put the footnote macro directly adjacent to a word makes it difficult to read, you can insert an attribute reference in between that resolves to an empty string (e.g., `+word{empty}footnote:[text]+`).
 
 "#
-);
+    );
+
+    // The `{empty}` reference resolves to an empty string, so it separates the
+    // macro from the preceding word in the source without inserting anything in
+    // the output: the footnote marker still renders directly adjacent to the
+    // word.
+    let doc = Parser::default().parse("A word{empty}footnote:[The footnote text.] follows.");
+    assert_eq!(
+        rendered_paragraphs(&doc),
+        &[
+            r##"A word<sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup> follows."##
+        ]
+    );
+
+    let footnotes = doc.catalog().footnotes();
+    assert_eq!(footnotes.len(), 1);
+    assert_eq!(footnotes[0].text, "The footnote text.");
+}
 
 #[test]
 fn numbered_consecutively() {

--- a/parser/src/tests/asciidoc_lang/macros/mod.rs
+++ b/parser/src/tests/asciidoc_lang/macros/mod.rs
@@ -1,6 +1,7 @@
 mod audio_and_video;
 mod autolinks;
 mod complex_urls;
+mod footnote;
 mod icon_macro;
 mod icons;
 mod image_link;

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -4390,8 +4390,9 @@ mod macros {
 
         #[test]
         #[ignore]
-        // TODO: Resolve deferred cross-references (and bibliography references)
-        // inside footnote text. The crate defers cross-reference resolution to a
+        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/592):
+        // Resolve deferred cross-references (and bibliography references) inside
+        // footnote text. The crate defers cross-reference resolution to a
         // document-level pass over block content; because a footnote's text is
         // extracted out of the block, an `<<id>>` / `xref:id[]` inside a footnote
         // is not yet reached by that pass and stays unresolved in the stored
@@ -4402,8 +4403,9 @@ mod macros {
 
         #[test]
         #[ignore]
-        // TODO: Honor passthrough (`pass:[]` / `pass:q[]`) substitutions in the
-        // value of an externalized footnote attribute (e.g.
+        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/593):
+        // Honor passthrough (`pass:[]` / `pass:q[]`) substitutions in the value
+        // of an externalized footnote attribute (e.g.
         // `:fn-disclaimer: pass:q[footnote:[…_italic_…]]`).
         fn externalized_footnote_macro_may_contain_text_formatting() {}
 
@@ -4414,10 +4416,11 @@ mod macros {
 
         #[test]
         #[ignore]
-        // TODO: Footnotes used in section titles are converted out of document
-        // order (titles are converted eagerly to generate IDs), so their
-        // numbering differs from document order. The crate does not yet model
-        // the eager out-of-order conversion of section titles.
+        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/594):
+        // Footnotes used in section titles are converted out of document order
+        // (titles are converted eagerly to generate IDs), so their numbering
+        // differs from document order. The crate does not yet model the eager
+        // out-of-order conversion of section titles.
         fn footnotes_in_headings_are_numbered_out_of_sequence() {}
     }
 

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -4037,7 +4037,7 @@ mod macros {
 
             let footnotes = doc.catalog().footnotes();
             assert_eq!(footnotes.len(), 1);
-            assert_eq!(footnotes[0].index, 1);
+            assert_eq!(footnotes[0].index, "1");
             assert_eq!(footnotes[0].id, None);
             assert_eq!(footnotes[0].text, "An example footnote.");
         }
@@ -4055,7 +4055,7 @@ mod macros {
 
             let footnotes = doc.catalog().footnotes();
             assert_eq!(footnotes.len(), 1);
-            assert_eq!(footnotes[0].index, 1);
+            assert_eq!(footnotes[0].index, "1");
             assert_eq!(footnotes[0].id, None);
             assert_eq!(footnotes[0].text, "An example footnote with wrapped text.");
         }
@@ -4198,10 +4198,10 @@ mod macros {
 
             let footnotes = doc.catalog().footnotes();
             assert_eq!(footnotes.len(), 2);
-            assert_eq!(footnotes[0].index, 1);
+            assert_eq!(footnotes[0].index, "1");
             assert_eq!(footnotes[0].id, None);
             assert_eq!(footnotes[0].text, "An example footnote.");
-            assert_eq!(footnotes[1].index, 2);
+            assert_eq!(footnotes[1].index, "2");
             assert_eq!(footnotes[1].id, None);
             assert_eq!(footnotes[1].text, "Another footnote.");
         }
@@ -4219,7 +4219,7 @@ mod macros {
 
             let footnotes = doc.catalog().footnotes();
             assert_eq!(footnotes.len(), 1);
-            assert_eq!(footnotes[0].index, 1);
+            assert_eq!(footnotes[0].index, "1");
             assert_eq!(footnotes[0].id.as_deref(), Some("ex1"));
             assert_eq!(footnotes[0].text, "An example footnote.");
         }
@@ -4256,7 +4256,7 @@ mod macros {
 
             let footnotes = doc.catalog().footnotes();
             assert_eq!(footnotes.len(), 1);
-            assert_eq!(footnotes[0].index, 1);
+            assert_eq!(footnotes[0].index, "1");
             assert_eq!(footnotes[0].id.as_deref(), Some("ex1"));
             assert_eq!(footnotes[0].text, "An example footnote.");
         }
@@ -4395,6 +4395,31 @@ mod macros {
                 &["A footnote:[not a footnote] here."]
             );
             assert!(doc.catalog().footnotes().is_empty());
+        }
+
+        #[test]
+        fn footnote_number_honors_a_non_integer_counter_seed() {
+            // The `footnote-number` counter honors whatever seed the document
+            // sets. A non-integer seed advances like Ruby's `String#succ`
+            // (`z` -> `aa` -> `ab`), and the footnote number is rendered
+            // verbatim, matching Asciidoctor rather than collapsing to `0`.
+            let doc = Parser::default()
+                .parse(":footnote-number: z\n\nOne.footnote:[first] two.footnote:[second]");
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 2);
+            assert_eq!(footnotes[0].index, "aa");
+            assert_eq!(footnotes[1].index, "ab");
+
+            let paras = rendered_paragraphs(&doc);
+            assert!(
+                paras[0].contains(
+                    r##"<a id="_footnoteref_aa" class="footnote" href="#_footnotedef_aa" title="View footnote.">aa</a>"##
+                ),
+                "{}",
+                paras[0]
+            );
+            assert!(paras[0].contains(r##"id="_footnoteref_ab""##));
         }
 
         #[test]

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -4020,316 +4020,413 @@ mod macros {
         }
     }
 
+    /// Ported from the `Macros` > footnote tests in Asciidoctor's
+    /// `test/substitutions_test.rb`.
+    mod footnotes {
+        use crate::tests::prelude::*;
+
+        #[test]
+        fn single_line_footnote_macro_is_registered_and_output() {
+            let doc = Parser::default().parse("Sentence text footnote:[An example footnote.].");
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &[
+                    r##"Sentence text <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>."##
+                ]
+            );
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 1);
+            assert_eq!(footnotes[0].index, 1);
+            assert_eq!(footnotes[0].id, None);
+            assert_eq!(footnotes[0].text, "An example footnote.");
+        }
+
+        #[test]
+        fn multi_line_footnote_macro_is_output_without_newline() {
+            let doc = Parser::default()
+                .parse("Sentence text footnote:[An example footnote\nwith wrapped text.].");
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &[
+                    r##"Sentence text <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>."##
+                ]
+            );
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 1);
+            assert_eq!(footnotes[0].index, 1);
+            assert_eq!(footnotes[0].id, None);
+            assert_eq!(footnotes[0].text, "An example footnote with wrapped text.");
+        }
+
+        #[test]
+        fn escaped_closing_square_bracket_is_unescaped_when_converted() {
+            let doc = Parser::default().parse("footnote:[a \\] b].");
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &[
+                    r##"<sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>."##
+                ]
+            );
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 1);
+            assert_eq!(footnotes[0].text, "a ] b");
+        }
+
+        #[test]
+        fn footnote_macro_can_be_directly_adjacent_to_preceding_word() {
+            let doc = Parser::default().parse("Sentence textfootnote:[An example footnote.].");
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &[
+                    r##"Sentence text<sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>."##
+                ]
+            );
+        }
+
+        #[test]
+        fn footnote_macro_may_contain_an_escaped_backslash() {
+            let doc = Parser::default()
+                .parse("footnote:[\\]]\nfootnote:[a \\] b]\nfootnote:[a \\]\\] b]");
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 3);
+            assert_eq!(footnotes[0].text, "]");
+            assert_eq!(footnotes[1].text, "a ] b");
+            assert_eq!(footnotes[2].text, "a ]] b");
+        }
+
+        #[test]
+        fn footnote_macro_may_contain_a_link_macro() {
+            let doc =
+                Parser::default().parse("Share your code. footnote:[https://github.com[GitHub]]");
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &[
+                    r##"Share your code. <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>"##
+                ]
+            );
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 1);
+            assert_eq!(
+                footnotes[0].text,
+                r#"<a href="https://github.com">GitHub</a>"#
+            );
+        }
+
+        #[test]
+        fn footnote_macro_may_contain_a_plain_url() {
+            let doc = Parser::default()
+                .parse("the JLine footnote:[https://github.com/jline/jline2]\nlibrary.");
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &[
+                    "the JLine <sup class=\"footnote\">[<a id=\"_footnoteref_1\" class=\"footnote\" href=\"#_footnotedef_1\" title=\"View footnote.\">1</a>]</sup>\nlibrary."
+                ]
+            );
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 1);
+            assert_eq!(
+                footnotes[0].text,
+                r#"<a href="https://github.com/jline/jline2" class="bare">https://github.com/jline/jline2</a>"#
+            );
+        }
+
+        #[test]
+        fn footnote_macro_followed_by_a_semicolon_may_contain_a_plain_url() {
+            let doc = Parser::default()
+                .parse("the JLine footnote:[https://github.com/jline/jline2];\nlibrary.");
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &[
+                    "the JLine <sup class=\"footnote\">[<a id=\"_footnoteref_1\" class=\"footnote\" href=\"#_footnotedef_1\" title=\"View footnote.\">1</a>]</sup>;\nlibrary."
+                ]
+            );
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 1);
+            assert_eq!(
+                footnotes[0].text,
+                r#"<a href="https://github.com/jline/jline2" class="bare">https://github.com/jline/jline2</a>"#
+            );
+        }
+
+        #[test]
+        fn footnote_macro_may_contain_text_formatting() {
+            let doc = Parser::default().parse(
+                "You can download patches from the product page.footnote:[Only available with an _active_ subscription.]",
+            );
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 1);
+            assert_eq!(
+                footnotes[0].text,
+                "Only available with an <em>active</em> subscription."
+            );
+        }
+
+        #[test]
+        fn footnote_macro_may_contain_an_anchor_macro() {
+            let doc = Parser::default().parse("text footnote:[a [[b]] [[c\\]\\] d]");
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &[
+                    r##"text <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>"##
+                ]
+            );
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 1);
+            assert_eq!(footnotes[0].text, r#"a <a id="b"></a> [[c]] d"#);
+        }
+
+        #[test]
+        fn should_increment_index_of_subsequent_footnote_macros() {
+            let doc = Parser::default().parse(
+                "Sentence text footnote:[An example footnote.]. Sentence text footnote:[Another footnote.].",
+            );
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &[
+                    r##"Sentence text <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>. Sentence text <sup class="footnote">[<a id="_footnoteref_2" class="footnote" href="#_footnotedef_2" title="View footnote.">2</a>]</sup>."##
+                ]
+            );
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 2);
+            assert_eq!(footnotes[0].index, 1);
+            assert_eq!(footnotes[0].id, None);
+            assert_eq!(footnotes[0].text, "An example footnote.");
+            assert_eq!(footnotes[1].index, 2);
+            assert_eq!(footnotes[1].id, None);
+            assert_eq!(footnotes[1].text, "Another footnote.");
+        }
+
+        #[test]
+        fn footnoteref_macro_with_id_and_single_line_text_is_registered() {
+            let doc = Parser::default()
+                .parse(":compat-mode:\n\nSentence text footnoteref:[ex1, An example footnote.].");
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &[
+                    r##"Sentence text <sup class="footnote" id="_footnote_ex1">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>."##
+                ]
+            );
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 1);
+            assert_eq!(footnotes[0].index, 1);
+            assert_eq!(footnotes[0].id.as_deref(), Some("ex1"));
+            assert_eq!(footnotes[0].text, "An example footnote.");
+        }
+
+        #[test]
+        fn footnoteref_macro_with_id_and_multi_line_text_is_registered_without_newlines() {
+            let doc = Parser::default().parse(
+                ":compat-mode:\n\nSentence text footnoteref:[ex1, An example footnote\nwith wrapped text.].",
+            );
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &[
+                    r##"Sentence text <sup class="footnote" id="_footnote_ex1">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>."##
+                ]
+            );
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 1);
+            assert_eq!(footnotes[0].id.as_deref(), Some("ex1"));
+            assert_eq!(footnotes[0].text, "An example footnote with wrapped text.");
+        }
+
+        #[test]
+        fn footnoteref_macro_with_id_should_refer_to_footnoteref_with_same_id() {
+            let doc = Parser::default().parse(
+                ":compat-mode:\n\nSentence text footnoteref:[ex1, An example footnote.]. Sentence text footnoteref:[ex1].",
+            );
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &[
+                    r##"Sentence text <sup class="footnote" id="_footnote_ex1">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>. Sentence text <sup class="footnoteref">[<a class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>."##
+                ]
+            );
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 1);
+            assert_eq!(footnotes[0].index, 1);
+            assert_eq!(footnotes[0].id.as_deref(), Some("ex1"));
+            assert_eq!(footnotes[0].text, "An example footnote.");
+        }
+
+        #[test]
+        fn unresolved_footnote_reference_produces_a_warning_and_red_fallback() {
+            let doc = Parser::default().parse("Sentence text.footnote:ex1[]");
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &[
+                    r#"Sentence text.<sup class="footnoteref red" title="Unresolved footnote reference.">[ex1]</sup>"#
+                ]
+            );
+
+            let warnings: Vec<_> = doc.warnings().collect();
+            assert_eq!(warnings.len(), 1);
+            assert_eq!(
+                warnings[0].warning,
+                WarningType::InvalidFootnoteReference("ex1".to_string())
+            );
+        }
+
+        #[test]
+        fn footnoteref_macro_warns_when_compat_mode_is_not_enabled() {
+            let doc = Parser::default()
+                .parse("Sentence text.footnoteref:[fn1,Commentary on this sentence.]");
+
+            let warnings: Vec<_> = doc.warnings().collect();
+            assert_eq!(warnings.len(), 1);
+            assert_eq!(
+                warnings[0].warning,
+                WarningType::DeprecatedFootnorefMacro(
+                    "footnoteref:[fn1,Commentary on this sentence.]".to_string()
+                )
+            );
+        }
+
+        #[test]
+        fn inline_footnote_macro_can_define_and_reference_a_footnote() {
+            let doc = Parser::default().parse(
+                ":compat-mode:\n\nYou can download the software from the product page.footnote:sub[Option only available if you have an active subscription.]\n\nYou can also file a support request.footnote:sub[]\n\nIf all else fails, you can give us a call.footnoteref:[sub]",
+            );
+
+            // The footnote is defined once and referenced twice.
+            assert_eq!(doc.catalog().footnotes().len(), 1);
+            // Every occurrence links to the single footnote definition.
+            assert_css(&doc, r##"a[href="#_footnotedef_1"]"##, 3);
+            // Setting compat mode suppresses the footnoteref deprecation warning.
+            assert_eq!(doc.warnings().count(), 0);
+        }
+
+        #[test]
+        fn should_parse_multiple_footnote_references_in_a_single_line() {
+            let doc = Parser::default().parse(
+                "notable text.footnote:id[about this [text\\]], footnote:id[], footnote:id[]",
+            );
+
+            // One defining occurrence and two references, all numbered 1.
+            assert_css(&doc, "sup.footnote", 1);
+            assert_css(&doc, "sup.footnoteref", 2);
+            assert_xpath(&doc, r#"//a[@class="footnote"]"#, 3);
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 1);
+            assert_eq!(footnotes[0].text, "about this [text]");
+        }
+
+        #[test]
+        fn should_not_register_footnote_with_id_and_text_if_id_already_registered() {
+            let doc = Parser::default().parse(
+                ":fn-notable-text: footnote:id[about this text]\n\nnotable text.{fn-notable-text}\n\nmore notable text.{fn-notable-text}",
+            );
+
+            assert_css(&doc, "sup.footnote", 1);
+            assert_css(&doc, "sup.footnoteref", 1);
+            assert_eq!(doc.catalog().footnotes().len(), 1);
+        }
+
+        #[test]
+        fn should_not_resolve_an_inline_footnote_macro_missing_both_id_and_text() {
+            let doc = Parser::default().parse(
+                "The footnote:[] macro can be used for defining and referencing footnotes.\n\nThe footnoteref:[] macro is now deprecated.",
+            );
+
+            assert_rendered_contains(&doc, "The footnote:[] macro");
+            assert_rendered_contains(&doc, "The footnoteref:[] macro");
+            assert!(doc.catalog().footnotes().is_empty());
+        }
+
+        #[test]
+        fn inline_footnote_macro_can_define_a_numeric_id() {
+            let doc = Parser::default().parse(
+                "You can download the software from the product page.footnote:1[Option only available if you have an active subscription.]",
+            );
+
+            assert_css(&doc, "sup#_footnote_1", 1);
+            assert_css(&doc, "a#_footnoteref_1", 1);
+            assert_css(&doc, r##"a[href="#_footnotedef_1"]"##, 1);
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 1);
+            assert_eq!(footnotes[0].id.as_deref(), Some("1"));
+        }
+
+        #[test]
+        fn inline_footnote_macro_can_define_an_id_with_unicode_word_characters() {
+            let doc = Parser::default().parse(
+                "L'origine du mot forêt{blank}footnote:forêt[un massif forestier] est complexe.\n\nQu'est-ce qu'une forêt ?{blank}footnote:forêt[]",
+            );
+
+            // (The DOM-based assert helpers can't slice the multi-byte `ê`, so
+            // the rendered markup is checked directly.)
+            let paras = rendered_paragraphs(&doc);
+            assert!(
+                paras[0].contains(r#"<sup class="footnote" id="_footnote_forêt">"#),
+                "{}",
+                paras[0]
+            );
+            // Both occurrences link to footnote 1.
+            assert!(paras[0].contains(r##"href="#_footnotedef_1""##));
+            assert!(paras[1].contains(r##"href="#_footnotedef_1""##));
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 1);
+            assert_eq!(footnotes[0].id.as_deref(), Some("forêt"));
+            assert_eq!(footnotes[0].text, "un massif forestier");
+        }
+
+        // ---------------------------------------------------------------------
+        // Deferred: these depend on features the crate does not yet implement.
+
+        #[test]
+        #[ignore]
+        // TODO: Resolve deferred cross-references (and bibliography references)
+        // inside footnote text. The crate defers cross-reference resolution to a
+        // document-level pass over block content; because a footnote's text is
+        // extracted out of the block, an `<<id>>` / `xref:id[]` inside a footnote
+        // is not yet reached by that pass and stays unresolved in the stored
+        // footnote text. (Covers the Ruby tests "a footnote macro may contain a
+        // shorthand xref" / "an xref macro" and "should be able to reference a
+        // bibliography entry in a footnote".)
+        fn footnote_macro_may_contain_an_xref() {}
+
+        #[test]
+        #[ignore]
+        // TODO: Honor passthrough (`pass:[]` / `pass:q[]`) substitutions in the
+        // value of an externalized footnote attribute (e.g.
+        // `:fn-disclaimer: pass:q[footnote:[…_italic_…]]`).
+        fn externalized_footnote_macro_may_contain_text_formatting() {}
+
+        // Backend-specific test omitted: "subsequent footnote macros with
+        // escaped URLs should be restored in DocBook" asserts only against
+        // DocBook output (`backend: 'docbook'`), which the crate does not
+        // target.
+
+        #[test]
+        #[ignore]
+        // TODO: Footnotes used in section titles are converted out of document
+        // order (titles are converted eagerly to generate IDs), so their
+        // numbering differs from document order. The crate does not yet model
+        // the eager out-of-order conversion of section titles.
+        fn footnotes_in_headings_are_numbered_out_of_sequence() {}
+    }
+
     #[ignore]
     #[test]
     fn todo_migrate_from_ruby_2() {
         todo!(
             "{}",
             r###"
-        test 'a single-line footnote macro should be registered and output as a footnote' do
-            para = block_from_string 'Sentence text footnote:[An example footnote.].'
-            assert_equal %(Sentence text <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>.), para.sub_macros(para.source)
-            assert_equal 1, para.document.catalog[:footnotes].size
-            footnote = para.document.catalog[:footnotes].first
-            assert_equal 1, footnote.index
-            assert_nil footnote.id
-            assert_equal 'An example footnote.', footnote.text
-        end
-
-        test 'a multi-line footnote macro should be registered and output as a footnote without newline' do
-            para = block_from_string "Sentence text footnote:[An example footnote\nwith wrapped text.]."
-            assert_equal %(Sentence text <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>.), para.sub_macros(para.source)
-            assert_equal 1, para.document.catalog[:footnotes].size
-            footnote = para.document.catalog[:footnotes].first
-            assert_equal 1, footnote.index
-            assert_nil footnote.id
-            assert_equal 'An example footnote with wrapped text.', footnote.text
-        end
-
-        test 'an escaped closing square bracket in a footnote should be unescaped when converted' do
-            para = block_from_string %(footnote:[a #{BACKSLASH}] b].)
-            assert_equal %(<sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>.), para.sub_macros(para.source)
-            assert_equal 1, para.document.catalog[:footnotes].size
-            footnote = para.document.catalog[:footnotes].first
-            assert_equal 'a ] b', footnote.text
-        end
-
-        test 'a footnote macro can be directly adjacent to preceding word' do
-            para = block_from_string 'Sentence textfootnote:[An example footnote.].'
-            assert_equal 'Sentence text<sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>.', para.sub_macros(para.source)
-        end
-
-        test 'a footnote macro may contain an escaped backslash' do
-            para = block_from_string "footnote:[\\]]\nfootnote:[a \\] b]\nfootnote:[a \\]\\] b]"
-            para.sub_macros para.source
-            assert_equal 3, para.document.catalog[:footnotes].size
-            footnote1 = para.document.catalog[:footnotes][0]
-            assert_equal ']', footnote1.text
-            footnote2 = para.document.catalog[:footnotes][1]
-            assert_equal 'a ] b', footnote2.text
-            footnote3 = para.document.catalog[:footnotes][2]
-            assert_equal 'a ]] b', footnote3.text
-        end
-
-        test 'a footnote macro may contain a link macro' do
-            para = block_from_string 'Share your code. footnote:[https://github.com[GitHub]]'
-            assert_equal %(Share your code. <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>), para.sub_macros(para.source)
-            assert_equal 1, para.document.catalog[:footnotes].size
-            footnote1 = para.document.catalog[:footnotes][0]
-            assert_equal '<a href="https://github.com">GitHub</a>', footnote1.text
-        end
-
-        test 'a footnote macro may contain a plain URL' do
-            para = block_from_string %(the JLine footnote:[https://github.com/jline/jline2]\nlibrary.)
-            result = para.sub_macros para.source
-            assert_equal %(the JLine <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>\nlibrary.), result
-            assert_equal 1, para.document.catalog[:footnotes].size
-            fn1 = para.document.catalog[:footnotes].first
-            assert_equal '<a href="https://github.com/jline/jline2" class="bare">https://github.com/jline/jline2</a>', fn1.text
-        end
-
-        test 'a footnote macro followed by a semi-colon may contain a plain URL' do
-            para = block_from_string %(the JLine footnote:[https://github.com/jline/jline2];\nlibrary.)
-            result = para.sub_macros para.source
-            assert_equal %(the JLine <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>;\nlibrary.), result
-            assert_equal 1, para.document.catalog[:footnotes].size
-            fn1 = para.document.catalog[:footnotes].first
-            assert_equal '<a href="https://github.com/jline/jline2" class="bare">https://github.com/jline/jline2</a>', fn1.text
-        end
-
-        test 'a footnote macro may contain text formatting' do
-            para = block_from_string 'You can download patches from the product page.footnote:[Only available with an _active_ subscription.]'
-            para.convert
-            footnotes = para.document.catalog[:footnotes]
-            assert_equal 1, footnotes.size
-            assert_equal 'Only available with an <em>active</em> subscription.', footnotes[0].text
-        end
-
-        test 'an externalized footnote macro may contain text formatting' do
-            input = <<~'EOS'
-            :fn-disclaimer: pass:q[footnote:[Only available with an _active_ subscription.]]
-
-            You can download patches from the production page.{fn-disclaimer}
-            EOS
-            doc = document_from_string input
-            doc.convert
-            footnotes = doc.catalog[:footnotes]
-            assert_equal 1, footnotes.size
-            assert_equal 'Only available with an <em>active</em> subscription.', footnotes[0].text
-        end
-
-        test 'a footnote macro may contain a shorthand xref' do
-            # specialcharacters escaping is simulated
-            para = block_from_string 'text footnote:[&lt;&lt;_install,install&gt;&gt;]'
-            doc = para.document
-            doc.register :refs, ['_install', (Asciidoctor::Inline.new doc, :anchor, 'Install', type: :ref, target: '_install'), 'Install']
-            catalog = doc.catalog
-            assert_equal %(text <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>), para.sub_macros(para.source)
-            assert_equal 1, catalog[:footnotes].size
-            footnote1 = catalog[:footnotes][0]
-            assert_equal '<a href="#_install">install</a>', footnote1.text
-        end
-
-        test 'a footnote macro may contain an xref macro' do
-            para = block_from_string 'text footnote:[xref:_install[install]]'
-            doc = para.document
-            doc.register :refs, ['_install', (Asciidoctor::Inline.new doc, :anchor, 'Install', type: :ref, target: '_install'), 'Install']
-            catalog = doc.catalog
-            assert_equal %(text <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>), para.sub_macros(para.source)
-            assert_equal 1, catalog[:footnotes].size
-            footnote1 = catalog[:footnotes][0]
-            assert_equal '<a href="#_install">install</a>', footnote1.text
-        end
-
-        test 'a footnote macro may contain an anchor macro' do
-            para = block_from_string 'text footnote:[a [[b]] [[c\]\] d]'
-            assert_equal %(text <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>), para.sub_macros(para.source)
-            assert_equal 1, para.document.catalog[:footnotes].size
-            footnote1 = para.document.catalog[:footnotes][0]
-            assert_equal 'a <a id="b"></a> [[c]] d', footnote1.text
-        end
-
-        test 'subsequent footnote macros with escaped URLs should be restored in DocBook' do
-            input = 'foofootnote:[+http://example.com+]barfootnote:[+http://acme.com+]baz'
-
-            result = convert_string_to_embedded input, doctype: 'inline', backend: 'docbook'
-            assert_equal 'foo<footnote><simpara>http://example.com</simpara></footnote>bar<footnote><simpara>http://acme.com</simpara></footnote>baz', result
-        end
-
-        test 'should increment index of subsequent footnote macros' do
-            para = block_from_string 'Sentence text footnote:[An example footnote.]. Sentence text footnote:[Another footnote.].'
-            assert_equal 'Sentence text <sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>. Sentence text <sup class="footnote">[<a id="_footnoteref_2" class="footnote" href="#_footnotedef_2" title="View footnote.">2</a>]</sup>.', para.sub_macros(para.source)
-            assert_equal 2, para.document.catalog[:footnotes].size
-            footnote1 = para.document.catalog[:footnotes][0]
-            assert_equal 1, footnote1.index
-            assert_nil footnote1.id
-            assert_equal 'An example footnote.', footnote1.text
-            footnote2 = para.document.catalog[:footnotes][1]
-            assert_equal 2, footnote2.index
-            assert_nil footnote2.id
-            assert_equal 'Another footnote.', footnote2.text
-        end
-
-        test 'a footnoteref macro with id and single-line text should be registered and output as a footnote' do
-            para = block_from_string 'Sentence text footnoteref:[ex1, An example footnote.].', attributes: { 'compat-mode' => '' }
-            assert_equal %(Sentence text <sup class="footnote" id="_footnote_ex1">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>.), para.sub_macros(para.source)
-            assert_equal 1, para.document.catalog[:footnotes].size
-            footnote = para.document.catalog[:footnotes].first
-            assert_equal 1, footnote.index
-            assert_equal 'ex1', footnote.id
-            assert_equal 'An example footnote.', footnote.text
-        end
-
-        test 'a footnoteref macro with id and multi-line text should be registered and output as a footnote without newlines' do
-            para = block_from_string "Sentence text footnoteref:[ex1, An example footnote\nwith wrapped text.].", attributes: { 'compat-mode' => '' }
-            assert_equal %(Sentence text <sup class="footnote" id="_footnote_ex1">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>.), para.sub_macros(para.source)
-            assert_equal 1, para.document.catalog[:footnotes].size
-            footnote = para.document.catalog[:footnotes].first
-            assert_equal 1, footnote.index
-            assert_equal 'ex1', footnote.id
-            assert_equal 'An example footnote with wrapped text.', footnote.text
-        end
-
-        test 'a footnoteref macro with id should refer to footnoteref with same id' do
-            para = block_from_string 'Sentence text footnoteref:[ex1, An example footnote.]. Sentence text footnoteref:[ex1].', attributes: { 'compat-mode' => '' }
-            assert_equal %(Sentence text <sup class="footnote" id="_footnote_ex1">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>. Sentence text <sup class="footnoteref">[<a class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup>.), para.sub_macros(para.source)
-            assert_equal 1, para.document.catalog[:footnotes].size
-            footnote = para.document.catalog[:footnotes].first
-            assert_equal 1, footnote.index
-            assert_equal 'ex1', footnote.id
-            assert_equal 'An example footnote.', footnote.text
-        end
-
-        test 'an unresolved footnote reference should produce a warning message and output fallback text in red' do
-            input = 'Sentence text.footnote:ex1[]'
-            using_memory_logger do |logger|
-            para = block_from_string input
-            output = para.sub_macros para.source
-            assert_equal 'Sentence text.<sup class="footnoteref red" title="Unresolved footnote reference.">[ex1]</sup>', output
-            assert_message logger, :WARN, 'invalid footnote reference: ex1'
-            end
-        end
-
-        test 'using a footnoteref macro should generate a warning when compat mode is not enabled' do
-            input = 'Sentence text.footnoteref:[fn1,Commentary on this sentence.]'
-            using_memory_logger do |logger|
-            para = block_from_string input
-            para.sub_macros para.source
-            assert_message logger, :WARN, 'found deprecated footnoteref macro: footnoteref:[fn1,Commentary on this sentence.]; use footnote macro with target instead'
-            end
-        end
-
-        test 'inline footnote macro can be used to define and reference a footnote reference' do
-            input = <<~'EOS'
-            You can download the software from the product page.footnote:sub[Option only available if you have an active subscription.]
-
-            You can also file a support request.footnote:sub[]
-
-            If all else fails, you can give us a call.footnoteref:[sub]
-            EOS
-
-            using_memory_logger do |logger|
-            output = convert_string_to_embedded input, attributes: { 'compat-mode' => '' }
-            assert_css '#_footnotedef_1', output, 1
-            assert_css 'p a[href="#_footnotedef_1"]', output, 3
-            assert_css '#footnotes .footnote', output, 1
-            assert_empty logger
-            end
-        end
-
-        test 'should parse multiple footnote references in a single line' do
-            input = 'notable text.footnote:id[about this [text\]], footnote:id[], footnote:id[]'
-            output = convert_string_to_embedded input
-            assert_xpath '(//p)[1]/sup[starts-with(@class,"footnote")]', output, 3
-            assert_xpath '(//p)[1]/sup[@class="footnote"]', output, 1
-            assert_xpath '(//p)[1]/sup[@class="footnoteref"]', output, 2
-            assert_xpath '(//p)[1]/sup[starts-with(@class,"footnote")]/a[@class="footnote"][text()="1"]', output, 3
-            assert_css '#footnotes .footnote', output, 1
-        end
-
-        test 'should not register footnote with id and text if id already registered' do
-            input = <<~'EOS'
-            :fn-notable-text: footnote:id[about this text]
-
-            notable text.{fn-notable-text}
-
-            more notable text.{fn-notable-text}
-            EOS
-            output = convert_string_to_embedded input
-            assert_xpath '(//p)[1]/sup[@class="footnote"]', output, 1
-            assert_xpath '(//p)[2]/sup[@class="footnoteref"]', output, 1
-            assert_css '#footnotes .footnote', output, 1
-        end
-
-        test 'should not resolve an inline footnote macro missing both id and text' do
-            input = <<~'EOS'
-            The footnote:[] macro can be used for defining and referencing footnotes.
-
-            The footnoteref:[] macro is now deprecated.
-            EOS
-
-            output = convert_string_to_embedded input
-            assert_includes output, 'The footnote:[] macro'
-            assert_includes output, 'The footnoteref:[] macro'
-        end
-
-        test 'inline footnote macro can define a numeric id without conflicting with auto-generated ID' do
-            input = 'You can download the software from the product page.footnote:1[Option only available if you have an active subscription.]'
-
-            output = convert_string_to_embedded input
-            assert_css '#_footnote_1', output, 1
-            assert_css 'p sup#_footnote_1', output, 1
-            assert_css 'p a#_footnoteref_1', output, 1
-            assert_css 'p a[href="#_footnotedef_1"]', output, 1
-            assert_css '#footnotes #_footnotedef_1', output, 1
-        end
-
-        test 'inline footnote macro can define an id that uses any word characters in Unicode' do
-            input = <<~'EOS'
-            L'origine du mot forêt{blank}footnote:forêt[un massif forestier] est complexe.
-
-            Qu'est-ce qu'une forêt ?{blank}footnote:forêt[]
-            EOS
-            output = convert_string_to_embedded input
-            assert_css '#_footnote_forêt', output, 1
-            assert_css '#_footnotedef_1', output, 1
-            assert_xpath '//a[@class="footnote"][text()="1"]', output, 2
-        end
-
-        test 'should be able to reference a bibliography entry in a footnote' do
-            input = <<~'EOS'
-            Choose a design pattern.footnote:[See <<gof>> to find a collection of design patterns.]
-
-            [bibliography]
-            == Bibliography
-
-            * [[[gof]]] Erich Gamma, et al. _Design Patterns: Elements of Reusable Object-Oriented Software._ Addison-Wesley. 1994.
-            EOS
-
-            result = convert_string_to_embedded input
-            assert_include '<a href="#_footnoteref_1">1</a>. See <a href="#gof">[gof]</a> to find a collection of design patterns.', result
-        end
-
-        test 'footnotes in headings are expected to be numbered out of sequence' do
-            input = <<~'EOS'
-            == Section 1
-
-            para.footnote:[first footnote]
-
-            == Section 2footnote:[second footnote]
-
-            para.footnote:[third footnote]
-            EOS
-
-            result = convert_string_to_embedded input
-            footnote_refs = xmlnodes_at_css 'a.footnote', result
-            footnote_defs = xmlnodes_at_css 'div.footnote', result
-            assert_equal 3, footnote_refs.length
-            assert_equal %w(1 1 2), footnote_refs.map(&:text)
-            assert_equal 3, footnote_defs.length
-            assert_equal ['1. second footnote', '1. first footnote', '2. third footnote'], footnote_defs.map(&:text).map(&:strip)
-        end
-
         context 'Button macro' do
             test 'btn macro' do
             para = block_from_string 'btn:[Save]', attributes: { 'experimental' => '' }

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -4385,6 +4385,43 @@ mod macros {
             assert_eq!(footnotes[0].text, "un massif forestier");
         }
 
+        #[test]
+        fn an_escaped_footnote_macro_is_emitted_literally() {
+            // A leading backslash escapes the macro: the backslash is dropped
+            // and the macro text is emitted verbatim, defining no footnote.
+            let doc = Parser::default().parse("A \\footnote:[not a footnote] here.");
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                &["A footnote:[not a footnote] here."]
+            );
+            assert!(doc.catalog().footnotes().is_empty());
+        }
+
+        #[test]
+        fn text_matching_the_footnote_gate_but_not_the_macro_is_left_untouched() {
+            // The footnote pass is gated on the text merely containing `tnote`
+            // (a substring of `footnote`). A macro-like token that trips the
+            // gate without being a footnote macro produces no match and is
+            // emitted unchanged, defining no footnote.
+            let doc = Parser::default().parse("A tnote:[x] here.");
+            assert_eq!(rendered_paragraphs(&doc), &["A tnote:[x] here."]);
+            assert!(doc.catalog().footnotes().is_empty());
+        }
+
+        #[test]
+        fn a_footnote_macro_immediately_before_a_closing_anchor_tag_is_not_matched() {
+            // Re-creates Asciidoctor's `(?!</a>)` look-ahead: a footnote macro
+            // whose closing bracket is immediately followed by `</a>` (i.e. it
+            // sits at the end of an already-rendered link's text) is left
+            // untouched rather than being processed a second time.
+            let mut content =
+                crate::content::Content::from(crate::Span::new("x footnote:[note]</a>"));
+            let parser = Parser::default();
+            crate::content::SubstitutionStep::Macros.apply(&mut content, &parser, None);
+
+            assert_eq!(content.rendered(), "x footnote:[note]</a>");
+        }
+
         // ---------------------------------------------------------------------
         // Deferred: these depend on features the crate does not yet implement.
 

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -4402,12 +4402,18 @@ mod macros {
         fn footnote_macro_may_contain_an_xref() {}
 
         #[test]
-        #[ignore]
-        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/593):
-        // Honor passthrough (`pass:[]` / `pass:q[]`) substitutions in the value
-        // of an externalized footnote attribute (e.g.
-        // `:fn-disclaimer: pass:q[footnote:[…_italic_…]]`).
-        fn externalized_footnote_macro_may_contain_text_formatting() {}
+        fn externalized_footnote_macro_may_contain_text_formatting() {
+            let doc = Parser::default().parse(
+                ":fn-disclaimer: pass:q[footnote:[Only available with an _active_ subscription.]]\n\nYou can download patches from the production page.{fn-disclaimer}",
+            );
+
+            let footnotes = doc.catalog().footnotes();
+            assert_eq!(footnotes.len(), 1);
+            assert_eq!(
+                footnotes[0].text,
+                "Only available with an <em>active</em> subscription."
+            );
+        }
 
         // Backend-specific test omitted: "subsequent footnote macros with
         // escaped URLs should be restored in DocBook" asserts only against

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1382,11 +1382,23 @@ mod psv {
     fn should_catalog_anchor_at_start_of_cell_in_first_row() {}
 
     #[test]
-    #[ignore]
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/544):
-    // Footnotes must not be shared between an AsciiDoc table cell and the main
-    // document.
-    fn footnotes_should_not_be_shared_between_an_asciidoc_table_cell_and_the_main_document() {}
+    fn footnotes_should_not_be_shared_between_an_asciidoc_table_cell_and_the_main_document() {
+        let doc = Parser::default()
+            .parse("|===\na|AsciiDoc footnote:[A lightweight markup language.]\n|===");
+
+        // The footnote defined inside the cell is numbered and rendered within
+        // the cell's own (nested) document.
+        assert_css(&doc, "sup.footnote", 1);
+        assert_css(&doc, "a#_footnoteref_1", 1);
+
+        // It is *not* shared with the enclosing document: the main document's
+        // footnote registry stays empty, so the footnote would not appear in the
+        // main document's footnote list.
+        assert!(
+            doc.catalog().footnotes().is_empty(),
+            "cell footnote leaked into the main document's registry"
+        );
+    }
 
     // Backend-specific test omitted: DocBook ("callout numbers should be
     // globally unique, including AsciiDoc table cells"). Out of scope: it

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -103,6 +103,16 @@ pub enum WarningType {
 
     #[error("invalid substitution type for stem macro: {0}")]
     InvalidSubstitutionTypeForStemMacro(String),
+
+    /// A footnote reference (`footnote:id[]`) names an ID that was never
+    /// defined by an earlier footnote.
+    #[error("invalid footnote reference: {0}")]
+    InvalidFootnoteReference(String),
+
+    /// The deprecated `footnoteref:[…]` macro was used outside compatibility
+    /// mode. The footnote macro with a target should be used instead.
+    #[error("found deprecated footnoteref macro: {0}; use footnote macro with target instead")]
+    DeprecatedFootnorefMacro(String),
 }
 
 impl std::fmt::Debug for WarningType {
@@ -212,6 +222,16 @@ impl std::fmt::Debug for WarningType {
             WarningType::InvalidSubstitutionTypeForStemMacro(subs) => f
                 .debug_tuple("WarningType::InvalidSubstitutionTypeForStemMacro")
                 .field(subs)
+                .finish(),
+
+            WarningType::InvalidFootnoteReference(id) => f
+                .debug_tuple("WarningType::InvalidFootnoteReference")
+                .field(id)
+                .finish(),
+
+            WarningType::DeprecatedFootnorefMacro(macro_text) => f
+                .debug_tuple("WarningType::DeprecatedFootnorefMacro")
+                .field(macro_text)
                 .finish(),
         }
     }


### PR DESCRIPTION
## Summary

Implements the AsciiDoc [`footnote` macro](https://docs.asciidoctor.org/asciidoc/latest/macros/footnote/) — the previously-unimplemented `todo!("Port footnote macro")` in `content/macros.rs` — and the features described on `docs/modules/macros/pages/footnote.adoc`.

**Closes #544** (footnotes must not be shared between an AsciiDoc table cell and the main document).

## What's implemented

- **Footnote macro** parsing/substitution for all forms:
  - `footnote:[text]` — anonymous footnote
  - `footnote:id[text]` — footnote with an ID (so it can be referenced again)
  - `footnote:id[]` — reference to a previously-defined footnote (reuses its number)
  - `footnoteref:[id,text]` / `footnoteref:[id]` — the deprecated equivalents (warns outside `compat-mode`)
- **Per-document footnote registry** exposed via `Catalog::footnotes()` (a new public `Footnote { index, id, text }` type), numbered consecutively via the `footnote-number` counter.
- **Inline rendering** matching Asciidoctor's HTML exactly (`<sup class="footnote">…`, `footnoteref`, and the red unresolved-reference marker), via a new `render_footnote` method on `InlineSubstitutionRenderer` (+ `FootnoteRenderParams`).
- **Nested-document isolation (#544):** an AsciiDoc table cell keeps its own footnote registry, so a footnote defined in a cell is not shared with (or numbered into the list of) the enclosing document. The global `footnote-number` counter is preserved across the cell, matching Asciidoctor.
- **Warnings:** `InvalidFootnoteReference` (unresolved `footnote:id[]`) and `DeprecatedFootnorefMacro` (`footnoteref:` outside compat mode).

## Tests

- Un-ignored and implemented the #544 table-cell test.
- Ported the footnote substitution tests from Ruby Asciidoctor's `substitutions_test.rb` into `substitutions_test.rs` (`mod footnotes`) — 22 passing.
- Added line-by-line spec coverage for `footnote.adoc` (`tests/asciidoc_lang/macros/footnote.rs`); `cd sdd && cargo run` reports the page fully accounted for.

Full suite: `2639 passed; 0 failed`. `cargo +nightly fmt --check`, `cargo clippy`, and `cargo +nightly doc` are clean.

## Deferred (left `#[ignore]`d with explanatory TODOs)

These depend on infrastructure beyond footnotes and are scoped out of this PR:

- **Cross-reference / bibliography references inside footnote text** ([#592](https://github.com/asciidoc-rs/asciidoc-parser/issues/592)) — the crate defers xref resolution to a document-level pass over block content, which doesn't reach text extracted into a footnote.
- **Footnotes in section titles numbered out of document order** ([#594](https://github.com/asciidoc-rs/asciidoc-parser/issues/594)) — titles are converted eagerly, and the crate still leaks the heading footnote into an xref's reference text.
- DocBook-only footnote test omitted (the crate does not target DocBook).

Passthrough (`pass:c,q[]` / `pass:q[]`) substitutions in externalized footnote attributes already work and are now covered by spec tests, so #593 has been closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)