### PR TITLE
feat: Retain comments in the data model; implement [comment] block styles

### DIFF
--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -218,9 +218,14 @@ impl<'src> RawDelimitedBlock<'src> {
 /// block whose style turns it into a raw delimited block:
 ///
 /// * the verbatim contexts — `source` and `listing` (both rendered as a listing
-///   block), or `literal` — make the open block a verbatim raw block; and
+///   block), or `literal` — make the open block a verbatim raw block;
 /// * the `pass` context makes the open block a passthrough (raw) block, whose
-///   content is emitted with no substitutions and no block parsing.
+///   content is emitted with no substitutions and no block parsing; and
+/// * the `comment` context makes the open block a comment block — the alternate
+///   open-block form of a `////` comment block. Its content is retained in the
+///   parsed model (this parser deliberately does not discard comments) but is
+///   raw: no substitutions are applied and no AsciiDoc syntax within it,
+///   including preprocessor directives, is interpreted.
 ///
 /// Returns the resulting content model, context, and substitution group, or
 /// `None` when the style is absent or names a context that keeps the compound
@@ -241,6 +246,7 @@ fn open_block_verbatim_masquerade(
             SubstitutionGroup::Verbatim,
         )),
         "pass" => Some((ContentModel::Raw, "pass", SubstitutionGroup::Pass)),
+        "comment" => Some((ContentModel::Raw, "comment", SubstitutionGroup::None)),
         _ => None,
     }
 }

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -142,8 +142,14 @@ impl<'src> RawDelimitedBlock<'src> {
 
                 let mut content: Content<'src> = content.into();
 
-                substitution_group =
-                    substitution_group.override_via_attrlist(metadata.attrlist.as_ref());
+                // A comment block (`////` or a `[comment]` open block) is never
+                // interpreted, so a `subs` attribute must not override its
+                // (empty) substitution group; every other raw context honors a
+                // `subs` override.
+                if context != "comment" {
+                    substitution_group =
+                        substitution_group.override_via_attrlist(metadata.attrlist.as_ref());
+                }
 
                 substitution_group.apply(&mut content, parser, metadata.attrlist.as_ref());
 

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -326,6 +326,11 @@ fn parse_lines<'src>(
         }
     }
 
+    // A `[comment]` paragraph is raw: its content is retained verbatim and not
+    // interpreted, so (like the `////` and `[comment]` open-block forms) inner
+    // `//` lines must be preserved rather than stripped as line comments.
+    let comment_style = is_comment_style(attrlist.as_ref());
+
     let mut next = source;
     let mut filtered_lines: Vec<&'src str> = vec![];
     let mut skipped_comment_line = false;
@@ -432,8 +437,10 @@ fn parse_lines<'src>(
         next = line_mi.after;
 
         // Only strip comment lines in paragraph style. In literal/listing/source
-        // blocks, "//" lines are preserved as content.
-        if style == SimpleBlockStyle::Paragraph
+        // blocks, "//" lines are preserved as content; likewise a `[comment]`
+        // paragraph retains its content verbatim (raw).
+        if !comment_style
+            && style == SimpleBlockStyle::Paragraph
             && line.starts_with("//")
             && !line.starts_with("///")
         {

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -459,13 +459,17 @@ fn parse_lines<'src>(
     let filtered_lines = filtered_lines.join("\n");
     let mut content: Content<'src> = Content::from_filtered(source, filtered_lines);
 
-    let sub_group = base_substitution_group(style);
+    // A `[comment]`-styled paragraph is the single-paragraph form of a comment
+    // block. Its content is retained in the parsed model (this parser does not
+    // discard comments) but is not interpreted: no substitutions are applied,
+    // matching the raw content model of a `////` comment block.
+    let sub_group = if is_comment_style(attrlist.as_ref()) {
+        SubstitutionGroup::None
+    } else {
+        base_substitution_group(style).override_via_attrlist(attrlist.as_ref())
+    };
 
-    sub_group.override_via_attrlist(attrlist.as_ref()).apply(
-        &mut content,
-        parser,
-        attrlist.as_ref(),
-    );
+    sub_group.apply(&mut content, parser, attrlist.as_ref());
 
     Some(MatchedItem {
         item: (content, style),
@@ -486,6 +490,13 @@ fn base_substitution_group(style: SimpleBlockStyle) -> SubstitutionGroup {
             SubstitutionGroup::Normal
         }
     }
+}
+
+/// Returns `true` if this paragraph carries the `comment` block style (i.e.
+/// `[comment]`), making it a comment paragraph whose content is retained but
+/// not interpreted.
+fn is_comment_style(attrlist: Option<&Attrlist<'_>>) -> bool {
+    attrlist.and_then(|attrlist| attrlist.block_style()) == Some("comment")
 }
 
 impl<'src> IsBlock<'src> for SimpleBlock<'src> {
@@ -535,9 +546,14 @@ impl<'src> IsBlock<'src> for SimpleBlock<'src> {
 
     fn substitution_group(&'src self) -> SubstitutionGroup {
         // Mirror the group actually applied to this block's content in
-        // `parse_lines`: the base group derived from the style, then any `subs`
+        // `parse_lines`: a `[comment]` paragraph is raw (no substitutions),
+        // otherwise the base group derived from the style, then any `subs`
         // override from the attribute list.
-        base_substitution_group(self.style).override_via_attrlist(self.attrlist.as_ref())
+        if is_comment_style(self.attrlist.as_ref()) {
+            SubstitutionGroup::None
+        } else {
+            base_substitution_group(self.style).override_via_attrlist(self.attrlist.as_ref())
+        }
     }
 }
 

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -470,7 +470,7 @@ fn parse_lines<'src>(
     // block. Its content is retained in the parsed model (this parser does not
     // discard comments) but is not interpreted: no substitutions are applied,
     // matching the raw content model of a `////` comment block.
-    let sub_group = if is_comment_style(attrlist.as_ref()) {
+    let sub_group = if comment_style {
         SubstitutionGroup::None
     } else {
         base_substitution_group(style).override_via_attrlist(attrlist.as_ref())

--- a/parser/src/tests/asciidoc_lang/root/comments.rs
+++ b/parser/src/tests/asciidoc_lang/root/comments.rs
@@ -195,14 +195,21 @@ Additionally, no AsciiDoc syntax within the delimited lines is interpreted, not 
     );
 
     // The content of a comment block is raw: neither inline markup nor an
-    // attribute reference is interpreted.
-    let doc = Parser::default().parse("////\n*bold* {attr}\n////");
+    // attribute reference is interpreted, and an inner `//` line (a preprocessor
+    // line comment) is retained verbatim rather than stripped.
+    let doc = Parser::default().parse("////\n*bold* {attr}\n// inner\n////");
     let block = doc.nested_blocks().next().expect("expected a block");
     assert_eq!(
         block.rendered_content(),
-        Some("*bold* {attr}"),
+        Some("*bold* {attr}\n// inner"),
         "comment block content must be raw"
     );
+
+    // Even an explicit `subs` attribute does not cause a comment block to be
+    // interpreted.
+    let doc = Parser::default().parse("[subs=quotes]\n////\n*bold*\n////");
+    let block = doc.nested_blocks().next().expect("expected a block");
+    assert_eq!(block.rendered_content(), Some("*bold*"));
 
     non_normative!(
         r#"
@@ -226,11 +233,17 @@ A comment block can also be written as an open block with the comment style:
     );
 
     // An open block (`--`) carrying the `comment` style is the alternate form of
-    // a comment block: same `comment` context, raw (uninterpreted) content.
-    let doc = Parser::default().parse("[comment]\n--\n*bold* {attr}\n--");
+    // a comment block: same `comment` context, raw (uninterpreted) content —
+    // inner `//` lines retained, and a `subs` override ignored — matching the
+    // `////` form exactly.
+    let doc = Parser::default().parse("[comment]\n--\n*bold* {attr}\n// inner\n--");
     let block = doc.nested_blocks().next().expect("expected a block");
     assert_eq!(block.resolved_context().as_ref(), "comment");
-    assert_eq!(block.rendered_content(), Some("*bold* {attr}"));
+    assert_eq!(block.rendered_content(), Some("*bold* {attr}\n// inner"));
+
+    let doc = Parser::default().parse("[comment,subs=quotes]\n--\n*bold*\n--");
+    let block = doc.nested_blocks().next().expect("expected a block");
+    assert_eq!(block.rendered_content(), Some("*bold*"));
 
     non_normative!(
         r#"
@@ -265,6 +278,21 @@ A comment block that can consists of a single paragraph can be written as a para
     let second = doc.nested_blocks().nth(1).expect("expected a second block");
     assert_eq!(second.declared_style(), None);
     assert_eq!(second.rendered_content(), Some("Not a comment."));
+
+    // Like the `////` and open-block forms, a `[comment]` paragraph retains its
+    // content verbatim: an inner `//` line is preserved (not stripped as a line
+    // comment), inline markup is not interpreted, and a `subs` override is
+    // ignored.
+    let doc = Parser::default().parse("[comment]\nfirst line\n// inner\n*bold*");
+    let first = doc.nested_blocks().next().expect("expected a block");
+    assert_eq!(
+        first.rendered_content(),
+        Some("first line\n// inner\n*bold*")
+    );
+
+    let doc = Parser::default().parse("[comment,subs=quotes]\n*bold*");
+    let first = doc.nested_blocks().next().expect("expected a block");
+    assert_eq!(first.rendered_content(), Some("*bold*"));
 
     non_normative!(
         r#"

--- a/parser/src/tests/asciidoc_lang/root/comments.rs
+++ b/parser/src/tests/asciidoc_lang/root/comments.rs
@@ -261,6 +261,7 @@ A comment block that can consists of a single paragraph can be written as a para
         .parse("[comment]\nA paragraph comment.\nLike all paragraphs, the lines must be contiguous.\n\nNot a comment.");
     let first = doc.nested_blocks().next().expect("expected a block");
     assert_eq!(first.declared_style(), Some("comment"));
+    assert_eq!(first.substitution_group(), SubstitutionGroup::None);
     let second = doc.nested_blocks().nth(1).expect("expected a second block");
     assert_eq!(second.declared_style(), None);
     assert_eq!(second.rendered_content(), Some("Not a comment."));

--- a/parser/src/tests/asciidoc_lang/root/comments.rs
+++ b/parser/src/tests/asciidoc_lang/root/comments.rs
@@ -1,0 +1,351 @@
+use crate::{blocks::Block, tests::prelude::*};
+
+track_file!("docs/modules/ROOT/pages/comments.adoc");
+
+// NOTE ON DATA-MODEL DEVIATION: The AsciiDoc language specifies that comments
+// are dropped from the parsed document. This parser deliberately deviates: it
+// *retains* comments in the parsed model so that tooling can round-trip or
+// inspect them. Comment blocks (in all three forms — `////`, a `[comment]` open
+// block, and a `[comment]` paragraph) are retained as blocks with the `comment`
+// context; comment lines are retained either in `Header::comments` (header) or
+// as empty-rendered paragraph blocks (body). The two spec sentences that assert
+// comments are "not included" / "dropped" are therefore mirrored here as
+// `non_normative!` rather than `verifies!`.
+
+#[test]
+fn overview() {
+    non_normative!(
+        r#"
+= Comments
+
+Like programming languages, AsciiDoc provides a way to add commentary to your document that's not carried over into the published document.
+This artifact is collectively known as a [.term]*comment*.
+Putting text in a comment is often referred to as "`commenting it out`".
+
+A comment is often used to insert a writer-facing notation or to hide draft content that's not ready for publishing.
+In general, you can use comments anytime you want to hide lines from the processor.
+Comments can also be useful as a processor hint to keep adjacent blocks of content separate.
+
+"#
+    );
+
+    // DEVIATION: the language drops comments; this parser retains them (see the
+    // note at the top of this file), so this sentence is non-normative here.
+    non_normative!(
+        r#"
+The AsciiDoc processor will ignore comments during parsing and, thus, will not include them in the parsed document.
+"#
+    );
+
+    verifies!(
+        r#"
+It will, however, account for the lines when mapping line numbers back to the source document.
+
+"#
+    );
+
+    // A comment line does not disturb the line numbering of the blocks that
+    // follow it: the trailing paragraph still reports its true source line (5),
+    // accounting for the comment line (3) and the blank lines around it.
+    let doc = Parser::default().parse("first\n\n// a comment\n\nsecond");
+    let second = doc
+        .nested_blocks()
+        .find(|b| b.span().data() == "second")
+        .expect("expected the 'second' paragraph");
+    assert_eq!(second.span().line(), 5);
+
+    non_normative!(
+        r#"
+AsciiDoc supports two styles of comments, line and block.
+A line comment is for making comments line-by-line (i.e., comment line).
+A block comment is for enclosing an arbitrary range of lines as a comment (i.e., comment block).
+
+"#
+    );
+}
+
+#[test]
+fn comment_lines() {
+    verifies!(
+        r#"
+[#comment-lines]
+== Comment lines
+
+A comment line is any line outside of a verbatim block that begins with a double forward slash (`//`) that's not immediately followed by a third forward slash.
+Following this prefix, the line may contain an arbitrary number of characters.
+It's customary to insert a single space between the prefix and the comment text (e.g., `// line comment`).
+
+"#
+    );
+
+    // A `//` line is a comment (dropped from the rendered output)...
+    let doc = Parser::default().parse("text\n// a comment\nmore");
+    assert_eq!(rendered_paragraphs(&doc), vec!["text\nmore".to_string()]);
+
+    // ...but a `///` line (a third forward slash) is not a comment; it stays as
+    // ordinary content.
+    let doc = Parser::default().parse("/// not a comment");
+    assert_eq!(
+        rendered_paragraphs(&doc),
+        vec!["/// not a comment".to_string()]
+    );
+
+    non_normative!(
+        r#"
+.Line comment syntax
+----
+// A single-line comment.
+----
+
+"#
+    );
+
+    verifies!(
+        r#"
+When the processor encounters a line comment, it ignores the line and continues processing as though the line is not there.
+Line comments are processed as lines are read, so they can be used where paragraph text is not permitted, such as between attribute entries in the document header.
+
+"#
+    );
+
+    // A comment line between two attribute entries in the header is skipped and
+    // retained on the header, without breaking the header.
+    let doc = Parser::default().parse("= Title\n:a: 1\n// between attributes\n:b: 2\n\nbody");
+    assert_eq!(doc.header().attributes().count(), 2);
+    assert_eq!(doc.header().comments().count(), 1);
+
+    verifies!(
+        r#"
+Line comments can be used strategically to separate blocks that otherwise have affinity, such as two adjacent lists.
+
+"#
+    );
+
+    // A lone `//` between two lists forces them apart into two separate lists.
+    let doc = Parser::default().parse("* first list\n\n//\n\n* second list");
+    let lists = doc
+        .nested_blocks()
+        .filter(|b| matches!(b, Block::List(_)))
+        .count();
+    assert_eq!(lists, 2);
+
+    non_normative!(
+        r#"
+.Line comment separating two lists
+----
+* first list
+
+//
+
+* second list
+----
+
+"#
+    );
+
+    // DEVIATION: the comment line is retained as an empty-rendered paragraph
+    // rather than dropped, but it still serves as the block boundary described
+    // here.
+    non_normative!(
+        r#"
+In this case, the single line comment effectively acts as an empty paragraph that's dropped from the parsed document.
+But before then, it will have served its purpose as a block boundary.
+
+"#
+    );
+}
+
+#[test]
+fn comment_blocks() {
+    verifies!(
+        r#"
+== Comment blocks
+
+A comment block is a specialized delimited block.
+It consists of an arbitrary number of lines bounded on either side by `////` delimiter lines.
+
+"#
+    );
+
+    // A `////` delimited block parses as a block with the `comment` context.
+    let doc = Parser::default().parse("////\nA comment block.\n////");
+    let block = doc.nested_blocks().next().expect("expected a block");
+    assert_eq!(block.raw_context().as_ref(), "comment");
+    assert_eq!(block.resolved_context().as_ref(), "comment");
+
+    verifies!(
+        r#"
+A comment block can be used anywhere a delimited block is normal accepted.
+"#
+    );
+
+    // DEVIATION: the block is retained (with the `comment` context) instead of
+    // being dropped from the parsed document.
+    non_normative!(
+        r#"
+The main difference is that once the block is read, it's dropped from the parsed document (effectively ignored).
+"#
+    );
+
+    verifies!(
+        r#"
+Additionally, no AsciiDoc syntax within the delimited lines is interpreted, not even preprocessor directives.
+
+"#
+    );
+
+    // The content of a comment block is raw: neither inline markup nor an
+    // attribute reference is interpreted.
+    let doc = Parser::default().parse("////\n*bold* {attr}\n////");
+    let block = doc.nested_blocks().next().expect("expected a block");
+    assert_eq!(
+        block.rendered_content(),
+        Some("*bold* {attr}"),
+        "comment block content must be raw"
+    );
+
+    non_normative!(
+        r#"
+.Block comment syntax
+----
+////
+A comment block.
+
+Notice it's a delimited block.
+////
+----
+
+"#
+    );
+
+    verifies!(
+        r#"
+A comment block can also be written as an open block with the comment style:
+
+"#
+    );
+
+    // An open block (`--`) carrying the `comment` style is the alternate form of
+    // a comment block: same `comment` context, raw (uninterpreted) content.
+    let doc = Parser::default().parse("[comment]\n--\n*bold* {attr}\n--");
+    let block = doc.nested_blocks().next().expect("expected a block");
+    assert_eq!(block.resolved_context().as_ref(), "comment");
+    assert_eq!(block.rendered_content(), Some("*bold* {attr}"));
+
+    non_normative!(
+        r#"
+.Alternate block comment syntax
+----
+[comment]
+--
+A comment block.
+
+Notice it's a delimited block.
+--
+----
+
+"#
+    );
+
+    verifies!(
+        r#"
+A comment block that can consists of a single paragraph can be written as a paragraph with the comment style:
+
+"#
+    );
+
+    // A `[comment]` paragraph is a comment: it carries the `comment` declared
+    // style and its content is raw. A following, unstyled paragraph is ordinary
+    // content.
+    let doc = Parser::default()
+        .parse("[comment]\nA paragraph comment.\nLike all paragraphs, the lines must be contiguous.\n\nNot a comment.");
+    let first = doc.nested_blocks().next().expect("expected a block");
+    assert_eq!(first.declared_style(), Some("comment"));
+    let second = doc.nested_blocks().nth(1).expect("expected a second block");
+    assert_eq!(second.declared_style(), None);
+    assert_eq!(second.rendered_content(), Some("Not a comment."));
+
+    non_normative!(
+        r#"
+.Comment paragraph syntax
+----
+[comment]
+A paragraph comment.
+Like all paragraphs, the lines must be contiguous.
+
+Not a comment.
+----
+
+"#
+    );
+
+    verifies!(
+        r#"
+If comment blocks are used in a list item, they must be attached to the list item just like any other block.
+
+"#
+    );
+
+    // A comment block attached with a list continuation (`+`) stays inside the
+    // list item.
+    let doc = Parser::default()
+        .parse("* first item\n+\n////\nA comment block in a list.\n////\n\n* second item");
+    assert_css(&doc, "ul", 1);
+    assert_css(&doc, "ul > li", 2);
+
+    non_normative!(
+        r#"
+.Block comment attached to list item
+----
+* first item
++
+////
+A comment block in a list.
+
+Notice it's attached to the preceding list item.
+////
+
+* second item
+----
+
+"#
+    );
+
+    verifies!(
+        r#"
+Within a table, a comment block can only be used in an AsciiDoc table cell.
+
+"#
+    );
+
+    // A comment block inside an AsciiDoc (`a|`) table cell parses without
+    // disturbing the surrounding table.
+    let doc = Parser::default()
+        .parse("|===\na|\ncell text\n\n////\nA comment block in a table.\n////\n|===");
+    assert_css(&doc, "table", 1);
+
+    non_normative!(
+        r#"
+.Block comment within a table
+----
+|===
+a|
+cell text
+
+////
+A comment block in a table.
+
+Notice the cell has the "a" (AsciiDoc) style.
+////
+|===
+----
+
+"#
+    );
+
+    non_normative!(
+        r#"
+Comment blocks can be very effective for commenting out sections of the document that are not ready for publishing or that provide background material or an outline for the text being drafted.
+"#
+    );
+}

--- a/parser/src/tests/asciidoc_lang/root/mod.rs
+++ b/parser/src/tests/asciidoc_lang/root/mod.rs
@@ -1,4 +1,5 @@
 mod asciidoc_vs_markdown;
+mod comments;
 mod document_processing;
 mod document_structure;
 mod faq;


### PR DESCRIPTION
## Summary

Implements the remaining features from the **Comments** spec page (`docs/modules/ROOT/pages/comments.adoc`) and, per project direction, **deliberately deviates from the AsciiDoc data model** by *retaining* comments in the parsed document rather than discarding them.

## What was already working
- `////` comment blocks were retained as blocks with the `comment` context.
- Comment lines were retained — in `Header::comments` (header) or as empty-rendered paragraph blocks (body) — with source line numbers preserved.
- Comment lines inside a paragraph were stripped from rendered output but kept in the block's source span.

## Gaps this PR fixes
- **`[comment]` open block** (`--`): was mis-parsed as a normal open block and rendered as ordinary content. Now routed through the open-block masquerade to a raw block with the `comment` context — content retained but **not interpreted** (no substitutions, no nested block parsing), matching the `////` form and the spec ("no AsciiDoc syntax ... is interpreted, not even preprocessor directives").
- **`[comment]` paragraph**: normal substitutions were applied to its (dropped) content. Now treated as raw (`SubstitutionGroup::None`), so commented-out content is not interpreted and cannot raise spurious substitution warnings, while remaining identifiable via its `comment` declared style.

## Data-model deviation (intentional)
The spec says comments are dropped from the parsed document. This parser retains them so tooling can round-trip / inspect them. All three comment-block forms (`////`, `[comment]` open block, `[comment]` paragraph) are retained with the `comment` context; comment lines are retained on the header or as empty-rendered paragraphs. The two spec sentences asserting comments are "not included" / "dropped" are mirrored as `non_normative!` in the coverage test, with inline notes.

## Tests
- New SDD coverage file `parser/src/tests/asciidoc_lang/root/comments.rs` mirrors `comments.adoc` **verbatim** (119/119 lines; all normative statements `verifies!`, backed by behavioral assertions) and is registered in `root/mod.rs`.
- Full suite green: **2921 passed, 0 failed**; `cargo clippy` clean; `cargo +nightly fmt --check` clean.
- Verified via the `sdd` tool that `comments.adoc` has no uncovered (`0`) lines.

## Notes for reviewers
- No stubbed-out or `to_do_verifies!` comment tests were found in the codebase during the scan.
- Existing behavior for bare `//` line comments (retained as empty-rendered paragraph blocks / header comments, acting as block separators) is left intact — it is already a form of retention and is depended on by existing list-separation and xpath tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
