### PR TITLE
chore: Implement tests for catalog anchors and resolve xrefs in AsciiDoc table cells (#543)

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -3096,4 +3096,36 @@ mod tests {
             assert_eq!(doc.warnings().count(), 0);
         }
     }
+
+    // Cataloging a leading anchor found in a table cell (issue #543) is covered
+    // for header and default-style cells by the ported tests in
+    // `tests::asciidoctor_rb::tables_test`. Those styled-column fixtures place
+    // the anchor in the first (header) row, and a header cell is always parsed
+    // with the default column style — so `cols=1a` never actually parses the
+    // anchored value as an AsciiDoc-style cell there. This exercises that
+    // missing case directly: a leading anchor in an AsciiDoc-style *body* cell
+    // must still be cataloged in the main document.
+    mod anchor_in_asciidoc_body_cell {
+        use crate::tests::prelude::*;
+
+        #[test]
+        fn leading_anchor_in_asciidoc_body_cell_is_cataloged() {
+            // Two `|` rows with no blank line between them defeat the implicit-
+            // header heuristic (which requires a blank line after the first row),
+            // so both cells are AsciiDoc-style *body* cells rather than a header.
+            let doc = Parser::default()
+                .parse("[cols=1a]\n|===\n|[[foo,Foo]]body anchor\n|second cell\n|===");
+
+            // Guard the premise: the anchored cell is a genuine AsciiDoc-style
+            // body cell (each `a` cell renders its content as a nested document in
+            // `div.content`), not a header cell — no `th` is produced, and the
+            // anchor renders as a target inside the cell.
+            assert_css(&doc, "th", 0);
+            assert_css(&doc, "table.tableblock td.tableblock > div.content", 2);
+            assert_xpath(&doc, "//td//div[@class=\"content\"]//a[@id=\"foo\"]", 1);
+
+            // The leading anchor is cataloged in the main document's catalog.
+            assert!(doc.catalog().contains_id("foo"));
+        }
+    }
 }

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1411,40 +1411,70 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/543):
-    // Cross-reference resolution from inside an AsciiDoc table cell to a
-    // reference in the main document.
     fn cross_reference_link_in_an_asciidoc_table_cell_should_resolve_to_reference_in_main_document()
     {
+        let doc =
+            Parser::default().parse("== Some\n\n|===\na|See <<_more>>\n|===\n\n== More\n\ncontent");
+
+        // The cross-reference inside the AsciiDoc cell resolves against the main
+        // document's catalog, even though its target section is defined *after*
+        // the table.
+        assert_xpath(&doc, "//a[@href=\"#_more\"]", 1);
+        assert_xpath(&doc, "//a[@href=\"#_more\"][text()=\"More\"]", 1);
     }
 
     #[test]
-    #[ignore]
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/543):
-    // Cataloging an anchor at the start of an AsciiDoc table cell as a document
-    // reference.
-    fn should_discover_anchor_at_start_of_cell_and_register_it_as_a_reference() {}
+    fn should_discover_anchor_at_start_of_cell_and_register_it_as_a_reference() {
+        let doc = Parser::default().parse(
+            "The highest peak in the Front Range is <<grays-peak>>, which tops <<mount-evans>> by just a few feet.\n\n[cols=\"1s,1\"]\n|===\n|[[mount-evans,Mount Evans]]Mount Evans\n|14,271 feet\n\nh|[[grays-peak,Grays Peak]]\nGrays Peak\n|14,278 feet\n|===",
+        );
+
+        // The anchors at the start of the cells are cataloged as document
+        // references.
+        let catalog = doc.catalog();
+        assert!(catalog.contains_id("mount-evans"));
+        assert!(catalog.contains_id("grays-peak"));
+
+        // The cross-references in the introductory paragraph resolve against
+        // those cataloged anchors, using each anchor's reftext.
+        assert_xpath(
+            &doc,
+            "(//p)[1]/a[@href=\"#grays-peak\"][text()=\"Grays Peak\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "(//p)[1]/a[@href=\"#mount-evans\"][text()=\"Mount Evans\"]",
+            1,
+        );
+
+        // The anchors render as targets within their respective cells.
+        assert_xpath(&doc, "(//table/tbody/tr)[1]//td//a[@id=\"mount-evans\"]", 1);
+        assert_xpath(&doc, "(//table/tbody/tr)[2]//th//a[@id=\"grays-peak\"]", 1);
+    }
 
     #[test]
-    #[ignore]
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/543):
-    // Cataloging an anchor at the start of a cell in an implicit header row when
-    // the column has a style.
-    fn should_catalog_anchor_at_start_of_cell_in_implicit_header_row_when_column_has_a_style() {}
+    fn should_catalog_anchor_at_start_of_cell_in_implicit_header_row_when_column_has_a_style() {
+        let doc = Parser::default()
+            .parse("[cols=1a]\n|===\n|[[foo,Foo]]* not AsciiDoc\n\n| AsciiDoc\n|===");
+
+        assert!(doc.catalog().contains_id("foo"));
+    }
 
     #[test]
-    #[ignore]
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/543):
-    // Cataloging an anchor at the start of a cell in an explicit header row when
-    // the column has a style.
-    fn should_catalog_anchor_at_start_of_cell_in_explicit_header_row_when_column_has_a_style() {}
+    fn should_catalog_anchor_at_start_of_cell_in_explicit_header_row_when_column_has_a_style() {
+        let doc = Parser::default()
+            .parse("[%header,cols=1a]\n|===\n|[[foo,Foo]]* not AsciiDoc\n| AsciiDoc\n|===");
+
+        assert!(doc.catalog().contains_id("foo"));
+    }
 
     #[test]
-    #[ignore]
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/543):
-    // Cataloging an anchor at the start of a cell in the first row.
-    fn should_catalog_anchor_at_start_of_cell_in_first_row() {}
+    fn should_catalog_anchor_at_start_of_cell_in_first_row() {
+        let doc = Parser::default().parse("|===\n|[[foo,Foo]]foo\n| bar\n|===");
+
+        assert!(doc.catalog().contains_id("foo"));
+    }
 
     #[test]
     fn footnotes_should_not_be_shared_between_an_asciidoc_table_cell_and_the_main_document() {


### PR DESCRIPTION
Closes #543.

## What

Fills in the five ported-but-`#[ignore]`d tests in
[`parser/src/tests/asciidoctor_rb/tables_test.rs`](parser/src/tests/asciidoctor_rb/tables_test.rs)
that cover reference cataloging/resolution for AsciiDoc (`a`) and styled table
cells:

- `cross_reference_link_in_an_asciidoc_table_cell_should_resolve_to_reference_in_main_document`
- `should_discover_anchor_at_start_of_cell_and_register_it_as_a_reference`
- `should_catalog_anchor_at_start_of_cell_in_implicit_header_row_when_column_has_a_style`
- `should_catalog_anchor_at_start_of_cell_in_explicit_header_row_when_column_has_a_style`
- `should_catalog_anchor_at_start_of_cell_in_first_row`

Each stub was an empty `#[ignore]`d body; they now carry the assertions
adapted from the Ruby originals in `tables_test.rb`, and all five pass.

## Why no parser change

The feature the issue describes — the nested cell's blocks participating in
the **main document's** reference catalog — is already satisfied by the
existing plumbing:

- AsciiDoc/styled cells are parsed against the **shared** `Parser` catalog
  (only footnotes get a private, per-cell registry), so an anchor discovered
  in a cell is registered in the one document catalog.
- The deferred reference-resolution pass recurses into table cells
  (`Table::resolve_references` → `cell.resolve_references`), so a
  cross-reference inside a cell resolves against that same catalog — including
  a target (e.g. a section) defined **after** the table.

Both pieces have existed since tables landed (#508); the test bodies were
deferred to this issue. This PR enables and verifies the behavior rather than
changing parser logic. The tests are load-bearing: `contains_id` and the
`href`/`id` XPath assertions fail if the anchor is not cataloged or the xref
does not resolve.

Cross-document xref resolution remains out of scope (single-document only),
matching the issue.

## Testing

- `cargo test -p asciidoc-parser --lib` — 3044 passed, 0 failed.
- `cargo clippy -p asciidoc-parser --tests` — clean.
- `cargo +nightly fmt` — applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)