### PR TITLE
chore: Improve reliability of CI workflows and tool installations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Taplo CLI
-        run: cargo install taplo-cli --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli
 
       - name: Check TOML format
         run: taplo fmt --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
       - name: Install Taplo CLI
         uses: taiki-e/install-action@v2
         with:
-          tool: taplo-cli
+          tool: taplo-cli@0.9.3
 
       - name: Check TOML format
         run: taplo fmt --check

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -82,9 +82,16 @@ jobs:
             exit 0;
           fi
 
-          echo "Installing commitlint-rs. Please wait 30-40 seconds ..."
-          cargo install --quiet commitlint-rs
+          # Enable `set -e` before installing so a failed `cargo install`
+          # fails this step immediately, instead of surfacing later as a
+          # confusing "commitlint: command not found". The `if ... grep`
+          # exception checks above intentionally run before this point, since
+          # a non-matching grep is an expected non-zero exit.
           set -e
+          echo "Installing commitlint-rs. Please wait 30-40 seconds ..."
+          # Pin the version so a breaking upstream release can't silently
+          # change how PR titles are validated. Bump this deliberately.
+          cargo install --quiet --version 0.2.4 commitlint-rs
 
           echo  
           echo  


### PR DESCRIPTION
## Summary
This PR improves the reliability and maintainability of CI workflows by adding better error handling, pinning tool versions, and using a more robust installation method.

## Key Changes

- **PR title validation workflow**: 
  - Added `set -e` to fail immediately if `cargo install` fails, preventing confusing "command not found" errors later
  - Pinned `commitlint-rs` to version 0.2.4 to prevent breaking changes from upstream releases
  - Improved comments explaining the rationale for these changes

- **TOML formatting check workflow**:
  - Replaced direct `cargo install` with `taiki-e/install-action@v2` for more reliable tool installation
  - This action provides better error handling and caching compared to manual cargo installation

## Notable Details
The `set -e` placement in the PR title workflow is intentional—it's positioned after the early exit checks (grep exceptions) to avoid failing on expected non-zero exits, while still catching actual installation failures.

https://claude.ai/code/session_01JruSHHeVmM3J3bN6G58ACL