### PR TITLE
feat: Support the `title=` block attribute (#578)

### DIFF
--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -263,17 +263,22 @@ impl<'src> Attrlist<'src> {
         self.anchor.as_deref()
     }
 
-    /// Returns the value of the `title=` attribute, if present.
+    /// Returns the `title=` attribute's value and whether the normal
+    /// substitution group has already been applied to it, if the attribute is
+    /// present.
     ///
     /// Unlike [`named_attribute`](Self::named_attribute), this borrows for the
     /// duration of the call only, so it can be read from an `Attrlist` that is
     /// about to be moved (as when block metadata derives a block title from a
-    /// `title=` attribute before storing the attribute list on the block).
-    pub(crate) fn title_attribute_value(&self) -> Option<&str> {
+    /// `title=` attribute before storing the attribute list on the block). The
+    /// returned flag (see [`ElementAttribute::value_is_substituted`]) lets the
+    /// caller avoid substituting an already-substituted (single-quoted) value a
+    /// second time.
+    pub(crate) fn title_attribute(&self) -> Option<(&str, bool)> {
         self.attributes
             .iter()
             .find(|attr| attr.name_str() == Some("title"))
-            .map(ElementAttribute::value_str)
+            .map(|attr| (attr.value_str(), attr.value_is_substituted()))
     }
 
     /// Returns the first attribute with the given name.

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -263,6 +263,19 @@ impl<'src> Attrlist<'src> {
         self.anchor.as_deref()
     }
 
+    /// Returns the value of the `title=` attribute, if present.
+    ///
+    /// Unlike [`named_attribute`](Self::named_attribute), this borrows for the
+    /// duration of the call only, so it can be read from an `Attrlist` that is
+    /// about to be moved (as when block metadata derives a block title from a
+    /// `title=` attribute before storing the attribute list on the block).
+    pub(crate) fn title_attribute_value(&self) -> Option<&str> {
+        self.attributes
+            .iter()
+            .find(|attr| attr.name_str() == Some("title"))
+            .map(ElementAttribute::value_str)
+    }
+
     /// Returns the first attribute with the given name.
     pub fn named_attribute(&'src self, name: &str) -> Option<&'src ElementAttribute<'src>> {
         self.attributes.iter().find(|attr| {

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -496,9 +496,10 @@ impl<'src> ElementAttribute<'src> {
     }
 
     /// Returns `true` when the normal substitution group has already been
-    /// applied to this attribute's [`value`](Self::value) (a single-quoted value
-    /// in a block attribute list). A consumer that would otherwise substitute
-    /// the value itself uses this to avoid substituting it a second time.
+    /// applied to this attribute's [`value`](Self::value) (a single-quoted
+    /// value in a block attribute list). A consumer that would otherwise
+    /// substitute the value itself uses this to avoid substituting it a
+    /// second time.
     pub(crate) fn value_is_substituted(&self) -> bool {
         self.value_is_substituted
     }

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -14,11 +14,32 @@ use crate::{
 /// element in a document (including macros). Although the include directive is
 /// not technically an element, element attributes can also be defined on an
 /// include directive.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct ElementAttribute<'src> {
     name: Option<CowStr<'src>>,
     value: CowStr<'src>,
     shorthand_item_indices: Vec<usize>,
+
+    /// `true` when the normal substitution group was already applied to `value`
+    /// while parsing this attribute (a single-quoted value in a block attribute
+    /// list). Consumers that would otherwise substitute the value themselves —
+    /// such as deriving a block title from a `title=` attribute — use this to
+    /// avoid substituting it a second time (which would, e.g., double-escape
+    /// special characters).
+    value_is_substituted: bool,
+}
+
+impl std::fmt::Debug for ElementAttribute<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `value_is_substituted` is an internal parsing detail and is
+        // deliberately omitted so the debug representation stays focused on the
+        // attribute's observable content.
+        f.debug_struct("ElementAttribute")
+            .field("name", &self.name)
+            .field("value", &self.value)
+            .field("shorthand_item_indices", &self.shorthand_item_indices)
+            .finish()
+    }
 }
 
 impl<'src> ElementAttribute<'src> {
@@ -31,7 +52,7 @@ impl<'src> ElementAttribute<'src> {
     ) -> (Self, usize, Vec<WarningType>) {
         let mut warnings: Vec<WarningType> = vec![];
 
-        let (name, value, shorthand_item_indices, offset) = {
+        let (name, value, shorthand_item_indices, value_is_substituted, offset) = {
             let mut source = Span::new(source_text.as_ref());
             source = source.discard(start_index);
 
@@ -73,6 +94,7 @@ impl<'src> ElementAttribute<'src> {
 
             let after = value.after;
             let mut value = cowstr_from_source_and_span(source_text, &value.item);
+            let mut value_is_substituted = false;
 
             if let Some(first) = first_char
                 && (first == '\'' || first == '\"')
@@ -81,6 +103,10 @@ impl<'src> ElementAttribute<'src> {
                 let mut new_value = value.replace(&escaped_quote, &first.to_string());
 
                 if first == '\'' && attrlist_context == AttrlistContext::Block {
+                    // A single-quoted value in a block attribute list has the
+                    // normal substitution group applied at assignment time.
+                    value_is_substituted = true;
+
                     let span = Span::new(&new_value);
                     let mut content = Content::from(span);
                     SubstitutionGroup::Normal.apply(&mut content, parser, None);
@@ -103,7 +129,13 @@ impl<'src> ElementAttribute<'src> {
 
             let name = name.map(|name| cowstr_from_source_and_span(source_text, &name));
 
-            (name, value, shorthand_item_indices, after.byte_offset())
+            (
+                name,
+                value,
+                shorthand_item_indices,
+                value_is_substituted,
+                after.byte_offset(),
+            )
         };
 
         (
@@ -111,6 +143,7 @@ impl<'src> ElementAttribute<'src> {
                 name,
                 value,
                 shorthand_item_indices,
+                value_is_substituted,
             },
             offset,
             warnings,
@@ -138,6 +171,7 @@ impl<'src> ElementAttribute<'src> {
             name: None,
             value: CowStr::from(SOURCE),
             shorthand_item_indices,
+            value_is_substituted: false,
         }
     }
 
@@ -150,6 +184,7 @@ impl<'src> ElementAttribute<'src> {
             name: None,
             value: CowStr::from(span.data()),
             shorthand_item_indices: vec![],
+            value_is_substituted: false,
         }
     }
 
@@ -439,6 +474,7 @@ impl<'src> ElementAttribute<'src> {
             name: None,
             value: CowStr::from(value),
             shorthand_item_indices,
+            value_is_substituted: false,
         }
     }
 
@@ -457,6 +493,14 @@ impl<'src> ElementAttribute<'src> {
     /// example while an owned attribute list is still being assembled).
     pub(crate) fn value_str(&self) -> &str {
         self.value.as_ref()
+    }
+
+    /// Returns `true` when the normal substitution group has already been
+    /// applied to this attribute's [`value`](Self::value) (a single-quoted value
+    /// in a block attribute list). A consumer that would otherwise substitute
+    /// the value itself uses this to avoid substituting it a second time.
+    pub(crate) fn value_is_substituted(&self) -> bool {
+        self.value_is_substituted
     }
 }
 

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -449,6 +449,15 @@ impl<'src> ElementAttribute<'src> {
     pub fn value(&'src self) -> &'src str {
         self.value.as_ref()
     }
+
+    /// Return the attribute's value.
+    ///
+    /// Unlike [`value`](Self::value), this borrows for the duration of the call
+    /// only, so it can be used on temporary `ElementAttribute` values (for
+    /// example while an owned attribute list is still being assembled).
+    pub(crate) fn value_str(&self) -> &str {
+        self.value.as_ref()
+    }
 }
 
 fn parse_shorthand_items(source: &str, warnings: &mut Vec<WarningType>) -> Vec<usize> {

--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -158,25 +158,32 @@ impl<'src> BlockMetadata<'src> {
 
         // Determine the block title. A `.Title` line takes precedence; failing
         // that, a `title=` attribute in the block's attribute list supplies the
-        // title (Asciidoctor treats the two as equivalent). In both cases the
-        // value receives the normal title substitutions. Attribute references in
-        // a `title=` value were already resolved when the attribute list was
-        // parsed, so only the remaining substitutions (special characters,
-        // quotes, replacements, and macros) still apply here.
+        // title (Asciidoctor treats the two as equivalent).
         let title = match title_source.as_ref() {
             Some(span) => {
                 let mut content = Content::from(*span);
                 SubstitutionGroup::Normal.apply(&mut content, parser, None);
                 Some(content.rendered.into_string())
             }
-            None => attrlist
-                .as_ref()
-                .and_then(Attrlist::title_attribute_value)
-                .map(|value| {
-                    let mut content = Content::from(Span::new(value));
-                    SubstitutionGroup::Normal.apply(&mut content, parser, None);
-                    content.rendered.into_string()
-                }),
+            None => attrlist.as_ref().and_then(Attrlist::title_attribute).map(
+                |(value, value_is_substituted)| {
+                    // A single-quoted `title=` value already had the normal
+                    // substitution group applied when the attribute list was
+                    // parsed; substituting it again here would double-escape
+                    // special characters (and re-process inline markup), so it is
+                    // used verbatim. Any other form receives the title (normal)
+                    // substitutions now, matching a `.Title` line. (Attribute
+                    // references in the value were resolved when the attribute
+                    // list was parsed, so they are not re-evaluated here.)
+                    if value_is_substituted {
+                        value.to_string()
+                    } else {
+                        let mut content = Content::from(Span::new(value));
+                        SubstitutionGroup::Normal.apply(&mut content, parser, None);
+                        content.rendered.into_string()
+                    }
+                },
+            ),
         };
 
         MatchAndWarnings {
@@ -730,6 +737,29 @@ mod tests {
                 crate::blocks::metadata::BlockMetadata::new("[title=\"a > b\"]\ncontent\n");
 
             assert_eq!(metadata.title.as_deref(), Some("a &gt; b"));
+        }
+
+        #[test]
+        fn single_quoted_value_is_not_double_substituted() {
+            // A single-quoted value already had the normal substitutions applied
+            // when the attribute list was parsed. Substituting it again would
+            // double-escape the `>` to `&amp;gt;`; the title must instead render
+            // `a &gt; b`, matching the double-quoted form.
+            let metadata =
+                crate::blocks::metadata::BlockMetadata::new("[title='a > b']\ncontent\n");
+
+            assert_eq!(metadata.title.as_deref(), Some("a &gt; b"));
+        }
+
+        #[test]
+        fn single_quoted_value_preserves_inline_markup() {
+            // A single-quoted value's inline markup is rendered once (at
+            // attribute-list parse time) and must not be re-escaped when the
+            // title is formed.
+            let metadata =
+                crate::blocks::metadata::BlockMetadata::new("[title='*bold*']\ncontent\n");
+
+            assert_eq!(metadata.title.as_deref(), Some("<strong>bold</strong>"));
         }
 
         #[test]

--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -156,11 +156,28 @@ impl<'src> BlockMetadata<'src> {
             break;
         }
 
-        let title = title_source.as_ref().map(|span| {
-            let mut content = Content::from(*span);
-            SubstitutionGroup::Normal.apply(&mut content, parser, None);
-            content.rendered.into_string()
-        });
+        // Determine the block title. A `.Title` line takes precedence; failing
+        // that, a `title=` attribute in the block's attribute list supplies the
+        // title (Asciidoctor treats the two as equivalent). In both cases the
+        // value receives the normal title substitutions. Attribute references in
+        // a `title=` value were already resolved when the attribute list was
+        // parsed, so only the remaining substitutions (special characters,
+        // quotes, replacements, and macros) still apply here.
+        let title = match title_source.as_ref() {
+            Some(span) => {
+                let mut content = Content::from(*span);
+                SubstitutionGroup::Normal.apply(&mut content, parser, None);
+                Some(content.rendered.into_string())
+            }
+            None => attrlist
+                .as_ref()
+                .and_then(Attrlist::title_attribute_value)
+                .map(|value| {
+                    let mut content = Content::from(Span::new(value));
+                    SubstitutionGroup::Normal.apply(&mut content, parser, None);
+                    content.rendered.into_string()
+                }),
+        };
 
         MatchAndWarnings {
             item: Self {
@@ -673,6 +690,82 @@ mod tests {
             assert_eq!(attrlist.id().unwrap(), "id1");
             assert_eq!(attrlist.roles(), vec!["r1", "r2"]);
             assert_eq!(attrlist.named_attribute("foo").unwrap().value(), "bar");
+        }
+    }
+
+    mod title_attribute {
+        use crate::tests::prelude::*;
+
+        #[test]
+        fn sets_title_from_attribute() {
+            // A `title=` entry in a block's attribute list sets the block title,
+            // equivalent to a `.Title` line.
+            let metadata =
+                crate::blocks::metadata::BlockMetadata::new("[title=\"My Title\"]\ncontent\n");
+
+            assert_eq!(metadata.title.as_deref(), Some("My Title"));
+
+            // A title supplied through an attribute has no `.Title` source line.
+            assert!(metadata.title_source.is_none());
+        }
+
+        #[test]
+        fn dot_title_line_wins_over_attribute() {
+            // When both a `.Title` line and a `title=` attribute are present, the
+            // `.Title` line takes precedence.
+            let metadata = crate::blocks::metadata::BlockMetadata::new(
+                ".Line Title\n[title=\"Attr Title\"]\ncontent\n",
+            );
+
+            assert_eq!(metadata.title.as_deref(), Some("Line Title"));
+            assert!(metadata.title_source.is_some());
+        }
+
+        #[test]
+        fn applies_normal_substitutions() {
+            // A double-quoted `title=` value is not substituted while the
+            // attribute list is parsed, so the title (normal) substitutions run
+            // here: `>` becomes `&gt;`.
+            let metadata =
+                crate::blocks::metadata::BlockMetadata::new("[title=\"a > b\"]\ncontent\n");
+
+            assert_eq!(metadata.title.as_deref(), Some("a &gt; b"));
+        }
+
+        #[test]
+        fn empty_title_attribute_yields_empty_title() {
+            // An explicitly empty `title=` sets an empty (but present) title,
+            // mirroring `.{empty}`.
+            let metadata = crate::blocks::metadata::BlockMetadata::new("[title=]\ncontent\n");
+
+            assert_eq!(metadata.title.as_deref(), Some(""));
+        }
+
+        #[test]
+        fn resolves_attribute_references_in_value() {
+            // Attribute references in a `title=` value are resolved (when the
+            // attribute list is parsed), then the title substitutions render the
+            // result.
+            let doc =
+                Parser::default().parse(":who: World\n\n[title=\"Hello {who}\"]\n====\nbody\n====");
+
+            let block = doc.nested_blocks().next().unwrap();
+            assert_eq!(block.title(), Some("Hello World"));
+        }
+
+        #[test]
+        fn straddles_a_second_attribute_line() {
+            // A `title=` attribute merges across multiple attribute lines just
+            // like any other named attribute, so it still supplies the title when
+            // it sits on a separate line from the block style.
+            let metadata = crate::blocks::metadata::BlockMetadata::new(
+                "[title=\"Merged Title\"]\n[sidebar]\ncontent\n",
+            );
+
+            assert_eq!(metadata.title.as_deref(), Some("Merged Title"));
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.block_style().unwrap(), "sidebar");
         }
     }
 }

--- a/parser/src/tests/asciidoc_lang/tables/customize_title_label.rs
+++ b/parser/src/tests/asciidoc_lang/tables/customize_title_label.rs
@@ -225,14 +225,7 @@ If you want the caption of the table to only consist of the caption label, use t
 "#
     );
 
-    // The `{counter:table-number}` counter reference is now supported, but this
-    // form additionally requires setting a block's title through a `title`
-    // attribute (`title=...` in the attribute list), which the parser does not
-    // yet support. The example is tracked here but not yet exercised.
-    //
-    // TODO: Promote to `verifies!` once the `title` block attribute lands.
-    // https://github.com/asciidoc-rs/asciidoc-parser/issues/578
-    to_do_verifies!(
+    verifies!(
         r#"
 [source]
 ----
@@ -243,9 +236,18 @@ include::example$table.adoc[tag=b-col-h]
 "#
     );
 
-    if false {
-        todo!("block title attribute support");
-    }
+    // This alternate form disables the caption *label* (`caption=` clears it) and
+    // instead supplies the whole caption line through the block's `title`
+    // attribute. The `title` value resolves `{table-caption}` to its default
+    // ("Table") and `{counter:table-number}` to the table's number, yielding
+    // "Table 1"; with the label suppressed, the rendered `<caption>` is just the
+    // title. (`example$table.adoc[tag=b-col-h]` is inlined here to avoid
+    // depending on include resolution.)
+    let doc = Parser::default().parse(
+        "[caption=,title=\"{table-caption} {counter:table-number}\"]\n[%header,cols=2*]\n|===\n|Name of Column 1\n|Name of Column 2\n\n|Cell in column 1, row 1\n|Cell in column 2, row 1\n\n|Cell in column 1, row 2\n|Cell in column 2, row 2\n|===",
+    );
+
+    assert_xpath(&doc, "//caption[text()=\"Table 1\"]", 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Implements the `title=` block attribute requested in #578. A `title=` entry in a block's attribute list now sets the block title, equivalent to a `.Title` line, with normal attribute-reference substitution applied to the value.

```asciidoc
[caption=,title="{table-caption} {counter:table-number}"]
|===
|a
|===
```

## What changed

- **`BlockMetadata::parse`** ([parser/src/blocks/metadata.rs](parser/src/blocks/metadata.rs)) — When no `.Title` line is present, the block title is now derived from a `title=` attribute in the block's (merged) attribute list. The value receives the normal title substitutions, exactly like a `.Title` line. A `.Title` line still takes precedence when both are present. Because this lives in the shared metadata path, every block type (tables, examples, sidebars, …) gets the feature for free.
- **`Attrlist::title_attribute_value`** / **`ElementAttribute::value_str`** ([parser/src/attributes](parser/src/attributes)) — small `&self` (call-lifetime) accessors so the title can be read from the owned attribute list before it is moved onto the block. Mirrors the existing `name_str` pattern.

Attribute references in a `title=` value (e.g. `{table-caption}`, `{counter:table-number}`) are already resolved when the attribute list is parsed, so only the remaining substitutions (special characters, quotes, replacements, macros) run when the title is formed — no double resolution of counters.

## SDD coverage

- Promotes the "Customize the Title Label → only the caption label" example in [customize_title_label.rs](parser/src/tests/asciidoc_lang/tables/customize_title_label.rs) from `to_do_verifies!` to `verifies!` (this was the last blocker called out in #578), with an assertion that `[caption=,title="{table-caption} {counter:table-number}"]` renders `<caption>Table 1</caption>`.
- Adds a `title_attribute` unit-test module in `metadata.rs` covering: attribute-set title, `.Title` precedence, normal substitutions (`>` → `&gt;`), empty `title=`, attribute-reference resolution, and merging across attribute lines.

## Testing

- `cargo test -p asciidoc-parser` — all pass (3028 + doctests), no regressions.
- `cargo clippy --all-targets` and `cargo fmt` clean.

Closes #578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)