### PR TITLE
chore: Enable ruler/description-list interaction tests (#601)

### DIFF
--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -2335,6 +2335,7 @@ mod description_lists_dlist {
 
             assert_xpath(&doc, "//dl", 2);
             assert_xpath(&doc, "//dl/dt", 2);
+            assert_xpath(&doc, "//hr", 1);
             assert_xpath(&doc, "//dl//hr", 0);
             assert_xpath(&doc, "(//dl)[1]/dt", 1);
             assert_xpath(&doc, "(//dl)[2]/dt", 1);

--- a/parser/src/tests/asciidoctor_rb/lists_test.rs
+++ b/parser/src/tests/asciidoctor_rb/lists_test.rs
@@ -2330,16 +2330,14 @@ mod description_lists_dlist {
         }
 
         #[test]
-        #[ignore]
-        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/601):
-        // Enable this test when rulers are implemented.
         fn a_ruler_between_elements_should_divide_them_into_separate_lists() {
-            let _doc = Parser::default().parse("term1:: def1\n\n'''\n\nterm2:: def2\n");
-            todo!("assert_xpath: '//dl', output, 2");
-            todo!("assert_xpath: '//dl/dt', output, 2");
-            todo!("assert_xpath: '//dl//hr', output, 0");
-            todo!("assert_xpath: '(//dl)[1]/dt', output, 1");
-            todo!("assert_xpath: '(//dl)[2]/dt', output, 1");
+            let doc = Parser::default().parse("term1:: def1\n\n'''\n\nterm2:: def2\n");
+
+            assert_xpath(&doc, "//dl", 2);
+            assert_xpath(&doc, "//dl/dt", 2);
+            assert_xpath(&doc, "//dl//hr", 0);
+            assert_xpath(&doc, "(//dl)[1]/dt", 1);
+            assert_xpath(&doc, "(//dl)[2]/dt", 1);
         }
 
         #[test]
@@ -3725,9 +3723,6 @@ mod description_lists_redux {
         }
 
         #[test]
-        #[ignore]
-        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/601):
-        // Enable this test when rulers are implemented.
         fn folds_text_that_looks_like_ruler_offset_by_blank_line_and_line_comment() {
             let doc = Parser::default().parse("== Lists\n\nterm1::\n\n// comment\n'''\n");
 
@@ -3891,9 +3886,6 @@ mod description_lists_redux {
         }
 
         #[test]
-        #[ignore]
-        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/601):
-        // Enable this test when rulers are implemented.
         fn appends_line_attached_by_continuation_as_block_if_item_has_no_inline_description_followed_by_ruler()
          {
             let doc = Parser::default().parse("== Lists\n\nterm1::\n+\npara\n\n'''\n");
@@ -4573,22 +4565,27 @@ mod description_lists_redux {
         }
 
         #[test]
-        #[ignore]
-        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/601):
-        // Enable this test when rulers are implemented.
         fn appends_literal_line_attached_by_continuation_as_block_if_item_has_inline_description_followed_by_ruler()
          {
-            let _doc = Parser::default().parse("== Lists\n\nterm1:: def1\n+\n  literal\n\n'''\n");
-            todo!("assert_xpath: '//*[@class=\"dlist\"]/dl', output, 1");
-            todo!("assert_xpath: '//*[@class=\"dlist\"]//dd', output, 1");
-            todo!("assert_xpath: '//*[@class=\"dlist\"]//dd/p[text()=\"def1\"]', output, 1");
-            todo!(
-                "assert_xpath: '//*[@class=\"dlist\"]//dd/p/following-sibling::*[@class=\"literalblock\"]', output, 1"
+            let doc = Parser::default().parse("== Lists\n\nterm1:: def1\n+\n  literal\n\n'''\n");
+
+            assert_xpath(&doc, "//*[@class=\"dlist\"]/dl", 1);
+            assert_xpath(&doc, "//*[@class=\"dlist\"]//dd", 1);
+            assert_xpath(&doc, "//*[@class=\"dlist\"]//dd/p[text()=\"def1\"]", 1);
+
+            assert_xpath(
+                &doc,
+                "//*[@class=\"dlist\"]//dd/p/following-sibling::*[@class=\"literalblock\"]",
+                1,
             );
-            todo!(
-                "assert_xpath: '//*[@class=\"dlist\"]//dd/p/following-sibling::*[@class=\"literalblock\"]//pre[text()=\"literal\"]', output, 1"
+
+            assert_xpath(
+                &doc,
+                "//*[@class=\"dlist\"]//dd/p/following-sibling::*[@class=\"literalblock\"]//pre[text()=\"literal\"]",
+                1,
             );
-            todo!("assert_xpath: '//*[@class=\"dlist\"]/following-sibling::hr', output, 1");
+
+            assert_xpath(&doc, "//*[@class=\"dlist\"]/following-sibling::hr", 1);
         }
 
         #[test]
@@ -4774,12 +4771,10 @@ mod description_lists_redux {
         }
 
         #[test]
-        #[ignore]
-        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/601):
-        // Enable this test when rulers are implemented.
         fn ruler_offset_by_blank_line_divides_lists_because_item_has_text() {
-            let _doc = Parser::default().parse("== Lists\n\nterm1:: def1\n\n'''\n\nterm2:: def2\n");
-            todo!("assert_xpath: '//*[@class=\"dlist\"]/dl', output, 2");
+            let doc = Parser::default().parse("== Lists\n\nterm1:: def1\n\n'''\n\nterm2:: def2\n");
+
+            assert_xpath(&doc, "//*[@class=\"dlist\"]/dl", 2);
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Closes #601. Un-ignores and completes the five ported Asciidoctor tests in `parser/src/tests/asciidoctor_rb/lists_test.rs` that were gated on ruler (`'''`) interaction with description lists:

- `a_ruler_between_elements_should_divide_them_into_separate_lists`
- `folds_text_that_looks_like_ruler_offset_by_blank_line_and_line_comment`
- `appends_line_attached_by_continuation_as_block_if_item_has_no_inline_description_followed_by_ruler`
- `appends_literal_line_attached_by_continuation_as_block_if_item_has_inline_description_followed_by_ruler`
- `ruler_offset_by_blank_line_divides_lists_because_item_has_text`

The standalone `'''` ruler / thematic-break syntax was already implemented and verified under #474, and the description-list interaction behavior these tests assert already works correctly. So no parser changes were required — the tests pass as-is once the `#[ignore]` attributes are removed. Three of the five still carried `todo!()` stub bodies (from the original port); those are replaced with the intended `assert_xpath` assertions taken directly from the corresponding Asciidoctor tests.

## SDD coverage

No SDD (spec-driven-development) coverage is applicable here:

- Nothing new was implemented in the parser — the behavior already existed.
- These are Asciidoctor behavioral ports (`asciidoctor_rb/`), which do not carry `track_file!`/`verifies!` spec markers.
- The AsciiDoc language spec pages for lists (`ref/asciidoc-lang/docs/modules/lists/`) do not mention rulers/thematic breaks at all, so there is no normative spec text to mark as covered. The ruler's own spec coverage already lives in `parser/src/tests/asciidoc_lang/blocks/breaks.rs` and `thematic_breaks.rs`.

## Testing

- `cargo test -p asciidoc-parser` — 2994 passed, 0 failed (ignored count dropped from 48 to 43).
- `cargo +nightly fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)