### PR TITLE
feat: Expose AsciiDoc table cell as introspectable nested document (#545)

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -13,7 +13,7 @@ use crate::{
     document::{InterpretedValue, TocConfig, TocMode},
     parser::{
         AttributeValue, InlineSubstitutionRenderer, ModificationContext, ReferenceResolver,
-        ReferenceWarning, built_in_attr, built_in_attrs_iter,
+        ReferenceWarning, ResolvedAttributes, built_in_attr, built_in_attrs_iter,
         preprocessor::preprocess_with_initial_file_name,
     },
     span::MatchedItem,
@@ -1763,7 +1763,7 @@ fn process_content<'src>(
                 // (include-expanded) source, so a table nested within cannot
                 // mis-map its spans against the document source map.
                 parser.owned_cell_source_depth += 1;
-                let (title, inline, toc, blocks) =
+                let (title, inline, toc, blocks, attributes) =
                     parse_asciidoc_cell_body(Span::new(source), parser, &mut owned_warnings);
                 parser.owned_cell_source_depth -= 1;
 
@@ -1780,16 +1780,19 @@ fn process_content<'src>(
                     inline,
                     toc,
                     blocks,
+                    attributes,
                 }
             });
             AsciiDocCell::Owned(Arc::new(owned))
         } else {
-            let (title, inline, toc, blocks) = parse_asciidoc_cell_body(trimmed, parser, warnings);
+            let (title, inline, toc, blocks, attributes) =
+                parse_asciidoc_cell_body(trimmed, parser, warnings);
             AsciiDocCell::Borrowed(BorrowedCell {
                 title,
                 inline,
                 toc,
                 blocks,
+                attributes,
             })
         };
 
@@ -1814,8 +1817,9 @@ fn process_content<'src>(
 }
 
 /// Parses the body of an AsciiDoc table cell — a nested, standalone AsciiDoc
-/// document — returning its (shown) title, whether its doctype is `inline`, and
-/// its blocks.
+/// document — returning its (shown) title, whether its doctype is `inline`, its
+/// table-of-contents configuration, its blocks, and a snapshot of the cell's
+/// resolved attribute state.
 ///
 /// A leading level-0 title line (`= Title`) is the nested document's title
 /// rather than a section, so it is split off and rendered here (a level-0
@@ -1823,11 +1827,23 @@ fn process_content<'src>(
 /// (`inline`, and whether the title is shown) depend on the cell's now-mutated
 /// attribute state, so they are resolved before the caller restores the
 /// parent's attribute snapshot.
+///
+/// The attribute snapshot is likewise taken here, before that restore, so the
+/// cell can be introspected as the nested document it is: it captures the
+/// attributes the cell inherited from the parent (plus any the cell body set),
+/// mirroring how a top-level [`Document`](crate::Document) retains its own
+/// resolved attribute state.
 fn parse_asciidoc_cell_body<'src>(
     content: Span<'src>,
     parser: &mut Parser,
     warnings: &mut Vec<Warning<'src>>,
-) -> (Option<String>, bool, TocConfig, Vec<Block<'src>>) {
+) -> (
+    Option<String>,
+    bool,
+    TocConfig,
+    Vec<Block<'src>>,
+    ResolvedAttributes,
+) {
     let first_line = content.take_line();
     let (title_source, body) = if first_line.item.data().starts_with("= ") {
         (
@@ -1878,7 +1894,15 @@ fn parse_asciidoc_cell_body<'src>(
     // restores the parent's attribute snapshot.
     let toc = TocConfig::from_parser(parser);
 
-    (title, inline, toc, maw.item.item)
+    // Snapshot the cell's resolved attribute state while the parser still holds
+    // it (the caller restores the parent's snapshot immediately after this
+    // returns). The snapshot shares the parser's attribute tables by `Arc`, so
+    // it is cheap. It lets a caller introspect the nested cell document —
+    // including the attributes it inherited from the parent — the same way the
+    // top-level `Document` exposes its own.
+    let attributes = parser.snapshot_attributes();
+
+    (title, inline, toc, maw.item.item, attributes)
 }
 
 /// Returns `true` when the cell content holds an `include::` preprocessor
@@ -2219,6 +2243,56 @@ impl<'src> AsciiDocCell<'src> {
         }
     }
 
+    /// Returns `true` because an AsciiDoc table cell is always a nested,
+    /// standalone document.
+    ///
+    /// This mirrors Asciidoctor's `Document#nested?`, which is `true` for the
+    /// document parsed from an AsciiDoc (`a`) cell and `false` for a top-level
+    /// document. It is provided so a caller that has navigated to the cell can
+    /// confirm it is introspecting a nested document (see also
+    /// [`attribute_value`](Self::attribute_value) and its siblings, which
+    /// expose the attributes the cell inherited from its parent).
+    pub fn is_nested(&self) -> bool {
+        true
+    }
+
+    /// Returns the resolved interpreted value of the named document attribute
+    /// as the cell's nested document saw it.
+    ///
+    /// The cell inherits the parent document's attributes, so this reports an
+    /// inherited value (such as a directory option the parent was configured
+    /// with) as well as any attribute the cell body set for itself. It mirrors
+    /// [`Document::attribute_value`](crate::Document::attribute_value) exactly,
+    /// resolving the cell's introspectable attribute state the same way the
+    /// top-level document resolves its own.
+    pub fn attribute_value<N: AsRef<str>>(&self, name: N) -> InterpretedValue {
+        self.attributes().attribute_value(name)
+    }
+
+    /// Returns `true` if the cell's nested document has a document attribute by
+    /// this name (whether or not it is set).
+    ///
+    /// Mirrors [`Document::has_attribute`](crate::Document::has_attribute).
+    pub fn has_attribute<N: AsRef<str>>(&self, name: N) -> bool {
+        self.attributes().has_attribute(name)
+    }
+
+    /// Returns `true` if the cell's nested document has a document attribute by
+    /// this name and it is set (i.e. not unset).
+    ///
+    /// Mirrors [`Document::is_attribute_set`](crate::Document::is_attribute_set).
+    pub fn is_attribute_set<N: AsRef<str>>(&self, name: N) -> bool {
+        self.attributes().is_attribute_set(name)
+    }
+
+    /// Returns the snapshot of the cell's resolved attribute state.
+    fn attributes(&self) -> &ResolvedAttributes {
+        match self {
+            Self::Borrowed(cell) => &cell.attributes,
+            Self::Owned(cell) => &cell.borrow_dependent().attributes,
+        }
+    }
+
     /// Resolves any deferred cross-references in the cell's blocks.
     fn resolve_references(
         &mut self,
@@ -2257,6 +2331,7 @@ pub struct BorrowedCell<'src> {
     inline: bool,
     toc: TocConfig,
     blocks: Vec<Block<'src>>,
+    attributes: ResolvedAttributes,
 }
 
 self_cell! {
@@ -2279,6 +2354,7 @@ struct OwnedCellInner<'src> {
     inline: bool,
     toc: TocConfig,
     blocks: Vec<Block<'src>>,
+    attributes: ResolvedAttributes,
 }
 
 /// Parse the value of the `cols` attribute into a list of columns, mirroring
@@ -2924,7 +3000,7 @@ fn line_has_unclosed_quote(line: &str) -> bool {
 mod tests {
     use std::sync::Arc;
 
-    use super::{AsciiDocCell, OwnedCell, OwnedCellInner, TocConfig};
+    use super::{AsciiDocCell, OwnedCell, OwnedCellInner, ResolvedAttributes, TocConfig};
     use crate::parser::{
         HtmlSubstitutionRenderer, ReferenceResolver, ResolutionContext, ResolvedReference,
     };
@@ -2953,6 +3029,7 @@ mod tests {
                 inline: false,
                 toc: TocConfig::disabled(),
                 blocks: vec![],
+                attributes: ResolvedAttributes::default(),
             }
         })));
 

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -669,6 +669,68 @@ fn asciidoc_cell_attributes_are_scoped_to_the_cell() {
     assert!(parser.has_attribute("parent-attr"));
 }
 
+#[test]
+fn asciidoc_cell_is_always_nested() {
+    // An AsciiDoc cell is a nested, standalone document, so `is_nested()` is
+    // always true (mirroring Asciidoctor's `Document#nested?`).
+    let doc = Parser::default().parse("[cols=\"a\"]\n|===\n|nested content\n|===");
+
+    let table = doc
+        .nested_blocks()
+        .find_map(|block| match block {
+            Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .unwrap();
+
+    match table.body_rows()[0].cells()[0].content() {
+        TableCellContent::AsciiDoc(cell) => assert!(cell.is_nested()),
+        TableCellContent::Simple(_) => panic!("expected AsciiDoc cell content"),
+    }
+}
+
+#[test]
+fn asciidoc_cell_exposes_inherited_attributes_for_introspection() {
+    // The cell's attribute state is scoped to the cell and restored on the parser
+    // once the cell is parsed, so it can no longer be read from the parser. The
+    // cell nonetheless retains a snapshot of it, letting a caller introspect the
+    // nested document's attributes — both those inherited from the parent and any
+    // the cell set for itself — after parsing has finished.
+    let doc = Parser::default().parse(
+        ":parent-attr: inherited\n\n[cols=\"a\"]\n|===\n|\n:cell-attr: local\ncontent\n|===",
+    );
+
+    let table = doc
+        .nested_blocks()
+        .find_map(|block| match block {
+            Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .unwrap();
+
+    let TableCellContent::AsciiDoc(cell) = table.body_rows()[0].cells()[0].content() else {
+        panic!("expected AsciiDoc cell content");
+    };
+
+    // The inherited parent attribute is visible on the nested document and equal
+    // to what the parent document sees.
+    assert!(cell.is_attribute_set("parent-attr"));
+    assert_eq!(
+        cell.attribute_value("parent-attr"),
+        doc.attribute_value("parent-attr")
+    );
+
+    // The attribute the cell set for itself is visible on the cell but did not
+    // leak into the parent document.
+    assert!(cell.is_attribute_set("cell-attr"));
+    assert!(cell.has_attribute("cell-attr"));
+    assert!(!doc.has_attribute("cell-attr"));
+
+    // An attribute that neither the parent nor the cell defines is absent.
+    assert!(!cell.has_attribute("no-such-attr"));
+    assert!(!cell.is_attribute_set("no-such-attr"));
+}
+
 /// Collect the rendered text of every block in an AsciiDoc cell.
 fn asciidoc_cell_text(table: &TableBlock<'_>, row: usize, col: usize) -> String {
     match table.body_rows()[row].cells()[col].content() {

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -731,6 +731,45 @@ fn asciidoc_cell_exposes_inherited_attributes_for_introspection() {
     assert!(!cell.is_attribute_set("no-such-attr"));
 }
 
+#[test]
+fn include_expanded_asciidoc_cell_exposes_inherited_attributes_for_introspection() {
+    // A cell whose first line is an `include::` directive is parsed from an
+    // owned, include-expanded source (the `AsciiDocCell::Owned` variant) rather
+    // than borrowed from the document source. The introspection accessors reach
+    // through that owned store just the same, so the nested document still
+    // reports itself nested and exposes the attributes it inherited.
+    use crate::{SafeMode, tests::fixtures::inline_file_handler::InlineFileHandler};
+
+    let handler = InlineFileHandler::from_pairs([("fixtures/cell.adoc", "included cell content")]);
+    let doc = Parser::default()
+        .with_safe_mode(SafeMode::Server)
+        .with_include_file_handler(handler)
+        .with_intrinsic_attribute("outdir", "/path/to/output", ModificationContext::ApiOnly)
+        .parse("|===\na|include::fixtures/cell.adoc[]\n|===");
+
+    let table = doc
+        .nested_blocks()
+        .find_map(|block| match block {
+            Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .unwrap();
+
+    let TableCellContent::AsciiDoc(cell) = table.body_rows()[0].cells()[0].content() else {
+        panic!("expected AsciiDoc cell content");
+    };
+
+    // The cell is the include-expanded (owned) variant, so this exercises the
+    // owned-store branch of the introspection accessors.
+    assert!(cell.is_nested());
+    assert!(cell.is_attribute_set("outdir"));
+    assert_eq!(
+        cell.attribute_value("outdir"),
+        doc.attribute_value("outdir")
+    );
+    assert!(!cell.has_attribute("no-such-attr"));
+}
+
 /// Collect the rendered text of every block in an AsciiDoc cell.
 fn asciidoc_cell_text(table: &TableBlock<'_>, row: usize, col: usize) -> String {
     match table.body_rows()[row].cells()[col].content() {

--- a/parser/src/parser/resolved_attributes.rs
+++ b/parser/src/parser/resolved_attributes.rs
@@ -24,7 +24,7 @@ use crate::{
 ///
 /// [`Parser`]: crate::Parser
 /// [`Document`]: crate::Document
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct ResolvedAttributes {
     /// Attribute values as of the end of parsing (shared with the parser via
     /// [`Arc`]).

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1530,17 +1530,50 @@ mod psv {
         assert_xpath(&doc, "/table/tbody/tr/td[2]//table/tbody/tr/td", 1);
     }
 
-    // Attribute/option inheritance into the nested AsciiDoc-cell document is
-    // implemented; the `to_dir` test below remains unported for a narrower
-    // reason: it needs the nested cell exposed as an introspectable document
-    // object carrying inherited options.
-
     #[test]
-    #[ignore]
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/545): AsciiDoc
-    // table cell should expose the nested document for introspection of inherited
-    // options (here, `to_dir`).
-    fn asciidoc_table_cell_should_inherit_to_dir_option_from_parent_document() {}
+    fn asciidoc_table_cell_should_inherit_to_dir_option_from_parent_document() {
+        // Adapted from Asciidoctor's "AsciiDoc table cell should inherit to_dir
+        // option from parent document". Asciidoctor passes a `to_dir` *option*
+        // when building the document and, after locating the nested cell
+        // document, asserts it is `nested?` and that its `options[:to_dir]`
+        // matches the parent's.
+        //
+        // This crate has no options bag: a document's configuration is carried by
+        // its attributes, and Asciidoctor itself surfaces the `to_dir` option as
+        // the `outdir` document attribute. So the faithful analog is to configure
+        // the parent with an `outdir` attribute (as if from the API, the way an
+        // option is supplied) and confirm the nested AsciiDoc-cell document both
+        // reports itself as nested and has inherited that value.
+        let doc = Parser::default()
+            .with_intrinsic_attribute("outdir", "/path/to/output", ModificationContext::ApiOnly)
+            .parse("|===\na|\nAsciiDoc table cell\n|===");
+
+        // Locate the nested document: the single table's single cell, which is an
+        // AsciiDoc cell (`a|`) and therefore a nested, standalone document. This
+        // is the crate's equivalent of Ruby's
+        // `doc.blocks[0].find_by context: :document, traverse_documents: true`.
+        let table = match doc.nested_blocks().next() {
+            Some(crate::blocks::Block::Table(table)) => table,
+            other => panic!("expected a table block, got {other:?}"),
+        };
+        let crate::blocks::TableCellContent::AsciiDoc(nested_doc) =
+            table.body_rows()[0].cells()[0].content()
+        else {
+            panic!("expected an AsciiDoc cell");
+        };
+
+        // `assert nested_doc.nested?`
+        assert!(nested_doc.is_nested());
+
+        // `assert_equal doc.options[:to_dir], nested_doc.options[:to_dir]` — the
+        // inherited option (here the `outdir` attribute) is visible on the nested
+        // document and equals the parent's.
+        assert!(nested_doc.is_attribute_set("outdir"));
+        assert_eq!(
+            nested_doc.attribute_value("outdir"),
+            doc.attribute_value("outdir")
+        );
+    }
 
     #[test]
     fn asciidoc_table_cell_should_not_inherit_toc_setting_from_parent_document() {


### PR DESCRIPTION
## Summary

Closes #545.

An AsciiDoc (`a`) table cell is parsed as a nested, standalone document that inherits the parent document's attributes. Previously that nested document could not be introspected after parsing — its attribute state was scoped to the cell and restored on the parser as soon as the cell finished parsing, so callers had no way to ask "is this cell a nested document?" or "what options/attributes did it inherit?"

This PR exposes the cell as an introspectable document object:

- Captures a cheap, `Arc`-shared `ResolvedAttributes` snapshot of the cell's resolved attribute state while the parser still holds it (taken in `parse_asciidoc_cell_body`, before the parent's snapshot is restored). This reuses the exact mechanism a top-level `Document` already uses to retain its own resolved attributes, so lookups return the same values the parser would report.
- Adds four public accessors on `AsciiDocCell`, mirroring the ones `Document` already offers:
  - `is_nested()` — always `true` (mirrors Asciidoctor's `Document#nested?`)
  - `attribute_value(name)`
  - `has_attribute(name)`
  - `is_attribute_set(name)`

## SDD / test coverage

The concrete coverage gap for this issue was the ignored Asciidoctor port `asciidoc_table_cell_should_inherit_to_dir_option_from_parent_document`, which the issue notes was blocked precisely because the nested cell wasn't exposed as an introspectable document carrying inherited options. It is now implemented and passing.

Asciidoctor's original test passes a `to_dir` *option* and asserts `nested_doc.nested?` plus `doc.options[:to_dir] == nested_doc.options[:to_dir]`. This crate has no options bag — configuration is carried by attributes, and Asciidoctor itself surfaces the `to_dir` option as the `outdir` attribute — so the faithful analog configures the parent with an `outdir` attribute and confirms the nested cell reports itself as nested and inherited that value. The adaptation is documented inline in the test.

Also adds focused unit tests in `blocks/tests/table.rs`:
- `asciidoc_cell_is_always_nested`
- `asciidoc_cell_exposes_inherited_attributes_for_introspection` (inherited value matches the parent, cell-local attributes don't leak to the parent, unknown attributes are absent)

The out-of-scope items called out in the issue (TOC rendering in table cells, doctitle-isolation) are unaffected; those behaviors are already covered by existing passing tests.

## Verification

- `cargo test` (parser package): 3074 passed, 0 failed, 35 ignored (one fewer ignored than before)
- `cargo clippy --all-targets`: clean
- `cargo +nightly fmt --all --check`: clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`: clean (intra-doc links resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)