### PR TITLE
feat: Support xrefstyle full/short cross-reference text formatting

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -10,7 +10,7 @@ use crate::{
         starts_with_admonition_label,
     },
     content::{Content, SubstitutionGroup},
-    document::{Attribute, RefType},
+    document::{Attribute, InterpretedValue, RefType},
     parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning, XrefSignifier},
     span::MatchedItem,
     strings::CowStr,
@@ -252,7 +252,7 @@ impl<'src> Block<'src> {
             Self::register_block_id(
                 block.id(),
                 Self::block_reftext(&block),
-                Self::block_signifier(&block),
+                Self::block_signifier(&block, parser),
                 block.span(),
                 parser,
                 &mut warnings,
@@ -324,7 +324,7 @@ impl<'src> Block<'src> {
                 Self::register_block_id(
                     block.id(),
                     Self::block_reftext(&block),
-                    Self::block_signifier(&block),
+                    Self::block_signifier(&block, parser),
                     block.span(),
                     parser,
                     &mut warnings,
@@ -351,7 +351,7 @@ impl<'src> Block<'src> {
                 Self::register_block_id(
                     block.id(),
                     Self::block_reftext(&block),
-                    Self::block_signifier(&block),
+                    Self::block_signifier(&block, parser),
                     block.span(),
                     parser,
                     &mut warnings,
@@ -378,7 +378,7 @@ impl<'src> Block<'src> {
                 Self::register_block_id(
                     block.id(),
                     Self::block_reftext(&block),
-                    Self::block_signifier(&block),
+                    Self::block_signifier(&block, parser),
                     block.span(),
                     parser,
                     &mut warnings,
@@ -405,7 +405,7 @@ impl<'src> Block<'src> {
                 Self::register_block_id(
                     block.id(),
                     Self::block_reftext(&block),
-                    Self::block_signifier(&block),
+                    Self::block_signifier(&block, parser),
                     block.span(),
                     parser,
                     &mut warnings,
@@ -432,7 +432,7 @@ impl<'src> Block<'src> {
                 Self::register_block_id(
                     block.id(),
                     Self::block_reftext(&block),
-                    Self::block_signifier(&block),
+                    Self::block_signifier(&block, parser),
                     block.span(),
                     parser,
                     &mut warnings,
@@ -484,7 +484,7 @@ impl<'src> Block<'src> {
                     Self::register_block_id(
                         block.id(),
                         Self::block_reftext(&block),
-                        Self::block_signifier(&block),
+                        Self::block_signifier(&block, parser),
                         block.span(),
                         parser,
                         &mut warnings,
@@ -612,7 +612,7 @@ impl<'src> Block<'src> {
             Self::register_block_id(
                 matched_item.item.id(),
                 Self::block_reftext(&matched_item.item),
-                Self::block_signifier(&matched_item.item),
+                Self::block_signifier(&matched_item.item, parser),
                 matched_item.item.span(),
                 parser,
                 &mut result.warnings,
@@ -631,11 +631,10 @@ impl<'src> Block<'src> {
     /// reftext. A block with an explicit `reftext` attribute or a
     /// `[[id,reftext]]` anchor reftext uses that text verbatim, so it gets no
     /// signifier; neither does an uncaptioned block or one whose caption was
-    /// overridden with `[caption=...]` (which carries no number).
-    fn block_signifier(block: &Block<'_>) -> Option<XrefSignifier> {
-        // Only auto-numbered captioned blocks are eligible; an explicit caption
-        // override has no number.
-        block.number()?;
+    /// overridden with `[caption=...]` (which is not numbered).
+    fn block_signifier<'a>(block: &'a Block<'a>, parser: &Parser) -> Option<XrefSignifier> {
+        // Only captioned blocks are eligible.
+        let caption = block.caption()?;
 
         let has_explicit_reftext = block
             .attrlist()
@@ -646,14 +645,46 @@ impl<'src> Block<'src> {
             return None;
         }
 
+        // Exclude explicit caption overrides, which are not numbered. This is
+        // *not* the same as `block.number().is_none()`: an auto-numbered block
+        // whose context counter holds a non-integer value (e.g. `:figure-number:
+        // A`, rendering "Figure B") also has no bare integer number, yet it is
+        // genuinely numbered and must keep its signifier ("Figure B").
+        if Self::has_caption_override(block, parser) {
+            return None;
+        }
+
         // The caption prefix is "<label> <n>. "; the xrefstyle label is that
         // prefix without its trailing ". " separator (e.g. "Figure 1").
-        let caption = block.caption()?;
         let label = caption.strip_suffix(". ").unwrap_or(caption).to_string();
         Some(XrefSignifier {
             label,
             emphasize: false,
         })
+    }
+
+    /// Whether a captioned block's caption comes from an explicit override
+    /// rather than automatic numbering.
+    ///
+    /// An override is a `caption` attribute on the block (or, for an image, on
+    /// the image macro), or a non-empty document-wide `caption` attribute. This
+    /// mirrors the override detection in
+    /// [`caption::assign_block_caption`](crate::blocks::caption) and
+    /// [`MediaBlock::assign_caption`], so the two agree on which blocks are
+    /// numbered.
+    fn has_caption_override<'a>(block: &'a Block<'a>, parser: &Parser) -> bool {
+        let attribute_override = block
+            .attrlist()
+            .and_then(|attrlist| attrlist.named_attribute("caption"))
+            .is_some()
+            || matches!(block, Block::Media(media)
+                if media.macro_attrlist().named_attribute("caption").is_some());
+
+        attribute_override
+            || matches!(
+                parser.attribute_value("caption"),
+                InterpretedValue::Value(value) if !value.is_empty(),
+            )
     }
 
     /// Determine the reftext (a.k.a. xreflabel) used as the link text when a

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     content::{Content, SubstitutionGroup},
     document::{Attribute, RefType},
-    parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning},
+    parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning, XrefSignifier},
     span::MatchedItem,
     strings::CowStr,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -252,6 +252,7 @@ impl<'src> Block<'src> {
             Self::register_block_id(
                 block.id(),
                 Self::block_reftext(&block),
+                Self::block_signifier(&block),
                 block.span(),
                 parser,
                 &mut warnings,
@@ -323,6 +324,7 @@ impl<'src> Block<'src> {
                 Self::register_block_id(
                     block.id(),
                     Self::block_reftext(&block),
+                    Self::block_signifier(&block),
                     block.span(),
                     parser,
                     &mut warnings,
@@ -349,6 +351,7 @@ impl<'src> Block<'src> {
                 Self::register_block_id(
                     block.id(),
                     Self::block_reftext(&block),
+                    Self::block_signifier(&block),
                     block.span(),
                     parser,
                     &mut warnings,
@@ -375,6 +378,7 @@ impl<'src> Block<'src> {
                 Self::register_block_id(
                     block.id(),
                     Self::block_reftext(&block),
+                    Self::block_signifier(&block),
                     block.span(),
                     parser,
                     &mut warnings,
@@ -401,6 +405,7 @@ impl<'src> Block<'src> {
                 Self::register_block_id(
                     block.id(),
                     Self::block_reftext(&block),
+                    Self::block_signifier(&block),
                     block.span(),
                     parser,
                     &mut warnings,
@@ -427,6 +432,7 @@ impl<'src> Block<'src> {
                 Self::register_block_id(
                     block.id(),
                     Self::block_reftext(&block),
+                    Self::block_signifier(&block),
                     block.span(),
                     parser,
                     &mut warnings,
@@ -478,6 +484,7 @@ impl<'src> Block<'src> {
                     Self::register_block_id(
                         block.id(),
                         Self::block_reftext(&block),
+                        Self::block_signifier(&block),
                         block.span(),
                         parser,
                         &mut warnings,
@@ -605,6 +612,7 @@ impl<'src> Block<'src> {
             Self::register_block_id(
                 matched_item.item.id(),
                 Self::block_reftext(&matched_item.item),
+                Self::block_signifier(&matched_item.item),
                 matched_item.item.span(),
                 parser,
                 &mut result.warnings,
@@ -612,6 +620,40 @@ impl<'src> Block<'src> {
         }
 
         result
+    }
+
+    /// Determine the [`XrefSignifier`] a cross-reference uses to build
+    /// `full`/`short` [`xrefstyle`](crate::parser::XrefStyle) text when this
+    /// block is the target.
+    ///
+    /// A signifier is produced only for an auto-numbered captioned block (e.g.
+    /// an image → "Figure 1", a titled table → "Table 1") that has no explicit
+    /// reftext. A block with an explicit `reftext` attribute or a
+    /// `[[id,reftext]]` anchor reftext uses that text verbatim, so it gets no
+    /// signifier; neither does an uncaptioned block or one whose caption was
+    /// overridden with `[caption=...]` (which carries no number).
+    fn block_signifier(block: &Block<'_>) -> Option<XrefSignifier> {
+        // Only auto-numbered captioned blocks are eligible; an explicit caption
+        // override has no number.
+        block.number()?;
+
+        let has_explicit_reftext = block
+            .attrlist()
+            .and_then(|attrlist| attrlist.named_attribute("reftext"))
+            .is_some()
+            || block.anchor_reftext().is_some();
+        if has_explicit_reftext {
+            return None;
+        }
+
+        // The caption prefix is "<label> <n>. "; the xrefstyle label is that
+        // prefix without its trailing ". " separator (e.g. "Figure 1").
+        let caption = block.caption()?;
+        let label = caption.strip_suffix(". ").unwrap_or(caption).to_string();
+        Some(XrefSignifier {
+            label,
+            emphasize: false,
+        })
     }
 
     /// Determine the reftext (a.k.a. xreflabel) used as the link text when a
@@ -634,18 +676,26 @@ impl<'src> Block<'src> {
     fn register_block_id(
         id: Option<&str>,
         reftext: Option<&str>,
+        signifier: Option<XrefSignifier>,
         span: Span<'src>,
         parser: &mut Parser,
         warnings: &mut Vec<Warning<'src>>,
     ) {
-        if let Some(id) = id
-            && let Err(_duplicate_error) = parser.register_ref(id, reftext, RefType::Anchor)
-        {
-            // If registration fails due to duplicate ID, issue a warning.
-            warnings.push(Warning {
-                source: span,
-                warning: WarningType::DuplicateId(id.to_string()),
-            });
+        if let Some(id) = id {
+            match parser.register_ref(id, reftext, RefType::Anchor) {
+                Ok(()) => {
+                    if let Some(signifier) = signifier {
+                        parser.set_ref_signifier(id, signifier);
+                    }
+                }
+                Err(_duplicate_error) => {
+                    // If registration fails due to duplicate ID, issue a warning.
+                    warnings.push(Warning {
+                        source: span,
+                        warning: WarningType::DuplicateId(id.to_string()),
+                    });
+                }
+            }
         }
     }
 

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -11,6 +11,7 @@ use crate::{
     content::{Content, SubstitutionGroup},
     document::{InterpretedValue, RefType},
     internal::debug::DebugSliceReference,
+    parser::XrefSignifier,
     span::MatchedItem,
     strings::CowStr,
     warnings::{Warning, WarningType},
@@ -87,18 +88,45 @@ impl<'src> SectionBlock<'src> {
 
         let is_appendix_root = !discrete && level == 1 && section_type == SectionType::Appendix;
 
-        let (section_number, caption) = if is_appendix_root {
+        // A cross-reference builds `full`/`short` xrefstyle text from a section's
+        // signifier and number, but only when the section has a number *and* no
+        // explicit reftext (an explicit reftext is used verbatim instead).
+        let has_explicit_reftext = metadata
+            .attrlist
+            .as_ref()
+            .and_then(|a| a.named_attribute("reftext"))
+            .is_some();
+
+        let (section_number, caption, xref_signifier) = if is_appendix_root {
             parser
                 .last_appendix_section_number
                 .assign_next_number(level);
             let number = parser.last_appendix_section_number.clone();
             let caption = appendix_caption(parser, &number);
+            // An appendix is always lettered and its title is emphasized, even
+            // when `sectnums` is unset; its reference signifier is
+            // `appendix-refsig`.
+            let signifier = (!has_explicit_reftext).then(|| XrefSignifier {
+                label: join_signifier(
+                    parser.attribute_value("appendix-refsig").as_maybe_str(),
+                    &number.to_string(),
+                ),
+                emphasize: true,
+            });
             let section_number = if sectnums_active { Some(number) } else { None };
-            (section_number, Some(caption))
+            (section_number, Some(caption), signifier)
         } else if sectnums_active {
-            (Some(parser.assign_section_number(level)), None)
+            let number = parser.assign_section_number(level);
+            let signifier = (!has_explicit_reftext).then(|| XrefSignifier {
+                label: join_signifier(
+                    parser.attribute_value("section-refsig").as_maybe_str(),
+                    &number.to_string(),
+                ),
+                emphasize: false,
+            });
+            (Some(number), None, signifier)
         } else {
-            (None, None)
+            (None, None, None)
         };
 
         let mut most_recent_level = level;
@@ -148,21 +176,30 @@ impl<'src> SectionBlock<'src> {
             .unwrap_or_else(|| section_title.rendered());
 
         let section_id = if sectids && manual_id.is_none() {
-            Some(parser.generate_and_register_unique_id(
+            let id = parser.generate_and_register_unique_id(
                 &proposed_base_id,
                 Some(reftext),
                 RefType::Section,
-            ))
+            );
+            if let Some(signifier) = xref_signifier {
+                parser.set_ref_signifier(&id, signifier);
+            }
+            Some(id)
         } else {
-            if let Some(manual_id) = manual_id
-                && parser
-                    .register_ref(manual_id, Some(reftext), RefType::Section)
-                    .is_err()
-            {
-                warnings.push(Warning {
-                    source: metadata.source.trim_remainder(level_and_title.after),
-                    warning: WarningType::DuplicateId(manual_id.to_string()),
-                });
+            if let Some(manual_id) = manual_id {
+                match parser.register_ref(manual_id, Some(reftext), RefType::Section) {
+                    Ok(()) => {
+                        if let Some(signifier) = xref_signifier {
+                            parser.set_ref_signifier(manual_id, signifier);
+                        }
+                    }
+                    Err(_duplicate_error) => {
+                        warnings.push(Warning {
+                            source: metadata.source.trim_remainder(level_and_title.after),
+                            warning: WarningType::DuplicateId(manual_id.to_string()),
+                        });
+                    }
+                }
             }
 
             None
@@ -250,6 +287,17 @@ fn appendix_caption(parser: &Parser, number: &SectionNumber) -> String {
     match parser.attribute_value("appendix-caption") {
         InterpretedValue::Value(label) if !label.is_empty() => format!("{label} {letter}: "),
         _ => format!("{letter}. "),
+    }
+}
+
+/// Combines a reference signifier with a reference number for the `full`/`short`
+/// xrefstyle label. When the signifier is set the label is `"<signifier>
+/// <number>"` (e.g. `"Section 2.3"`); when it is unset (or empty) — as after
+/// `:!section-refsig:` — the signifier is dropped and only the number remains.
+fn join_signifier(signifier: Option<&str>, number: &str) -> String {
+    match signifier {
+        Some(signifier) if !signifier.is_empty() => format!("{signifier} {number}"),
+        _ => number.to_string(),
     }
 }
 

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -103,6 +103,7 @@ impl<'src> SectionBlock<'src> {
                 .assign_next_number(level);
             let number = parser.last_appendix_section_number.clone();
             let caption = appendix_caption(parser, &number);
+
             // An appendix is always lettered and its title is emphasized, even
             // when `sectnums` is unset; its reference signifier is
             // `appendix-refsig`.

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -290,10 +290,11 @@ fn appendix_caption(parser: &Parser, number: &SectionNumber) -> String {
     }
 }
 
-/// Combines a reference signifier with a reference number for the `full`/`short`
-/// xrefstyle label. When the signifier is set the label is `"<signifier>
-/// <number>"` (e.g. `"Section 2.3"`); when it is unset (or empty) — as after
-/// `:!section-refsig:` — the signifier is dropped and only the number remains.
+/// Combines a reference signifier with a reference number for the
+/// `full`/`short` xrefstyle label. When the signifier is set the label is
+/// `"<signifier> <number>"` (e.g. `"Section 2.3"`); when it is unset (or empty)
+/// — as after `:!section-refsig:` — the signifier is dropped and only the
+/// number remains.
 fn join_signifier(signifier: Option<&str>, number: &str) -> String {
     match signifier {
         Some(signifier) if !signifier.is_empty() => format!("{signifier} {number}"),

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -90,12 +90,15 @@ impl<'src> SectionBlock<'src> {
 
         // A cross-reference builds `full`/`short` xrefstyle text from a section's
         // signifier and number, but only when the section has a number *and* no
-        // explicit reftext (an explicit reftext is used verbatim instead).
+        // explicit reftext (an explicit reftext is used verbatim instead). An
+        // explicit reftext can come from a `reftext` attribute or the second
+        // field of a `[[id,reftext]]` block anchor.
         let has_explicit_reftext = metadata
             .attrlist
             .as_ref()
             .and_then(|a| a.named_attribute("reftext"))
-            .is_some();
+            .is_some()
+            || metadata.anchor_reftext.is_some();
 
         let (section_number, caption, xref_signifier) = if is_appendix_root {
             parser
@@ -170,10 +173,14 @@ impl<'src> SectionBlock<'src> {
             .and_then(|a| a.id())
             .or_else(|| metadata.anchor.as_ref().map(|anchor| anchor.data()));
 
+        // Reftext precedence mirrors `Block::block_reftext`: an explicit
+        // `reftext` attribute, then a `[[id,reftext]]` anchor reftext, then the
+        // section title.
         let reftext = metadata
             .attrlist
             .as_ref()
             .and_then(|a| a.named_attribute("reftext").map(|a| a.value()))
+            .or_else(|| metadata.anchor_reftext.as_ref().map(|span| span.data()))
             .unwrap_or_else(|| section_title.rendered());
 
         let section_id = if sectids && manual_id.is_none() {

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -101,6 +101,13 @@ pub(crate) struct XrefSegment {
     /// Roles supplied via a `role` attribute on the `xref:` macro, if any.
     pub(crate) roles: Vec<String>,
 
+    /// The cross-reference text style in effect for this reference: the
+    /// `xrefstyle=` attribute on the `xref:` macro if given, otherwise the
+    /// document-wide `xrefstyle` at the reference's location. `None` when
+    /// `xrefstyle` is unset, in which case the target's reftext is used
+    /// verbatim.
+    pub(crate) xrefstyle: Option<crate::parser::XrefStyle>,
+
     /// The resolved destination, filled in by resolution; `None` until then.
     pub(crate) resolved: Option<crate::parser::ResolvedReference>,
 }
@@ -397,6 +404,7 @@ fn render_template(
                         provided_text: xref.provided_text.as_deref(),
                         window: xref.window.as_deref(),
                         roles: &xref.roles,
+                        xrefstyle: xref.xrefstyle,
                         resolved: xref.resolved.as_ref(),
                     },
                     &mut out,
@@ -546,6 +554,7 @@ mod tests {
                 provided_text: None,
                 window: None,
                 roles: vec![],
+                xrefstyle: None,
                 resolved: None,
             }
         }

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -7,10 +7,11 @@ use crate::{
     Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     content::{Content, content::XrefSegment},
+    document::InterpretedValue,
     internal::{LookaheadReplacer, LookaheadResult, replace_with_lookahead},
     parser::{
         FootnoteRenderParams, IconRenderParams, ImageRenderParams, IndexTermRenderParams,
-        LinkRenderParams, LinkRenderType, MenuRenderParams,
+        LinkRenderParams, LinkRenderType, MenuRenderParams, XrefStyle,
     },
     warnings::WarningType,
 };
@@ -1458,6 +1459,19 @@ struct InlineXrefReplacer<'p, 'x> {
     xrefs: &'x mut Vec<XrefSegment>,
 }
 
+/// Reads the document-wide `xrefstyle` attribute as an [`XrefStyle`].
+///
+/// An unset attribute yields `None` (the target's reftext is used verbatim). A
+/// set-but-empty value (`:xrefstyle:`) and any unrecognized value both resolve
+/// to [`XrefStyle::Basic`], mirroring Asciidoctor.
+fn document_xrefstyle(parser: &Parser) -> Option<XrefStyle> {
+    match parser.attribute_value("xrefstyle") {
+        InterpretedValue::Value(value) => Some(XrefStyle::parse(&value)),
+        InterpretedValue::Set => Some(XrefStyle::Basic),
+        InterpretedValue::Unset => None,
+    }
+}
+
 impl Replacer for InlineXrefReplacer<'_, '_> {
     fn replace_append(&mut self, caps: &Captures<'_>, dest: &mut String) {
         if caps.get(1).is_some() {
@@ -1468,6 +1482,10 @@ impl Replacer for InlineXrefReplacer<'_, '_> {
 
         let mut window: Option<String> = None;
         let mut roles: Vec<String> = vec![];
+
+        // A `xrefstyle=` attribute on the `xref:` macro overrides the
+        // document-wide `xrefstyle` for this one reference.
+        let mut xrefstyle_override: Option<XrefStyle> = None;
 
         let (target, provided_text) = if let Some(inner) = caps.get(2) {
             // Shorthand form: split an optional ", reftext" off the id. The id
@@ -1507,6 +1525,9 @@ impl Replacer for InlineXrefReplacer<'_, '_> {
                     .named_attribute("window")
                     .map(|a| a.value().to_string());
                 roles = attrlist.roles().iter().map(|r| r.to_string()).collect();
+                xrefstyle_override = attrlist
+                    .named_attribute("xrefstyle")
+                    .map(|a| XrefStyle::parse(a.value()));
 
                 attrlist
                     .nth_attribute(1)
@@ -1519,12 +1540,17 @@ impl Replacer for InlineXrefReplacer<'_, '_> {
             (target, provided_text)
         };
 
+        // The effective style is the macro-level override if present, otherwise
+        // the document-wide `xrefstyle` at this point in the document.
+        let xrefstyle = xrefstyle_override.or_else(|| document_xrefstyle(self.parser));
+
         let index = self.xrefs.len();
         self.xrefs.push(XrefSegment {
             target,
             provided_text,
             window,
             roles,
+            xrefstyle,
             resolved: None,
         });
 

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{content::FootnoteDeferred, internal::debug::DebugHashMapFrom};
+use crate::{content::FootnoteDeferred, internal::debug::DebugHashMapFrom, parser::XrefSignifier};
 
 /// Document catalog for tracking referenceable elements.
 ///
@@ -65,6 +65,7 @@ impl Catalog {
             id: id.to_string(),
             reftext: reftext.map(|s| s.to_owned()),
             ref_type,
+            signifier: None,
         };
 
         self.refs.insert(id.to_string(), entry);
@@ -115,6 +116,7 @@ impl Catalog {
             id: unique_id.clone(),
             reftext: reftext.map(|s| s.to_owned()),
             ref_type,
+            signifier: None,
         };
 
         self.refs.insert(unique_id.clone(), entry);
@@ -141,6 +143,16 @@ impl Catalog {
     /// Resolve reference text to an ID, if possible.
     pub fn resolve_id(&self, reftext: &str) -> Option<String> {
         self.reftext_to_id.get(reftext).cloned()
+    }
+
+    /// Attaches an [`XrefSignifier`] to an already-registered element, so a
+    /// cross-reference to it can build `full`/`short`
+    /// [`xrefstyle`](crate::parser::XrefStyle) text. A no-op if `id` is not
+    /// registered.
+    pub(crate) fn set_signifier(&mut self, id: &str, signifier: XrefSignifier) {
+        if let Some(entry) = self.refs.get_mut(id) {
+            entry.signifier = Some(signifier);
+        }
     }
 
     /// Returns an iterator over all registered reference IDs, in an
@@ -315,6 +327,14 @@ pub struct RefEntry {
 
     /// Type of referenceable element.
     pub ref_type: RefType,
+
+    /// The signifier and number used to build `full`/`short`
+    /// [`xrefstyle`](crate::parser::XrefStyle) cross-reference text for this
+    /// target. Present only for a numbered section or captioned block that has
+    /// no explicit reftext; `None` for every other element (plain anchors,
+    /// bibliography entries, unnumbered sections, and targets carrying an
+    /// explicit reftext, for which `xrefstyle` formatting does not apply).
+    pub signifier: Option<XrefSignifier>,
 }
 
 /// Error that occurs when attempting to register a duplicate ID.

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -1307,9 +1307,9 @@ static URI_SNIFF: LazyLock<Regex> = LazyLock::new(|| {
 /// `base` is the target's reference text (its title, when the target has no
 /// explicit reftext). Styling applies only when a style is selected *and* the
 /// target carries an [`XrefSignifier`] (a numbered section or captioned block);
-/// otherwise `base` is returned unchanged. The HTML conventions live here in the
-/// HTML renderer: a title is wrapped in typographic quotes, except a chapter or
-/// appendix title, which is emphasized with `<em>` (in every style).
+/// otherwise `base` is returned unchanged. The HTML conventions live here in
+/// the HTML renderer: a title is wrapped in typographic quotes, except a
+/// chapter or appendix title, which is emphasized with `<em>` (in every style).
 fn apply_xrefstyle(
     style: Option<XrefStyle>,
     signifier: Option<&XrefSignifier>,

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 use crate::{
     Parser,
     attributes::Attrlist,
-    parser::{ResolvedReference, SafeMode},
+    parser::{ResolvedReference, SafeMode, XrefSignifier, XrefStyle},
 };
 
 /// An implementation of `InlineSubstitutionRenderer` is used when converting
@@ -448,6 +448,12 @@ pub struct XrefRenderParams<'a> {
     /// Roles supplied via a `role` attribute on the `xref:` macro. Empty when
     /// none were given.
     pub roles: &'a [String],
+
+    /// The cross-reference text style in effect for this reference (from the
+    /// `xrefstyle=` macro attribute or the document-wide `xrefstyle`). `None`
+    /// when `xrefstyle` is unset, in which case the target's reference text is
+    /// used verbatim.
+    pub xrefstyle: Option<XrefStyle>,
 
     /// The resolved destination, or `None` if the reference is unresolved.
     pub resolved: Option<&'a ResolvedReference>,
@@ -915,11 +921,18 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
 
         match params.resolved {
             Some(resolved) => {
-                let text = params
-                    .provided_text
-                    .map(str::to_string)
-                    .or_else(|| resolved.text.clone())
-                    .unwrap_or_else(|| format!("[{target}]", target = params.target));
+                // Explicit link text always wins; otherwise use the target's
+                // reference text, optionally reformatted by the `xrefstyle`.
+                let text = match params.provided_text {
+                    Some(provided) => provided.to_string(),
+                    None => {
+                        let base = resolved
+                            .text
+                            .clone()
+                            .unwrap_or_else(|| format!("[{target}]", target = params.target));
+                        apply_xrefstyle(params.xrefstyle, resolved.signifier.as_ref(), base)
+                    }
+                };
 
                 dest.push_str(&format!(
                     r#"<a href="{href}"{class}{constraint_attrs}>{text}</a>"#,
@@ -1287,6 +1300,37 @@ static URI_SNIFF: LazyLock<Regex> = LazyLock::new(|| {
     )
     .unwrap()
 });
+
+/// Builds the display text for a resolved cross-reference under the selected
+/// [`XrefStyle`].
+///
+/// `base` is the target's reference text (its title, when the target has no
+/// explicit reftext). Styling applies only when a style is selected *and* the
+/// target carries an [`XrefSignifier`] (a numbered section or captioned block);
+/// otherwise `base` is returned unchanged. The HTML conventions live here in the
+/// HTML renderer: a title is wrapped in typographic quotes, except a chapter or
+/// appendix title, which is emphasized with `<em>` (in every style).
+fn apply_xrefstyle(
+    style: Option<XrefStyle>,
+    signifier: Option<&XrefSignifier>,
+    base: String,
+) -> String {
+    let (Some(style), Some(signifier)) = (style, signifier) else {
+        return base;
+    };
+
+    match style {
+        XrefStyle::Full if signifier.emphasize => {
+            format!("{label}, <em>{base}</em>", label = signifier.label)
+        }
+        XrefStyle::Full => {
+            format!("{label}, &#8220;{base}&#8221;", label = signifier.label)
+        }
+        XrefStyle::Short => signifier.label.clone(),
+        XrefStyle::Basic if signifier.emphasize => format!("<em>{base}</em>"),
+        XrefStyle::Basic => base,
+    }
+}
 
 /// Builds the `target`/`rel` attributes for a cross-reference whose `xref:`
 /// macro carried a `window` attribute. Mirrors the link macro: a `_blank`

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -43,7 +43,7 @@ pub(crate) use resolved_attributes::ResolvedAttributes;
 mod reference_resolver;
 pub use reference_resolver::{
     CatalogResolver, ReferenceResolver, ReferenceWarning, ReferenceWarningKind, ResolutionContext,
-    ResolvedReference,
+    ResolvedReference, XrefSignifier, XrefStyle,
 };
 
 mod source_map;

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -595,7 +595,8 @@ impl Parser {
     /// already-registered catalog element, so a cross-reference to it can build
     /// `full`/`short` [`xrefstyle`](crate::parser::XrefStyle) text.
     ///
-    /// Takes `&self` for the same reason as [`register_ref`](Self::register_ref).
+    /// Takes `&self` for the same reason as
+    /// [`register_ref`](Self::register_ref).
     pub(crate) fn set_ref_signifier(&self, id: &str, signifier: crate::parser::XrefSignifier) {
         self.catalog.borrow_mut().set_signifier(id, signifier);
     }

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -591,6 +591,15 @@ impl Parser {
             .register_ref(id, reftext, ref_type)
     }
 
+    /// Attaches an [`XrefSignifier`](crate::parser::XrefSignifier) to an
+    /// already-registered catalog element, so a cross-reference to it can build
+    /// `full`/`short` [`xrefstyle`](crate::parser::XrefStyle) text.
+    ///
+    /// Takes `&self` for the same reason as [`register_ref`](Self::register_ref).
+    pub(crate) fn set_ref_signifier(&self, id: &str, signifier: crate::parser::XrefSignifier) {
+        self.catalog.borrow_mut().set_signifier(id, signifier);
+    }
+
     /// Registers a callout number defined by a verbatim block.
     ///
     /// Takes `&self` so it can be called from the callouts substitution step,

--- a/parser/src/parser/reference_resolver.rs
+++ b/parser/src/parser/reference_resolver.rs
@@ -13,6 +13,65 @@
 
 use crate::document::Catalog;
 
+/// The cross-reference text style selected by the `xrefstyle` attribute.
+///
+/// The style is chosen from the `xrefstyle` value in effect for a reference:
+/// the `xrefstyle=` attribute on the `xref:` macro if present, otherwise the
+/// document-wide `xrefstyle` attribute. It controls how the automatic text of a
+/// cross-reference is generated for a target that carries a reference number
+/// (see [Cross reference styles]).
+///
+/// A reference whose `xrefstyle` is *unset* has no `XrefStyle`; it uses the
+/// target's reference text verbatim. An unrecognized value is treated as
+/// [`Basic`](Self::Basic), mirroring Asciidoctor.
+///
+/// [Cross reference styles]: https://docs.asciidoctor.org/asciidoc/latest/macros/xref-text-and-style/#cross-reference-styles
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum XrefStyle {
+    /// The signifier and number followed by the title, quoted (or emphasized
+    /// for a chapter or appendix): e.g. `Section 2.3, “Installation”`.
+    Full,
+
+    /// The signifier and number only: e.g. `Section 2.3`.
+    Short,
+
+    /// The title only, emphasized for a chapter or appendix: e.g.
+    /// `Installation`.
+    Basic,
+}
+
+impl XrefStyle {
+    /// Interprets an `xrefstyle` attribute value. `full` and `short` select
+    /// those styles; every other value (including `basic` and any unrecognized
+    /// value) yields [`Basic`](Self::Basic), mirroring Asciidoctor.
+    pub(crate) fn parse(value: &str) -> Self {
+        match value {
+            "full" => Self::Full,
+            "short" => Self::Short,
+            _ => Self::Basic,
+        }
+    }
+}
+
+/// A referenceable target's signifier and reference number, used to build the
+/// automatic text of a cross-reference for the [`Full`](XrefStyle::Full) and
+/// [`Short`](XrefStyle::Short) styles (and to emphasize a chapter or appendix
+/// title under [`Basic`](XrefStyle::Basic)).
+///
+/// This carries only the target-derived pieces; how they are combined with the
+/// target's title is decided by the reference's [`XrefStyle`] at render time.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct XrefSignifier {
+    /// The signifier and reference number, already combined (e.g. `"Section
+    /// 2.3"`, `"Figure 1"`, or just `"2.3"` when the target's `*-refsig`
+    /// attribute is unset).
+    pub label: String,
+
+    /// Whether the target's title is emphasized (rendered inside `<em>`) rather
+    /// than quoted. `true` for chapters and appendices.
+    pub emphasize: bool,
+}
+
 /// The resolved destination of a cross-reference.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ResolvedReference {
@@ -24,6 +83,27 @@ pub struct ResolvedReference {
     /// The display text to use when the cross-reference did not specify its own
     /// text. This is typically the target's reference text (reftext).
     pub text: Option<String>,
+
+    /// The target's signifier and number, when it carries one and has no
+    /// explicit reftext. Present only for targets eligible for `full`/`short`
+    /// [`xrefstyle`](XrefStyle) formatting (numbered sections and captioned
+    /// blocks); `None` otherwise. Ignored unless the reference selects a style.
+    pub signifier: Option<XrefSignifier>,
+}
+
+impl ResolvedReference {
+    /// Constructs a resolved reference with no [`signifier`](Self::signifier).
+    ///
+    /// This is the common case for a host-supplied (cross-document) resolver,
+    /// which resolves a target to an `href` and display `text` but does not
+    /// participate in `xrefstyle` number formatting.
+    pub fn new(href: String, text: Option<String>) -> Self {
+        Self {
+            href,
+            text,
+            signifier: None,
+        }
+    }
 }
 
 /// A warning produced while resolving cross-references.
@@ -106,15 +186,17 @@ impl ReferenceResolver for CatalogResolver<'_> {
             return Some(ResolvedReference {
                 href: format!("#{target}"),
                 text: entry.reftext.clone(),
+                signifier: entry.signifier.clone(),
             });
         }
 
         // Natural cross-reference: match on reference text.
         if let Some(id) = self.catalog.resolve_id(target) {
-            let text = self.catalog.get_ref(&id).and_then(|e| e.reftext.clone());
+            let entry = self.catalog.get_ref(&id);
             return Some(ResolvedReference {
                 href: format!("#{id}"),
-                text,
+                text: entry.and_then(|e| e.reftext.clone()),
+                signifier: entry.and_then(|e| e.signifier.clone()),
             });
         }
 

--- a/parser/src/parser/reference_resolver.rs
+++ b/parser/src/parser/reference_resolver.rs
@@ -94,12 +94,12 @@ pub struct ResolvedReference {
 impl ResolvedReference {
     /// Constructs a resolved reference with no [`signifier`](Self::signifier).
     ///
-    /// Use this when the target is not a numbered/captioned element, or when the
-    /// resolver builds the display `text` from scratch. When the target came
-    /// from a [`Catalog`] (the usual case, including cross-document resolution),
-    /// prefer [`from_entry`](Self::from_entry) so `full`/`short` `xrefstyle`
-    /// formatting keeps working; or attach a signifier explicitly with
-    /// [`with_signifier`](Self::with_signifier).
+    /// Use this when the target is not a numbered/captioned element, or when
+    /// the resolver builds the display `text` from scratch. When the target
+    /// came from a [`Catalog`] (the usual case, including cross-document
+    /// resolution), prefer [`from_entry`](Self::from_entry) so
+    /// `full`/`short` `xrefstyle` formatting keeps working; or attach a
+    /// signifier explicitly with [`with_signifier`](Self::with_signifier).
     pub fn new(href: String, text: Option<String>) -> Self {
         Self {
             href,
@@ -118,8 +118,8 @@ impl ResolvedReference {
     /// the `href` it computed for that document, and the target's signifier and
     /// number — computed while *that* document was parsed — ride along. The
     /// style itself comes from the *referencing* document and is applied later,
-    /// so the resolver need not know it. The single-document [`CatalogResolver`]
-    /// is built on this same helper.
+    /// so the resolver need not know it. The single-document
+    /// [`CatalogResolver`] is built on this same helper.
     ///
     /// [`RefEntry`]: crate::document::RefEntry
     pub fn from_entry(href: String, entry: &crate::document::RefEntry) -> Self {
@@ -130,7 +130,8 @@ impl ResolvedReference {
         }
     }
 
-    /// Attaches a [`signifier`](Self::signifier), returning `self` for chaining.
+    /// Attaches a [`signifier`](Self::signifier), returning `self` for
+    /// chaining.
     ///
     /// For a host resolver that builds its `href`/`text` from scratch but still
     /// wants `full`/`short` `xrefstyle` formatting for a numbered or captioned

--- a/parser/src/parser/reference_resolver.rs
+++ b/parser/src/parser/reference_resolver.rs
@@ -94,15 +94,50 @@ pub struct ResolvedReference {
 impl ResolvedReference {
     /// Constructs a resolved reference with no [`signifier`](Self::signifier).
     ///
-    /// This is the common case for a host-supplied (cross-document) resolver,
-    /// which resolves a target to an `href` and display `text` but does not
-    /// participate in `xrefstyle` number formatting.
+    /// Use this when the target is not a numbered/captioned element, or when the
+    /// resolver builds the display `text` from scratch. When the target came
+    /// from a [`Catalog`] (the usual case, including cross-document resolution),
+    /// prefer [`from_entry`](Self::from_entry) so `full`/`short` `xrefstyle`
+    /// formatting keeps working; or attach a signifier explicitly with
+    /// [`with_signifier`](Self::with_signifier).
     pub fn new(href: String, text: Option<String>) -> Self {
         Self {
             href,
             text,
             signifier: None,
         }
+    }
+
+    /// Constructs a resolved reference to a catalog element at `href`, carrying
+    /// the element's reference text **and** its
+    /// [`signifier`](Self::signifier).
+    ///
+    /// This is the seam that makes `full`/`short` `xrefstyle` formatting work
+    /// across documents: a multi-document (Antora-style) resolver that has
+    /// located the target's [`RefEntry`] in some document's [`Catalog`] passes
+    /// the `href` it computed for that document, and the target's signifier and
+    /// number — computed while *that* document was parsed — ride along. The
+    /// style itself comes from the *referencing* document and is applied later,
+    /// so the resolver need not know it. The single-document [`CatalogResolver`]
+    /// is built on this same helper.
+    ///
+    /// [`RefEntry`]: crate::document::RefEntry
+    pub fn from_entry(href: String, entry: &crate::document::RefEntry) -> Self {
+        Self {
+            href,
+            text: entry.reftext.clone(),
+            signifier: entry.signifier.clone(),
+        }
+    }
+
+    /// Attaches a [`signifier`](Self::signifier), returning `self` for chaining.
+    ///
+    /// For a host resolver that builds its `href`/`text` from scratch but still
+    /// wants `full`/`short` `xrefstyle` formatting for a numbered or captioned
+    /// target.
+    pub fn with_signifier(mut self, signifier: XrefSignifier) -> Self {
+        self.signifier = Some(signifier);
+        self
     }
 }
 
@@ -183,21 +218,15 @@ impl ReferenceResolver for CatalogResolver<'_> {
 
         // Direct ID match.
         if let Some(entry) = self.catalog.get_ref(target) {
-            return Some(ResolvedReference {
-                href: format!("#{target}"),
-                text: entry.reftext.clone(),
-                signifier: entry.signifier.clone(),
-            });
+            return Some(ResolvedReference::from_entry(format!("#{target}"), entry));
         }
 
         // Natural cross-reference: match on reference text.
         if let Some(id) = self.catalog.resolve_id(target) {
-            let entry = self.catalog.get_ref(&id);
-            return Some(ResolvedReference {
-                href: format!("#{id}"),
-                text: entry.and_then(|e| e.reftext.clone()),
-                signifier: entry.and_then(|e| e.signifier.clone()),
-            });
+            return self
+                .catalog
+                .get_ref(&id)
+                .map(|entry| ResolvedReference::from_entry(format!("#{id}"), entry));
         }
 
         None

--- a/parser/src/tests/asciidoc_lang/macros/xref_text_and_style.rs
+++ b/parser/src/tests/asciidoc_lang/macros/xref_text_and_style.rs
@@ -90,17 +90,31 @@ image::big-cats.png[]
 "##
 );
 
-#[ignore]
+/// Builds the spec's running-example document under the given `header` lines: a
+/// section titled "Installation" numbered 2.3 and a captioned figure "Big Cats"
+/// (Figure 1), preceded by a paragraph that cross-references both.
+fn installation_and_figure(header: &str) -> String {
+    format!(
+        "{header}\n\n\
+         Section: <<install>>. Figure: <<big-cats>>.\n\n\
+         == One\n\n== Two\n\n=== Two-A\n\n=== Two-B\n\n\
+         [#install]\n=== Installation\n\n\
+         .Big Cats\n[#big-cats]\nimage::big-cats.png[]\n"
+    )
+}
+
+/// Parses `input` and returns its first rendered paragraph (the one carrying the
+/// cross references in these tests).
+fn first_paragraph(input: &str) -> String {
+    rendered_paragraphs(&Parser::default().parse(input))
+        .into_iter()
+        .next()
+        .unwrap_or_default()
+}
+
 #[test]
 fn cross_reference_styles() {
-    // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/605):
-    // The full/short xrefstyle formatting builds the reference text from the
-    // target's signifier and number (e.g. "Section 2.3"), which requires
-    // section/figure numbering and the corresponding `<context>-caption`
-    // attributes. The crate does not yet compute those numbers, so the
-    // xrefstyle value is parsed (including the `xrefstyle=` attribute on the
-    // xref macro) but does not yet change the generated reference text.
-    to_do_verifies!(
+    verifies!(
         r##"
 There are three built-in styles supported by the xrefstyle document attribute that you can choose from to customize the generated text of a cross reference.
 
@@ -141,10 +155,91 @@ Otherwise, the *basic* style is used.
 
 "##
     );
+
+    // `full`: the signifier and number, then the title in typographic quotes.
+    // A section takes its signifier from `section-refsig` ("Section"); a figure
+    // (captioned image) from its `figure-caption` label ("Figure").
+    assert_eq!(
+        first_paragraph(&installation_and_figure(":sectnums:\n:xrefstyle: full")),
+        r##"Section: <a href="#install">Section 2.3, &#8220;Installation&#8221;</a>. Figure: <a href="#big-cats">Figure 1, &#8220;Big Cats&#8221;</a>."##
+    );
+
+    // `short`: the signifier and number only.
+    assert_eq!(
+        first_paragraph(&installation_and_figure(":sectnums:\n:xrefstyle: short")),
+        r##"Section: <a href="#install">Section 2.3</a>. Figure: <a href="#big-cats">Figure 1</a>."##
+    );
+
+    // `basic`: the title only (no emphasis, since neither is a chapter or
+    // appendix).
+    assert_eq!(
+        first_paragraph(&installation_and_figure(":sectnums:\n:xrefstyle: basic")),
+        r##"Section: <a href="#install">Installation</a>. Figure: <a href="#big-cats">Big Cats</a>."##
+    );
+
+    // The `xrefstyle=` attribute on the xref macro overrides the document value
+    // for a single reference.
+    let doc = Parser::default().parse(
+        ":sectnums:\n:xrefstyle: full\n\n\
+         Full: <<install>>. Short: xref:install[xrefstyle=short].\n\n\
+         == One\n\n== Two\n\n=== Two-A\n\n=== Two-B\n\n[#install]\n=== Installation\n",
+    );
+    assert_eq!(
+        rendered_paragraphs(&doc),
+        &[
+            r##"Full: <a href="#install">Section 2.3, &#8220;Installation&#8221;</a>. Short: <a href="#install">Section 2.3</a>."##
+        ]
+    );
+
+    // A chapter or appendix title is emphasized (rendered in `<em>`) instead of
+    // quoted — in every style, including `basic`. An appendix is lettered (A,
+    // B, ...) and takes its signifier from `appendix-refsig`.
+    let appendix = |style: &str| {
+        format!(":xrefstyle: {style}\n\nSee <<data>>.\n\n[appendix]\n[#data]\n== Data\n")
+    };
+    assert_eq!(
+        first_paragraph(&appendix("full")),
+        r##"See <a href="#data">Appendix A, <em>Data</em></a>."##
+    );
+    assert_eq!(
+        first_paragraph(&appendix("short")),
+        r##"See <a href="#data">Appendix A</a>."##
+    );
+    assert_eq!(
+        first_paragraph(&appendix("basic")),
+        r##"See <a href="#data"><em>Data</em></a>."##
+    );
+
+    // The formatting applies only when the target has no explicit reftext: an
+    // explicit reftext is used verbatim, whatever the style.
+    let doc = Parser::default().parse(
+        ":sectnums:\n:xrefstyle: full\n\nSee <<install>>.\n\n\
+         [reftext=\"the installer\"]\n[#install]\n== Installation\n",
+    );
+    assert_eq!(
+        rendered_paragraphs(&doc),
+        &[r##"See <a href="#install">the installer</a>."##]
+    );
+
+    // The *full* and *short* styles apply only to a target with a caption. A
+    // listing has no caption unless `listing-caption` is set, so it falls back
+    // to *basic* (its title) — then gains a "Listing 1" caption once the
+    // attribute is set.
+    let listing = ":xrefstyle: short\n\nSee <<lst>>.\n\n.My Code\n[#lst]\n----\ncode\n----\n";
+    assert_eq!(
+        first_paragraph(listing),
+        r##"See <a href="#lst">My Code</a>."##
+    );
+    assert_eq!(
+        first_paragraph(&format!(":listing-caption: Listing\n{listing}")),
+        r##"See <a href="#lst">Listing 1</a>."##
+    );
 }
 
-non_normative!(
-    r##"
+#[test]
+fn reference_signifiers() {
+    verifies!(
+        r##"
 == Reference signifiers
 
 You can use document attributes to customize the signifier that is placed in front of the reference's number.
@@ -197,6 +292,53 @@ The *short* xrefstyle will fall back to the number only:
 
 The *basic* xrefstyle is unaffected by the value of the signifier.
 
+"##
+    );
+
+    // Customizing `section-refsig` replaces the word in front of a section's
+    // number. (`chapter-refsig` applies only in the `book` doctype, which this
+    // parser does not model.) The figure signifier, from `figure-caption`, is
+    // unaffected.
+    assert_eq!(
+        first_paragraph(&installation_and_figure(
+            ":sectnums:\n:xrefstyle: full\n:section-refsig: Sect."
+        )),
+        r##"Section: <a href="#install">Sect. 2.3, &#8220;Installation&#8221;</a>. Figure: <a href="#big-cats">Figure 1, &#8220;Big Cats&#8221;</a>."##
+    );
+    assert_eq!(
+        first_paragraph(&installation_and_figure(
+            ":sectnums:\n:xrefstyle: short\n:section-refsig: Sect."
+        )),
+        r##"Section: <a href="#install">Sect. 2.3</a>. Figure: <a href="#big-cats">Figure 1</a>."##
+    );
+
+    // Unsetting the signifier drops the word, leaving only the number; *short*
+    // then falls back to the number alone.
+    assert_eq!(
+        first_paragraph(&installation_and_figure(
+            ":sectnums:\n:xrefstyle: full\n:!section-refsig:"
+        )),
+        r##"Section: <a href="#install">2.3, &#8220;Installation&#8221;</a>. Figure: <a href="#big-cats">Figure 1, &#8220;Big Cats&#8221;</a>."##
+    );
+    assert_eq!(
+        first_paragraph(&installation_and_figure(
+            ":sectnums:\n:xrefstyle: short\n:!section-refsig:"
+        )),
+        r##"Section: <a href="#install">2.3</a>. Figure: <a href="#big-cats">Figure 1</a>."##
+    );
+
+    // The *basic* xrefstyle uses the title only, so it is unaffected by the
+    // signifier's value (set or unset).
+    assert_eq!(
+        first_paragraph(&installation_and_figure(
+            ":sectnums:\n:xrefstyle: basic\n:section-refsig: Sect."
+        )),
+        r##"Section: <a href="#install">Installation</a>. Figure: <a href="#big-cats">Big Cats</a>."##
+    );
+}
+
+non_normative!(
+    r##"
 Only the aforementioned styles are provided out of the box.
 Support for a custom formatting string is planned.
 Refer to https://github.com/asciidoctor/asciidoctor/issues/2212[#2212^] for details.

--- a/parser/src/tests/asciidoc_lang/macros/xref_text_and_style.rs
+++ b/parser/src/tests/asciidoc_lang/macros/xref_text_and_style.rs
@@ -103,8 +103,8 @@ fn installation_and_figure(header: &str) -> String {
     )
 }
 
-/// Parses `input` and returns its first rendered paragraph (the one carrying the
-/// cross references in these tests).
+/// Parses `input` and returns its first rendered paragraph (the one carrying
+/// the cross references in these tests).
 fn first_paragraph(input: &str) -> String {
     rendered_paragraphs(&Parser::default().parse(input))
         .into_iter()

--- a/parser/src/tests/asciidoc_lang/macros/xref_text_and_style.rs
+++ b/parser/src/tests/asciidoc_lang/macros/xref_text_and_style.rs
@@ -337,6 +337,70 @@ The *basic* xrefstyle is unaffected by the value of the signifier.
     );
 }
 
+#[test]
+fn anchor_reftext_suppresses_signifier() {
+    // A `[[id,reftext]]` block anchor supplies an explicit reftext, which is
+    // used verbatim even under `full`/`short` — the section is *not* rendered
+    // as "Section 2.3". (Regression: the signifier gate previously checked only
+    // the `reftext` attribute, not the anchor reftext.)
+    let input = "\
+        :sectnums:\n:xrefstyle: full\n\n\
+        See <<install>>.\n\n\
+        == One\n\n== Two\n\n=== Two-A\n\n=== Two-B\n\n\
+        [[install,Read the install guide]]\n=== Installation\n";
+
+    assert_eq!(
+        first_paragraph(input),
+        r##"See <a href="#install">Read the install guide</a>."##
+    );
+}
+
+#[test]
+fn non_integer_caption_counter_keeps_signifier() {
+    // A captioned block whose context counter holds a non-integer value (here
+    // `figure-number` seeded to render "Figure B") is genuinely auto-numbered
+    // even though it exposes no bare integer number. `full`/`short` must still
+    // build the signifier from its caption rather than falling back to the
+    // title. (Regression: the gate previously required an integer number.)
+    let numbered = "\
+        :xrefstyle: {style}\n:figure-number: A\n\n\
+        See <<big-cats>>.\n\n\
+        .Big Cats\n[#big-cats]\nimage::big-cats.png[]\n";
+
+    assert_eq!(
+        first_paragraph(&numbered.replace("{style}", "full")),
+        r##"See <a href="#big-cats">Figure B, &#8220;Big Cats&#8221;</a>."##
+    );
+    assert_eq!(
+        first_paragraph(&numbered.replace("{style}", "short")),
+        r##"See <a href="#big-cats">Figure B</a>."##
+    );
+
+    // An explicit caption override, by contrast, is not numbered and gets no
+    // signifier, so `full` falls back to the title. An override can come from
+    // the block attrlist, the image macro's own attrlist, or a document-wide
+    // `caption` attribute — each suppresses the signifier.
+    let expected = r##"See <a href="#big-cats">Big Cats</a>."##;
+
+    let block_attr_override = "\
+        :xrefstyle: full\n\n\
+        See <<big-cats>>.\n\n\
+        .Big Cats\n[#big-cats,caption=\"Plate \"]\nimage::big-cats.png[]\n";
+    assert_eq!(first_paragraph(block_attr_override), expected);
+
+    let macro_attr_override = "\
+        :xrefstyle: full\n\n\
+        See <<big-cats>>.\n\n\
+        .Big Cats\n[#big-cats]\nimage::big-cats.png[caption=\"Plate \"]\n";
+    assert_eq!(first_paragraph(macro_attr_override), expected);
+
+    let document_wide_override = "\
+        :xrefstyle: full\n:caption: Plate \n\n\
+        See <<big-cats>>.\n\n\
+        .Big Cats\n[#big-cats]\nimage::big-cats.png[]\n";
+    assert_eq!(first_paragraph(document_wide_override), expected);
+}
+
 non_normative!(
     r##"
 Only the aforementioned styles are provided out of the box.

--- a/parser/src/tests/asciidoc_lang/sections/custom_ids.rs
+++ b/parser/src/tests/asciidoc_lang/sections/custom_ids.rs
@@ -402,11 +402,11 @@ include::example$section.adoc[tag=with-anchor-and-reftext]
                     "tigers-subspecies",
                     RefEntry {
                         id: "tigers-subspecies",
-                        reftext: Some("Subspecies of Tiger",),
+                        reftext: Some("Subspecies",),
                         ref_type: RefType::Section,
                     }
                 ),]),
-                reftext_to_id: HashMap::from([("Subspecies of Tiger", "tigers-subspecies"),]),
+                reftext_to_id: HashMap::from([("Subspecies", "tigers-subspecies"),]),
             },
         }
     );

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -112,6 +112,42 @@ fn unresolved_reference_falls_back_and_warns() {
 }
 
 #[test]
+fn xrefstyle_survives_deferred_resolution() {
+    // `xrefstyle` formatting is compatible with the two-phase resolve mechanism
+    // used for forward (and cross-document) references. The two inputs it needs
+    // are resolved at their natural points: the effective *style* is a property
+    // of the reference site, captured during parsing (alongside `provided_text`,
+    // `window`, and `roles`), while the target's *signifier and number* live in
+    // the catalog and are read only when references are resolved (alongside the
+    // target's `reftext`). So a forward reference is an unresolved fallback
+    // until resolution, then picks up its full styled text — the same lifecycle
+    // as a plain reference.
+    let src = ":sectnums:\n:xrefstyle: full\n\nSee <<install>>.\n\n\
+              == One\n\n== Two\n\n=== Two-A\n\n=== Two-B\n\n\
+              [#install]\n=== Installation\n";
+
+    // Parse without resolving: the target section is parsed *after* the
+    // reference, so it is still pending and renders the unresolved fallback.
+    let mut doc = Parser::default().parse_deferred(src);
+    assert!(first_simple(&doc).content().has_unresolved_refs());
+    assert_eq!(
+        first_paragraph(&doc),
+        "See <a href=\"#install\">[install]</a>."
+    );
+
+    // Resolving against the now-complete catalog applies the full style, drawing
+    // the signifier and number from the catalog entry registered for the target.
+    let catalog = doc.catalog().clone();
+    let resolver = CatalogResolver::new(&catalog);
+    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    assert!(warnings.is_empty());
+    assert_eq!(
+        first_paragraph(&doc),
+        "See <a href=\"#install\">Section 2.3, &#8220;Installation&#8221;</a>.",
+    );
+}
+
+#[test]
 fn escaped_reference_is_not_a_cross_reference() {
     // A backslash-escaped shorthand is emitted literally and is not deferred.
     let doc = Parser::default().parse("See \\<<later>>.\n\n[#later]\n== Later\n");

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -176,13 +176,15 @@ fn cross_document_resolution() {
     let doc_b = parser.parse_deferred("[#b-topic]\n== B Topic\n\nContent.\n");
 
     // The host builds a combined index from each document's catalog, assigning
-    // its own cross-document hrefs.
+    // its own cross-document hrefs. Building each entry with `from_entry` carries
+    // the target's reftext and signifier, so cross-document `xrefstyle`
+    // formatting keeps working (see `xrefstyle_carries_across_documents`).
     let mut index = HashMap::new();
     for id in ["b-topic"] {
         if let Some(entry) = doc_b.catalog().get_ref(id) {
             index.insert(
                 entry.id.clone(),
-                ResolvedReference::new(format!("doc-b.html#{id}"), entry.reftext.clone()),
+                ResolvedReference::from_entry(format!("doc-b.html#{id}"), entry),
             );
         }
     }
@@ -199,6 +201,39 @@ fn cross_document_resolution() {
         "See <a href=\"doc-b.html#b-topic\">B Topic</a> for details."
     );
     assert!(!first_simple(&doc_a).content().has_unresolved_refs());
+}
+
+#[test]
+fn xrefstyle_carries_across_documents() {
+    // Cross-document `xrefstyle` formatting works when the host resolver carries
+    // the target's signifier. The two inputs come from different documents: the
+    // *style* (`full`) is a property of the referencing document (doc A), while
+    // the *signifier and number* ("Section 2.3") are computed in the target
+    // document (doc B) and travel on its catalog entry. A host that builds its
+    // result with `ResolvedReference::from_entry` carries the signifier through
+    // automatically.
+    let mut parser = Parser::default();
+
+    let mut doc_a = parser.parse_deferred(":xrefstyle: full\n\nSee <<install>>.\n");
+    let doc_b = parser.parse_deferred(
+        ":sectnums:\n\n== One\n\n== Two\n\n=== Two-A\n\n=== Two-B\n\n[#install]\n=== Installation\n",
+    );
+
+    let mut index = HashMap::new();
+    if let Some(entry) = doc_b.catalog().get_ref("install") {
+        index.insert(
+            "install".to_string(),
+            ResolvedReference::from_entry("doc-b.html#install".to_string(), entry),
+        );
+    }
+    let resolver = CrossDocResolver { index };
+
+    let warnings = doc_a.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    assert!(warnings.is_empty());
+    assert_eq!(
+        first_paragraph(&doc_a),
+        "See <a href=\"doc-b.html#install\">Section 2.3, &#8220;Installation&#8221;</a>.",
+    );
 }
 
 #[test]

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -146,10 +146,7 @@ fn cross_document_resolution() {
         if let Some(entry) = doc_b.catalog().get_ref(id) {
             index.insert(
                 entry.id.clone(),
-                ResolvedReference {
-                    href: format!("doc-b.html#{id}"),
-                    text: entry.reftext.clone(),
-                },
+                ResolvedReference::new(format!("doc-b.html#{id}"), entry.reftext.clone()),
             );
         }
     }
@@ -177,10 +174,7 @@ fn resolution_is_repeatable() {
     let first = CrossDocResolver {
         index: HashMap::from([(
             "topic".to_string(),
-            ResolvedReference {
-                href: "first.html#topic".to_string(),
-                text: Some("First".to_string()),
-            },
+            ResolvedReference::new("first.html#topic".to_string(), Some("First".to_string())),
         )]),
     };
     doc.resolve_references(&first, &HtmlSubstitutionRenderer {});
@@ -192,10 +186,7 @@ fn resolution_is_repeatable() {
     let second = CrossDocResolver {
         index: HashMap::from([(
             "topic".to_string(),
-            ResolvedReference {
-                href: "second.html#topic".to_string(),
-                text: Some("Second".to_string()),
-            },
+            ResolvedReference::new("second.html#topic".to_string(), Some("Second".to_string())),
         )]),
     };
     doc.resolve_references(&second, &HtmlSubstitutionRenderer {});
@@ -216,10 +207,7 @@ fn re_resolution_is_a_full_independent_sweep() {
     let knows_topic = CrossDocResolver {
         index: HashMap::from([(
             "topic".to_string(),
-            ResolvedReference {
-                href: "first.html#topic".to_string(),
-                text: Some("Topic".to_string()),
-            },
+            ResolvedReference::new("first.html#topic".to_string(), Some("Topic".to_string())),
         )]),
     };
     let warnings = doc.resolve_references(&knows_topic, &HtmlSubstitutionRenderer {});
@@ -251,10 +239,7 @@ fn footnote_cross_references_resolve_via_host_resolver() {
     let resolver = CrossDocResolver {
         index: HashMap::from([(
             "topic".to_string(),
-            ResolvedReference {
-                href: "other.html#topic".to_string(),
-                text: Some("Topic".to_string()),
-            },
+            ResolvedReference::new("other.html#topic".to_string(), Some("Topic".to_string())),
         )]),
     };
     let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
@@ -284,6 +269,43 @@ fn xref_macro_honors_role_and_non_blank_window() {
     assert_eq!(
         first_paragraph(&doc),
         r##"<a href="#sec" class="hint" target="_top">Go</a>"##
+    );
+}
+
+#[test]
+fn xrefstyle_value_interpretation() {
+    // Whether `xrefstyle` is *set* matters, not just its value. An appendix
+    // title is emphasized under any set style (its title is italicized rather
+    // than shown verbatim), but when `xrefstyle` is unset the target's reftext
+    // is used verbatim — no emphasis. This mirrors Ruby Asciidoctor, whose
+    // default `xrefstyle` is nil (not `basic`).
+    let with_xrefstyle = |header: &str| {
+        Parser::default().parse(&format!(
+            "{header}See <<data>>.\n\n[appendix]\n[#data]\n== Data\n"
+        ))
+    };
+
+    // Unset: reftext verbatim, no emphasis.
+    assert_eq!(
+        first_paragraph(&with_xrefstyle("")),
+        r##"See <a href="#data">Data</a>."##
+    );
+
+    // Explicit `basic`: the appendix title is emphasized.
+    assert_eq!(
+        first_paragraph(&with_xrefstyle(":xrefstyle: basic\n\n")),
+        r##"See <a href="#data"><em>Data</em></a>."##
+    );
+
+    // Set but empty (`:xrefstyle:`) and any unrecognized value both behave as
+    // `basic`.
+    assert_eq!(
+        first_paragraph(&with_xrefstyle(":xrefstyle:\n\n")),
+        r##"See <a href="#data"><em>Data</em></a>."##
+    );
+    assert_eq!(
+        first_paragraph(&with_xrefstyle(":xrefstyle: bogus\n\n")),
+        r##"See <a href="#data"><em>Data</em></a>."##
     );
 }
 

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -14,7 +14,7 @@ use crate::{
     blocks::{Block, IsBlock, SimpleBlock},
     parser::{
         CatalogResolver, HtmlSubstitutionRenderer, ReferenceResolver, ResolutionContext,
-        ResolvedReference,
+        ResolvedReference, XrefSignifier,
     },
 };
 
@@ -144,6 +144,36 @@ fn xrefstyle_survives_deferred_resolution() {
     assert_eq!(
         first_paragraph(&doc),
         "See <a href=\"#install\">Section 2.3, &#8220;Installation&#8221;</a>.",
+    );
+}
+
+#[test]
+fn host_resolver_can_attach_signifier() {
+    // A host resolver that builds its `href`/`text` from scratch (rather than
+    // from a catalog `RefEntry`) can still opt a target into `full`/`short`
+    // formatting by attaching a signifier with `with_signifier`. The style still
+    // comes from the referencing document.
+    let mut doc = Parser::default().parse_deferred(":xrefstyle: full\n\nSee <<install>>.\n");
+
+    let resolver = CrossDocResolver {
+        index: HashMap::from([(
+            "install".to_string(),
+            ResolvedReference::new(
+                "guide.html#install".to_string(),
+                Some("Installation".to_string()),
+            )
+            .with_signifier(XrefSignifier {
+                label: "Section 2.3".to_string(),
+                emphasize: false,
+            }),
+        )]),
+    };
+
+    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    assert!(warnings.is_empty());
+    assert_eq!(
+        first_paragraph(&doc),
+        "See <a href=\"guide.html#install\">Section 2.3, &#8220;Installation&#8221;</a>.",
     );
 }
 


### PR DESCRIPTION
Closes #605.

Implements the `xrefstyle` document attribute — and the per-reference
`xrefstyle=` attribute on the `xref:` macro — which selects how the automatic
text of a cross reference is generated: `full`, `short`, or `basic`.

## What it does

The `full` and `short` styles build the reference text from the target's
**signifier and number**, applying only to a target that carries a number and
has no explicit reftext:

| `xrefstyle` | section (numbered 2.3) | figure (Figure 1) | appendix (A) |
|---|---|---|---|
| `full`  | `Section 2.3, “Installation”` | `Figure 1, “Big Cats”` | `Appendix A, <em>Data</em>` |
| `short` | `Section 2.3` | `Figure 1` | `Appendix A` |
| `basic` | `Installation` | `Big Cats` | `<em>Data</em>` |

- The section signifier comes from `section-refsig` / `appendix-refsig`
  (unsetting it drops the word, leaving just the number); a captioned block's
  comes from its `<context>-caption` label (`figure-caption`, `table-caption`,
  `example-caption`, `listing-caption`).
- A chapter or appendix title is emphasized (`<em>`) rather than quoted, in
  every style including `basic`. (Chapters are `book`-doctype only and so never
  arise here.)
- The `full`/`short` styles require a caption/number; a listing with no
  `listing-caption`, or a section with no `sectnums`, falls back to the title.
- An explicit reftext on the target, or explicit link text on the macro, is
  always used verbatim.
- An **unset** `xrefstyle` uses the reftext verbatim; a **set-but-empty**
  (`:xrefstyle:`) or unrecognized value behaves as `basic` — matching Ruby
  Asciidoctor (whose default `xrefstyle` is nil, not `basic`).

## Design

Most of the machinery already existed — section numbering (`SectionNumber`),
per-context block captions/numbers, and the `*-refsig` / `*-caption` defaults.
This wires that data through the deferred cross-reference path, splitting the
work cleanly along the existing parse/resolve seam:

- **The style** is a property of the *reference site* — captured during parsing
  onto the deferred `XrefSegment`, right alongside the reference-site data the
  mechanism already captured early (`provided_text`, `window`, `roles`).
- **The signifier and number** are a property of the *target* — stored as a
  structured `XrefSignifier { label, emphasize }` on the target's catalog
  `RefEntry`, computed at parse time (where the number and attributes are known,
  mirroring how captions/section numbers are assigned), and read only at
  resolution time, exactly like the target's `reftext`.
- **The renderer** owns the HTML conventions (typographic quotes, `<em>`) in
  `render_xref`, keeping backend-specific formatting out of the catalog and
  resolver.

Because these resolve at their natural points, the feature is compatible with
the deferred resolution mechanism for **forward** and **cross-document**
references (both covered by tests, see below).

### Cross-document support

A multi-document (Antora-style) host resolver builds its own `ResolvedReference`
for an inter-document target. To make `full`/`short` formatting work across
documents, `ResolvedReference::from_entry(href, &RefEntry)` builds a result from
a catalog entry carrying its reftext **and** signifier: the host supplies the
href it computed for the target's document, and the signifier/number computed
while that document was parsed rides along. `CatalogResolver` is built on the
same helper. (`with_signifier` covers the build-from-scratch case; `new` remains
for targets with no signifier.)

### Public API changes (pre-1.0)

- `parser::XrefStyle` and `parser::XrefSignifier` (new).
- `ResolvedReference` gains a `signifier` field, plus
  `from_entry(href, &RefEntry)`, `with_signifier(..)`, and `new(href, text)`.
- `XrefRenderParams` gains an `xrefstyle` field.
- `RefEntry` gains a `signifier` field.

## Tests

- Enables the previously-`#[ignore]`d `cross_reference_styles` test with full
  assertions for every style, the per-macro override, the reftext/caption gates,
  and appendix emphasis.
- Promotes the reference-signifiers spec section from non-normative to a
  verified `reference_signifiers` test (custom + unset `section-refsig`).
- `xrefstyle_value_interpretation` — the unset-vs-`basic` nuance.
- `xrefstyle_survives_deferred_resolution` — a forward reference styled through
  the explicit `parse_deferred` → `resolve_references` path.
- `xrefstyle_carries_across_documents` — full style resolved through a host
  resolver, with the signifier drawn from the target document's catalog.

All expected outputs were verified against Asciidoctor 2.0.26. Full suite green
(`cargo test`), `cargo clippy --all-targets -- -Dwarnings` clean, `cargo fmt`
applied.

## Note

The effective `xrefstyle` and the target's signifier attributes are read at
**parse time** (at the reference's location and the target's location,
respectively) rather than at a separate convert step as Ruby Asciidoctor does.
For header-set attributes the result is identical; this only differs for a
document that reassigns `xrefstyle`/`*-refsig` mid-body between a target and a
reference. Happy to revisit if you'd prefer convert-time resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)