### PR TITLE
chore: Cover language-fence info-string edge cases

### DIFF
--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -512,6 +512,21 @@ mod tests {
             assert!(!RawDelimitedBlock::is_valid_delimiter(&crate::Span::new(
                 "``"
             )));
+
+            // Backticks followed only by whitespace declare no language, so the
+            // line is not a language-aware fence.
+            assert!(!RawDelimitedBlock::is_valid_delimiter(&crate::Span::new(
+                "```\t"
+            )));
+            assert!(super::super::fenced_code_language(&crate::Span::new("```  ")).is_none());
+
+            // A language token is extracted from the info string, skipping any
+            // leading whitespace and ignoring anything after the first token.
+            assert_eq!(
+                super::super::fenced_code_language(&crate::Span::new("``` ruby extra"))
+                    .map(|s| s.data()),
+                Some("ruby")
+            );
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Follow-up to #630 (language-aware fenced code blocks), which merged before this test coverage landed.

The `fenced_code_language` helper added in #630 has one branch that no test exercised: the guard that returns `None` when the backticks are followed only by whitespace (an empty language token). This showed up as a code-coverage gap on the merged patch.

This adds unit coverage for that helper:

- `` ``` `` followed only by whitespace declares no language, so the line is not a language-aware fence (closes the previously uncovered empty-language branch).
- A language token is extracted from the info string, skipping leading whitespace and ignoring anything after the first token (`` ``` ruby extra `` → `ruby`).

## Verification

- `cargo test -p asciidoc-parser` — passes.
- `cargo llvm-cov` — `blocks/raw_delimited.rs` now reports zero missed regions.

Test-only change; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)