### PR TITLE
fix: Number footnotes in section titles in document order (#594)

### DIFF
--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -135,6 +135,20 @@ impl<'src> SectionBlock<'src> {
 
         let mut most_recent_level = level;
 
+        // Apply the title's substitutions BEFORE parsing the section body, so
+        // that a `footnote:[…]` macro in the title is numbered ahead of any
+        // footnotes in the body (document order: the title precedes its body).
+        // Substituting before the body also means the title only sees document
+        // attributes defined ahead of it, not ones its body sets later.
+        //
+        // Asciidoctor instead converts headings eagerly and out of document
+        // order (to build IDs and cross-reference text), which numbers heading
+        // footnotes out of sequence. The crate deliberately diverges toward
+        // straightforward document-order numbering; see
+        // https://github.com/asciidoc-rs/asciidoc-parser/issues/594.
+        let mut section_title = Content::from(level_and_title.item.1);
+        SubstitutionGroup::Title.apply(&mut section_title, parser, metadata.attrlist.as_ref());
+
         // A section carrying the `bibliography` style implicitly adds that style
         // to each top-level unordered list in its body (see the "Bibliography
         // section syntax" section of the spec). Record that we are parsing such a
@@ -161,9 +175,6 @@ impl<'src> SectionBlock<'src> {
 
         let blocks = maw_blocks.item;
         let source = metadata.source.trim_remainder(blocks.after);
-
-        let mut section_title = Content::from(level_and_title.item.1);
-        SubstitutionGroup::Title.apply(&mut section_title, parser, metadata.attrlist.as_ref());
 
         let proposed_base_id = generate_section_id(section_title.rendered(), parser);
 

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -149,6 +149,21 @@ impl<'src> SectionBlock<'src> {
         let mut section_title = Content::from(level_and_title.item.1);
         SubstitutionGroup::Title.apply(&mut section_title, parser, metadata.attrlist.as_ref());
 
+        // A footnote in the title is a real, document-order footnote (see above),
+        // but its marker must not leak into the section's reference text (an
+        // xref's link text) or its auto-generated ID. Derive a footnote-free
+        // rendering of the title for those uses by substituting it again with
+        // footnotes suppressed. Only needed when the title actually contains a
+        // footnote macro; otherwise the primary rendering is already clean.
+        let footnote_free_title: Option<String> =
+            level_and_title.item.1.data().contains("footnote").then(|| {
+                let mut title = Content::from(level_and_title.item.1);
+                parser.suppress_footnotes.set(true);
+                SubstitutionGroup::Title.apply(&mut title, parser, metadata.attrlist.as_ref());
+                parser.suppress_footnotes.set(false);
+                title.rendered_owned()
+            });
+
         // A section carrying the `bibliography` style implicitly adds that style
         // to each top-level unordered list in its body (see the "Bibliography
         // section syntax" section of the spec). Record that we are parsing such a
@@ -176,7 +191,14 @@ impl<'src> SectionBlock<'src> {
         let blocks = maw_blocks.item;
         let source = metadata.source.trim_remainder(blocks.after);
 
-        let proposed_base_id = generate_section_id(section_title.rendered(), parser);
+        // Prefer the footnote-free rendering (when the title carried a footnote)
+        // so neither the generated ID nor the reference text includes the
+        // footnote marker.
+        let title_reftext = footnote_free_title
+            .as_deref()
+            .unwrap_or(section_title.rendered());
+
+        let proposed_base_id = generate_section_id(title_reftext, parser);
 
         let manual_id = metadata
             .attrlist
@@ -192,7 +214,7 @@ impl<'src> SectionBlock<'src> {
             .as_ref()
             .and_then(|a| a.named_attribute("reftext").map(|a| a.value()))
             .or_else(|| metadata.anchor_reftext.as_ref().map(|span| span.data()))
-            .unwrap_or_else(|| section_title.rendered());
+            .unwrap_or(title_reftext);
 
         let section_id = if sectids && manual_id.is_none() {
             let id = parser.generate_and_register_unique_id(

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -8,7 +8,7 @@ use crate::{
     blocks::{
         Block, ContentModel, IsBlock, metadata::BlockMetadata, parse_utils::parse_blocks_until,
     },
-    content::{Content, SubstitutionGroup},
+    content::{Content, SubstitutionGroup, strip_footnote_marker_spans},
     document::{InterpretedValue, RefType},
     internal::debug::DebugSliceReference,
     parser::XrefSignifier,
@@ -146,23 +146,25 @@ impl<'src> SectionBlock<'src> {
         // footnotes out of sequence. The crate deliberately diverges toward
         // straightforward document-order numbering; see
         // https://github.com/asciidoc-rs/asciidoc-parser/issues/594.
+        //
+        // A footnote in the title is a real, document-order footnote, but its
+        // marker must not leak into the section's reference text (an xref's link
+        // text) or auto-generated ID. Marking the title's footnote markers with
+        // sentinels lets those be excised below from a single render — no second
+        // substitution pass, so counters and attribute-expanded footnotes are
+        // processed exactly once.
         let mut section_title = Content::from(level_and_title.item.1);
+        parser.mark_footnote_spans.set(true);
         SubstitutionGroup::Title.apply(&mut section_title, parser, metadata.attrlist.as_ref());
+        parser.mark_footnote_spans.set(false);
 
-        // A footnote in the title is a real, document-order footnote (see above),
-        // but its marker must not leak into the section's reference text (an
-        // xref's link text) or its auto-generated ID. Derive a footnote-free
-        // rendering of the title for those uses by substituting it again with
-        // footnotes suppressed. Only needed when the title actually contains a
-        // footnote macro; otherwise the primary rendering is already clean.
-        let footnote_free_title: Option<String> =
-            level_and_title.item.1.data().contains("footnote").then(|| {
-                let mut title = Content::from(level_and_title.item.1);
-                parser.suppress_footnotes.set(true);
-                SubstitutionGroup::Title.apply(&mut title, parser, metadata.attrlist.as_ref());
-                parser.suppress_footnotes.set(false);
-                title.rendered_owned()
-            });
+        // The footnote-free rendering of the title, for the reference text and
+        // auto-generated ID; a no-op string copy when the title had no footnote.
+        let title_reftext = strip_footnote_marker_spans(section_title.rendered());
+
+        // Strip the now-consumed sentinels from the title itself, keeping the
+        // footnote marker so the heading still renders it.
+        section_title.remove_footnote_marker_sentinels();
 
         // A section carrying the `bibliography` style implicitly adds that style
         // to each top-level unordered list in its body (see the "Bibliography
@@ -191,14 +193,7 @@ impl<'src> SectionBlock<'src> {
         let blocks = maw_blocks.item;
         let source = metadata.source.trim_remainder(blocks.after);
 
-        // Prefer the footnote-free rendering (when the title carried a footnote)
-        // so neither the generated ID nor the reference text includes the
-        // footnote marker.
-        let title_reftext = footnote_free_title
-            .as_deref()
-            .unwrap_or(section_title.rendered());
-
-        let proposed_base_id = generate_section_id(title_reftext, parser);
+        let proposed_base_id = generate_section_id(&title_reftext, parser);
 
         let manual_id = metadata
             .attrlist
@@ -214,7 +209,7 @@ impl<'src> SectionBlock<'src> {
             .as_ref()
             .and_then(|a| a.named_attribute("reftext").map(|a| a.value()))
             .or_else(|| metadata.anchor_reftext.as_ref().map(|span| span.data()))
-            .unwrap_or(title_reftext);
+            .unwrap_or(&title_reftext);
 
         let section_id = if sectids && manual_id.is_none() {
             let id = parser.generate_and_register_unique_id(

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -118,6 +118,47 @@ pub(crate) struct XrefSegment {
 const XREF_PLACEHOLDER_START: char = '\u{E000}';
 const XREF_PLACEHOLDER_END: char = '\u{E001}';
 
+/// Sentinel codepoints (Unicode Private Use Area) bracketing a footnote's
+/// rendered inline marker while a section title is being substituted. Like the
+/// cross-reference placeholders above, these cannot collide with user text and
+/// are inert to the remaining substitution steps.
+///
+/// A footnote in a section title is a real, document-order footnote, but its
+/// marker must be kept out of the section's reference text and auto-generated
+/// ID. Marking the marker in a single render (rather than re-rendering the
+/// title with footnotes suppressed) means stateful substitutions — counters,
+/// attribute references that expand into footnotes — run exactly once. See
+/// [`strip_footnote_marker_spans`] and
+/// [`Content::remove_footnote_marker_sentinels`].
+pub(crate) const FOOTNOTE_MARKER_START: char = '\u{E002}';
+pub(crate) const FOOTNOTE_MARKER_END: char = '\u{E003}';
+
+/// Removes each footnote marker span — a [`FOOTNOTE_MARKER_START`] …
+/// [`FOOTNOTE_MARKER_END`] region and everything between, i.e. the sentinels
+/// *and* the marker they bracket — leaving footnote-free text suitable for a
+/// section's reference text and auto-generated ID.
+pub(crate) fn strip_footnote_marker_spans(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+
+    while let Some(start) = rest.find(FOOTNOTE_MARKER_START) {
+        out.push_str(&rest[..start]);
+        rest = &rest[start + FOOTNOTE_MARKER_START.len_utf8()..];
+
+        // Drop through the matching end sentinel (the marker text). A start
+        // without an end cannot occur — the substitution always emits both — but
+        // if it somehow did, drop the remainder rather than reintroduce the
+        // stray sentinel.
+        rest = match rest.find(FOOTNOTE_MARKER_END) {
+            Some(end) => &rest[end + FOOTNOTE_MARKER_END.len_utf8()..],
+            None => "",
+        };
+    }
+
+    out.push_str(rest);
+    out
+}
+
 impl<'src> Content<'src> {
     /// Constructs a `Content` from a source `Span` and a potentially-filtered
     /// view of that source text.
@@ -193,6 +234,31 @@ impl<'src> Content<'src> {
     /// Returns `true` if `self` contains no text.
     pub fn is_empty(&self) -> bool {
         self.rendered.as_ref().is_empty()
+    }
+
+    /// Removes the [`FOOTNOTE_MARKER_START`]/[`FOOTNOTE_MARKER_END`] sentinels
+    /// bracketing each footnote marker, *keeping* the marker itself, so the
+    /// content renders normally. Called after a section title's reference text
+    /// and ID have been derived (via [`strip_footnote_marker_spans`], which
+    /// needs the sentinels to locate the markers). The sentinels are removed
+    /// from the deferred template too, so a later cross-reference resolution
+    /// rebuild does not reintroduce them.
+    pub(crate) fn remove_footnote_marker_sentinels(&mut self) {
+        if !self.rendered.as_ref().contains(FOOTNOTE_MARKER_START) {
+            return;
+        }
+
+        self.rendered = self
+            .rendered
+            .as_ref()
+            .replace([FOOTNOTE_MARKER_START, FOOTNOTE_MARKER_END], "")
+            .into();
+
+        if let Some(deferred) = self.deferred.as_mut() {
+            deferred.template = deferred
+                .template
+                .replace([FOOTNOTE_MARKER_START, FOOTNOTE_MARKER_END], "");
+        }
     }
 
     /// Returns `true` if this content contains one or more cross-references
@@ -539,6 +605,41 @@ mod tests {
         fn basic_non_empty_span() {
             let content = crate::content::Content::from(crate::Span::new("blah"));
             assert!(!content.is_empty());
+        }
+    }
+
+    mod strip_footnote_marker_spans {
+        use super::super::{
+            FOOTNOTE_MARKER_END, FOOTNOTE_MARKER_START, strip_footnote_marker_spans,
+        };
+
+        fn marked(marker: &str) -> String {
+            format!("{FOOTNOTE_MARKER_START}{marker}{FOOTNOTE_MARKER_END}")
+        }
+
+        #[test]
+        fn leaves_unmarked_text_unchanged() {
+            assert_eq!(strip_footnote_marker_spans("Plain title"), "Plain title");
+        }
+
+        #[test]
+        fn removes_a_marker_span_and_its_sentinels() {
+            let input = format!("Title{}", marked("[1]"));
+            assert_eq!(strip_footnote_marker_spans(&input), "Title");
+        }
+
+        #[test]
+        fn removes_multiple_spans_keeping_surrounding_text() {
+            let input = format!("a{}b{}c", marked("[1]"), marked("[2]"));
+            assert_eq!(strip_footnote_marker_spans(&input), "abc");
+        }
+
+        #[test]
+        fn a_start_without_an_end_drops_the_remainder() {
+            // Defensive: the substitution always emits balanced sentinels, but a
+            // lone start must not leak the sentinel into the output.
+            let input = format!("Title{FOOTNOTE_MARKER_START}dangling");
+            assert_eq!(strip_footnote_marker_spans(&input), "Title");
         }
     }
 

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -1636,16 +1636,6 @@ impl LookaheadReplacer for InlineFootnoteMacroReplacer<'_, '_, '_> {
 
         let parser = self.parser;
 
-        // When rendering a footnote-free variant of the content (e.g. a section
-        // title's reference text and auto-generated ID), drop the footnote
-        // entirely: emit no marker, register nothing, advance no counter, and
-        // record no warning. The content's primary rendering handles all of
-        // that. A bare `footnote:[]` (neither ID nor text) is not a footnote and
-        // falls through to the literal-text branch below either way.
-        if parser.suppress_footnotes.get() && (caps.get(2).is_some() || caps.get(3).is_some()) {
-            return LookaheadResult::Continue;
-        }
-
         // Resolve the macro into an (id, text) pair. The deprecated
         // `footnoteref:` form packs both into the bracketed text (`id,text`),
         // whereas the `footnote:` form takes the id from the macro target.
@@ -1676,6 +1666,17 @@ impl LookaheadReplacer for InlineFootnoteMacroReplacer<'_, '_, '_> {
                 caps.get(3).map(|m| m.as_str().to_string()),
             )
         };
+
+        // While a section title is substituted, bracket a real footnote's marker
+        // with sentinels so it can later be excised from the section's reference
+        // text and auto-generated ID (see `Parser::mark_footnote_spans`). The
+        // footnote is still defined and numbered here, in document order; only
+        // the marker's *placement* is annotated. A bare `footnote:[]` (the
+        // literal-text branch below) is not a footnote and is left unmarked.
+        let mark_span = parser.mark_footnote_spans.get() && (id.is_some() || content.is_some());
+        if mark_span {
+            dest.push(crate::content::FOOTNOTE_MARKER_START);
+        }
 
         // `id` and `content` own their data, so each branch renders its marker
         // before they are dropped (the params borrow them).
@@ -1742,6 +1743,10 @@ impl LookaheadReplacer for InlineFootnoteMacroReplacer<'_, '_, '_> {
         } else {
             // `footnote:[]` with neither an ID nor text is not a footnote.
             dest.push_str(&caps[0]);
+        }
+
+        if mark_span {
+            dest.push(crate::content::FOOTNOTE_MARKER_END);
         }
 
         LookaheadResult::Continue

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -1636,6 +1636,16 @@ impl LookaheadReplacer for InlineFootnoteMacroReplacer<'_, '_, '_> {
 
         let parser = self.parser;
 
+        // When rendering a footnote-free variant of the content (e.g. a section
+        // title's reference text and auto-generated ID), drop the footnote
+        // entirely: emit no marker, register nothing, advance no counter, and
+        // record no warning. The content's primary rendering handles all of
+        // that. A bare `footnote:[]` (neither ID nor text) is not a footnote and
+        // falls through to the literal-text branch below either way.
+        if parser.suppress_footnotes.get() && (caps.get(2).is_some() || caps.get(3).is_some()) {
+            return LookaheadResult::Continue;
+        }
+
         // Resolve the macro into an (id, text) pair. The deprecated
         // `footnoteref:` form packs both into the bracketed text (`id,text`),
         // whereas the `footnote:` form takes the id from the macro target.

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -5,7 +5,10 @@
 
 mod content;
 pub use content::Content;
-pub(crate) use content::{FootnoteDeferred, XrefSegment, rehome_xref_placeholders};
+pub(crate) use content::{
+    FOOTNOTE_MARKER_END, FOOTNOTE_MARKER_START, FootnoteDeferred, XrefSegment,
+    rehome_xref_placeholders, strip_footnote_marker_spans,
+};
 
 mod macros;
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -119,6 +119,17 @@ pub struct Parser {
     /// parser.
     pub(crate) in_bibliography_list_item: Cell<bool>,
 
+    /// True while a footnote-free variant of some content is being substituted,
+    /// so a `footnote:[…]` macro is dropped entirely rather than numbered and
+    /// rendered as a marker. Used to derive a section title's reference text and
+    /// auto-generated ID without the footnote leaking into either (see
+    /// `SectionBlock::parse`).
+    ///
+    /// Wrapped in a [`Cell`] for the same reason as
+    /// [`in_bibliography_list_item`](Self::in_bibliography_list_item): the
+    /// substitution code paths hold only a shared reference to the parser.
+    pub(crate) suppress_footnotes: Cell<bool>,
+
     /// Live values of [counter] attributes, keyed by counter name (e.g.
     /// `index`, `example-number`, `table-number`).
     ///
@@ -275,6 +286,7 @@ impl Default for Parser {
             topmost_section_type: SectionType::Normal,
             parsing_bibliography_section_body: false,
             in_bibliography_list_item: Cell::new(false),
+            suppress_footnotes: Cell::new(false),
             counter_values: RefCell::new(HashMap::new()),
             locked_attribute_names: HashSet::new(),
             nested_document_depth: 0,

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -119,16 +119,19 @@ pub struct Parser {
     /// parser.
     pub(crate) in_bibliography_list_item: Cell<bool>,
 
-    /// True while a footnote-free variant of some content is being substituted,
-    /// so a `footnote:[…]` macro is dropped entirely rather than numbered and
-    /// rendered as a marker. Used to derive a section title's reference text
-    /// and auto-generated ID without the footnote leaking into either (see
+    /// True while a section title is being substituted, so each `footnote:[…]`
+    /// macro's rendered marker is bracketed with
+    /// [`FOOTNOTE_MARKER_START`](crate::content::FOOTNOTE_MARKER_START) /
+    /// [`FOOTNOTE_MARKER_END`](crate::content::FOOTNOTE_MARKER_END) sentinels.
+    /// The footnote is still defined and numbered in document order; the
+    /// sentinels merely let the marker be excised from the section's reference
+    /// text and auto-generated ID without a second substitution pass (see
     /// `SectionBlock::parse`).
     ///
     /// Wrapped in a [`Cell`] for the same reason as
     /// [`in_bibliography_list_item`](Self::in_bibliography_list_item): the
     /// substitution code paths hold only a shared reference to the parser.
-    pub(crate) suppress_footnotes: Cell<bool>,
+    pub(crate) mark_footnote_spans: Cell<bool>,
 
     /// Live values of [counter] attributes, keyed by counter name (e.g.
     /// `index`, `example-number`, `table-number`).
@@ -286,7 +289,7 @@ impl Default for Parser {
             topmost_section_type: SectionType::Normal,
             parsing_bibliography_section_body: false,
             in_bibliography_list_item: Cell::new(false),
-            suppress_footnotes: Cell::new(false),
+            mark_footnote_spans: Cell::new(false),
             counter_values: RefCell::new(HashMap::new()),
             locked_attribute_names: HashSet::new(),
             nested_document_depth: 0,

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -121,8 +121,8 @@ pub struct Parser {
 
     /// True while a footnote-free variant of some content is being substituted,
     /// so a `footnote:[…]` macro is dropped entirely rather than numbered and
-    /// rendered as a marker. Used to derive a section title's reference text and
-    /// auto-generated ID without the footnote leaking into either (see
+    /// rendered as a marker. Used to derive a section title's reference text
+    /// and auto-generated ID without the footnote leaking into either (see
     /// `SectionBlock::parse`).
     ///
     /// Wrapped in a [`Cell`] for the same reason as

--- a/parser/src/tests/asciidoc_lang/macros/footnote.rs
+++ b/parser/src/tests/asciidoc_lang/macros/footnote.rs
@@ -319,13 +319,15 @@ fn footnotes_in_headings_are_numbered_in_document_order() {
 // verified. The crate applies a heading's substitutions before parsing its
 // section body (see `SectionBlock::parse`), so a footnote in a heading is
 // numbered in document order — verified by
-// `footnotes_in_headings_are_numbered_in_document_order` above. The prose below
-// documents Asciidoctor's *out-of-order* default and its explicit-ID-plus-
-// reftext workaround, neither of which the crate models (it always numbers in
-// document order), so it is not verifiable against the crate's behavior. One
-// related divergence remains: a footnote placed in a heading still reappears in
-// the reference text of an xref to that heading, which Asciidoctor's workaround
-// suppresses. Tracked by
+// `footnotes_in_headings_are_numbered_in_document_order` above — and its marker
+// does not leak into the heading's reference text or auto-generated ID —
+// verified by `xref::footnote_in_heading_does_not_leak_into_xref_text` and
+// `xref::footnote_in_heading_does_not_leak_into_generated_id`. The crate thus
+// achieves unconditionally what the prose below says Asciidoctor achieves only
+// via an explicit-ID-plus-reftext workaround. The prose documents Asciidoctor's
+// *out-of-order* default and that workaround, neither of which the crate models
+// (it always numbers in document order), so it is not verifiable against the
+// crate's behavior. Tracked by
 // https://github.com/asciidoc-rs/asciidoc-parser/issues/594.
 non_normative!(
     r#"

--- a/parser/src/tests/asciidoc_lang/macros/footnote.rs
+++ b/parser/src/tests/asciidoc_lang/macros/footnote.rs
@@ -275,11 +275,57 @@ That means the text formatting in the footnote text will already be applied when
     );
 }
 
+#[test]
+fn footnotes_in_headings_are_numbered_in_document_order() {
+    // The crate deliberately diverges from Asciidoctor here (see the note on the
+    // "Footnotes in headings" section below and issue #594). Rather than
+    // converting section titles eagerly and out of document order, it applies a
+    // title's substitutions before parsing the section body. A footnote in a
+    // heading is therefore numbered in straightforward document order: the
+    // heading's footnote follows footnotes in preceding content and precedes
+    // footnotes in the heading's own section body.
+    let doc = Parser::default().parse(concat!(
+        "== Section 1\n",
+        "\n",
+        "para.footnote:[first footnote]\n",
+        "\n",
+        "== Section 2footnote:[second footnote]\n",
+        "\n",
+        "para.footnote:[third footnote]\n",
+    ));
+
+    let footnotes = doc.catalog().footnotes();
+    assert_eq!(
+        footnotes
+            .iter()
+            .map(|f| (f.index.as_str(), f.text.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("1", "first footnote"),
+            ("2", "second footnote"),
+            ("3", "third footnote"),
+        ]
+    );
+
+    // The heading's footnote (number 2) is registered between the two body
+    // footnotes, confirming it is numbered in document order rather than
+    // deferred to the end (Asciidoctor's default) or numbered eagerly ahead of
+    // preceding body content.
+    assert_eq!(footnotes[1].index, "2");
+    assert_eq!(footnotes[1].text, "second footnote");
+}
+
 // The "Footnotes in headings" section is left non-normative rather than
-// verified: the crate does not yet implement the workaround it describes.
-// Section titles are not converted eagerly/out of document order, so a footnote
-// placed in a heading still reappears in the reference text of an xref to that
-// heading (Asciidoctor's workaround suppresses it). Tracked by
+// verified. The crate applies a heading's substitutions before parsing its
+// section body (see `SectionBlock::parse`), so a footnote in a heading is
+// numbered in document order — verified by
+// `footnotes_in_headings_are_numbered_in_document_order` above. The prose below
+// documents Asciidoctor's *out-of-order* default and its explicit-ID-plus-
+// reftext workaround, neither of which the crate models (it always numbers in
+// document order), so it is not verifiable against the crate's behavior. One
+// related divergence remains: a footnote placed in a heading still reappears in
+// the reference text of an xref to that heading, which Asciidoctor's workaround
+// suppresses. Tracked by
 // https://github.com/asciidoc-rs/asciidoc-parser/issues/594.
 non_normative!(
     r#"

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -4708,11 +4708,15 @@ mod macros {
 
         #[test]
         #[ignore]
-        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/594):
-        // Footnotes used in section titles are converted out of document order
-        // (titles are converted eagerly to generate IDs), so their numbering
-        // differs from document order. The crate does not yet model the eager
-        // out-of-order conversion of section titles.
+        // Intentional divergence (https://github.com/asciidoc-rs/asciidoc-parser/issues/594):
+        // Asciidoctor converts section titles eagerly and out of document order
+        // (to generate IDs and cross-reference text), so footnotes in headings
+        // are numbered out of sequence — this test asserts that quirk. The crate
+        // instead applies a title's substitutions before parsing its section
+        // body, numbering heading footnotes in straightforward document order.
+        // That in-order behavior is covered by
+        // `asciidoc_lang::macros::footnote::footnotes_in_headings_are_numbered_in_document_order`,
+        // so this Asciidoctor-fidelity test stays ignored.
         fn footnotes_in_headings_are_numbered_out_of_sequence() {}
     }
 

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -39,6 +39,24 @@ fn first_paragraph<'a>(doc: &'a Document<'a>) -> &'a str {
     first_simple(doc).content().rendered()
 }
 
+/// Returns the first `SectionBlock` found in document order (recursing into
+/// nested blocks).
+fn first_section<'a>(doc: &'a Document<'a>) -> &'a crate::blocks::SectionBlock<'a> {
+    fn walk<'a>(
+        mut blocks: impl Iterator<Item = &'a Block<'a>>,
+    ) -> Option<&'a crate::blocks::SectionBlock<'a>> {
+        blocks.find_map(|block| {
+            if let Block::Section(section) = block {
+                Some(section)
+            } else {
+                walk(block.nested_blocks())
+            }
+        })
+    }
+
+    walk(doc.nested_blocks()).expect("expected at least one section block")
+}
+
 #[test]
 fn forward_reference_resolves() {
     let doc = Parser::default().parse("See <<later>>.\n\n[#later]\n== Later\n");
@@ -171,6 +189,38 @@ fn footnote_reaching_a_heading_via_attribute_is_kept_out_of_xref_text() {
     assert_eq!(footnotes.len(), 1);
     assert_eq!(footnotes[0].index, "1");
     assert_eq!(footnotes[0].text, "Not legal advice.");
+}
+
+#[test]
+fn footnote_and_xref_in_the_same_heading_render_without_sentinels() {
+    // A title containing both a footnote and a cross-reference exercises the
+    // deferred-template path: the footnote marker's sentinels must be stripped
+    // from the deferred template too, so resolving the xref (which rebuilds the
+    // rendered text from that template) does not reintroduce them.
+    let doc = Parser::default().parse(concat!(
+        "== Title footnote:[a note] see <<other>>\n",
+        "\n",
+        "[#other]\n",
+        "== Other\n",
+    ));
+
+    let title = first_section(&doc).section_title();
+
+    // No Private-Use-Area marker sentinels survive into the rendered heading.
+    assert!(
+        !title.contains('\u{E002}') && !title.contains('\u{E003}'),
+        "heading still contains marker sentinels: {title:?}"
+    );
+
+    // The heading keeps its footnote marker and its resolved cross-reference.
+    assert!(title.contains(r#"class="footnote""#), "{title:?}");
+    assert!(
+        title.contains(r##"<a href="#other">Other</a>"##),
+        "{title:?}"
+    );
+
+    // The footnote is registered exactly once.
+    assert_eq!(doc.catalog().footnotes().len(), 1);
 }
 
 #[test]

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -152,6 +152,66 @@ fn footnote_in_heading_does_not_leak_into_generated_id() {
 }
 
 #[test]
+fn footnote_reaching_a_heading_via_attribute_is_kept_out_of_xref_text() {
+    // The footnote enters the title through an attribute reference, so it is not
+    // visible in the raw title source. Because markers are annotated during the
+    // single title render (not gated on the source text), the footnote is still
+    // kept out of the reference text — and remains a real, numbered footnote.
+    let doc = Parser::default().parse(concat!(
+        ":disclaimer: footnote:[Not legal advice.]\n",
+        "\n",
+        "See <<Terms>>.\n",
+        "\n",
+        "== Terms{disclaimer}\n",
+    ));
+
+    assert_eq!(first_paragraph(&doc), "See <a href=\"#_terms\">Terms</a>.");
+
+    let footnotes = doc.catalog().footnotes();
+    assert_eq!(footnotes.len(), 1);
+    assert_eq!(footnotes[0].index, "1");
+    assert_eq!(footnotes[0].text, "Not legal advice.");
+}
+
+#[test]
+fn footnote_in_heading_does_not_advance_a_counter_twice() {
+    // Deriving the footnote-free reference text from the same single render
+    // means a stateful `{counter:…}` in the title advances exactly once: the
+    // heading, its reference text, and the following body all agree.
+    let doc = Parser::default().parse(concat!(
+        "See <<Chapter 1>>.\n",
+        "\n",
+        "== Chapter {counter:ch}footnote:[a note]\n",
+        "\n",
+        "Next is {counter:ch}.\n",
+    ));
+
+    // The reference text reflects the first (and only) counter value, `1`.
+    assert_eq!(
+        first_paragraph(&doc),
+        "See <a href=\"#_chapter_1\">Chapter 1</a>."
+    );
+
+    // The body's counter is `2`, not `3`: the title render did not advance it a
+    // second time.
+    let mut paragraphs = vec![];
+    fn collect<'a>(blocks: impl Iterator<Item = &'a Block<'a>>, out: &mut Vec<String>) {
+        for block in blocks {
+            if let Block::Simple(simple) = block {
+                out.push(simple.content().rendered().to_string());
+            }
+            collect(block.nested_blocks(), out);
+        }
+    }
+    collect(doc.nested_blocks(), &mut paragraphs);
+
+    assert!(
+        paragraphs.iter().any(|p| p == "Next is 2."),
+        "paragraphs were {paragraphs:?}"
+    );
+}
+
+#[test]
 fn unresolved_reference_falls_back_and_warns() {
     // Parse without resolving, then resolve against the document's own catalog
     // (cloned so it does not alias the `&mut doc` borrow).

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -92,6 +92,66 @@ fn xref_macro_form_resolves() {
 }
 
 #[test]
+fn footnote_in_heading_does_not_leak_into_xref_text() {
+    // A footnote in a section title is still a real, document-order footnote,
+    // but its marker must not appear in the reference text of an xref to that
+    // heading. (Asciidoctor achieves this only via an explicit-ID-plus-reftext
+    // workaround; the crate does it unconditionally. See issue #594.)
+    let doc = Parser::default().parse(concat!(
+        "See <<sect2>>.\n",
+        "\n",
+        "== Section 1\n",
+        "\n",
+        "para.footnote:[first footnote]\n",
+        "\n",
+        "[#sect2]\n",
+        "== Section 2footnote:[second footnote]\n",
+        "\n",
+        "para.footnote:[third footnote]\n",
+    ));
+
+    // The xref link text is the bare title, with no footnote marker.
+    assert_eq!(
+        first_paragraph(&doc),
+        "See <a href=\"#sect2\">Section 2</a>."
+    );
+
+    // The heading's footnote is nonetheless registered, numbered in document
+    // order (1: first, 2: second/heading, 3: third).
+    let footnotes = doc.catalog().footnotes();
+    assert_eq!(
+        footnotes
+            .iter()
+            .map(|f| (f.index.as_str(), f.text.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("1", "first footnote"),
+            ("2", "second footnote"),
+            ("3", "third footnote"),
+        ]
+    );
+}
+
+#[test]
+fn footnote_in_heading_does_not_leak_into_generated_id() {
+    // The auto-generated section ID is likewise derived from the footnote-free
+    // title, so the footnote's number does not pollute the ID. A natural
+    // reference (by the title's reference text) resolves to the clean ID.
+    let doc = Parser::default().parse(concat!(
+        "See <<Section 2>>.\n",
+        "\n",
+        "== Section 2footnote:[a note]\n",
+    ));
+
+    // Without the footnote-free derivation the ID would absorb the footnote
+    // number (e.g. `_section_21`); it is instead the clean `_section_2`.
+    assert_eq!(
+        first_paragraph(&doc),
+        "See <a href=\"#_section_2\">Section 2</a>."
+    );
+}
+
+#[test]
 fn unresolved_reference_falls_back_and_warns() {
     // Parse without resolving, then resolve against the document's own catalog
     // (cloned so it does not alias the `&mut doc` borrow).


### PR DESCRIPTION
## Summary

Fixes #594. A `footnote:[…]` macro placed in a **section title** was mishandled in three ways; this PR addresses all of them while keeping the crate's clean, document-order model.

### 1. Numbering order
A heading footnote was numbered *after* the footnotes in that section's own body, because the title's substitutions ran only after the body was parsed. The fix applies the title's substitutions **before** parsing the section body, so a heading footnote is numbered in straightforward document order. For the issue's example:

```adoc
== Section 1

para.footnote:[first footnote]

== Section 2footnote:[second footnote]

para.footnote:[third footnote]
```

footnotes are numbered `first` → 1, `second` (in the Section 2 heading) → 2, `third` → 3.

### 2. Footnote marker leaking into xref text
An xref to a footnoted heading previously showed the footnote `<sup>` marker inside the link text. The section's reference text is now derived from a **footnote-free rendering** of the title, so an xref to the heading renders just the title.

### 3. Footnote number leaking into the generated ID
The auto-generated section ID was likewise polluted by the footnote (e.g. `_section_21`). It now uses the same footnote-free rendering, producing a clean `_section_2`.

## Mechanism (single render + sentinels)

The title is rendered **once**. While it is being substituted, each footnote's rendered marker is bracketed with Private-Use-Area sentinels — mirroring the crate's existing xref-placeholder technique (`content.rs`). The footnote is still defined and numbered in document order; the sentinels merely let the marker be excised afterward:

- the footnote-free **reftext / ID** are produced by `strip_footnote_marker_spans` (drops each sentinel span and the marker between);
- the **title** keeps its marker for the heading, via `Content::remove_footnote_marker_sentinels` (drops just the sentinels).

A single render (rather than re-substituting the title with footnotes suppressed) means stateful substitutions run exactly once — this is what resolved the two Greptile P1s:
- a `{counter:…}` in a footnoted title advances once (reftext, heading, and following body agree); and
- a footnote reaching the title through an attribute reference (`:x: footnote:[…]` + `== Title{x}`) is still kept out of the reftext/ID, because marking happens at render time rather than by inspecting the raw source.

## Intentional divergence from Asciidoctor

Asciidoctor converts section titles *eagerly and out of document order*, numbering heading footnotes out of sequence; the marker also leaks into xref text unless the author applies an explicit-ID-plus-reftext workaround. The spec documents this as unsupported/buggy behavior (`macros/pages/footnote.adoc`, "Footnotes in headings"). The crate instead numbers in document order **and** keeps the marker out of the reftext/ID unconditionally — the same result Asciidoctor reaches only via its workaround. Confirmed as a deliberate scope decision.

## Test coverage

- `footnotes_in_headings_are_numbered_in_document_order` (`tests/asciidoc_lang/macros/footnote.rs`)
- `footnote_in_heading_does_not_leak_into_xref_text`, `footnote_in_heading_does_not_leak_into_generated_id`, `footnote_reaching_a_heading_via_attribute_is_kept_out_of_xref_text`, `footnote_in_heading_does_not_advance_a_counter_twice` (`tests/xref.rs`)
- Unit tests for `strip_footnote_marker_spans` (`tests/content/content.rs`), including the defensive unbalanced-sentinel branch.
- The "Footnotes in headings" spec prose stays `non_normative!` with its note updated; the ported Asciidoctor `footnotes_in_headings_are_numbered_out_of_sequence` stays `#[ignore]`d with a divergence note pointing at the in-order test.

## Testing

- `cargo test` — 3070 passed, 0 failed, 36 ignored (branch merged up to date with `main`).
- `cargo clippy --all-targets` — clean.
- `cargo +nightly fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)