### PR TITLE
chore: Enable colspan-aware row-grouping test (#548)

### DIFF
--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -976,6 +976,9 @@ mod psv {
             warnings[0].warning,
             WarningType::TableCellExceedsColumnCount
         );
+
+        // The warning is logged against the overrunning first row (line 3).
+        assert_eq!(warnings[0].source.line(), 3);
     }
 
     #[test]

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -962,12 +962,6 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/548): The crate
-    // mis-groups cells into rows when a leading row's colspans overflow the
-    // column count: for this input it produces seven single-cell rows instead of
-    // dropping the overflowing first row and forming one row of seven cells.
-    // Enable once row grouping accounts for the dropped colspan row.
     fn should_take_colspan_into_account_when_taking_cells_for_row() {
         let doc = Parser::default()
             .parse("[cols=7]\n|===\n2+|a 2+|b 2+|c 2+|d\n|e |f |g |h |i |j |k\n|===");


### PR DESCRIPTION
## Summary

Closes #548.

Issue #548 describes cells being mis-grouped into rows when a leading row's colspans overflow the column count. For:

```
[cols=7]
|===
2+|a 2+|b 2+|c 2+|d
|e |f |g |h |i |j |k
|===
```

Asciidoctor drops the overflowing first row (`2+`×4 = 8 slots > 7 cols) with a `TableCellExceedsColumnCount` warning and forms **one** row of seven cells from the second line.

## What changed

Investigating this issue, the crate **already produces the correct result**: the grid walk in `build_psv_table` (`parser/src/blocks/table.rs`) accounts for each cell's colspan via the `active_rowspans` bookkeeping, and its `effective > ncols` overrun branch drops the whole overrunning row and emits the `TableCellExceedsColumnCount` warning — exactly the Asciidoctor behaviour. That logic landed after the issue was filed but the ported test was never un-ignored.

This PR simply removes the `#[ignore]` (and its stale TODO) from `should_take_colspan_into_account_when_taking_cells_for_row` in `parser/src/tests/asciidoctor_rb/tables_test.rs`. The test passes as-is, locking in the behaviour.

No SDD spec-coverage markers apply — `tables_test.rs` is a straight port of Asciidoctor's Ruby suite and carries no `track_file!`/`verifies!` annotations.

## Verification

- `cargo test -p asciidoc-parser --lib` — 3004 passed, 0 failed (ignored count 42→41).
- The previously ignored test now runs and passes.
- `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)