### PR TITLE
chore: Add SDD coverage for faq and glossary pages

### DIFF
--- a/parser/src/tests/asciidoc_lang/root/faq.rs
+++ b/parser/src/tests/asciidoc_lang/root/faq.rs
@@ -1,0 +1,87 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/ROOT/pages/faq.adoc");
+
+non_normative!(
+    r#"
+= Frequently Asked Questions (FAQ)
+:page-aliases: faqs.adoc
+
+== Does AsciiDoc only support ASCII text?
+
+No.
+AsciiDoc provides full Unicode support (UTF-8 by default, UTF-16 with a BOM).
+👌
+
+The "`Ascii`" in AsciiDoc (and Asciidoctor) merely refers to the range of characters used to define the language syntax (e.g., block delimiters, section markers, list markers, attribute list boundaries, built-in attribute and block names, etc.).
+In other words, you only have to use characters from US-ASCII in order to express the structure of an AsciiDoc document.
+The content itself, which includes paragraphs, titles, verbatim blocks, attribute names and values, custom block names, and so forth, may contain characters from any character range in Unicode.
+
+An AsciiDoc processor assumes the input is encoded in UTF-8 and it encodes output documents in UTF-8 as well.
+The include directive allows the encoding to be specified if the include file is not encoded in UTF-8.
+
+== What's the relationship between a converter and a backend?
+
+A *converter* is the software that performs conversion from AsciiDoc to a publishable format.
+A *backend* is an identifier for the intended output format, and thus tells the AsciiDoc processor which converter to use.
+You can think of the backend as an alias for a converter.
+
+The backend represents the user's intent to transform the AsciiDoc document to a given format (e.g., `html5` for HTML 5).
+That backend also serves as an identifier that tells the processor which converter to use.
+More than one converter can bind to (i.e., stake claim to) the same backend in order to provide the user with alternatives for generating a given output format.
+For example, the backend `pdf` could be satisfied by Asciidoctor PDF, but it may also be mapped to a different implementation.
+The last converter that registers itself with a backend wins.
+
+== What's the media type (aka MIME type) for AsciiDoc?
+
+A https://en.wikipedia.org/wiki/Media_type[media type], or MIME type, is a code for identifying file formats and content formats transmitted over the Internet.
+As of yet, there's no official media type registered for AsciiDoc.
+However, the AsciiDoc Working Group, which oversees the specification for the AsciiDoc language, has plans to submit a proposal to register an official the media type for AsciiDoc.
+See https://github.com/asciidoctor/asciidoctor/issues/2502[asciidoctor#2502].
+
+The proposed media type for AsciiDoc is as follows:
+
+ name: text/asciidoc
+ extensions: .adoc, .asciidoc
+
+The name `text/asciidoc` follows the convention used for Markdown.
+The `.adoc` extension is the preferred one.
+The `.asciidoc` extension is only included for backwards compatibility with existing documents.
+
+See https://tools.ietf.org/html/rfc7763 for details about naming a media type.
+
+== Why is my document attribute being ignored?
+
+If the document attribute is a header-only attribute, make sure it is defined in the document header or passed in via a CLI or API.
+Otherwise, the document attribute will not have any affect.
+
+Recall that the document header ends at the first empty line or block, whichever comes first.
+If you have an empty line somewhere in what you intend to be the document header, the attribute entries that fall after that empty line are going to be defined in the body, not the header.
+That likely explains your problem.
+If you remove the empty line(s), your attribute should be recognized.
+
+If the document attribute is not a header-only attribute, make sure it is being defined (using an attribute entry) outside of any delimited block and offset from other blocks by at least one empty line.
+
+== Part way through the document, the blocks stop rendering correctly. What went wrong?
+
+When content does not display as you expect in the later part of a document, it's usually due to a delimited block missing its closing delimiter line.
+The parsing rules inside a delimited block are different.
+If left open, it can impact how the AsciiDoc processor interprets the document structure.
+For example, the AsciiDoc processor will stop recognizing section titles from that point forward.
+
+To solve this problem, first look for missing delimiter lines.
+An AsciiDoc processor must warn you when this situation is detected.
+Syntax highlighting in your text editor can also help with this.
+Also look at the rendered output to see if the block styles are extending past where you intended.
+
+The most sly culprit is the open block.
+Although an open block doesn't have any special styling, it does apply delimited block semantics to its contents.
+You can add a role that applies a custom style, such as a red outline, so you can see its boundaries.
+
+== Why don't links to URLs that contain an underscore or caret work?
+
+An AsciiDoc processor applies normal substitutions to paragraph content, including the target of a URL or link macro.
+It's up to the author to escape this syntax.
+See xref:macros:complex-urls.adoc[] to find techniques you can use to address this problem.
+"#
+);

--- a/parser/src/tests/asciidoc_lang/root/glossary.rs
+++ b/parser/src/tests/asciidoc_lang/root/glossary.rs
@@ -1,0 +1,69 @@
+use crate::tests::prelude::*;
+
+track_file!("docs/modules/ROOT/pages/glossary.adoc");
+
+non_normative!(
+    r#"
+= Glossary of Terms
+
+[caption="Work in Progress"]
+CAUTION: This glossary is a work in progress.
+It does not include all the terms in AsciiDoc.
+
+attribute reference:: an expression for dereferencing the value of a document attribute.
+
+attrlist:: the source text that defines attributes for an element (i.e., block, block macro, inline macro) or an include directive.
+
+admonition:: a callout paragraph or block that has a label or icon indicating its priority.
+
+backend:: a moniker for the expected output format; used as a key to select which converter to use; often used interchangeably with the name of a converter (i.e., the "html5" backend").
+
+block element:: a line-oriented chunk of content in an AsciiDoc document.
+
+block attribute:: an attribute associated with a delimited block or paragraph; these attributes can affect processing of the block, and are available to block processors, but cannot be referenced using an attribute reference.
+
+block name:: used to refer to custom blocks, which can map an arbitrary name to one or more contexts; has a similar role as the style for a built-in block, such as an admonition block
+
+block style:: a modifier that specializes the context of a block
+
+built-in attribute:: a document attribute that controls processing, integrations, styling, and localization.
+
+content model:: determines how the content of a block is parsed and processed (e.g., simple, compound, verbatim, raw, etc.)
+
+context:: the element's type; describes the primary function of an element (e.g., sidebar, listing, example)
+
+converter:: a software component that an AsciiDoc processor calls to convert a parsed AsciiDoc document to a given output format;
+the converter and output format are correlated using a backend identifier.
+
+cross reference:: a link from one location in the document to another location marked by an anchor.
+
+document attribute:: an attribute associated with the document (node); in other words, an attribute in the global document attributes dictionary; the value of these attributes can be referenced using an attribute reference; if defined in the header, the document attribute is known as a header attribute.
+
+element:: discrete content in the source or output document.
+May be a branch (contains child elements) or a leaf (does not contain child elements).
+
+element attribute:: an attribute associated with a block, macro, formatted text, or the include directive; these attributes can affect processing of the element (or include directive) and are available in the document model; however, the value of these attributes cannot be resolved using an attribute reference.
+
+environment attribute:: a dynamic document attribute that pertains to, or gives information about, the runtime environment.
+
+header attribute:: a document attribute defined in the document header; visible from all nodes in the document; often required for global settings such as the source highlighter or icons mode.
+
+inline element:: a phrase (i.e., span of content) within a block element or one of its attributes in an AsciiDoc document.
+
+list continuation:: a plus sign (`+`) on a line by itself that connects adjacent lines of text to a list item.
+
+macro:: a syntax for representing non-text elements or that expands into text using the provided metadata.
+
+macro attribute:: an attribute associated with a block or inline macro; these attributes can affect processing of the macro, and are available to macro processors, but cannot be referenced using an attribute reference.
+
+node:: an in-memory representation of a block or inline element in the parsed document model.
+
+predefined attribute:: a document attribute defined for convenience; often used for inserting special content characters.
+
+structural container:: the fixed set of reusable block enclosures (delimited regions) defined by the AsciiDoc language; implies the block's content model; characterized by a pair of matching delimited lines defining the boundaries of the block's content
+
+quoted text:: text which is enclosed in special punctuation to give it emphasis or special meaning.
+
+user-defined attribute:: a document attribute defined by the content author; used for storing reusable content, and controlling conditional inclusion.
+"#
+);

--- a/parser/src/tests/asciidoc_lang/root/mod.rs
+++ b/parser/src/tests/asciidoc_lang/root/mod.rs
@@ -1,6 +1,8 @@
 mod asciidoc_vs_markdown;
 mod document_processing;
 mod document_structure;
+mod faq;
+mod glossary;
 mod index;
 mod key_concepts;
 mod normalization;


### PR DESCRIPTION
## Summary

Adds spec-driven-development (SDD) coverage for two ROOT-module pages:

- `docs/modules/ROOT/pages/faq.adoc`
- `docs/modules/ROOT/pages/glossary.adoc`

Both pages are conversational / informative reference material (a Q&A FAQ and a work-in-progress glossary of term definitions) rather than testable, normative parser requirements. Each is therefore mirrored verbatim under a single `non_normative!` marker with its own `track_file!`, which closes the spec-coverage gap without asserting parser behavior. This follows the existing fully-non-normative `asciidoc_vs_markdown.rs`.

## Verification

- `cargo build -p asciidoc-parser --tests` — passes.
- The SDD tool (`cd sdd && cargo run`) reports **no uncovered lines** for either page.
- Formatted with `cargo +nightly fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)