### PR TITLE
chore: Pin release workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,16 +16,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0.5.130
+        uses: MarcoIeni/release-plz-action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_SECRET }}


### PR DESCRIPTION
## Summary

Applies the supply-chain hardening from [`asciidoc-html5`'s release workflow](https://github.com/asciidoc-rs/asciidoc-html5/blob/main/.github/workflows/release-plz.yml) to this repo's `.github/workflows/release.yml`.

Each GitHub Action in the release-plz workflow is now pinned to a full commit SHA (with a version comment) instead of a mutable tag. Mutable tags can be silently repointed to a malicious commit; pinning to an immutable SHA makes every action reference auditable and tamper-resistant.

## Changes

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `@v7` | `@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0` |
| `dtolnay/rust-toolchain` | `@stable` | `@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable` |
| `MarcoIeni/release-plz-action` | `@v0.5.130` | `@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130` |

## Verification

Each pinned SHA was verified against the upstream ref via `git ls-remote`:
- `actions/checkout` `v7.0.0` → `9c091bb…`
- `MarcoIeni/release-plz-action` `v0.5.130` (annotated tag, dereferenced) → `e8792575…`
- `dtolnay/rust-toolchain` `stable` branch → `4be7066…`

No behavioral change — the pinned commits are the exact same code the tags currently reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtVopC8TWAZFRqn6RtUaD5)_