### PR TITLE
feat: Recognize language-aware fenced code blocks

### DIFF
--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -151,6 +151,31 @@ impl<'src> Attrlist<'src> {
         }
     }
 
+    /// Build the attribute list implied by a language-aware fenced code block
+    /// (`` ```lang ``).
+    ///
+    /// A fenced code block whose opening fence carries a language is shorthand
+    /// for a source block: it is equivalent to a `[source,<language>]`
+    /// attribute list applied to a listing block. The synthesized list
+    /// therefore carries the `source` block style in the first position and
+    /// the language in the second, so that downstream consumers resolve the
+    /// block to a source (highlighted listing) block and can read the
+    /// language via [`nth_attribute(2)`](Self::nth_attribute) — without
+    /// this parser performing any syntax highlighting itself.
+    ///
+    /// The `source` span is set to the language span, since that is the only
+    /// portion of the synthesized list that appears in the document source.
+    pub(crate) fn source_with_language(language: Span<'src>) -> Self {
+        Self {
+            attributes: vec![
+                ElementAttribute::synthesized_source_style(),
+                ElementAttribute::positional_from_span(language),
+            ],
+            anchor: None,
+            source: language,
+        }
+    }
+
     /// Merge a subsequent block attribute line into this one.
     ///
     /// A block can be preceded by more than one attribute list line (optionally

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -117,6 +117,42 @@ impl<'src> ElementAttribute<'src> {
         )
     }
 
+    /// Synthesize the `source` block-style attribute implied by a
+    /// language-aware fenced code block (`` ```lang ``). This is the first
+    /// positional attribute of the equivalent `[source,<lang>]` attribute list;
+    /// its shorthand items resolve the block style to `source`.
+    pub(crate) fn synthesized_source_style() -> Self {
+        const SOURCE: &str = "source";
+        let mut warnings: Vec<WarningType> = vec![];
+        let shorthand_item_indices = parse_shorthand_items(SOURCE, &mut warnings);
+
+        // `source` is a single shorthand item with no delimiters, so parsing it
+        // can never warn. Guard that invariant rather than plumb an always-empty
+        // list back to the caller.
+        debug_assert!(
+            warnings.is_empty(),
+            "synthesizing the `source` block style should not produce warnings, got: {warnings:?}"
+        );
+
+        Self {
+            name: None,
+            value: CowStr::from(SOURCE),
+            shorthand_item_indices,
+        }
+    }
+
+    /// Construct a bare positional attribute whose value is drawn directly from
+    /// `span`, carrying no shorthand items. Used for the language on a
+    /// language-aware fenced code block (the second positional attribute of the
+    /// equivalent `[source,<lang>]` attribute list).
+    pub(crate) fn positional_from_span(span: Span<'src>) -> Self {
+        Self {
+            name: None,
+            value: CowStr::from(span.data()),
+            shorthand_item_indices: vec![],
+        }
+    }
+
     /// Return the attribute name, if one was found.
     pub fn name(&'src self) -> Option<&'src str> {
         self.name_str()

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -25,6 +25,13 @@ use crate::{
 /// listing block. Like the open-block delimiter, it has a fixed length; four
 /// or more backticks are not a fence.
 ///
+/// A language may be declared on the opening fence (`` ```ruby ``). This is a
+/// shorthand for a source block — equivalent to `[source,ruby]` over a listing
+/// block — so the synthesized attribute list carries the `source` block style
+/// and the language, and the closing fence is a bare `` ``` ``. This parser
+/// records the language for a downstream renderer but performs no syntax
+/// highlighting itself.
+///
 /// In addition, an open-block delimiter (`--`) is recognized here when it
 /// carries a verbatim masquerade style: `source` or `listing` (parsed as a
 /// listing block) or `literal` (parsed as a literal block). Every other open
@@ -50,11 +57,12 @@ impl<'src> RawDelimitedBlock<'src> {
     pub(crate) fn is_valid_delimiter(line: &Span<'src>) -> bool {
         let data = line.data();
 
-        // The fenced code block delimiter is exactly three backticks. Unlike the
-        // four-character verbatim/raw delimiters, its length is fixed (as with
-        // the two-character open-block delimiter): a run of four or more
-        // backticks is not a fence.
-        if data == "```" {
+        // The fenced code block delimiter is exactly three backticks, optionally
+        // followed by a language on the opening fence (```ruby). Unlike the
+        // four-character verbatim/raw delimiters, its backtick run has a fixed
+        // length (as with the two-character open-block delimiter): a run of four
+        // or more backticks is not a fence.
+        if data == "```" || fenced_code_language(line).is_some() {
             return true;
         }
 
@@ -86,6 +94,15 @@ impl<'src> RawDelimitedBlock<'src> {
         let delimiter = metadata.block_start.take_normalized_line();
         let delimiter_data = delimiter.item.data();
 
+        // The line that closes the block. Every delimiter closes on a line that
+        // matches it exactly, except a language-aware fenced code block
+        // (```ruby), whose closing fence is a bare ``` — set below.
+        let mut close_delimiter = delimiter_data;
+
+        // The attribute list synthesized for a language-aware fenced code block.
+        // For every other block the author's own attribute list (if any) is used.
+        let mut fenced_attrlist: Option<Attrlist<'src>> = None;
+
         // A `--` open-block delimiter normally forms a compound (open) block, but
         // a verbatim masquerade style (`source`, `listing`, or `literal`) set on
         // it turns the block into a verbatim raw block. Every other delimiter
@@ -99,6 +116,23 @@ impl<'src> RawDelimitedBlock<'src> {
             // Its delimiter has a fixed length, so no trailing-character
             // validity check is required. The closing fence must match the
             // opening delimiter exactly, which the scan loop below enforces.
+            (
+                ContentModel::Verbatim,
+                "listing",
+                SubstitutionGroup::Verbatim,
+            )
+        } else if let Some(language) = fenced_code_language(&delimiter.item) {
+            // A fenced code block whose opening fence carries a language
+            // (```ruby) is shorthand for a source block: `[source,<language>]`
+            // over a listing block. The closing fence is a bare ``` (the
+            // language appears only on the opening fence). When the author has
+            // not supplied their own attribute list, synthesize the equivalent
+            // `[source,<language>]` so a downstream renderer can resolve the
+            // source language; an explicit attribute list takes precedence.
+            close_delimiter = "```";
+            if metadata.attrlist.is_none() {
+                fenced_attrlist = Some(Attrlist::source_with_language(language));
+            }
             (
                 ContentModel::Verbatim,
                 "listing",
@@ -140,18 +174,18 @@ impl<'src> RawDelimitedBlock<'src> {
             block_type
         };
 
+        // The block's effective attribute list: the one synthesized for a
+        // language-aware fenced code block, or otherwise the author's own list.
+        let attrlist = fenced_attrlist.or_else(|| metadata.attrlist.clone());
+
         // Assign the caption (and its number) from the block's context. Among
         // the raw delimited contexts only `listing` is captionable (a `source`
         // block resolves to the `listing` context); for every other context
         // `assign_block_caption` returns `None`. The caption is computed once,
         // here, so the context counter is consumed exactly once regardless of
         // which return path the block takes below.
-        let caption = assign_block_caption(
-            parser,
-            context,
-            metadata.attrlist.as_ref(),
-            metadata.title.is_some(),
-        );
+        let caption =
+            assign_block_caption(parser, context, attrlist.as_ref(), metadata.title.is_some());
         let number = caption.as_ref().and_then(|c| c.number);
         let caption = caption.map(|c| c.prefix);
 
@@ -160,7 +194,7 @@ impl<'src> RawDelimitedBlock<'src> {
 
         while !next.is_empty() {
             let line = next.take_normalized_line();
-            if line.item.data() == delimiter.item.data() {
+            if line.item.data() == close_delimiter {
                 let content = content_start.trim_remainder(next).trim_trailing_line_end();
 
                 let mut content: Content<'src> = content.into();
@@ -171,10 +205,10 @@ impl<'src> RawDelimitedBlock<'src> {
                 // `subs` override.
                 if context != "comment" {
                     substitution_group =
-                        substitution_group.override_via_attrlist(metadata.attrlist.as_ref());
+                        substitution_group.override_via_attrlist(attrlist.as_ref());
                 }
 
-                substitution_group.apply(&mut content, parser, metadata.attrlist.as_ref());
+                substitution_group.apply(&mut content, parser, attrlist.as_ref());
 
                 return Some(MatchAndWarnings {
                     item: Some(MatchedItem {
@@ -192,7 +226,7 @@ impl<'src> RawDelimitedBlock<'src> {
                             number,
                             anchor: metadata.anchor,
                             anchor_reftext: metadata.anchor_reftext,
-                            attrlist: metadata.attrlist.clone(),
+                            attrlist: attrlist.clone(),
                             substitution_group,
                         },
                         after: line.after,
@@ -222,7 +256,7 @@ impl<'src> RawDelimitedBlock<'src> {
                     number,
                     anchor: metadata.anchor,
                     anchor_reftext: metadata.anchor_reftext,
-                    attrlist: metadata.attrlist.clone(),
+                    attrlist,
                     substitution_group,
                 },
                 after: next,
@@ -237,6 +271,34 @@ impl<'src> RawDelimitedBlock<'src> {
     /// Return the interpreted content of this block.
     pub fn content(&self) -> &Content<'src> {
         &self.content
+    }
+}
+
+/// If `line` opens a language-aware fenced code block, return the language
+/// declared on the opening fence.
+///
+/// A language-aware fence is exactly three backticks immediately followed by an
+/// info string (`` ```ruby ``). The language is the first whitespace-delimited
+/// token of that info string. A bare `` ``` `` fence, a run of four or more
+/// backticks, and any non-fence line all return `None`.
+fn fenced_code_language<'src>(line: &Span<'src>) -> Option<Span<'src>> {
+    let rest = line.data().strip_prefix("```")?;
+
+    // A bare fence carries no language; a fourth backtick makes this a longer
+    // run, which is not a fence.
+    if rest.is_empty() || rest.starts_with('`') {
+        return None;
+    }
+
+    // The language is the first whitespace-delimited token of the info string
+    // (any leading whitespace is skipped; trailing content is ignored).
+    let info = line.discard(3).take_whitespace().after;
+    let language = info.take_while(|c| c != ' ' && c != '\t').item;
+
+    if language.is_empty() {
+        None
+    } else {
+        Some(language)
     }
 }
 
@@ -429,21 +491,26 @@ mod tests {
 
         #[test]
         fn fenced() {
-            // The fenced code block delimiter is exactly three backticks.
+            // The fenced code block delimiter is exactly three backticks ...
             assert!(RawDelimitedBlock::is_valid_delimiter(&crate::Span::new(
                 "```"
             )));
 
-            // A run of four or more backticks is not a fence (the delimiter has
-            // a fixed length, unlike the four-character delimiters).
+            // ... optionally followed by a language on the opening fence.
+            assert!(RawDelimitedBlock::is_valid_delimiter(&crate::Span::new(
+                "```java"
+            )));
+            assert!(RawDelimitedBlock::is_valid_delimiter(&crate::Span::new(
+                "```ruby"
+            )));
+
+            // A run of four or more backticks is not a fence (the backtick run
+            // has a fixed length, unlike the four-character delimiters).
             assert!(!RawDelimitedBlock::is_valid_delimiter(&crate::Span::new(
                 "````"
             )));
             assert!(!RawDelimitedBlock::is_valid_delimiter(&crate::Span::new(
                 "``"
-            )));
-            assert!(!RawDelimitedBlock::is_valid_delimiter(&crate::Span::new(
-                "```java"
             )));
         }
 

--- a/parser/src/blocks/tests/raw_delimited.rs
+++ b/parser/src/blocks/tests/raw_delimited.rs
@@ -879,6 +879,185 @@ mod fenced {
     }
 
     #[test]
+    fn language_on_fence_sets_source_style() {
+        // A language on the opening fence (```ruby) is shorthand for a source
+        // block: the block resolves like `[source,ruby]` over a listing block.
+        // The synthesized attribute list carries the `source` block style in the
+        // first position and the language in the second, so a downstream renderer
+        // can read the source language without this parser highlighting it.
+        let mut parser = Parser::default();
+
+        let mi =
+            crate::blocks::Block::parse(crate::Span::new("```ruby\nputs 'hi'\n```"), &mut parser)
+                .unwrap_if_no_warnings()
+                .unwrap();
+
+        assert_eq!(
+            mi.item,
+            Block::RawDelimited(RawDelimitedBlock {
+                content: Content {
+                    original: Span {
+                        data: "puts 'hi'",
+                        line: 2,
+                        col: 1,
+                        offset: 8,
+                    },
+                    rendered: "puts 'hi'",
+                },
+                content_model: ContentModel::Verbatim,
+                context: "listing",
+                source: Span {
+                    data: "```ruby\nputs 'hi'\n```",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                caption: None,
+                number: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: Some(Attrlist {
+                    attributes: &[
+                        ElementAttribute {
+                            name: None,
+                            value: "source",
+                            shorthand_items: &["source"],
+                        },
+                        ElementAttribute {
+                            name: None,
+                            value: "ruby",
+                            shorthand_items: &[],
+                        },
+                    ],
+                    anchor: None,
+                    source: Span {
+                        data: "ruby",
+                        line: 1,
+                        col: 4,
+                        offset: 3,
+                    },
+                }),
+                substitution_group: SubstitutionGroup::Verbatim,
+            })
+        );
+
+        // The block resolves to a source (highlighted listing) block, and the
+        // language is exposed as the second positional attribute.
+        assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
+        assert_eq!(mi.item.raw_context().as_ref(), "listing");
+        assert_eq!(mi.item.resolved_context().as_ref(), "listing");
+        assert_eq!(mi.item.declared_style(), Some("source"));
+        assert_eq!(mi.item.rendered_content(), Some("puts 'hi'"));
+
+        assert_eq!(
+            mi.item
+                .attrlist()
+                .and_then(|a| a.nth_attribute(2))
+                .map(|a| a.value()),
+            Some("ruby")
+        );
+    }
+
+    #[test]
+    fn language_on_fence_closes_on_bare_fence() {
+        // The closing fence of a language-aware fenced block is a bare ``` — the
+        // language appears only on the opening fence, so the closing fence never
+        // repeats it.
+        let mut parser = Parser::default();
+
+        let mi =
+            crate::blocks::Block::parse(crate::Span::new("```rust\nlet x = 1;\n```"), &mut parser)
+                .unwrap_if_no_warnings()
+                .unwrap();
+
+        assert_eq!(mi.item.resolved_context().as_ref(), "listing");
+        assert_eq!(mi.item.declared_style(), Some("source"));
+        assert_eq!(mi.item.rendered_content(), Some("let x = 1;"));
+
+        assert_eq!(
+            mi.item
+                .attrlist()
+                .and_then(|a| a.nth_attribute(2))
+                .map(|a| a.value()),
+            Some("rust")
+        );
+    }
+
+    #[test]
+    fn explicit_attrlist_takes_precedence_over_fence_language() {
+        // When the author supplies their own attribute list above the fence, it
+        // wins over the language shorthand on the fence line: the explicit
+        // `[source,python]` style is used and the fence's `ruby` is ignored.
+        let mut parser = Parser::default();
+
+        let mi = crate::blocks::Block::parse(
+            crate::Span::new("[source,python]\n```ruby\nprint('hi')\n```"),
+            &mut parser,
+        )
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+        assert_eq!(mi.item.resolved_context().as_ref(), "listing");
+        assert_eq!(mi.item.declared_style(), Some("source"));
+        assert_eq!(mi.item.rendered_content(), Some("print('hi')"));
+
+        assert_eq!(
+            mi.item
+                .attrlist()
+                .and_then(|a| a.nth_attribute(2))
+                .map(|a| a.value()),
+            Some("python")
+        );
+    }
+
+    #[test]
+    fn language_on_fence_unterminated() {
+        // An unterminated language-aware fence still opens a listing block; the
+        // warning points at the full opening fence line.
+        let mut parser = Parser::default();
+
+        let maw = crate::blocks::Block::parse(crate::Span::new("```ruby\nputs 'hi'"), &mut parser);
+
+        let mi = maw.item.unwrap().clone();
+
+        assert_eq!(mi.item.raw_context().as_ref(), "listing");
+        assert_eq!(mi.item.declared_style(), Some("source"));
+        assert_eq!(mi.item.rendered_content(), Some("puts 'hi'"));
+
+        assert_eq!(
+            maw.warnings,
+            vec![Warning {
+                source: Span {
+                    data: "```ruby",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                warning: WarningType::UnterminatedDelimitedBlock,
+            }]
+        );
+    }
+
+    #[test]
+    fn four_backticks_with_language_is_not_a_fence() {
+        // A run of four (or more) backticks is not a fence, even when followed by
+        // a language token; it is ordinary paragraph text.
+        let mut parser = Parser::default();
+
+        let mi = crate::blocks::Block::parse(
+            crate::Span::new("````ruby\nnot a fence\n````"),
+            &mut parser,
+        )
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+        assert_eq!(mi.item.resolved_context().as_ref(), "paragraph");
+        assert_eq!(mi.item.content_model(), ContentModel::Simple);
+    }
+
+    #[test]
     fn unterminated() {
         let mut parser = Parser::default();
 

--- a/parser/src/tests/asciidoc_lang/blocks/block_name_table.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/block_name_table.rs
@@ -161,6 +161,15 @@ Will be colorized by the source highlighter if enabled on the document and a lan
     assert_eq!(resolved, "listing");
     assert_eq!(model, ContentModel::Verbatim);
     assert_eq!(style, None);
+
+    // "... a language is set": a language on the opening fence (```ruby) sets
+    // the `source` style, promoting the listing to a source block so the
+    // highlighter can colorize it. It still resolves to the `listing` context
+    // with the verbatim content model.
+    let (resolved, model, style) = facts("```ruby\nsource code\n```");
+    assert_eq!(resolved, "listing");
+    assert_eq!(model, ContentModel::Verbatim);
+    assert_eq!(style, Some("source".to_string()));
 }
 
 #[test]

--- a/parser/src/tests/asciidoc_lang/root/syntax_quick_reference.rs
+++ b/parser/src/tests/asciidoc_lang/root/syntax_quick_reference.rs
@@ -12,12 +12,13 @@ track_file!("ref/asciidoc-lang/docs/modules/ROOT/pages/syntax-quick-reference.ad
 // headings, page metadata, authoring comments, and rendering/output-only notes
 // (which this parser does not implement) are `non_normative!`.
 //
-// Two features described on the page are not yet implemented; they are marked
+// One feature described on the page is not yet implemented; it is marked
 // `to_do_verifies!` with assertions documenting current behavior:
 //   * `book` doctype parts / multi-part books (issue #380).
-//   * fenced code blocks with a language on the fence line, ```lang (issue
-//     #615). (The bare ``` fence IS supported and is verified in
-//     `markdown_compatibility`.)
+//
+// Language-aware fenced code blocks (```lang, issue #615) are now recognized;
+// both the bare ``` fence and the language-on-fence form are verified in
+// `markdown_compatibility`.
 
 #[test]
 fn preamble() {
@@ -2194,7 +2195,7 @@ include::sections:example$section.adoc[tag=b-md]
 "#
     );
 
-    to_do_verifies!(
+    verifies!(
         r#"
 .Fenced code block with syntax highlighting
 [#ex-fenced]
@@ -2210,16 +2211,25 @@ include::verbatim:example$source.adoc[tag=fence]
 "#
     );
 
-    // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/615): a
-    // language on the opening fence line (```ruby) is not yet recognized, so
-    // this example's fenced source block currently parses as a paragraph rather
-    // than a listing. (The bare ``` fence is supported; see the bare-fence
-    // assertion at the end of this function.)
+    // A language on the opening fence line (```ruby) is recognized as a source
+    // listing block: equivalent to `[source,ruby]` over a listing block
+    // (issue #615). The language is recorded as the second positional attribute
+    // so a downstream renderer can highlight it; this parser performs no
+    // highlighting itself. (The bare ``` fence is also supported; see the
+    // bare-fence assertion at the end of this function.)
     let doc = Parser::default().parse("```ruby\nputs 'hi'\n```");
-    assert!(!matches!(
-        doc.nested_blocks().next(),
-        Some(Block::RawDelimited(_))
-    ));
+    let Some(Block::RawDelimited(b)) = doc.nested_blocks().next() else {
+        panic!("expected a raw delimited (source listing) block");
+    };
+    assert_eq!(b.resolved_context().as_ref(), "listing");
+    assert_eq!(b.declared_style(), Some("source"));
+    assert_eq!(
+        b.attrlist()
+            .and_then(|a| a.nth_attribute(2))
+            .map(|a| a.value()),
+        Some("ruby")
+    );
+    assert!(b.content().rendered().contains("puts 'hi'"));
 
     verifies!(
         r#"


### PR DESCRIPTION
## Summary

Closes #615.

Recognizes a language declared on the opening fence of a Markdown-style fenced code block (`` ```ruby ``). Previously only the bare `` ``` `` fence was supported and `` ```ruby `` fell through to an ordinary paragraph.

A language-aware fence is treated as shorthand for a **source block** — equivalent to `[source,ruby]` over a listing block — so a downstream renderer can determine which language to highlight. As requested in the issue, this parser only *records* the language; it performs no syntax highlighting itself.

## Behavior

- The opening fence's info string is parsed; its first whitespace-delimited token is the language.
- The block resolves to the `listing` context with a synthesized `[source,<language>]` attribute list: `declared_style()` is `source`, and the language is the second positional attribute (`attrlist().nth_attribute(2)`).
- The closing fence is a bare `` ``` `` — the language appears only on the opening fence.
- A run of four or more backticks is still not a fence, even with a trailing language token.
- An explicit attribute list above the fence takes precedence over the fence-line language shorthand.

## Implementation

- `RawDelimitedBlock::is_valid_delimiter` / `parse` recognize `` ```<lang> ``, track a separate closing delimiter, and synthesize the attribute list.
- New `Attrlist::source_with_language` plus `ElementAttribute::synthesized_source_style` / `positional_from_span` build the `[source,<lang>]` equivalent (the language is borrowed directly from the source span).

## SDD coverage

- `syntax-quick-reference.adoc`: the fenced-source-block example moves from `to_do_verifies!` to `verifies!` with assertions (the acceptance criterion in #615).
- `block-name-table.adoc`: the `fenced` coverage now also exercises the "a language is set" sentence.

## Tests

- New unit tests in `blocks/tests/raw_delimited.rs`: full-fixture source-style fence, bare closing fence, explicit-attrlist precedence, unterminated fence, and four-backtick-with-language non-fence.
- Updated `is_valid_delimiter` unit test.
- Full suite: `cargo test -p asciidoc-parser` — 2994 passed, 0 failed. `cargo clippy` and nightly `cargo fmt --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)