### PR TITLE
chore: Close two line-coverage gaps in `parser.rs`

### DIFF
--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1260,16 +1260,18 @@ impl Parser {
     /// Assign the next section number for a given level.
     pub(crate) fn assign_section_number(&mut self, level: usize) -> SectionNumber {
         match self.topmost_section_type {
-            SectionType::Normal => {
-                self.last_section_number.assign_next_number(level);
-                self.last_section_number.clone()
-            }
             SectionType::Appendix => {
                 self.last_appendix_section_number.assign_next_number(level);
                 self.last_appendix_section_number.clone()
             }
-            SectionType::Discrete => {
-                // Shouldn't happen, but ignore if it does.
+
+            // `topmost_section_type` is only ever `Normal` or `Appendix`: a
+            // discrete heading never becomes the topmost section type (see
+            // `SectionBlock::parse`). `Discrete` therefore cannot reach this
+            // point, so it is folded in with `Normal` rather than carried as a
+            // separate, untestable arm.
+            SectionType::Normal | SectionType::Discrete => {
+                self.last_section_number.assign_next_number(level);
                 self.last_section_number.clone()
             }
         }
@@ -1553,6 +1555,22 @@ mod tests {
 
         assert_eq!(doc.warnings().count(), 0);
         assert_eq!(parser.attribute_value("sectids"), InterpretedValue::Set);
+    }
+
+    #[test]
+    fn silently_locked_bool_intrinsic_false_is_unset() {
+        // A `false` flag records an `Unset` tombstone, and a locked (`ApiOnly`)
+        // attribute rejects a document body reassignment without warning.
+        let mut parser = Parser::default().with_intrinsic_attribute_bool_silent(
+            "sectids",
+            false,
+            ModificationContext::ApiOnly,
+        );
+
+        let doc = parser.parse(concat!("= Title\n", ":sectids:\n"));
+
+        assert_eq!(doc.warnings().count(), 0);
+        assert_eq!(parser.attribute_value("sectids"), InterpretedValue::Unset);
     }
 
     #[test]


### PR DESCRIPTION
Closes two pre-existing line-coverage gaps in `parser/src/parser/parser.rs`, surfaced by:

```
cargo llvm-cov --all-features --show-missing-lines --ignore-filename-regex 'tests' -p asciidoc-parser
```

These predate and are unrelated to the #609 `leveloffset` work — they were noted while reviewing coverage on that branch but intentionally left out of its scope.

## Gap 1 — `Unset` arm of `with_intrinsic_attribute_bool_silent`

The `false → InterpretedValue::Unset` branch of the silent boolean intrinsic builder was never exercised; the existing test only covered the `true` path. Added `silently_locked_bool_intrinsic_false_is_unset`, which sets `sectids` to `false` via the silent `ApiOnly` builder, then confirms a document-body reassignment is dropped without warning and the value stays `Unset`.

## Gap 2 — defensive `SectionType::Discrete` arm of `assign_section_number`

Tracing every write to `topmost_section_type` (`section.rs` and its initializer) shows it is only ever set to `Normal` or `Appendix`: a `[discrete]` heading gets a local `Discrete` section type but never becomes the topmost section type, and `assign_section_number` is only called when `sectnums_active` (which requires `!discrete`). The arm is therefore **genuinely unreachable**.

Rather than a contrived test, `unreachable!()` (which llvm-cov would still flag as an unexecuted line), or nightly `#[coverage(off)]` machinery this repo doesn't use, the provably-dead `Discrete` arm is folded into the covered `Normal` arm via an or-pattern, with a comment documenting the invariant. The match stays exhaustive and the region is now exercised by the existing numbered-section tests.

## Verification

- `cargo llvm-cov --all-features --show-missing-lines --ignore-filename-regex 'tests' -p asciidoc-parser` — both lines now covered; the only remaining uncovered `parser.rs` lines are inside the inline `#[cfg(test)] mod tests`, which the `tests` filename regex can't exclude.
- `cargo test -p asciidoc-parser` — all pass.
- `cargo clippy -p asciidoc-parser --all-features` — clean.

Branch is up to date with `main` (merged #640).

🤖 Generated with [Claude Code](https://claude.com/claude-code)