### PR TITLE
feat: Parse and expose document subtitle from the title line

### DIFF
--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -205,8 +205,23 @@ impl<'src> Document<'src> {
     }
 
     /// Return the document title (the level-0 `= Title`), if there was one.
+    ///
+    /// If the title contains a subtitle, this returns the full, combined title.
+    /// Use [`Header::main_title`] and [`Header::subtitle`] (via [`header`]) to
+    /// access the partitioned title.
+    ///
+    /// [`header`]: Self::header
     pub fn doctitle(&self) -> Option<&str> {
         self.header().title()
+    }
+
+    /// Return the document subtitle, if the document title contained one.
+    ///
+    /// A subtitle is the text following the final subtitle separator (a colon
+    /// followed by a space, by default) in the document title. See
+    /// [`Header::subtitle`].
+    pub fn subtitle(&self) -> Option<&str> {
+        self.header().subtitle()
     }
 
     /// Returns the resolved interpreted value of the named [document
@@ -1364,6 +1379,10 @@ mod tests {
         title: Some(
             "Example Title",
         ),
+        main_title: Some(
+            "Example Title",
+        ),
+        subtitle: None,
         attributes: &[],
         author_line: None,
         revision_line: None,

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -2,6 +2,7 @@ use std::slice::Iter;
 
 use crate::{
     HasSpan, Parser, Span,
+    attributes::{Attrlist, AttrlistContext},
     content::{Content, SubstitutionGroup},
     document::{Attribute, Author, AuthorLine, InterpretedValue, RevisionLine},
     internal::debug::DebugSliceReference,
@@ -80,6 +81,23 @@ impl<'src> Header<'src> {
                 parser.set_attribute_from_header(&attr.item, &mut warnings);
                 attributes.push(attr.item);
                 source = attr.after;
+            } else if title.is_none()
+                && line.starts_with('[')
+                && line.ends_with(']')
+                && line_mi.after.take_normalized_line().item.starts_with("= ")
+                && let Some(separator) = parse_separator_attribute(line, parser)
+            {
+                // A `separator` block attribute directly above the document title
+                // sets the subtitle separator. It behaves exactly like assigning
+                // the `title-separator` document attribute at this point in the
+                // header, so both mechanisms share the same partitioning logic
+                // and follow document order when both are present.
+                //
+                // The line is only intercepted when a document title immediately
+                // follows; otherwise it is block metadata for the body (e.g. a
+                // table's `separator`) and is left for the block parser.
+                parser.set_attribute_by_value_from_header("title-separator", separator);
+                source = line_mi.after;
             } else if title.is_none() && line.starts_with("= ") {
                 let title_span = line.discard(2).discard_whitespace();
                 let title_str = apply_header_subs(title_span.data(), parser);
@@ -206,6 +224,38 @@ impl<'src> HasSpan<'src> for Header<'src> {
     fn span(&self) -> Span<'src> {
         self.source
     }
+}
+
+/// Extract the value of a `separator` attribute from a block attribute line
+/// (e.g. `[separator=::]`) appearing above the document title.
+///
+/// The `line` is expected to begin with `[` and end with `]`. Returns the
+/// `separator` value if the line is a well-formed block attribute list that
+/// contains one, and `None` otherwise (so the caller can fall through to its
+/// normal handling of the line).
+fn parse_separator_attribute(line: Span<'_>, parser: &Parser) -> Option<String> {
+    // Drop the enclosing square brackets now that the caller has confirmed they
+    // are present.
+    let inner = line.slice(1..line.len() - 1);
+
+    // Reject forms that are not block attribute lists, mirroring the checks used
+    // when parsing block metadata elsewhere: a leading space or tab, an empty
+    // list, or a `[[anchor]]` block anchor.
+    if inner.is_empty()
+        || inner.starts_with(' ')
+        || inner.starts_with('\t')
+        || (inner.starts_with('[') && inner.ends_with(']'))
+    {
+        return None;
+    }
+
+    let attrlist = Attrlist::parse(inner, parser, AttrlistContext::Block)
+        .item
+        .item;
+
+    attrlist
+        .named_attribute("separator")
+        .map(|attr| attr.value().to_string())
 }
 
 /// Partition a document title into its main title and optional subtitle.
@@ -775,5 +825,47 @@ mod tests {
 
         assert_eq!(doc.doctitle(), Some("Main Title: Subtitle"));
         assert_eq!(doc.subtitle(), Some("Subtitle"));
+    }
+
+    #[test]
+    fn separator_block_attribute_above_title() {
+        // A `[separator=::]` block attribute above the title changes the
+        // subtitle separator for that title.
+        let doc = Parser::default().parse("[separator=::]\n= Main Title:: Subtitle");
+        let header = doc.header();
+
+        assert_eq!(header.main_title(), Some("Main Title"));
+        assert_eq!(header.subtitle(), Some("Subtitle"));
+
+        // The custom separator replaces the default: a plain colon-space no
+        // longer partitions the title.
+        let doc = Parser::default().parse("[separator=::]\n= Main: Title:: Subtitle");
+        let header = doc.header();
+
+        assert_eq!(header.main_title(), Some("Main: Title"));
+        assert_eq!(header.subtitle(), Some("Subtitle"));
+    }
+
+    #[test]
+    fn separator_attribute_entry_overrides_block_attribute() {
+        // When both are present, the later assignment wins in document order.
+        // Here the `:title-separator:` entry follows the block attribute.
+        let doc = Parser::default()
+            .parse("[separator=::]\n= Main Title;; Subtitle\n:title-separator: ;;");
+        let header = doc.header();
+
+        assert_eq!(header.main_title(), Some("Main Title"));
+        assert_eq!(header.subtitle(), Some("Subtitle"));
+    }
+
+    #[test]
+    fn non_separator_block_attribute_terminates_header() {
+        // A block attribute line above the title that isn't a `separator`
+        // terminates the header without a title, preserving prior behavior.
+        let doc = Parser::default().parse("[foo=bar]\n= Not A Header Title");
+        let header = doc.header();
+
+        assert_eq!(header.title(), None);
+        assert_eq!(header.subtitle(), None);
     }
 }

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -3,7 +3,7 @@ use std::slice::Iter;
 use crate::{
     HasSpan, Parser, Span,
     content::{Content, SubstitutionGroup},
-    document::{Attribute, Author, AuthorLine, RevisionLine},
+    document::{Attribute, Author, AuthorLine, InterpretedValue, RevisionLine},
     internal::debug::DebugSliceReference,
     span::MatchedItem,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -16,6 +16,8 @@ use crate::{
 pub struct Header<'src> {
     title_source: Option<Span<'src>>,
     title: Option<String>,
+    main_title: Option<String>,
+    subtitle: Option<String>,
     attributes: Vec<Attribute<'src>>,
     author_line: Option<AuthorLine<'src>>,
     revision_line: Option<RevisionLine<'src>>,
@@ -107,11 +109,25 @@ impl<'src> Header<'src> {
         let after = source.discard_empty_lines();
         let source = original_source.trim_remainder(source);
 
+        // Partition the (fully substituted) document title into a main title and
+        // an optional subtitle. This happens after the header has been fully
+        // parsed so that a `title-separator` attribute takes effect even when it
+        // is defined below the document title line.
+        let (main_title, subtitle) = match &title {
+            Some(title) => {
+                let (main_title, subtitle) = partition_title(title, parser);
+                (Some(main_title), subtitle)
+            }
+            None => (None, None),
+        };
+
         MatchAndWarnings {
             item: MatchedItem {
                 item: Self {
                     title_source,
                     title,
+                    main_title,
+                    subtitle,
                     attributes,
                     author_line,
                     revision_line,
@@ -131,8 +147,38 @@ impl<'src> Header<'src> {
 
     /// Return the document's title, if there was one, having applied header
     /// substitutions.
+    ///
+    /// If the title contains a subtitle (see [`subtitle`]), this returns the
+    /// full, combined title. Use [`main_title`] to obtain only the portion
+    /// preceding the subtitle.
+    ///
+    /// [`subtitle`]: Self::subtitle
+    /// [`main_title`]: Self::main_title
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
+    }
+
+    /// Return the main portion of the document title, if there was a title.
+    ///
+    /// When the document title contains a subtitle separator (a colon followed
+    /// by a space, by default), the title is partitioned into a main title and
+    /// a [`subtitle`]. This returns the portion preceding the final separator.
+    /// When there is no subtitle, this is identical to [`title`].
+    ///
+    /// [`subtitle`]: Self::subtitle
+    /// [`title`]: Self::title
+    pub fn main_title(&self) -> Option<&str> {
+        self.main_title.as_deref()
+    }
+
+    /// Return the document's subtitle, if the title contained one.
+    ///
+    /// A subtitle is the text following the final subtitle separator in the
+    /// document title. The separator defaults to a colon followed by a space
+    /// (`:{sp}`) and can be overridden with the `title-separator` document
+    /// attribute. Returns `None` when the title has no subtitle.
+    pub fn subtitle(&self) -> Option<&str> {
+        self.subtitle.as_deref()
     }
 
     /// Return an iterator over the attributes in this header.
@@ -162,6 +208,31 @@ impl<'src> HasSpan<'src> for Header<'src> {
     }
 }
 
+/// Partition a document title into its main title and optional subtitle.
+///
+/// The separator is the value of the `title-separator` document attribute
+/// (defaulting to `:`) with a single space appended. The separator is searched
+/// for from the end of the title, so only the last occurrence partitions the
+/// title. When the separator is not present, the entire title is the main
+/// title and there is no subtitle.
+fn partition_title(title: &str, parser: &Parser) -> (String, Option<String>) {
+    let separator = match parser.attribute_value("title-separator") {
+        InterpretedValue::Value(value) if !value.is_empty() => value,
+        _ => ":".to_string(),
+    };
+
+    let separator = format!("{separator} ");
+
+    match title.rfind(&separator) {
+        Some(index) => {
+            let main_title = title[..index].to_string();
+            let subtitle = title[index + separator.len()..].to_string();
+            (main_title, Some(subtitle))
+        }
+        None => (title.to_string(), None),
+    }
+}
+
 fn apply_header_subs(source: &str, parser: &Parser) -> String {
     let span = Span::new(source);
 
@@ -176,6 +247,8 @@ impl std::fmt::Debug for Header<'_> {
         f.debug_struct("Header")
             .field("title_source", &self.title_source)
             .field("title", &self.title)
+            .field("main_title", &self.main_title)
+            .field("subtitle", &self.subtitle)
             .field("attributes", &DebugSliceReference(&self.attributes))
             .field("author_line", &self.author_line)
             .field("revision_line", &self.revision_line)
@@ -642,6 +715,10 @@ mod tests {
     title: Some(
         "Example Title",
     ),
+    main_title: Some(
+        "Example Title",
+    ),
+    subtitle: None,
     attributes: &[],
     author_line: None,
     revision_line: None,
@@ -654,5 +731,49 @@ mod tests {
     },
 }"#
         );
+    }
+
+    #[test]
+    fn no_subtitle() {
+        // A title without a colon-space sequence has no subtitle, and its main
+        // title equals its full title.
+        let doc = Parser::default().parse("= Just the Title");
+        let header = doc.header();
+
+        assert_eq!(header.title(), Some("Just the Title"));
+        assert_eq!(header.main_title(), Some("Just the Title"));
+        assert_eq!(header.subtitle(), None);
+    }
+
+    #[test]
+    fn no_title() {
+        // With no document title at all, every title accessor returns `None`.
+        let doc = Parser::default().parse(":foo: bar\n\nbody");
+        let header = doc.header();
+
+        assert_eq!(header.title(), None);
+        assert_eq!(header.main_title(), None);
+        assert_eq!(header.subtitle(), None);
+    }
+
+    #[test]
+    fn colon_without_space_is_not_a_separator() {
+        // The separator is a colon *followed by a space*; a bare colon does not
+        // partition the title.
+        let doc = Parser::default().parse("= Ratio 3:1 Explained");
+        let header = doc.header();
+
+        assert_eq!(header.main_title(), Some("Ratio 3:1 Explained"));
+        assert_eq!(header.subtitle(), None);
+    }
+
+    #[test]
+    fn subtitle_available_on_document() {
+        // The subtitle is reachable directly from `Document` as well as from its
+        // `Header`.
+        let doc = Parser::default().parse("= Main Title: Subtitle");
+
+        assert_eq!(doc.doctitle(), Some("Main Title: Subtitle"));
+        assert_eq!(doc.subtitle(), Some("Subtitle"));
     }
 }

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -868,4 +868,24 @@ mod tests {
         assert_eq!(header.title(), None);
         assert_eq!(header.subtitle(), None);
     }
+
+    #[test]
+    fn bracketed_line_that_is_not_a_separator_attribute_list() {
+        // A `[...]` line above the title that isn't a well-formed block
+        // attribute list carrying `separator` is not consumed as a separator. A
+        // block anchor (`[[...]]`) and a leading-space form are both rejected,
+        // so the line terminates the header exactly as any other unrecognized
+        // line would.
+        let doc = Parser::default().parse("[[anchor]]\n= Some Title: Subtitle");
+        let header = doc.header();
+
+        assert_eq!(header.title(), None);
+        assert_eq!(header.subtitle(), None);
+
+        let doc = Parser::default().parse("[ separator=::]\n= Main Title:: Subtitle");
+        let header = doc.header();
+
+        assert_eq!(header.title(), None);
+        assert_eq!(header.subtitle(), None);
+    }
 }

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -85,8 +85,10 @@ impl<'src> Header<'src> {
                 && line.starts_with('[')
                 && line.ends_with(']')
                 && line_mi.after.take_normalized_line().item.starts_with("= ")
-                && let Some(separator) = parse_separator_attribute(line, parser)
+                && let Some((separator, separator_warnings)) =
+                    parse_separator_attribute(line, parser)
             {
+                warnings.extend(separator_warnings);
                 // A `separator` block attribute directly above the document title
                 // sets the subtitle separator. It behaves exactly like assigning
                 // the `title-separator` document attribute at this point in the
@@ -230,10 +232,16 @@ impl<'src> HasSpan<'src> for Header<'src> {
 /// (e.g. `[separator=::]`) appearing above the document title.
 ///
 /// The `line` is expected to begin with `[` and end with `]`. Returns the
-/// `separator` value if the line is a well-formed block attribute list that
-/// contains one, and `None` otherwise (so the caller can fall through to its
-/// normal handling of the line).
-fn parse_separator_attribute(line: Span<'_>, parser: &Parser) -> Option<String> {
+/// `separator` value together with any warnings raised while parsing the
+/// attribute list if the line is a well-formed block attribute list that
+/// contains a `separator`, and `None` otherwise (so the caller can fall through
+/// to its normal handling of the line). The warnings are only surfaced when the
+/// line is actually consumed as a separator; otherwise the line is left for the
+/// block parser, which reports them on its own path.
+fn parse_separator_attribute<'src>(
+    line: Span<'src>,
+    parser: &Parser,
+) -> Option<(String, Vec<Warning<'src>>)> {
     // Drop the enclosing square brackets now that the caller has confirmed they
     // are present.
     let inner = line.slice(1..line.len() - 1);
@@ -249,13 +257,19 @@ fn parse_separator_attribute(line: Span<'_>, parser: &Parser) -> Option<String> 
         return None;
     }
 
-    let attrlist = Attrlist::parse(inner, parser, AttrlistContext::Block)
-        .item
-        .item;
+    let MatchAndWarnings {
+        item: MatchedItem {
+            item: attrlist,
+            after: _,
+        },
+        warnings,
+    } = Attrlist::parse(inner, parser, AttrlistContext::Block);
 
-    attrlist
+    let separator = attrlist
         .named_attribute("separator")
-        .map(|attr| attr.value().to_string())
+        .map(|attr| attr.value().to_string())?;
+
+    Some((separator, warnings))
 }
 
 /// Partition a document title into its main title and optional subtitle.
@@ -266,9 +280,16 @@ fn parse_separator_attribute(line: Span<'_>, parser: &Parser) -> Option<String> 
 /// title. When the separator is not present, the entire title is the main
 /// title and there is no subtitle.
 fn partition_title(title: &str, parser: &Parser) -> (String, Option<String>) {
-    let separator = match parser.attribute_value("title-separator") {
-        InterpretedValue::Value(value) if !value.is_empty() => value,
-        _ => ":".to_string(),
+    // Read the configured `title-separator` document attribute directly. Unlike
+    // `Parser::attribute_value`, this bypasses the counter overlay: the title
+    // separator is a configuration attribute, never a counter, and Asciidoctor
+    // likewise resolves it with a plain attribute lookup.
+    let separator = match parser.effective_attribute("title-separator") {
+        Some(av) => match &av.value {
+            InterpretedValue::Value(value) if !value.is_empty() => value.clone(),
+            _ => ":".to_string(),
+        },
+        None => ":".to_string(),
     };
 
     let separator = format!("{separator} ");
@@ -887,5 +908,30 @@ mod tests {
 
         assert_eq!(header.title(), None);
         assert_eq!(header.subtitle(), None);
+    }
+
+    #[test]
+    fn empty_title_separator_falls_back_to_default() {
+        // An explicitly empty `title-separator` falls back to the default
+        // `:{sp}` separator rather than partitioning on an empty string.
+        let doc = Parser::default().parse("= Main Title: Subtitle\n:title-separator:");
+        let header = doc.header();
+
+        assert_eq!(header.main_title(), Some("Main Title"));
+        assert_eq!(header.subtitle(), Some("Subtitle"));
+    }
+
+    #[test]
+    fn counter_does_not_shadow_title_separator() {
+        // A counter that happens to be named `title-separator` must not be
+        // mistaken for the configured separator: partitioning reads the document
+        // attribute directly, ignoring the counter overlay. Here the title
+        // creates such a counter, but the default `:{sp}` separator still
+        // applies.
+        let doc = Parser::default().parse("= Main Title: Subtitle {counter:title-separator}");
+        let header = doc.header();
+
+        assert_eq!(header.main_title(), Some("Main Title"));
+        assert_eq!(header.subtitle(), Some("Subtitle 1"));
     }
 }

--- a/parser/src/tests/asciidoc_lang/document/subtitle.rs
+++ b/parser/src/tests/asciidoc_lang/document/subtitle.rs
@@ -2,11 +2,6 @@ use crate::tests::prelude::*;
 
 track_file!("ref/asciidoc-lang/docs/modules/document/pages/subtitle.adoc");
 
-// TO DO: Consider adding support for subtitle parsing?
-// (https://github.com/asciidoc-rs/asciidoc-parser/issues/382)
-
-// Possible this will never be supported in this crate, so treating this page as
-// non-normative.
 non_normative!(
     r#"
 = Subtitle
@@ -18,8 +13,23 @@ NOTE: The HTML 5 converter does not currently split the subtitle out from the do
 The document title is only partitioned into a main and subtitle in the output of the DocBook, EPUB 3, and PDF converters.
 However, the subtitle is still available via the API, so you could add support for it by extending the HTML 5 converter.
 
+"#
+);
+
+mod subtitle_syntax {
+    use crate::tests::prelude::*;
+
+    non_normative!(
+        r#"
 == Subtitle syntax
 
+"#
+    );
+
+    #[test]
+    fn title_and_subtitle() {
+        verifies!(
+            r#"
 When the document title contains a colon followed by a space (i.e, `:{sp}`), the text after the final colon-space sequence is treated as a subtitle.
 
 .A document title and subtitle
@@ -28,6 +38,22 @@ When the document title contains a colon followed by a space (i.e, `:{sp}`), the
 = Main Title: Subtitle
 ----
 
+"#
+        );
+
+        let doc = Parser::default().parse("= Main Title: Subtitle");
+        let header = doc.header();
+
+        // `title` remains the full, combined title for backward compatibility.
+        assert_eq!(header.title(), Some("Main Title: Subtitle"));
+        assert_eq!(header.main_title(), Some("Main Title"));
+        assert_eq!(header.subtitle(), Some("Subtitle"));
+    }
+
+    #[test]
+    fn separator_searched_from_end() {
+        verifies!(
+            r#"
 The separator is searched for from the end of the text.
 Therefore, only the last occurrence of the separator (i.e, `:{sp}`) is used for partitioning the title.
 
@@ -37,8 +63,37 @@ Therefore, only the last occurrence of the separator (i.e, `:{sp}`) is used for 
 = Main Title: Main Title Continued: Subtitle
 ----
 
+"#
+        );
+
+        let doc = Parser::default().parse("= Main Title: Main Title Continued: Subtitle");
+        let header = doc.header();
+
+        assert_eq!(
+            header.main_title(),
+            Some("Main Title: Main Title Continued")
+        );
+        assert_eq!(header.subtitle(), Some("Subtitle"));
+    }
+
+    mod modify_the_title_separator {
+        use crate::tests::prelude::*;
+
+        non_normative!(
+            r#"
 === Modify the title separator
 
+"#
+        );
+
+        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/382):
+        // The `separator` block attribute placed above the document title is not
+        // yet supported. Block attribute lines in the document header are not
+        // currently parsed, so the default separator is used for the example
+        // below. The `title-separator` document attribute (verified further
+        // down) provides the same capability.
+        to_do_verifies!(
+            r#"
 You can change the title separator by specifying the `separator` block attribute explicitly above the document title.
 A space will automatically be appended to the separator value.
 
@@ -49,6 +104,13 @@ A space will automatically be appended to the separator value.
 = Main Title:: Subtitle
 ----
 
+"#
+        );
+
+        #[test]
+        fn title_separator_attribute() {
+            verifies!(
+                r#"
 You can also assign a separator using a document attribute `title-separator` in the header.
 
 .Assign title-separator to the document title
@@ -58,12 +120,38 @@ You can also assign a separator using a document attribute `title-separator` in 
 :title-separator: ::
 ----
 
+"#
+            );
+
+            // The `title-separator` attribute applies even though it is defined
+            // below the document title line, because the title is partitioned
+            // after the entire header has been parsed.
+            let doc = Parser::default().parse("= Main Title:: Subtitle\n:title-separator: ::");
+            let header = doc.header();
+
+            assert_eq!(header.main_title(), Some("Main Title"));
+            assert_eq!(header.subtitle(), Some("Subtitle"));
+        }
+
+        non_normative!(
+            r#"
 `title-separator` can also be assigned via the CLI.
 
 ....
 $ asciidoctor -a title-separator=:: document.adoc
 ....
 
+"#
+        );
+    }
+}
+
+// This crate always partitions the document title and exposes the result via
+// `Header::main_title` and `Header::subtitle` (and `Document::subtitle`). The
+// Ruby `doctitle partition:` API described below is therefore non-normative for
+// this crate.
+non_normative!(
+    r#"
 == Partition the title using the API
 
 You can partition the title from the API when calling the `doctitle` method on Document:

--- a/parser/src/tests/asciidoc_lang/document/subtitle.rs
+++ b/parser/src/tests/asciidoc_lang/document/subtitle.rs
@@ -86,14 +86,10 @@ Therefore, only the last occurrence of the separator (i.e, `:{sp}`) is used for 
 "#
         );
 
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/382):
-        // The `separator` block attribute placed above the document title is not
-        // yet supported. Block attribute lines in the document header are not
-        // currently parsed, so the default separator is used for the example
-        // below. The `title-separator` document attribute (verified further
-        // down) provides the same capability.
-        to_do_verifies!(
-            r#"
+        #[test]
+        fn separator_block_attribute() {
+            verifies!(
+                r#"
 You can change the title separator by specifying the `separator` block attribute explicitly above the document title.
 A space will automatically be appended to the separator value.
 
@@ -105,7 +101,14 @@ A space will automatically be appended to the separator value.
 ----
 
 "#
-        );
+            );
+
+            let doc = Parser::default().parse("[separator=::]\n= Main Title:: Subtitle");
+            let header = doc.header();
+
+            assert_eq!(header.main_title(), Some("Main Title"));
+            assert_eq!(header.subtitle(), Some("Subtitle"));
+        }
 
         #[test]
         fn title_separator_attribute() {


### PR DESCRIPTION
## Summary

Implements access to the **document subtitle** requested in #382, including both mechanisms the AsciiDoc spec defines for customizing the separator.

AsciiDoc treats the text after the final subtitle separator in a document title as a *subtitle*. The separator defaults to a colon followed by a space (`:{sp}`) and can be overridden. This PR partitions the (fully substituted) document title and exposes both parts:

| Accessor | Returns |
| --- | --- |
| `Header::title()` / `Document::doctitle()` | the full, combined title (**unchanged**) |
| `Header::main_title()` | the portion before the subtitle (equals the full title when there is no subtitle) |
| `Header::subtitle()` | the subtitle, or `None` |
| `Document::subtitle()` | convenience mirror of `Header::subtitle()` |

```
= Main Title: Subtitle
```
→ `title() == "Main Title: Subtitle"`, `main_title() == "Main Title"`, `subtitle() == "Subtitle"`.

### Customizing the separator

Both spec-defined mechanisms are supported:

```
:title-separator: ::
```
```
[separator=::]
= Main Title:: Subtitle
```

A `[separator=…]` block attribute directly above the title is treated as an assignment of the `title-separator` document attribute at that point in the header — so both mechanisms share one partitioning path and, when both are present, follow **document order** (last assignment wins).

### Design notes

- **Partition happens after the header is fully parsed**, reading the final value of `title-separator`. This matches Asciidoctor's lazy `doctitle partition:` behavior and correctly handles `title-separator` (or the block attribute) defined relative to the title line.
- The separator is searched from the **end** of the title, so only the last occurrence partitions it.
- A custom separator value has a single space appended, mirroring Asciidoctor (default value `:` → effective separator `": "`).
- A bare colon without a trailing space (e.g. `Ratio 3:1`) does **not** partition the title.
- The `[separator=…]` line is only intercepted when a document title immediately follows; otherwise it is left for the block parser, so a body block's `separator` attribute (e.g. a CSV table) is unaffected.
- `title()` is left untouched for backward compatibility; the new fields are purely additive.

## SDD coverage

`ref/asciidoc-lang/docs/modules/document/pages/subtitle.adoc` was previously marked **wholly non-normative** with a note that subtitle support might never be implemented. This PR resolves that gap — every normative rule on the page is now backed by a `verifies!` test:

- **Subtitle syntax** (colon-space, last-separator-wins).
- The **`title-separator`** document attribute.
- The **`separator` block attribute** above the title.
- The Ruby-specific `doctitle partition:` API section stays non-normative (this crate always partitions and exposes the result through its own API).

## Tests

- Spec tests in `document/subtitle.rs` for title/subtitle, last-separator-wins, `title-separator`, and the `separator` block attribute.
- Unit tests in `header.rs`: no-subtitle, no-title, bare-colon, `Document`-level access, block-attribute partitioning, block-vs-attribute precedence, and confirmation that a non-`separator` block attribute above the title still terminates the header (unchanged behavior).
- Full suite green (`cargo test -p asciidoc-parser`: 3082 passing); `cargo clippy --all-targets` and `cargo doc -D warnings` clean.

## Commits

1. Parse and expose the subtitle; support `title-separator`; resolve the SDD gap.
2. Support the `[separator=…]` block attribute above the title.

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)