### PR TITLE
feat: Seed intrinsic attributes that lock silently

### DIFF
--- a/parser/src/parser/attribute_value.rs
+++ b/parser/src/parser/attribute_value.rs
@@ -17,6 +17,20 @@ pub(crate) struct AttributeValue {
     /// Allowable contexts for modifying the attribute value.
     pub(crate) modification_context: ModificationContext,
 
+    /// Whether a rejected write (a document header or body assignment that
+    /// [`modification_context`](Self::modification_context) does not permit) is
+    /// silently ignored instead of recording an
+    /// [`AttributeValueIsLocked`](crate::warnings::WarningType::AttributeValueIsLocked)
+    /// warning.
+    ///
+    /// This is orthogonal to the scope axis: it does not change *where* the
+    /// attribute may be set, only whether a rejected write warns. It exists so
+    /// a caller can reproduce Asciidoctor's *silent* safe-mode attribute
+    /// restrictions — under `SERVER`/`SECURE`, a document assignment of a
+    /// restricted conversion attribute (`backend`, `doctype`, `docinfo`,
+    /// `source-highlighter`) is simply dropped, with no diagnostic.
+    pub(crate) silent_when_locked: bool,
+
     /// Current value of the attribute.
     pub(crate) value: InterpretedValue,
 }

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -57,6 +57,7 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
     let char_replacement = |value: &str| AttributeValue {
         allowable_value: AllowableValue::Any,
         modification_context: ModificationContext::ApiOnly,
+        silent_when_locked: false,
         value: InterpretedValue::Value(value.into()),
     };
 
@@ -117,6 +118,7 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
     let any = |ctx, value| AttributeValue {
         allowable_value: AllowableValue::Any,
         modification_context: ctx,
+        silent_when_locked: false,
         value,
     };
 
@@ -127,6 +129,7 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
     let set = |ctx, default: &str| AttributeValue {
         allowable_value: AllowableValue::Any,
         modification_context: ctx,
+        silent_when_locked: false,
         value: Value(default.to_owned()),
     };
 
@@ -134,6 +137,7 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
     let empty = |ctx, value| AttributeValue {
         allowable_value: AllowableValue::Empty,
         modification_context: ctx,
+        silent_when_locked: false,
         value,
     };
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -522,9 +522,9 @@ impl Parser {
     /// This behaves exactly like [`with_intrinsic_attribute()`] except that a
     /// document header or body assignment that the
     /// [`modification_context`](ModificationContext) does not permit is dropped
-    /// with **no** [`AttributeValueIsLocked`] warning, instead of recording
-    /// one. The rejected write is otherwise handled identically (the value
-    /// is left unchanged).
+    /// with **no** `AttributeValueIsLocked` warning, instead of recording one.
+    /// The rejected write is otherwise handled identically (the value is left
+    /// unchanged).
     ///
     /// This reproduces Asciidoctor's *silent* safe-mode attribute restrictions:
     /// under `SERVER`/`SECURE`, a document assignment of a restricted
@@ -541,7 +541,6 @@ impl Parser {
     /// [intrinsic attribute]: https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes-ref/#intrinsic-attributes
     ///
     /// [`with_intrinsic_attribute()`]: Self::with_intrinsic_attribute
-    /// [`AttributeValueIsLocked`]: crate::warnings::WarningType::AttributeValueIsLocked
     pub fn with_intrinsic_attribute_silent<N: AsRef<str>, V: AsRef<str>>(
         mut self,
         name: N,
@@ -816,9 +815,9 @@ impl Parser {
     /// This behaves exactly like [`with_intrinsic_attribute_bool()`] except
     /// that a document header or body assignment that the
     /// [`modification_context`](ModificationContext) does not permit is dropped
-    /// with **no** [`AttributeValueIsLocked`] warning, instead of recording
-    /// one. See [`with_intrinsic_attribute_silent()`] for the motivating
-    /// use case (Asciidoctor's silent safe-mode attribute restrictions).
+    /// with **no** `AttributeValueIsLocked` warning, instead of recording one.
+    /// See [`with_intrinsic_attribute_silent()`] for the motivating use case
+    /// (Asciidoctor's silent safe-mode attribute restrictions).
     ///
     /// A boolean `true` is interpreted as "set." A boolean `false` is
     /// interpreted as "unset."
@@ -831,7 +830,6 @@ impl Parser {
     ///
     /// [`with_intrinsic_attribute_bool()`]: Self::with_intrinsic_attribute_bool
     /// [`with_intrinsic_attribute_silent()`]: Self::with_intrinsic_attribute_silent
-    /// [`AttributeValueIsLocked`]: crate::warnings::WarningType::AttributeValueIsLocked
     pub fn with_intrinsic_attribute_bool_silent<N: AsRef<str>>(
         mut self,
         name: N,

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -450,6 +450,7 @@ impl Parser {
             AttributeValue {
                 allowable_value: AllowableValue::Any,
                 modification_context: ModificationContext::ApiOrDocumentBody,
+                silent_when_locked: false,
                 value: InterpretedValue::Value(value.to_string()),
             },
         );
@@ -470,6 +471,7 @@ impl Parser {
                 AttributeValue {
                     allowable_value: AllowableValue::Any,
                     modification_context: ModificationContext::Anywhere,
+                    silent_when_locked: false,
                     value: InterpretedValue::Value(String::new()),
                 },
             );
@@ -504,6 +506,52 @@ impl Parser {
         let attribute_value = AttributeValue {
             allowable_value: AllowableValue::Any,
             modification_context,
+            silent_when_locked: false,
+            value: InterpretedValue::Value(value.as_ref().to_string()),
+        };
+
+        Arc::make_mut(&mut self.attribute_values)
+            .insert(name.as_ref().to_lowercase(), attribute_value);
+
+        self
+    }
+
+    /// Sets the value of an [intrinsic attribute], rejecting any disallowed
+    /// subsequent write *silently*.
+    ///
+    /// This behaves exactly like [`with_intrinsic_attribute()`] except that a
+    /// document header or body assignment that the
+    /// [`modification_context`](ModificationContext) does not permit is dropped
+    /// with **no** [`AttributeValueIsLocked`] warning, instead of recording
+    /// one. The rejected write is otherwise handled identically (the value
+    /// is left unchanged).
+    ///
+    /// This reproduces Asciidoctor's *silent* safe-mode attribute restrictions:
+    /// under `SERVER`/`SECURE`, a document assignment of a restricted
+    /// conversion attribute (`backend`, `doctype`, `docinfo`,
+    /// `source-highlighter`) is simply dropped, with no diagnostic. Seed
+    /// such an attribute as an [`ApiOnly`](ModificationContext::ApiOnly)
+    /// silent intrinsic to lock it against document assignment without
+    /// warning.
+    ///
+    /// Subsequent calls to this function or the other
+    /// `with_intrinsic_attribute` variants are always permitted. The last
+    /// such call for any given attribute name takes precedence.
+    ///
+    /// [intrinsic attribute]: https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes-ref/#intrinsic-attributes
+    ///
+    /// [`with_intrinsic_attribute()`]: Self::with_intrinsic_attribute
+    /// [`AttributeValueIsLocked`]: crate::warnings::WarningType::AttributeValueIsLocked
+    pub fn with_intrinsic_attribute_silent<N: AsRef<str>, V: AsRef<str>>(
+        mut self,
+        name: N,
+        value: V,
+        modification_context: ModificationContext,
+    ) -> Self {
+        let attribute_value = AttributeValue {
+            allowable_value: AllowableValue::Any,
+            modification_context,
+            silent_when_locked: true,
             value: InterpretedValue::Value(value.as_ref().to_string()),
         };
 
@@ -748,6 +796,52 @@ impl Parser {
         let attribute_value = AttributeValue {
             allowable_value: AllowableValue::Any,
             modification_context,
+            silent_when_locked: false,
+            value: if value {
+                InterpretedValue::Set
+            } else {
+                InterpretedValue::Unset
+            },
+        };
+
+        Arc::make_mut(&mut self.attribute_values)
+            .insert(name.as_ref().to_lowercase(), attribute_value);
+
+        self
+    }
+
+    /// Sets the value of an [intrinsic attribute] from a boolean flag,
+    /// rejecting any disallowed subsequent write *silently*.
+    ///
+    /// This behaves exactly like [`with_intrinsic_attribute_bool()`] except
+    /// that a document header or body assignment that the
+    /// [`modification_context`](ModificationContext) does not permit is dropped
+    /// with **no** [`AttributeValueIsLocked`] warning, instead of recording
+    /// one. See [`with_intrinsic_attribute_silent()`] for the motivating
+    /// use case (Asciidoctor's silent safe-mode attribute restrictions).
+    ///
+    /// A boolean `true` is interpreted as "set." A boolean `false` is
+    /// interpreted as "unset."
+    ///
+    /// Subsequent calls to this function or the other
+    /// `with_intrinsic_attribute` variants are always permitted. The last
+    /// such call for any given attribute name takes precedence.
+    ///
+    /// [intrinsic attribute]: https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes-ref/#intrinsic-attributes
+    ///
+    /// [`with_intrinsic_attribute_bool()`]: Self::with_intrinsic_attribute_bool
+    /// [`with_intrinsic_attribute_silent()`]: Self::with_intrinsic_attribute_silent
+    /// [`AttributeValueIsLocked`]: crate::warnings::WarningType::AttributeValueIsLocked
+    pub fn with_intrinsic_attribute_bool_silent<N: AsRef<str>>(
+        mut self,
+        name: N,
+        value: bool,
+        modification_context: ModificationContext,
+    ) -> Self {
+        let attribute_value = AttributeValue {
+            allowable_value: AllowableValue::Any,
+            modification_context,
+            silent_when_locked: true,
             value: if value {
                 InterpretedValue::Set
             } else {
@@ -873,6 +967,7 @@ impl Parser {
         let intrinsic = |value: InterpretedValue| AttributeValue {
             allowable_value: AllowableValue::Any,
             modification_context: ModificationContext::ApiOnly,
+            silent_when_locked: false,
             value,
         };
 
@@ -955,10 +1050,14 @@ impl Parser {
             && (existing_attr.modification_context == ModificationContext::ApiOnly
                 || existing_attr.modification_context == ModificationContext::ApiOrDocumentBody)
         {
-            warnings.push(Warning {
-                source: attr.span(),
-                warning: WarningType::AttributeValueIsLocked(attr_name),
-            });
+            // A silently-locked intrinsic rejects the write without recording a
+            // warning (see `AttributeValue::silent_when_locked`).
+            if !existing_attr.silent_when_locked {
+                warnings.push(Warning {
+                    source: attr.span(),
+                    warning: WarningType::AttributeValueIsLocked(attr_name),
+                });
+            }
             return;
         }
 
@@ -973,6 +1072,7 @@ impl Parser {
         let attribute_value = AttributeValue {
             allowable_value: AllowableValue::Any,
             modification_context: ModificationContext::Anywhere,
+            silent_when_locked: false,
             value,
         };
 
@@ -1001,6 +1101,7 @@ impl Parser {
         let attribute_value = AttributeValue {
             allowable_value: AllowableValue::Any,
             modification_context: ModificationContext::Anywhere,
+            silent_when_locked: false,
             value: InterpretedValue::Value(value.as_ref().to_owned()),
         };
 
@@ -1080,16 +1181,21 @@ impl Parser {
             && (existing_attr.modification_context != ModificationContext::Anywhere
                 && existing_attr.modification_context != ModificationContext::ApiOrDocumentBody)
         {
-            warnings.push(Warning {
-                source: attr.span(),
-                warning: WarningType::AttributeValueIsLocked(attr_name),
-            });
+            // A silently-locked intrinsic rejects the write without recording a
+            // warning (see `AttributeValue::silent_when_locked`).
+            if !existing_attr.silent_when_locked {
+                warnings.push(Warning {
+                    source: attr.span(),
+                    warning: WarningType::AttributeValueIsLocked(attr_name),
+                });
+            }
             return;
         }
 
         let attribute_value = AttributeValue {
             allowable_value: AllowableValue::Any,
             modification_context: ModificationContext::Anywhere,
+            silent_when_locked: false,
             value: attr.value().clone(),
         };
 
@@ -1343,6 +1449,70 @@ mod tests {
         );
 
         assert_eq!(parser.attribute_value("sp"), InterpretedValue::Value(" "));
+    }
+
+    #[test]
+    fn silently_locked_intrinsic_rejects_header_and_body_without_warning() {
+        // A silently-locked `ApiOnly` intrinsic (as a converter would seed a
+        // safe-mode-restricted attribute) rejects both a header assignment and a
+        // body assignment of the same name, leaving the value unchanged and
+        // recording no warning.
+        let mut parser = Parser::default().with_intrinsic_attribute_silent(
+            "backend",
+            "html5",
+            ModificationContext::ApiOnly,
+        );
+
+        let doc = parser.parse(concat!(
+            "= Title\n",
+            ":backend: docbook5\n",
+            "\n",
+            "Body paragraph.\n",
+            "\n",
+            ":backend: manpage\n",
+        ));
+
+        assert_eq!(doc.warnings().count(), 0);
+        assert_eq!(
+            parser.attribute_value("backend"),
+            InterpretedValue::Value("html5")
+        );
+    }
+
+    #[test]
+    fn silently_locked_bool_intrinsic_rejects_without_warning() {
+        let mut parser = Parser::default().with_intrinsic_attribute_bool_silent(
+            "sectids",
+            true,
+            ModificationContext::ApiOnly,
+        );
+
+        let doc = parser.parse(concat!("= Title\n", ":!sectids:\n"));
+
+        assert_eq!(doc.warnings().count(), 0);
+        assert_eq!(parser.attribute_value("sectids"), InterpretedValue::Set);
+    }
+
+    #[test]
+    fn normally_locked_intrinsic_still_warns() {
+        // Regression: a non-silent `ApiOnly` intrinsic still records
+        // `AttributeValueIsLocked` when the document tries to reassign it.
+        let mut parser = Parser::default().with_intrinsic_attribute(
+            "backend",
+            "html5",
+            ModificationContext::ApiOnly,
+        );
+
+        let doc = parser.parse(concat!("= Title\n", ":backend: docbook5\n"));
+
+        assert_eq!(
+            doc.warnings().next().unwrap().warning,
+            WarningType::AttributeValueIsLocked("backend".to_owned())
+        );
+        assert_eq!(
+            parser.attribute_value("backend"),
+            InterpretedValue::Value("html5")
+        );
     }
 
     #[test]

--- a/parser/src/parser/resolved_attributes.rs
+++ b/parser/src/parser/resolved_attributes.rs
@@ -112,6 +112,7 @@ mod tests {
         AttributeValue {
             allowable_value: AllowableValue::Any,
             modification_context: ModificationContext::Anywhere,
+            silent_when_locked: false,
             value,
         }
     }


### PR DESCRIPTION
Closes #625.

## Summary

`ModificationContext` couples *where* an attribute may be set (the four scope variants) with *whether* a rejected write warns — every locked write emits `AttributeValueIsLocked`. Asciidoctor's safe-mode attribute restrictions, by contrast, are **silent**: under `SERVER`/`SECURE`, a document assignment of a restricted conversion attribute (`backend`, `doctype`, `docinfo`, `source-highlighter`) is simply dropped, with no diagnostic — something a converter cannot reproduce today.

This adds a silent dimension **orthogonal to scope** (per the issue's preferred shape — not a fifth scope variant):

- A `silent_when_locked: bool` field on the internal `AttributeValue`. When set, a rejected document header **or** body assignment is dropped without recording `AttributeValueIsLocked`. The scope axis is unchanged; the reject-and-skip behavior is otherwise identical.
- Both `set_attribute_from_header` and `set_attribute_from_body` consult the flag before pushing the warning.
- Two new public seeding entry points on `Parser`, mirroring the existing pair:
  - `with_intrinsic_attribute_silent`
  - `with_intrinsic_attribute_bool_silent`

All existing (non-silent) seeding paths default `silent_when_locked` to `false`, so current warning behavior is unchanged.

## Tests

- A silently-locked intrinsic rejects a header assignment **and** a body assignment of the same name, value unchanged, **no** warning recorded (both value and bool variants).
- Regression: a normally-locked (`ApiOnly`) intrinsic still records `AttributeValueIsLocked`.

Full suite (`cargo test -p asciidoc-parser`), `clippy --all-targets`, and nightly `fmt` all pass.

## Note for review

The issue raised an open question about whether `AttributeValueIsLocked` should warn for the plain API-lock case at all (Asciidoctor silently ignores that too), and whether the axis should invert to silent-by-default. This PR takes the conservative path: **opt-in silence**, current warning behavior preserved by default. Happy to invert if strict Asciidoctor parity is preferred as the default.

## Downstream

Unblocks exact safe-mode attribute parity in converters — see asciidoc-rs/asciidoc-html5, which will seed the SERVER/SECURE-restricted document attributes as silently-locked intrinsics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)