### PR TITLE
feat!: Let IncludeFileHandler transcode non-UTF-8 include content

### DIFF
--- a/parser/src/parser/include_file_handler.rs
+++ b/parser/src/parser/include_file_handler.rs
@@ -22,9 +22,9 @@ pub trait IncludeFileHandler: Debug {
     /// - `parser`: An implementation may read document attribute values from
     ///   the [`Parser`] state.
     ///
-    /// Return the string content of the include file if found. If no file is
-    /// found, return `None` and an appropriate warning message will be
-    /// generated.
+    /// Return the content of the include file (wrapped in [`IncludeContent`])
+    /// if found. If no file is found, return `None` and an appropriate warning
+    /// message will be generated.
     ///
     /// # Options
     /// With the exception of `encoding` (see below), the implementation should
@@ -33,17 +33,130 @@ pub trait IncludeFileHandler: Debug {
     /// attributes will be provided by the parser itself.
     ///
     /// # Encoding
-    /// If a `Some` result is provided, it is a typical Rust [`String`] and
-    /// therefore must be encoded as UTF-8. If the implementation is capable of
-    /// transcoding from other formats, it may use the `encoding` attribute as a
-    /// hint of the source format. If the implementation finds a file that is
-    /// not encoded in UTF-8 and is incapable of translating, it should return
-    /// `None`.
+    /// The content returned in [`IncludeContent`] is a typical Rust [`String`]
+    /// and therefore must be encoded as UTF-8.
+    ///
+    /// If the implementation is capable of transcoding from other formats, it
+    /// may use the `encoding` attribute as a hint of the source format. When it
+    /// transcodes the content to UTF-8, it should return the result via
+    /// [`IncludeContent::transcoded`] so that the parser knows the requested
+    /// encoding was honored and suppresses the non-UTF-8 include-encoding
+    /// warning.
+    ///
+    /// An implementation that only deals in UTF-8 should return its content via
+    /// [`IncludeContent::new`] (or the [`From`] conversions). If the directive
+    /// requested a non-UTF-8 `encoding`, the parser will emit a non-UTF-8
+    /// include-encoding warning in that case.
+    ///
+    /// If the implementation finds a file that is not encoded in UTF-8 and is
+    /// incapable of transcoding it, it should return `None`.
     fn resolve_target<'src>(
         &self,
         source: Option<&str>,
         target: &str,
         attrlist: &Attrlist<'src>,
         parser: &Parser,
-    ) -> Option<String>;
+    ) -> Option<IncludeContent>;
+}
+
+/// The content returned by an [`IncludeFileHandler`] for an `include::`
+/// directive, together with the metadata the parser needs to finish processing
+/// the include.
+///
+/// Construct one via [`IncludeContent::new`] for UTF-8 content that was read
+/// without interpreting the `encoding` attribute, or via
+/// [`IncludeContent::transcoded`] for content the handler transcoded to UTF-8
+/// while honoring a requested `encoding`. See the `# Encoding` section of
+/// [`IncludeFileHandler::resolve_target`] for details.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IncludeContent {
+    content: String,
+    encoding_handled: bool,
+}
+
+impl IncludeContent {
+    /// UTF-8 content that was read **without** interpreting the `encoding`
+    /// attribute.
+    ///
+    /// If the `include::` directive requested a non-UTF-8 `encoding`, the
+    /// parser will emit a non-UTF-8 include-encoding warning. This is the
+    /// appropriate constructor for a handler that only deals in UTF-8.
+    pub fn new(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            encoding_handled: false,
+        }
+    }
+
+    /// Content that the handler transcoded to UTF-8 while honoring the
+    /// requested `encoding` attribute.
+    ///
+    /// The parser will **not** emit a non-UTF-8 include-encoding warning for
+    /// content returned this way, since the handler has already reencoded it.
+    pub fn transcoded(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            encoding_handled: true,
+        }
+    }
+
+    /// Returns the UTF-8 content of the include.
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+
+    /// Returns `true` if the handler honored the requested `encoding` attribute
+    /// (i.e. the content was created via [`IncludeContent::transcoded`]).
+    pub fn encoding_handled(&self) -> bool {
+        self.encoding_handled
+    }
+
+    /// Consumes the `IncludeContent`, returning the owned UTF-8 content.
+    pub fn into_content(self) -> String {
+        self.content
+    }
+}
+
+impl From<String> for IncludeContent {
+    fn from(content: String) -> Self {
+        Self::new(content)
+    }
+}
+
+impl From<&str> for IncludeContent {
+    fn from(content: &str) -> Self {
+        Self::new(content)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IncludeContent;
+
+    #[test]
+    fn new_does_not_mark_encoding_handled() {
+        let content = IncludeContent::new("Content.");
+        assert_eq!(content.content(), "Content.");
+        assert!(!content.encoding_handled());
+        assert_eq!(content.into_content(), "Content.".to_owned());
+    }
+
+    #[test]
+    fn transcoded_marks_encoding_handled() {
+        let content = IncludeContent::transcoded("Résumé.");
+        assert_eq!(content.content(), "Résumé.");
+        assert!(content.encoding_handled());
+        assert_eq!(content.into_content(), "Résumé.".to_owned());
+    }
+
+    #[test]
+    fn from_string_and_str_do_not_mark_encoding_handled() {
+        let from_string = IncludeContent::from("Content.".to_owned());
+        assert_eq!(from_string, IncludeContent::new("Content."));
+        assert!(!from_string.encoding_handled());
+
+        let from_str: IncludeContent = "Content.".into();
+        assert_eq!(from_str, IncludeContent::new("Content."));
+        assert!(!from_str.encoding_handled());
+    }
 }

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -11,7 +11,7 @@ mod docinfo_file_handler;
 pub use docinfo_file_handler::DocinfoFileHandler;
 
 mod include_file_handler;
-pub use include_file_handler::IncludeFileHandler;
+pub use include_file_handler::{IncludeContent, IncludeFileHandler};
 
 mod inline_substitution_renderer;
 pub use inline_substitution_renderer::{

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -257,7 +257,7 @@ impl<'p> PreprocessorState<'p> {
                     continue;
                 }
 
-                if let Some(include_text) =
+                if let Some(include_content) =
                     self.parser.include_file_handler.as_ref().and_then(|ifh| {
                         ifh.resolve_target(file_name, &target, &attrlist, self.parser)
                     })
@@ -267,19 +267,26 @@ impl<'p> PreprocessorState<'p> {
                     // Asciidoctor. Any nested include/conditional directives in an
                     // AsciiDoc include are therefore interpreted only on the
                     // selected, re-indented lines.
-                    let selected = select_included_lines(&include_text, &attrlist);
+                    let selected = select_included_lines(include_content.content(), &attrlist);
                     let selected = reindent_included_lines(selected, &attrlist, self.parser);
 
                     // The parser only handles UTF-8 content, so an `encoding`
-                    // attribute requesting any other encoding cannot be honored;
-                    // record a warning (emitted below, once the offset of the
-                    // included content is known). See `include.adoc`. Letting a
-                    // handler transcode instead is tracked in
+                    // attribute requesting any other encoding cannot be honored
+                    // by the parser itself; record a warning (emitted below, once
+                    // the offset of the included content is known). See
+                    // `include.adoc`. A handler that transcodes the content to
+                    // UTF-8 itself signals this via `IncludeContent::transcoded`,
+                    // in which case the encoding has been honored and no warning
+                    // is recorded. See
                     // https://github.com/asciidoc-rs/asciidoc-parser/issues/611.
-                    let non_utf8_encoding = attrlist
-                        .named_attribute("encoding")
-                        .map(|a| a.value())
-                        .filter(|v| !is_utf8_encoding(v));
+                    let non_utf8_encoding = (!include_content.encoding_handled())
+                        .then(|| {
+                            attrlist
+                                .named_attribute("encoding")
+                                .map(|a| a.value())
+                                .filter(|v| !is_utf8_encoding(v))
+                        })
+                        .flatten();
 
                     // `leveloffset` wraps the included content in `:leveloffset:`
                     // attribute entries: the offset is applied to the included
@@ -1311,7 +1318,8 @@ mod tests {
 
     use crate::{
         SafeMode,
-        parser::{SourceLine, preprocessor::preprocess},
+        attributes::Attrlist,
+        parser::{IncludeContent, IncludeFileHandler, SourceLine, preprocessor::preprocess},
         tests::{fixtures::inline_file_handler::InlineFileHandler, prelude::*},
     };
 
@@ -2657,6 +2665,41 @@ mod tests {
             &output[warnings[0].offset..warnings[0].offset + warnings[0].len],
             "Résumé."
         );
+    }
+
+    #[test]
+    fn transcoded_include_suppresses_encoding_warning() {
+        // A handler that transcodes non-UTF-8 content to UTF-8 itself returns
+        // `IncludeContent::transcoded`, which honors the requested `encoding`
+        // and suppresses the `NonUtf8IncludeEncoding` warning. See
+        // https://github.com/asciidoc-rs/asciidoc-parser/issues/611.
+        #[derive(Debug)]
+        struct TranscodingFileHandler;
+
+        impl IncludeFileHandler for TranscodingFileHandler {
+            fn resolve_target<'src>(
+                &self,
+                _source: Option<&str>,
+                _target: &str,
+                _attrlist: &Attrlist<'src>,
+                _parser: &Parser,
+            ) -> Option<IncludeContent> {
+                // Pretend the bytes on disk were `iso-8859-1` and we decoded
+                // them; the returned content is valid UTF-8.
+                Some(IncludeContent::transcoded("Résumé."))
+            }
+        }
+
+        let source = "include::sample.adoc[encoding=iso-8859-1]";
+        let parser = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_primary_file_name("main.adoc")
+            .with_include_file_handler(TranscodingFileHandler);
+
+        let (output, _source_map, warnings) = preprocess(source, &parser);
+
+        assert_eq!(output, "Résumé.\n");
+        assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
     }
 
     #[test]

--- a/parser/src/tests/fixtures/inline_file_handler.rs
+++ b/parser/src/tests/fixtures/inline_file_handler.rs
@@ -1,6 +1,10 @@
 use std::collections::HashMap;
 
-use crate::{attributes::Attrlist, parser::IncludeFileHandler, tests::prelude::*};
+use crate::{
+    attributes::Attrlist,
+    parser::{IncludeContent, IncludeFileHandler},
+    tests::prelude::*,
+};
 
 #[derive(Debug)]
 pub(crate) struct InlineFileHandler(HashMap<&'static str, &'static str>);
@@ -18,7 +22,7 @@ impl IncludeFileHandler for InlineFileHandler {
         target: &str,
         _attrlist: &Attrlist<'src>,
         _parser: &Parser,
-    ) -> Option<String> {
-        self.0.get(target).map(|v| v.to_string())
+    ) -> Option<IncludeContent> {
+        self.0.get(target).map(|v| IncludeContent::new(*v))
     }
 }


### PR DESCRIPTION
Closes #611.

## What

Let an `IncludeFileHandler` transcode non-UTF-8 include content to UTF-8 itself and signal that it did so, suppressing the `NonUtf8IncludeEncoding` warning in that case.

`IncludeFileHandler::resolve_target` now returns `Option<IncludeContent>` instead of `Option<String>`. `IncludeContent` carries the UTF-8 content plus a flag recording whether the handler honored the include directive's `encoding` attribute:

- `IncludeContent::new(content)` (also `From<String>` / `From<&str>`) — UTF-8 content read **without** interpreting `encoding`. If the directive requested a non-UTF-8 `encoding`, the parser still emits the non-UTF-8 include-encoding warning (unchanged behavior).
- `IncludeContent::transcoded(content)` — content the handler already reencoded to UTF-8 while honoring `encoding`. The parser does **not** warn.

This is Option 1 from the issue. It keeps the safe "warn unless told otherwise" default and answers the parser's actual question (did the handler honor the encoding?) at the moment the content is produced, per-file — avoiding the split-brain of a separate `supports_encoding` capability query.

## API change (breaking)

```rust
// before
fn resolve_target<'src>(&self, ...) -> Option<String>;

// after
fn resolve_target<'src>(&self, ...) -> Option<IncludeContent>;
```

Existing UTF-8-only handlers migrate with a one-line `.map(Into::into)` (or `IncludeContent::new`). A handler that finds a non-UTF-8 file it cannot transcode still returns `None`, as before.

## Tests

- `transcoded_include_suppresses_encoding_warning` — a handler returning `IncludeContent::transcoded(...)` for an `iso-8859-1` include merges the content with **no** warning (mirrors the existing `non_utf8_encoding_warns_but_still_includes` test).
- Unit tests covering `IncludeContent` accessors and the `From` conversions.

`cargo test`, `cargo clippy --all-targets`, `cargo +nightly fmt --check`, and `RUSTDOCFLAGS="-D warnings" cargo doc` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)