### PR TITLE
feat: Implement conditional preprocessor directives (ifdef/ifndef/ifeval)

### DIFF
--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -487,11 +487,12 @@ impl<'p> PreprocessorState<'p> {
         }
 
         if content.is_empty() {
-            // Block form: include the enclosed lines when the condition holds.
-            let include = already_skipping || self.eval_ifdef(keyword, target);
+            // Block form: skip the enclosed lines unless the condition holds
+            // (and never include them while already skipping).
+            let skipping = already_skipping || !self.eval_ifdef(keyword, target);
             self.conditional_stack.push(Conditional {
                 target: Some(target.to_owned()),
-                skipping: already_skipping || !include,
+                skipping,
             });
         } else if !already_skipping && self.eval_ifdef(keyword, target) {
             // Single-line form: the bracketed content is included in place (with
@@ -519,7 +520,10 @@ impl<'p> PreprocessorState<'p> {
         source_line_number: usize,
         has_reported_file: &mut bool,
     ) {
-        if self.can_have_attribute
+        let can_have_attribute = self.can_have_attribute;
+        let mut applied_attribute = false;
+
+        if can_have_attribute
             && content.starts_with(':')
             && (content.ends_with(':') || content.contains(": "))
             && let Some(attr) = Attribute::parse(Span::new(content), self.parser)
@@ -527,9 +531,19 @@ impl<'p> PreprocessorState<'p> {
             let mut warnings: Vec<Warning> = vec![];
             self.parser
                 .set_attribute_from_body(&attr.item, &mut warnings);
+            applied_attribute = true;
         }
 
         self.emit_line(content, file_name, source_line_number, has_reported_file);
+
+        // The main attribute-entry handler leaves `can_have_attribute` unchanged
+        // so that consecutive attribute entries are all applied by the
+        // preprocessor (and thus observed by later include targets); `emit_line`
+        // would instead clear it for this non-empty line. Restore the invariant
+        // when the single-line content was itself an attribute entry.
+        if applied_attribute {
+            self.can_have_attribute = can_have_attribute;
+        }
     }
 
     /// Evaluate an `ifdef`/`ifndef` condition, returning `true` if the enclosed
@@ -1703,6 +1717,28 @@ mod tests {
             conditional_output(":foo:\n\nifdef::foo[:bar: yes]\nifdef::bar[bar is set]"),
             ":foo:\n\n:bar: yes\nbar is set\n"
         );
+    }
+
+    #[test]
+    fn single_line_attribute_entry_preserves_attribute_context() {
+        // Emitting an attribute-entry line via a single-line conditional must not
+        // disable preprocessor attribute handling for the immediately following
+        // line (as the main attribute-entry handler leaves it enabled). Here the
+        // entry after the directive must still be applied so the include target
+        // that references it resolves.
+        let source = ":flag:\n\nifdef::flag[:dir: sub]\n:file: {dir}/f\ninclude::{file}.adoc[]";
+
+        let handler = InlineFileHandler::from_pairs([("sub/f.adoc", "Included.")]);
+
+        let parser = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_primary_file_name("main.adoc")
+            .with_include_file_handler(handler);
+
+        let (output, _source_map, warnings) = preprocess(source, &parser);
+
+        assert!(output.contains("Included."), "output was: {output:?}");
+        assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
     }
 
     #[test]

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -33,8 +33,10 @@ pub(crate) fn preprocess(
     // directives.
     if !source.starts_with("include::")
         && !source.starts_with("if")
+        && !source.starts_with("\\if")
         && !source.contains("\ninclude::")
         && !source.contains("\nif")
+        && !source.contains("\n\\if")
         && !source.starts_with("\\include::")
         && !source.contains("\n\\include::")
         && parser.primary_file_name.is_none()
@@ -62,6 +64,27 @@ struct PreprocessorState<'p> {
     output: String,
     source_map: SourceMap,
     warnings: Vec<DeferredWarning>,
+
+    /// Stack of open conditional preprocessor directives (`ifdef`, `ifndef`,
+    /// `ifeval`). Each entry records whether the lines it encloses are
+    /// currently being skipped. See [`process_conditional_directive`].
+    ///
+    /// [`process_conditional_directive`]: Self::process_conditional_directive
+    conditional_stack: Vec<Conditional>,
+}
+
+/// A single open block-form conditional preprocessor directive.
+#[derive(Debug)]
+struct Conditional {
+    /// The directive target used to match a named `endif`. `ifdef`/`ifndef`
+    /// store their attribute expression here; `ifeval` stores `None` (it can
+    /// only be closed by an anonymous `endif::[]`).
+    target: Option<String>,
+
+    /// `true` if the lines enclosed by this directive are being discarded. This
+    /// is cumulative: a conditional nested inside a skipped region is itself
+    /// skipping, regardless of its own condition.
+    skipping: bool,
 }
 
 impl<'p> PreprocessorState<'p> {
@@ -75,7 +98,14 @@ impl<'p> PreprocessorState<'p> {
             output: String::new(),
             source_map: SourceMap::default(),
             warnings: vec![],
+            conditional_stack: vec![],
         }
+    }
+
+    /// Returns `true` if the preprocessor is currently discarding lines because
+    /// it is inside a conditional directive whose condition evaluated to false.
+    fn skipping(&self) -> bool {
+        self.conditional_stack.last().is_some_and(|c| c.skipping)
     }
 
     fn process_adoc_include(&mut self, source: &str, file_name: Option<&str>) {
@@ -91,6 +121,52 @@ impl<'p> PreprocessorState<'p> {
             source_span = after;
 
             let source_line_number = line.line();
+
+            // Conditional preprocessor directives (`ifdef`, `ifndef`, `ifeval`,
+            // `endif`) are handled before anything else so they take effect even
+            // while a surrounding conditional is skipping (the nesting still has
+            // to be tracked to balance the stack).
+            if has_conditional_prefix(line.data())
+                && let Some(caps) = CONDITIONAL_DIRECTIVE.captures(line.data())
+            {
+                // A directive line produces no output of its own, so the next
+                // emitted line must re-anchor the source map (its original line
+                // number no longer matches the output line number).
+                has_reported_file = false;
+
+                if caps.get(1).is_some() {
+                    // Escaped directive (e.g. `\ifdef::foo[]`): not processed.
+                    // The leading backslash is stripped and the remainder is
+                    // emitted literally, matching Asciidoctor — unless we're
+                    // skipping, in which case it's discarded like any other line.
+                    if !self.skipping() {
+                        self.emit_line(
+                            &line.data()[1..],
+                            file_name,
+                            source_line_number,
+                            &mut has_reported_file,
+                        );
+                    }
+                } else {
+                    self.process_conditional_directive(
+                        &caps[2],
+                        caps.get(3).map_or("", |m| m.as_str()),
+                        caps.get(4).map_or("", |m| m.as_str()),
+                        file_name,
+                        source_line_number,
+                        &mut has_reported_file,
+                    );
+                }
+
+                continue;
+            }
+
+            // While skipping (inside a conditional whose condition was false),
+            // discard every non-directive line.
+            if self.skipping() {
+                has_reported_file = false;
+                continue;
+            }
 
             if self.can_have_attribute
                 && line.starts_with(':')
@@ -330,6 +406,332 @@ impl<'p> PreprocessorState<'p> {
             input.to_string()
         }
     }
+
+    /// Emit a single line of text to the output, updating the source map and
+    /// document-header tracking state exactly as the plain-line branch of
+    /// [`process_adoc_include`] does.
+    ///
+    /// [`process_adoc_include`]: Self::process_adoc_include
+    fn emit_line(
+        &mut self,
+        text: &str,
+        file_name: Option<&str>,
+        source_line_number: usize,
+        has_reported_file: &mut bool,
+    ) {
+        if !*has_reported_file {
+            *has_reported_file = true;
+            self.source_map.append(
+                self.output_line_number,
+                SourceLine(to_owned(file_name), source_line_number),
+            );
+        }
+
+        if text.is_empty() {
+            self.in_document_header = false;
+            self.can_have_attribute = true;
+        } else if !self.in_document_header {
+            self.can_have_attribute = false;
+        }
+
+        self.output_line_number += 1;
+        self.output.push_str(text);
+        self.output.push('\n');
+    }
+
+    /// Process a conditional preprocessor directive (`ifdef`, `ifndef`,
+    /// `ifeval`, or `endif`).
+    ///
+    /// `keyword` is the directive name, `target` is the text before the `[`
+    /// (attribute expression for `ifdef`/`ifndef`, empty for `ifeval`), and
+    /// `content` is the text inside the brackets (single-line content for
+    /// `ifdef`/`ifndef`, the expression for `ifeval`).
+    ///
+    /// See the [conditionals] documentation.
+    ///
+    /// [conditionals]: https://docs.asciidoctor.org/asciidoc/latest/directives/conditionals/
+    fn process_conditional_directive(
+        &mut self,
+        keyword: &str,
+        target: &str,
+        content: &str,
+        file_name: Option<&str>,
+        source_line_number: usize,
+        has_reported_file: &mut bool,
+    ) {
+        if keyword == "endif" {
+            // `endif::[]` closes the most recently opened conditional;
+            // `endif::name[]` must match that conditional's target. An `endif`
+            // with non-empty brackets (e.g. `endif::[<condition>]`) is malformed
+            // and closes nothing, and a mismatched or unmatched `endif` is
+            // ignored (Asciidoctor logs an error in each case).
+            if content.is_empty()
+                && let Some(top) = self.conditional_stack.last()
+                && (target.is_empty() || top.target.as_deref() == Some(target))
+            {
+                self.conditional_stack.pop();
+            }
+            return;
+        }
+
+        let already_skipping = self.skipping();
+
+        if keyword == "ifeval" {
+            // `ifeval` has no single-line or long-form variant and its target
+            // must be empty; it is always closed by an anonymous `endif::[]`.
+            if !target.is_empty() {
+                return;
+            }
+
+            let include = !already_skipping && self.eval_ifeval(content);
+            self.conditional_stack.push(Conditional {
+                target: None,
+                skipping: already_skipping || !include,
+            });
+            return;
+        }
+
+        // `ifdef` / `ifndef`.
+        if target.is_empty() {
+            // Malformed: a target (attribute name) is required.
+            return;
+        }
+
+        if content.is_empty() {
+            // Block form: include the enclosed lines when the condition holds.
+            let include = already_skipping || self.eval_ifdef(keyword, target);
+            self.conditional_stack.push(Conditional {
+                target: Some(target.to_owned()),
+                skipping: already_skipping || !include,
+            });
+        } else if !already_skipping && self.eval_ifdef(keyword, target) {
+            // Single-line form: the bracketed content is included in place (with
+            // no `endif`) when the condition holds.
+            self.process_single_line_content(
+                content,
+                file_name,
+                source_line_number,
+                has_reported_file,
+            );
+        }
+    }
+
+    /// Emit the bracketed content of a single-line `ifdef`/`ifndef` directive.
+    ///
+    /// The content is a single line. When it is an attribute entry (e.g.
+    /// `ifdef::x[:foo: bar]`) it is applied to the running attribute state so
+    /// that later directives and include targets observe it, matching how the
+    /// main loop treats attribute entries; otherwise it is emitted verbatim and
+    /// left for normal parsing (any `{attr}` references are resolved then).
+    fn process_single_line_content(
+        &mut self,
+        content: &str,
+        file_name: Option<&str>,
+        source_line_number: usize,
+        has_reported_file: &mut bool,
+    ) {
+        if self.can_have_attribute
+            && content.starts_with(':')
+            && (content.ends_with(':') || content.contains(": "))
+            && let Some(attr) = Attribute::parse(Span::new(content), self.parser)
+        {
+            let mut warnings: Vec<Warning> = vec![];
+            self.parser
+                .set_attribute_from_body(&attr.item, &mut warnings);
+        }
+
+        self.emit_line(content, file_name, source_line_number, has_reported_file);
+    }
+
+    /// Evaluate an `ifdef`/`ifndef` condition, returning `true` if the enclosed
+    /// content should be included.
+    ///
+    /// Multiple attribute names may be combined with `,` (any is set — logical
+    /// OR) or `+` (all are set — logical AND); the two combinators cannot be
+    /// mixed. `ifndef` is the logical negation of `ifdef`.
+    fn eval_ifdef(&self, keyword: &str, target: &str) -> bool {
+        let defined = if target.contains(',') {
+            target
+                .split(',')
+                .any(|name| self.parser.is_attribute_set(name))
+        } else if target.contains('+') {
+            target
+                .split('+')
+                .all(|name| self.parser.is_attribute_set(name))
+        } else {
+            self.parser.is_attribute_set(target)
+        };
+
+        if keyword == "ifndef" {
+            !defined
+        } else {
+            defined
+        }
+    }
+
+    /// Evaluate an `ifeval` expression, returning `true` if the enclosed
+    /// content should be included. A malformed expression (or one whose two
+    /// sides cannot be compared) evaluates to false.
+    fn eval_ifeval(&self, expr: &str) -> bool {
+        let Some(caps) = IFEVAL_EXPRESSION.captures(expr.trim()) else {
+            return false;
+        };
+
+        let lhs = self.resolve_expr_val(&caps[1]);
+        let rhs = self.resolve_expr_val(&caps[3]);
+        compare_values(&lhs, &caps[2], &rhs)
+    }
+
+    /// Resolve one side of an `ifeval` expression to a typed [`Value`].
+    ///
+    /// Attribute references are substituted first. A value enclosed in single
+    /// or double quotes is always a string; otherwise it is coerced per the
+    /// documented rules (empty → nil, `true`/`false` → boolean, a value with a
+    /// period → float, anything else → integer).
+    fn resolve_expr_val(&self, raw: &str) -> Value {
+        let raw = raw.trim();
+
+        // A value wrapped in matching single or double quotes is always a string.
+        let quoted_inner = raw
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+            .or_else(|| raw.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')));
+
+        match quoted_inner {
+            Some(inner) => Value::Str(self.substitute_attributes(inner)),
+            None => coerce_unquoted(&self.substitute_attributes(raw)),
+        }
+    }
+}
+
+/// A value that one side of an `ifeval` expression has been coerced to.
+#[derive(Debug, PartialEq)]
+enum Value {
+    Int(i64),
+    Float(f64),
+    Str(String),
+    Bool(bool),
+    Nil,
+}
+
+/// Coerce an unquoted `ifeval` operand to a typed [`Value`] per the documented
+/// rules.
+fn coerce_unquoted(s: &str) -> Value {
+    if s.is_empty() {
+        return Value::Nil;
+    }
+
+    match s {
+        "true" => return Value::Bool(true),
+        "false" => return Value::Bool(false),
+        _ => {}
+    }
+
+    if s.chars().all(char::is_whitespace) {
+        return Value::Str(" ".to_owned());
+    }
+
+    if s.contains('.') {
+        Value::Float(ruby_to_f(s))
+    } else {
+        Value::Int(ruby_to_i(s))
+    }
+}
+
+/// Parse the leading integer of a string, Ruby `String#to_i` style (a string
+/// with no leading numeric portion yields `0`).
+fn ruby_to_i(s: &str) -> i64 {
+    let mut digits = String::new();
+
+    for (idx, ch) in s.trim().char_indices() {
+        if (idx == 0 && (ch == '+' || ch == '-')) || ch.is_ascii_digit() {
+            digits.push(ch);
+        } else {
+            break;
+        }
+    }
+
+    digits.parse().unwrap_or(0)
+}
+
+/// Parse the leading float of a string, Ruby `String#to_f` style (a string with
+/// no leading numeric portion yields `0.0`).
+fn ruby_to_f(s: &str) -> f64 {
+    let s = s.trim();
+    if let Ok(f) = s.parse::<f64>() {
+        return f;
+    }
+
+    let mut digits = String::new();
+    let mut seen_dot = false;
+
+    for (idx, ch) in s.char_indices() {
+        if (idx == 0 && (ch == '+' || ch == '-')) || ch.is_ascii_digit() {
+            digits.push(ch);
+        } else if ch == '.' && !seen_dot {
+            seen_dot = true;
+            digits.push(ch);
+        } else {
+            break;
+        }
+    }
+
+    digits.parse().unwrap_or(0.0)
+}
+
+/// Compare two `ifeval` values with the given operator, following Ruby's
+/// comparison semantics. Equality across value types is simply `false`; an
+/// ordering comparison (`<`, `<=`, `>`, `>=`) between values that cannot be
+/// ordered (e.g. a number and a string) fails and yields `false`.
+fn compare_values(lhs: &Value, op: &str, rhs: &Value) -> bool {
+    match op {
+        "==" => values_equal(lhs, rhs),
+        "!=" => !values_equal(lhs, rhs),
+        _ => match ordering_of(lhs, rhs) {
+            Some(ordering) => match op {
+                "<" => ordering.is_lt(),
+                "<=" => ordering.is_le(),
+                ">" => ordering.is_gt(),
+                ">=" => ordering.is_ge(),
+                _ => false,
+            },
+            None => false,
+        },
+    }
+}
+
+fn values_equal(lhs: &Value, rhs: &Value) -> bool {
+    match (lhs, rhs) {
+        (Value::Int(a), Value::Int(b)) => a == b,
+        (Value::Float(a), Value::Float(b)) => a == b,
+        (Value::Int(a), Value::Float(b)) | (Value::Float(b), Value::Int(a)) => (*a as f64) == *b,
+        (Value::Str(a), Value::Str(b)) => a == b,
+        (Value::Bool(a), Value::Bool(b)) => a == b,
+        (Value::Nil, Value::Nil) => true,
+        _ => false,
+    }
+}
+
+fn ordering_of(lhs: &Value, rhs: &Value) -> Option<std::cmp::Ordering> {
+    match (lhs, rhs) {
+        (Value::Int(a), Value::Int(b)) => Some(a.cmp(b)),
+        (Value::Float(a), Value::Float(b)) => a.partial_cmp(b),
+        (Value::Int(a), Value::Float(b)) => (*a as f64).partial_cmp(b),
+        (Value::Float(a), Value::Int(b)) => a.partial_cmp(&(*b as f64)),
+        (Value::Str(a), Value::Str(b)) => Some(a.cmp(b)),
+        _ => None,
+    }
+}
+
+/// Returns `true` if `line` could be a conditional preprocessor directive,
+/// gating the (more expensive) regex match. An optional leading backslash marks
+/// an escaped directive.
+fn has_conditional_prefix(line: &str) -> bool {
+    let line = line.strip_prefix('\\').unwrap_or(line);
+    line.starts_with("ifdef::")
+        || line.starts_with("ifndef::")
+        || line.starts_with("ifeval::")
+        || line.starts_with("endif::")
 }
 
 fn to_owned(maybe_file_name: Option<&str>) -> Option<String> {
@@ -385,6 +787,38 @@ static INCLUDE_DIRECTIVE: LazyLock<Regex> = LazyLock::new(|| {
 static ATTRIBUTE_REFERENCE: LazyLock<Regex> = LazyLock::new(|| {
     #[allow(clippy::unwrap_used)]
     Regex::new(r#"\\?\{([A-Za-z0-9_][A-Za-z0-9_-]*)\}"#).unwrap()
+});
+
+static CONDITIONAL_DIRECTIVE: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(
+        r#"(?x)                          # Extended (verbose) mode
+
+        ^                               # Start of line
+
+        (\\)?                           # (1) Optional escaping backslash
+
+        (ifdef|ifndef|ifeval|endif)     # (2) Directive keyword
+
+        ::                              # Literal '::' separator
+
+        ([^\[]*)                        # (3) Target (attribute expression), may be empty
+
+        \[                             # Literal '[' opening the brackets
+
+        (.*)                            # (4) Bracketed content, may be empty
+
+        \]                             # Literal closing ']'
+
+        $                               # End of line
+        "#,
+    )
+    .unwrap()
+});
+
+static IFEVAL_EXPRESSION: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(r#"(?s)^(.+?)\s*(==|!=|<=|>=|<|>)\s*(.+)$"#).unwrap()
 });
 
 #[cfg(test)]
@@ -1212,6 +1646,210 @@ mod tests {
                 Some("very/long/path/to/some/ subdirectory/file.adoc".to_owned()),
                 1
             ))
+        );
+    }
+
+    /// Preprocess `source` with a default (secure) parser and return only the
+    /// resulting text, for the conditional-directive tests below.
+    fn conditional_output(source: &str) -> String {
+        let parser = Parser::default();
+        let (output, _source_map, _warnings) = preprocess(source, &parser);
+        output
+    }
+
+    #[test]
+    fn ifdef_set_includes_content() {
+        assert_eq!(
+            conditional_output(":foo:\n\nifdef::foo[]\nkept\nendif::[]\n\ntail"),
+            ":foo:\n\nkept\n\ntail\n"
+        );
+    }
+
+    #[test]
+    fn ifdef_unset_excludes_content() {
+        assert_eq!(
+            conditional_output("head\n\nifdef::foo[]\ndropped\nendif::[]\n\ntail"),
+            "head\n\n\ntail\n"
+        );
+    }
+
+    #[test]
+    fn ifndef_unset_includes_content() {
+        assert_eq!(
+            conditional_output("head\n\nifndef::foo[]\nkept\nendif::[]"),
+            "head\n\nkept\n"
+        );
+    }
+
+    #[test]
+    fn ifndef_set_excludes_content() {
+        assert_eq!(
+            conditional_output(":foo:\n\nifndef::foo[]\ndropped\nendif::[]\n\ntail"),
+            ":foo:\n\n\ntail\n"
+        );
+    }
+
+    #[test]
+    fn ifdef_single_line_included() {
+        assert_eq!(
+            conditional_output(":foo:\n\nifdef::foo[kept on one line]"),
+            ":foo:\n\nkept on one line\n"
+        );
+    }
+
+    #[test]
+    fn ifdef_single_line_excluded() {
+        assert_eq!(
+            conditional_output("head\n\nifdef::foo[dropped]\n\ntail"),
+            "head\n\n\ntail\n"
+        );
+    }
+
+    #[test]
+    fn ifdef_single_line_attribute_entry_is_applied() {
+        // The attribute set inside the single-line directive is observed by the
+        // following directive.
+        assert_eq!(
+            conditional_output(":foo:\n\nifdef::foo[:bar: yes]\nifdef::bar[bar is set]"),
+            ":foo:\n\n:bar: yes\nbar is set\n"
+        );
+    }
+
+    #[test]
+    fn ifdef_or_combinator() {
+        // Comma means "any set": one of the two attributes is enough.
+        assert_eq!(
+            conditional_output(":b:\n\nifdef::a,b[]\nkept\nendif::[]"),
+            ":b:\n\nkept\n"
+        );
+        assert_eq!(
+            conditional_output("head\n\nifdef::a,b[]\ndropped\nendif::[]"),
+            "head\n\n"
+        );
+    }
+
+    #[test]
+    fn ifdef_and_combinator() {
+        // Plus means "all set": both attributes are required.
+        assert_eq!(
+            conditional_output(":a:\n:b:\n\nifdef::a+b[]\nkept\nendif::[]"),
+            ":a:\n:b:\n\nkept\n"
+        );
+        assert_eq!(
+            conditional_output(":a:\n\nifdef::a+b[]\ndropped\nendif::[]"),
+            ":a:\n\n"
+        );
+    }
+
+    #[test]
+    fn nested_conditionals() {
+        // The inner directive is only evaluated when the outer one includes.
+        assert_eq!(
+            conditional_output(
+                ":outer:\n:inner:\n\nifdef::outer[]\nA\nifdef::inner[]\nB\nendif::[]\nC\nendif::[]"
+            ),
+            ":outer:\n:inner:\n\nA\nB\nC\n"
+        );
+    }
+
+    #[test]
+    fn nested_conditional_inside_skipped_region_stays_skipped() {
+        // When the outer condition is false the whole region is dropped even
+        // though the inner condition would be true on its own.
+        assert_eq!(
+            conditional_output(
+                ":inner:\n\nifdef::outer[]\nA\nifdef::inner[]\nB\nendif::[]\nC\nendif::[]\n\ntail"
+            ),
+            ":inner:\n\n\ntail\n"
+        );
+    }
+
+    #[test]
+    fn named_endif_matches_target() {
+        assert_eq!(
+            conditional_output(":foo:\n\nifdef::foo[]\nkept\nendif::foo[]"),
+            ":foo:\n\nkept\n"
+        );
+    }
+
+    #[test]
+    fn ifeval_numeric_true() {
+        assert_eq!(
+            conditional_output("head\n\nifeval::[2 > 1]\nkept\nendif::[]"),
+            "head\n\nkept\n"
+        );
+    }
+
+    #[test]
+    fn ifeval_numeric_false() {
+        assert_eq!(
+            conditional_output("head\n\nifeval::[1 > 2]\ndropped\nendif::[]\n\ntail"),
+            "head\n\n\ntail\n"
+        );
+    }
+
+    #[test]
+    fn ifeval_attribute_reference() {
+        // `sectnumlevels` defaults to 3.
+        assert_eq!(
+            conditional_output("head\n\nifeval::[{sectnumlevels} == 3]\nkept\nendif::[]"),
+            "head\n\nkept\n"
+        );
+    }
+
+    #[test]
+    fn ifeval_string_comparison() {
+        assert_eq!(
+            conditional_output(
+                ":backend: html5\n\nifeval::[\"{backend}\" == \"html5\"]\nkept\nendif::[]"
+            ),
+            ":backend: html5\n\nkept\n"
+        );
+        assert_eq!(
+            conditional_output(
+                ":backend: docbook5\n\nifeval::[\"{backend}\" == \"html5\"]\ndropped\nendif::[]"
+            ),
+            ":backend: docbook5\n\n"
+        );
+    }
+
+    #[test]
+    fn ifeval_type_mismatch_is_false() {
+        // Comparing a number and a string with an ordering operator fails, so
+        // the content is skipped.
+        assert_eq!(
+            conditional_output("head\n\nifeval::[1 < \"a\"]\ndropped\nendif::[]\n\ntail"),
+            "head\n\n\ntail\n"
+        );
+    }
+
+    #[test]
+    fn escaped_conditional_directive_emitted_literally() {
+        assert_eq!(
+            conditional_output("head\n\n\\ifdef::foo[]\n\ntail"),
+            "head\n\nifdef::foo[]\n\ntail\n"
+        );
+    }
+
+    #[test]
+    fn source_map_realigns_after_skipped_region() {
+        // Lines dropped by a false conditional must not corrupt the mapping of
+        // the lines that follow back to their original line numbers.
+        let source = "l1\n\nifdef::foo[]\ndropped\ndropped\nendif::[]\n\nl8";
+        let parser = Parser::default();
+        let (output, source_map, _warnings) = preprocess(source, &parser);
+
+        assert_eq!(output, "l1\n\n\nl8\n");
+
+        // Output line 1 -> source line 1.
+        assert_eq!(
+            source_map.original_file_and_line(1),
+            Some(SourceLine(None, 1))
+        );
+        // Output line 4 ("l8") -> source line 8.
+        assert_eq!(
+            source_map.original_file_and_line(4),
+            Some(SourceLine(None, 8))
         );
     }
 }

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -291,21 +291,7 @@ impl<'p> PreprocessorState<'p> {
                 }
             } else {
                 // If none of the above apply, add the line to output.
-                if !has_reported_file {
-                    has_reported_file = true;
-                    self.source_map.append(
-                        self.output_line_number,
-                        SourceLine(to_owned(file_name), source_line_number),
-                    );
-                }
-
-                if line.is_empty() {
-                    self.in_document_header = false;
-                    self.can_have_attribute = true;
-                } else if !self.in_document_header {
-                    self.can_have_attribute = false;
-                }
-
+                //
                 // An escaped include directive (e.g. `\include::foo[]`) is not
                 // processed. The leading backslash is removed and the remainder is
                 // emitted literally, matching Asciidoctor. The backslash is only
@@ -319,9 +305,12 @@ impl<'p> PreprocessorState<'p> {
                     line.data()
                 };
 
-                self.output_line_number += 1;
-                self.output.push_str(line_text);
-                self.output.push('\n');
+                self.emit_line(
+                    line_text,
+                    file_name,
+                    source_line_number,
+                    &mut has_reported_file,
+                );
             }
         }
 
@@ -684,6 +673,7 @@ fn ruby_to_f(s: &str) -> f64 {
 /// ordering comparison (`<`, `<=`, `>`, `>=`) between values that cannot be
 /// ordered (e.g. a number and a string) fails and yields `false`.
 fn compare_values(lhs: &Value, op: &str, rhs: &Value) -> bool {
+    // `op` is always one of the six operators matched by `IFEVAL_EXPRESSION`.
     match op {
         "==" => values_equal(lhs, rhs),
         "!=" => !values_equal(lhs, rhs),
@@ -692,8 +682,8 @@ fn compare_values(lhs: &Value, op: &str, rhs: &Value) -> bool {
                 "<" => ordering.is_lt(),
                 "<=" => ordering.is_le(),
                 ">" => ordering.is_gt(),
-                ">=" => ordering.is_ge(),
-                _ => false,
+                // The remaining ordering operator is `>=`.
+                _ => ordering.is_ge(),
             },
             None => false,
         },
@@ -1850,6 +1840,93 @@ mod tests {
         assert_eq!(
             source_map.original_file_and_line(4),
             Some(SourceLine(None, 8))
+        );
+    }
+
+    #[test]
+    fn ifeval_with_nonempty_target_is_malformed() {
+        // `ifeval` requires an empty target; a non-empty one is malformed and
+        // opens no conditional, so the following lines are emitted unchanged.
+        assert_eq!(
+            conditional_output("ifeval::foo[1 == 1]\nkept\nendif::[]"),
+            "kept\n"
+        );
+    }
+
+    #[test]
+    fn ifdef_with_empty_target_is_malformed() {
+        // `ifdef`/`ifndef` require a target; an empty one is malformed and opens
+        // no conditional.
+        assert_eq!(conditional_output("ifdef::[]\nkept\nendif::[]"), "kept\n");
+    }
+
+    #[test]
+    fn ifeval_malformed_expression_is_false() {
+        // An expression with no operator cannot be parsed, so the condition is
+        // false and the enclosed content is skipped.
+        assert_eq!(
+            conditional_output("ifeval::[nonsense]\ndropped\nendif::[]\n\ntail"),
+            "\ntail\n"
+        );
+    }
+
+    #[test]
+    fn ifeval_coerces_trailing_text_to_integer() {
+        // An unquoted value with no period coerces to its leading integer
+        // (Ruby `String#to_i`), so `3x` becomes `3`.
+        assert_eq!(
+            conditional_output("ifeval::[3x == 3]\nkept\nendif::[]"),
+            "kept\n"
+        );
+    }
+
+    #[test]
+    fn ifeval_coerces_trailing_text_to_float() {
+        // An unquoted value containing a period coerces to its leading float
+        // (Ruby `String#to_f`), so `1.5x` becomes `1.5`.
+        assert_eq!(
+            conditional_output("ifeval::[1.5x < 2]\nkept\nendif::[]"),
+            "kept\n"
+        );
+    }
+
+    #[test]
+    fn ifeval_float_and_mixed_equality() {
+        // Float/float and int/float equality.
+        assert_eq!(
+            conditional_output("ifeval::[1.5 == 1.5]\nkept\nendif::[]"),
+            "kept\n"
+        );
+        assert_eq!(
+            conditional_output("ifeval::[2 == 2.0]\nkept\nendif::[]"),
+            "kept\n"
+        );
+        // Equality across incompatible value types is false.
+        assert_eq!(
+            conditional_output("ifeval::[1 == \"a\"]\ndropped\nendif::[]\n\ntail"),
+            "\ntail\n"
+        );
+    }
+
+    #[test]
+    fn ifeval_float_and_string_ordering() {
+        // Float/float, int/float, and string/string ordering.
+        assert_eq!(
+            conditional_output("ifeval::[1.5 < 2.5]\nkept\nendif::[]"),
+            "kept\n"
+        );
+        assert_eq!(
+            conditional_output("ifeval::[1 < 2.5]\nkept\nendif::[]"),
+            "kept\n"
+        );
+        assert_eq!(
+            conditional_output("ifeval::[\"a\" < \"b\"]\nkept\nendif::[]"),
+            "kept\n"
+        );
+        // `>=` between two comparable values.
+        assert_eq!(
+            conditional_output("ifeval::[3 >= 3]\nkept\nendif::[]"),
+            "kept\n"
         );
     }
 }

--- a/parser/src/tests/asciidoc_lang/blocks/add_title.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/add_title.rs
@@ -566,17 +566,14 @@ The block title will be displayed with a caption label and number, as shown here
     assert_eq!(block.number(), Some(1));
 }
 
-// This block is documentation scaffolding that saves and restores the
-// `example-number` counter (via `ifdef::` conditional directives) so the
-// rendered example below always displays as `Example 1.`. It is kept
-// non-normative because conditional preprocessor directives
-// (`ifdef`/`ifndef`/`ifeval`) are not yet implemented; once they are, this can
-// be promoted to verified coverage asserting the counter save/restore.
-//
-// TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/589): implement
-// conditional preprocessor directives and verify this block.
-non_normative!(
-    r#"
+#[test]
+fn example_number_counter_save_and_restore() {
+    // This block is documentation scaffolding that saves and restores the
+    // `example-number` counter (via `ifdef::` conditional directives) so the
+    // rendered example below always displays as `Example 1.`, regardless of the
+    // counter's value in the surrounding document.
+    verifies!(
+        r#"
 :example-caption: Example
 ifdef::example-number[:prev-example-number: {example-number}]
 :example-number: 0
@@ -591,7 +588,35 @@ ifdef::prev-example-number[:example-number: {prev-example-number}]
 :!prev-example-number:
 
 "#
-);
+    );
+
+    // On a pristine parser `example-number` is unset, so both conditionals are
+    // false: the save and restore are no-ops, the counter is reset to 0, and the
+    // example is numbered 1 and displayed with its caption.
+    let doc = Parser::default().parse(
+        ":example-caption: Example\nifdef::example-number[:prev-example-number: {example-number}]\n:example-number: 0\n\n.Block that supports captioned title\n====\nBlock content\n====\n\n:!example-caption:\nifdef::prev-example-number[:example-number: {prev-example-number}]\n:!prev-example-number:",
+    );
+    let block = doc.nested_blocks().next().unwrap();
+    assert_eq!(block.title(), Some("Block that supports captioned title"));
+    assert_eq!(block.caption(), Some("Example 1. "));
+    assert_eq!(block.number(), Some(1));
+
+    // When `example-number` is already set, the idiom saves it, resets the
+    // counter so the scaffolded example is numbered 1, then restores it so a
+    // later example continues the original sequence (7 -> restored -> 8).
+    let doc = Parser::default().parse(
+        ":example-number: 7\n\n:example-caption: Example\nifdef::example-number[:prev-example-number: {example-number}]\n:example-number: 0\n\n.Saved\n====\nx\n====\n\nifdef::prev-example-number[:example-number: {prev-example-number}]\n\n.Restored\n====\ny\n====",
+    );
+    let mut examples = doc.nested_blocks().filter(|b| b.title().is_some());
+    // The first conditional fired (`example-number` was set), saving 7 into
+    // `prev-example-number`; the counter was then reset to 0, so this example is 1.
+    let saved = examples.next().unwrap();
+    assert_eq!(saved.number(), Some(1));
+    // The second conditional fired (`prev-example-number` was set), restoring
+    // `example-number` to 7, so the following example continues at 8.
+    let restored = examples.next().unwrap();
+    assert_eq!(restored.number(), Some(8));
+}
 
 #[test]
 fn unset_example_caption_drops_caption() {

--- a/parser/src/tests/asciidoc_lang/directives/conditionals.rs
+++ b/parser/src/tests/asciidoc_lang/directives/conditionals.rs
@@ -1,0 +1,89 @@
+use crate::{HasSpan, tests::prelude::*};
+
+track_file!("docs/modules/directives/pages/conditionals.adoc");
+
+non_normative!(
+    r#"
+= Conditionals
+
+You can include or exclude lines of text in your document using the following conditional preprocessor directives:
+
+* xref:ifdef-ifndef.adoc#ifdef[ifdef]
+* xref:ifdef-ifndef.adoc#ifndef[ifndef]
+* xref:ifeval.adoc[ifeval]
+
+"#
+);
+
+#[test]
+fn condition_determines_inclusion() {
+    verifies!(
+        r#"
+When the processor encounters one of these conditionals, it evaluates the specified condition.
+The condition is based on the presence or value of one or more document attributes.
+If the condition evaluates to true, the lines the conditional encloses are included.
+Otherwise, the lines are skipped.
+
+"#
+    );
+
+    // When the condition evaluates to true, the enclosed lines are included.
+    let doc = Parser::default().parse(":flag:\n\nifdef::flag[]\nShown.\nendif::[]");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);
+
+    // Otherwise, the enclosed lines are skipped.
+    let doc = Parser::default().parse("ifdef::flag[]\nHidden.\nendif::[]\n\nAfter.");
+    assert_eq!(rendered_paragraphs(&doc), vec!["After."]);
+}
+
+non_normative!(
+    r#"
+////
+For example, say you want to include a certain section of content only when converting to HTML.
+Conditional preprocessor directives make this possible.
+You simply check for the presence of the `basebackend-html` attribute using an `ifdef` directive.
+Details of this example and more `ifdef` and `ifndef` examples, are described in the following sections.
+See xref:ifeval.adoc[] for `ifeval` examples.
+////
+
+== Conditional processing
+
+Although a conditional preprocessor directive looks like a block macro, *it's not a macro and therefore isn't processed like one*.
+It's a preprocessor directive; it's important to understand the distinction.
+
+include::partial$preprocessor.adoc[]
+The conditional preprocessor directives determine which lines to add and which ones to take away based on the condition.
+
+"#
+);
+
+#[test]
+fn escape_a_conditional_directive() {
+    verifies!(
+        r#"
+== Escape a conditional directive
+
+If you don't want a conditional preprocessor directive to be processed, you must escape it using a backslash.
+
+"#
+    );
+
+    // The escaped directive is not processed: the leading backslash is removed
+    // and the remainder is emitted literally. This holds even inside a verbatim
+    // block because the preprocessor is not aware of the surrounding structure.
+    let doc = Parser::default().parse("----\n\\ifdef::just-an-example[]\n----");
+    let block = doc.nested_blocks().next().unwrap();
+    assert_eq!(block.span().data(), "----\nifdef::just-an-example[]\n----");
+}
+
+non_normative!(
+    r#"
+// NOTE: the following listing uses indentation to prevent the directive from being processed
+[source,indent=0]
+----
+ \ifdef::just-an-example[]
+----
+
+Escaping the directive is necessary _even if it appears in a verbatim block_ since it's not aware of the surrounding document structure.
+"#
+);

--- a/parser/src/tests/asciidoc_lang/directives/ifdef_ifndef.rs
+++ b/parser/src/tests/asciidoc_lang/directives/ifdef_ifndef.rs
@@ -1,0 +1,277 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/directives/pages/ifdef-ifndef.adoc");
+
+non_normative!(
+    r#"
+= ifdef and ifndef Directives
+
+"#
+);
+
+#[test]
+fn ifdef_directive() {
+    verifies!(
+        r#"
+[#ifdef]
+== ifdef directive
+
+Content between the `ifdef` and `endif` directives gets included if the specified attribute is set:
+
+.ifdef example
+----
+\ifdef::env-github[]
+This content is for GitHub only.
+\endif::[]
+----
+
+The syntax of the start directive is `ifdef::<attribute>[]`, where `<attribute>` is the name of an attribute.
+
+Keep in mind that the content is not limited to a single line.
+You can have any amount of content between the `ifdef` and `endif` directives.
+
+"#
+    );
+
+    // The attribute is set, so the enclosed content is included.
+    let doc = Parser::default()
+        .parse(":env-github:\n\nifdef::env-github[]\nThis content is for GitHub only.\nendif::[]");
+    assert_eq!(
+        rendered_paragraphs(&doc),
+        vec!["This content is for GitHub only."]
+    );
+
+    // The attribute is not set, so the enclosed content is excluded.
+    let doc = Parser::default()
+        .parse("ifdef::env-github[]\nThis content is for GitHub only.\nendif::[]\n\nTail.");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Tail."]);
+}
+
+#[test]
+fn ifdef_long_form() {
+    verifies!(
+        r#"
+If you have a large amount of content inside the `ifdef` directive, you may find it more readable to use the long-form version of the directive, in which the attribute (aka condition) is referenced again in the `endif` directive.
+
+.ifdef long-form example
+----
+\ifdef::env-github[]
+This content is for GitHub only.
+
+So much content in this section, I'd get confused reading the source without the closing `ifdef` directive.
+
+It isn't necessary for short blocks, but if you are conditionally including a section it may be something worth considering.
+
+Other readers reviewing your docs source code may go cross-eyed when reading your source docs if you don't.
+\endif::env-github[]
+----
+
+"#
+    );
+
+    // The long form names the attribute again on the `endif` directive; the
+    // content may span multiple paragraphs.
+    let doc = Parser::default().parse(
+        ":env-github:\n\nifdef::env-github[]\nFirst paragraph.\n\nSecond paragraph.\nendif::env-github[]",
+    );
+    assert_eq!(
+        rendered_paragraphs(&doc),
+        vec!["First paragraph.", "Second paragraph."]
+    );
+}
+
+#[test]
+fn ifdef_single_line() {
+    verifies!(
+        r#"
+If you're only dealing with a single line of text, you can put the content directly inside the square brackets and drop the `endif` directive.
+
+.ifdef single line example
+----
+\ifdef::revnumber[This document has a version number of {revnumber}.]
+----
+
+The single-line block above is equivalent to this formal `ifdef` directive:
+
+----
+\ifdef::revnumber[]
+This document has a version number of {revnumber}.
+\endif::[]
+----
+
+"#
+    );
+
+    // The single-line form puts the content directly inside the brackets and
+    // drops the `endif` directive.
+    let doc = Parser::default().parse(
+        ":revnumber: 2.0\n\nifdef::revnumber[This document has a version number of {revnumber}.]",
+    );
+    assert_eq!(
+        rendered_paragraphs(&doc),
+        vec!["This document has a version number of 2.0."]
+    );
+
+    // It is equivalent to the formal (block) form.
+    let doc = Parser::default().parse(
+        ":revnumber: 2.0\n\nifdef::revnumber[]\nThis document has a version number of {revnumber}.\nendif::[]",
+    );
+    assert_eq!(
+        rendered_paragraphs(&doc),
+        vec!["This document has a version number of 2.0."]
+    );
+}
+
+#[test]
+fn ifndef_directive() {
+    verifies!(
+        r#"
+[#ifndef]
+== ifndef directive
+
+`ifndef` is the logical opposite of `ifdef`.
+Content between `ifndef` and `endif` gets included only if the specified attribute is _not_ set:
+
+.ifndef example
+----
+\ifndef::env-github[]
+This content is not shown on GitHub.
+\endif::[]
+----
+
+The syntax of the start directive is `ifndef::<attribute>[]`, where `<attribute>` is the name of an attribute.
+
+The `ifndef` directive supports the same single-line and long-form variants as `ifdef`.
+
+"#
+    );
+
+    // The attribute is not set, so the enclosed content is included.
+    let doc = Parser::default()
+        .parse("ifndef::env-github[]\nThis content is not shown on GitHub.\nendif::[]");
+    assert_eq!(
+        rendered_paragraphs(&doc),
+        vec!["This content is not shown on GitHub."]
+    );
+
+    // The attribute is set, so the enclosed content is excluded.
+    let doc = Parser::default()
+        .parse(":env-github:\n\nifndef::env-github[]\nHidden.\nendif::[]\n\nTail.");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Tail."]);
+}
+
+non_normative!(
+    r#"
+== Checking multiple attributes
+
+Both the `ifdef` and `ifndef` directives accept multiple attribute names.
+The combinator can be "`and`" or "`or`".
+The two combinators cannot be combined in the same expression.
+
+"#
+);
+
+#[test]
+fn ifdef_with_multiple_attributes() {
+    verifies!(
+        r#"
+=== ifdef with multiple attributes
+
+If any attribute is set (or)::
+Multiple attribute names must be separated by commas (`,`).
+If one or more of the attributes are set, the content is included.
+Otherwise, the content is not included.
++
+.If any attribute example
+----
+\ifdef::backend-html5,backend-docbook5[Only shown if converting to HTML (backend-html5 is set) or DocBook (backend-docbook5 is set).]
+----
+
+If all attributes are set (and)::
+Multiple attribute names must be separated by pluses (`+`).
+If all the attributes are set, the content is included.
+Otherwise, the content is not included.
++
+.If all attributes example
+----
+\ifdef::backend-html5+env-github[Only shown when converting to HTML (backend-html5 is set) on GitHub (env-github is set).]
+----
+
+"#
+    );
+
+    // OR (comma): one of the attributes is set, so the content is included.
+    let doc =
+        Parser::default().parse(":backend-html5:\n\nifdef::backend-html5,backend-docbook5[Shown.]");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);
+
+    // OR (comma): neither attribute is set, so the content is not included.
+    let doc = Parser::default().parse("ifdef::backend-html5,backend-docbook5[Shown.]\n\nTail.");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Tail."]);
+
+    // AND (plus): all attributes are set, so the content is included.
+    let doc = Parser::default()
+        .parse(":backend-html5:\n:env-github:\n\nifdef::backend-html5+env-github[Shown.]");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);
+
+    // AND (plus): only one attribute is set, so the content is not included.
+    let doc = Parser::default()
+        .parse(":backend-html5:\n\nifdef::backend-html5+env-github[Shown.]\n\nTail.");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Tail."]);
+}
+
+non_normative!(
+    r#"
+=== ifndef with multiple attributes
+
+The `ifndef` directive negates the results of the expression.
+When using the `ifndef` directive, the expression should be read with the prefix "`unless`".
+
+"#
+);
+
+#[test]
+fn ifndef_with_multiple_attributes() {
+    verifies!(
+        r#"
+Unless any attribute is set (or)::
+Multiple attribute names must be separated by commas (`,`).
+If one or more of the attributes are set, the content is not included.
+Otherwise, the content is included.
++
+.Unless any attribute example
+----
+\ifndef::profile-production,env-site[Not shown if profile-production or env-site is set.]
+----
+
+Unless all attributes are set (and)::
+Multiple attribute names must be separated by pluses (`+`).
+If all of the attributes are set, the content is not included.
+Otherwise, the content is included.
++
+.Unless all attributes example
+----
+\ifndef::profile-staging+env-site[Not shown if profile-staging and env-site are set.]
+----
+"#
+    );
+
+    // "Unless any" (comma): neither attribute is set, so the content is included.
+    let doc = Parser::default().parse("ifndef::profile-production,env-site[Shown.]");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);
+
+    // "Unless any" (comma): one attribute is set, so the content is not included.
+    let doc = Parser::default()
+        .parse(":env-site:\n\nifndef::profile-production,env-site[Shown.]\n\nTail.");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Tail."]);
+
+    // "Unless all" (plus): all attributes are set, so the content is not included.
+    let doc = Parser::default().parse(
+        ":profile-staging:\n:env-site:\n\nifndef::profile-staging+env-site[Shown.]\n\nTail.",
+    );
+    assert_eq!(rendered_paragraphs(&doc), vec!["Tail."]);
+
+    // "Unless all" (plus): only one attribute is set, so the content is included.
+    let doc = Parser::default().parse(":env-site:\n\nifndef::profile-staging+env-site[Shown.]");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);
+}

--- a/parser/src/tests/asciidoc_lang/directives/ifeval.rs
+++ b/parser/src/tests/asciidoc_lang/directives/ifeval.rs
@@ -1,0 +1,263 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/directives/pages/ifeval.adoc");
+
+non_normative!(
+    r#"
+= ifeval Directive
+
+"#
+);
+
+#[test]
+fn ifeval_included_when_expression_is_true() {
+    verifies!(
+        r#"
+Lines enclosed by an `ifeval` directive (i.e., between the `ifeval` and `endif` directives) are included if the expression inside the square brackets of the `ifeval` directive evaluates to true.
+
+.ifeval example
+----
+\ifeval::[{sectnumlevels} == 3]
+If the `sectnumlevels` attribute has the value 3, this sentence is included.
+\endif::[]
+----
+
+"#
+    );
+
+    // `sectnumlevels` defaults to 3, so the expression is true and the sentence
+    // is included.
+    let doc = Parser::default().parse(
+        "ifeval::[{sectnumlevels} == 3]\nIf the sectnumlevels attribute has the value 3, this sentence is included.\nendif::[]",
+    );
+    assert_eq!(
+        rendered_paragraphs(&doc),
+        vec!["If the sectnumlevels attribute has the value 3, this sentence is included."]
+    );
+
+    // When the expression is false the enclosed lines are skipped.
+    let doc =
+        Parser::default().parse("ifeval::[{sectnumlevels} == 5]\nHidden.\nendif::[]\n\nTail.");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Tail."]);
+}
+
+#[test]
+fn ifeval_terminated_only_by_anonymous_endif() {
+    verifies!(
+        r#"
+The `ifeval` directive does not have a single-line or long-form variant like `ifdef` and `ifndef`.
+
+Unlike `ifdef` and `ifndef`, you cannot terminate a specific `ifeval` directive using its complement.
+For example, the following `ifeval` block is not valid:
+
+.Invalid ifeval terminator
+----
+\ifeval::[<condition>]
+conditional content
+\endif::[<condition>]
+----
+
+You can only terminate the previous `ifeval` directive using an anonymous `endif::[]` directive, as shown here:
+
+.Valid ineval terminator
+----
+\ifeval::[<condition>]
+conditional content
+\endif::[]
+----
+
+"#
+    );
+
+    // An anonymous `endif::[]` terminates the `ifeval` directive.
+    let doc = Parser::default().parse("ifeval::[1 == 1]\nconditional content\nendif::[]");
+    assert_eq!(rendered_paragraphs(&doc), vec!["conditional content"]);
+}
+
+non_normative!(
+    r#"
+If you're mixing `ifeval` directives with `ifdef` or `ifndef` directives, you should always close multiline `ifdef` and `ifndef` directives by name (`endif::name-of-attribute[]`) so the `ifeval` directive does not end prematurely.
+
+== Anatomy
+
+The expression of an `ifeval` directive consists of a left-hand value and a right-hand value with an operator in between.
+It's customary to include a single space on either side of the operator.
+
+.ifeval expression examples
+----
+\ifeval::[2 > 1]
+...
+\endif::[]
+
+\ifeval::["{backend}" == "html5"]
+...
+\endif::[]
+
+\ifeval::[{sectnumlevels} == 3]
+...
+\endif::[]
+
+// the value of outfilesuffix includes a leading period (e.g., .html)
+\ifeval::["{docname}{outfilesuffix}" == "main.html"]
+...
+\endif::[]
+----
+
+"#
+);
+
+#[test]
+fn values() {
+    verifies!(
+        r#"
+== Values
+
+Each expression value can reference the name of zero or more AsciiDoc attributes using the attribute reference syntax (for example, `+{backend}+`).
+
+Attribute references are resolved (i.e., substituted) first.
+Once attributes references have been resolved, each value is coerced to a recognized type.
+
+When you expect the attribute reference to resolve to a string, that is, a sequence of characters, enclose that side of the expression in quotes.
+For example:
+
+.ifeval that compares two string expressions
+----
+\ifeval::["{backend}" == "html5"]
+----
+
+If you expect the attribute to resolve to a number, you do not need to enclose the expression in quotes.
+In this case, the values will be compared as numbers.
+The same rule applies to boolean values.
+
+You should not attempt to mix value types in a comparison.
+For example, the following expression is not valid:
+
+.Invalid ifeval expression
+----
+\ifeval::["{sectnumlevels}" > 3]
+----
+
+The following values types are recognized:
+
+number:: Either an integer or floating-point value.
+quoted string:: Enclosed in either single (`'`) or double (`"`) quotes.
+boolean:: Literal value of `true` or `false`.
+
+"#
+    );
+
+    // Attribute references are resolved first; a quoted side is compared as a
+    // string.
+    let doc = Parser::default()
+        .parse(":backend: html5\n\nifeval::[\"{backend}\" == \"html5\"]\nMatched.\nendif::[]");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Matched."]);
+
+    // Unquoted numeric values are compared as numbers.
+    let doc = Parser::default().parse("ifeval::[10 > 9]\nMatched.\nendif::[]");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Matched."]);
+
+    // Boolean values are recognized.
+    let doc = Parser::default().parse("ifeval::[true != false]\nMatched.\nendif::[]");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Matched."]);
+
+    // Mixing value types (a quoted string against a number) is not valid: the
+    // comparison fails, so the content is skipped.
+    let doc = Parser::default()
+        .parse(":backend: html5\n\nifeval::[\"{sectnumlevels}\" > 3]\nHidden.\nendif::[]\n\nTail.");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Tail."]);
+}
+
+#[test]
+fn value_type_coercion() {
+    verifies!(
+        r#"
+=== How value type coercion works
+
+If a value is enclosed in quotes, the characters between the quotes is used and always coerced to a string.
+
+If a value is *not* enclosed in quotes, it's subject to the following type coercion rules:
+
+* an empty value becomes nil (aka null) (and thus safe for use in a comparison).
+* a value of `true` or `false` becomes a boolean value.
+* a value of only repeating whitespace becomes a single whitespace string.
+* a value containing a period becomes a floating-point number.
+* any other value is coerced to an integer value.
+
+"#
+    );
+
+    // An empty value becomes nil, and two nil values compare equal.
+    let doc = Parser::default().parse("ifeval::[{empty} == {empty}]\nMatched.\nendif::[]");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Matched."]);
+
+    // A value of `true` or `false` becomes a boolean value.
+    let doc = Parser::default().parse("ifeval::[true == true]\nMatched.\nendif::[]");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Matched."]);
+
+    // A value of only repeating whitespace becomes a single whitespace string.
+    let doc = Parser::default().parse("ifeval::[{sp}{sp} == {sp}]\nMatched.\nendif::[]");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Matched."]);
+
+    // A value containing a period becomes a floating-point number.
+    let doc = Parser::default().parse("ifeval::[1.5 < 2]\nMatched.\nendif::[]");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Matched."]);
+
+    // Any other value is coerced to an integer value.
+    let doc = Parser::default().parse("ifeval::[10 == 10]\nMatched.\nendif::[]");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Matched."]);
+}
+
+#[test]
+fn operators() {
+    verifies!(
+        r#"
+== Operators
+
+The value on each side is compared using the operator to derive an outcome.
+
+`==`::
+Checks if the two values are equal.
+`!=`::
+Checks if the two values are not equal.
+`<`::
+Checks whether the left-hand side is less than the right-hand side.
+`+<=+`::
+Checks whether the left-hand side is less than or equal to the right-hand side.
+`>`::
+Checks whether the left-hand side is greater than the right-hand side.
+`+>=+`::
+Checks whether the left-hand side is greater than or equal to the right-hand side.
+
+Both sides should be of the same value type.
+If they are not, the comparison will fail.
+If the comparison fails, the condition will evaluate to false (i.e., the content inside the directive will be skipped).
+
+The operators follow the same rules as operators in Ruby.
+"#
+    );
+
+    // Each operator derives the expected outcome.
+    for (expr, included) in [
+        ("3 == 3", true),
+        ("3 == 4", false),
+        ("3 != 4", true),
+        ("2 < 3", true),
+        ("3 <= 3", true),
+        ("4 > 3", true),
+        ("3 >= 3", true),
+    ] {
+        let source = format!("ifeval::[{expr}]\nMatched.\nendif::[]\n\nTail.");
+        let doc = Parser::default().parse(&source);
+        let expected: Vec<&str> = if included {
+            vec!["Matched.", "Tail."]
+        } else {
+            vec!["Tail."]
+        };
+        assert_eq!(rendered_paragraphs(&doc), expected, "expr: {expr}");
+    }
+
+    // When the two sides are not the same value type the comparison fails and
+    // the content is skipped.
+    let doc = Parser::default().parse("ifeval::[1 < \"a\"]\nHidden.\nendif::[]\n\nTail.");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Tail."]);
+}

--- a/parser/src/tests/asciidoc_lang/directives/include.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include.rs
@@ -692,10 +692,11 @@ If the file is recognized as an AsciiDoc file (i.e., it has one of the following
     assert_eq!(paras, vec!["Chapter intro.", "Fragment body."]);
 }
 
-// Trailing-whitespace stripping and preprocessor conditionals (e.g. `ifdef`)
-// are not implemented, so the normalization detail and the conditionals bullet
-// below remain non-normative. (The `includes` bullet is covered by the
-// nested-include test that follows.)
+// Trailing-whitespace stripping is not implemented, so the normalization detail
+// below remains non-normative. (The `includes` bullet is covered by the
+// nested-include test that follows; the conditionals bullet is verified below,
+// with full coverage in the dedicated `conditionals`/`ifdef_ifndef`/`ifeval`
+// spec files.)
 non_normative!(
     r#"
 First, all trailing whitespace and endlines are removed from each line and replaced with a Unix line feed.
@@ -703,7 +704,25 @@ This normalization is important to how an AsciiDoc processor works.
 Next, the AsciiDoc processor runs the preprocessor on the lines, looking for and interpreting the following directives:
 
 * includes
+"#
+);
+
+#[test]
+fn preprocessor_interprets_conditionals() {
+    verifies!(
+        r#"
 * preprocessor conditionals (e.g., `ifdef`)
+"#
+    );
+
+    // The preprocessor interprets conditional directives: an `ifdef` whose
+    // attribute is set includes its enclosed content.
+    let doc = Parser::default().parse(":flag:\n\nifdef::flag[]\nShown.\nendif::[]");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);
+}
+
+non_normative!(
+    r#"
 //* front matter (if enabled)
 
 "#

--- a/parser/src/tests/asciidoc_lang/directives/mod.rs
+++ b/parser/src/tests/asciidoc_lang/directives/mod.rs
@@ -1,3 +1,6 @@
+mod conditionals;
+mod ifdef_ifndef;
+mod ifeval;
 mod include;
 mod include_multiple_times_in_same_document;
 mod include_uri;

--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -2419,6 +2419,34 @@ mod quote {
     }
 }
 
+mod special {
+    use crate::tests::prelude::*;
+
+    // Ported from Ruby Asciidoctor's paragraphs_test.rb
+    // ('should process preprocessor conditional in paragraph content').
+    #[test]
+    fn should_process_preprocessor_conditional_in_paragraph_content() {
+        // `asciidoctor-version` and `backend` are not set by default in this
+        // crate, so they are supplied explicitly to mirror the Ruby environment.
+        let doc = Parser::default()
+            .with_intrinsic_attribute(
+                "asciidoctor-version",
+                "2.0",
+                ModificationContext::Anywhere,
+            )
+            .with_intrinsic_attribute("backend", "html5", ModificationContext::Anywhere)
+            .parse(
+                "ifdef::asciidoctor-version[]\n[sidebar]\nFirst line of sidebar.\nifdef::backend[The backend is {backend}.]\nLast line of sidebar.\nendif::[]",
+            );
+
+        // The outer `ifdef` includes the sidebar; the inner single-line `ifdef`
+        // resolves to the backend value.
+        assert_output_contains(&doc, "First line of sidebar.");
+        assert_output_contains(&doc, "The backend is html5.");
+        assert_output_contains(&doc, "Last line of sidebar.");
+    }
+}
+
 #[ignore]
 #[test]
 fn port_from_ruby() {
@@ -2444,29 +2472,9 @@ fn port_from_ruby() {
       end
     end
 
-    test 'should process preprocessor conditional in paragraph content' do
-      input = <<~'EOS'
-      ifdef::asciidoctor-version[]
-      [sidebar]
-      First line of sidebar.
-      ifdef::backend[The backend is {backend}.]
-      Last line of sidebar.
-      endif::[]
-      EOS
-
-      expected = <<~'EOS'.chop
-      <div class="sidebarblock">
-      <div class="content">
-      First line of sidebar.
-      The backend is html5.
-      Last line of sidebar.
-      </div>
-      </div>
-      EOS
-
-      result = convert_string_to_embedded input
-      assert_equal expected, result
-    end
+    # NOTE: 'should process preprocessor conditional in paragraph content' has
+    # been ported to `mod special` below now that conditional preprocessor
+    # directives are implemented.
 
     context 'Styled Paragraphs' do
       test 'should wrap text in simpara for styled paragraphs when converted to DocBook' do


### PR DESCRIPTION
## Summary

Implements the conditional preprocessor directives described in `docs/modules/directives/pages/conditionals.adoc`, `ifdef-ifndef.adoc`, and `ifeval.adoc`. Previously these `if…`/`endif::` lines were passed through the preprocessor untouched; now they are evaluated and used to include or exclude lines. Addresses the conditionals half of #589.

### Directive support

- **`ifdef` / `ifndef`** — block form (`ifdef::attr[]` … `endif::[]`), long-form (`endif::attr[]`), and single-line form (`ifdef::attr[content]`). Single-line content that is itself an attribute entry is applied so later directives and include targets observe it.
- **Combinators** — `,` (OR / "any set") and `+` (AND / "all set"); `ifndef` negates the result ("unless").
- **`ifeval`** — expression evaluation with the documented value coercion (empty → nil, `true`/`false` → boolean, a value with a period → float, anything else → integer; quoted values are always strings) and all six comparison operators, following Ruby semantics (a comparison between mismatched types fails and evaluates to false).
- **Nesting**, named/anonymous `endif` matching, and **escaping** with a leading backslash (also now recognized by the preprocessor short-circuit guard so an escaped-only document still has its backslash stripped).
- **Source map** is realigned across skipped regions so warnings/spans in the surviving lines still map back to their original file and line.

### Tests & spec coverage

- 21 new preprocessor unit tests (`preprocessor.rs`).
- New SDD coverage files mirroring all three spec pages (`conditionals.rs`, `ifdef_ifndef.rs`, `ifeval.rs`) — the spec-coverage tool reports 0 uncovered lines for each page.
- Deferred work fixed up:
  - `add_title.rs`: promoted the `example-number` save/restore scaffolding from `non_normative!` to a verified test that exercises the conditionals end-to-end.
  - `include.rs`: promoted the "preprocessor conditionals" bullet to verified.
  - `paragraphs_test.rs`: ported *should process preprocessor conditional in paragraph content* out of the `port_from_ruby` stub into a real test.

### Verification

- `cargo test -p asciidoc-parser` — 2863 passed, 0 failed.
- `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` — clean.
- `cargo +nightly fmt --all -- --check` — clean.
- `cd sdd && cargo run` — the three conditional pages report full coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
