### PR TITLE
chore: Remove stale section source blank-line TO DO (#655)

### DIFF
--- a/parser/src/blocks/tests/mod.rs
+++ b/parser/src/blocks/tests/mod.rs
@@ -366,7 +366,6 @@ mod error_cases {
                     },),
                 ],
                 source: Span {
-                    // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/655): Fix bug that includes blank lines.
                     data: "=== Section Title\n\nabc\n\n.ancestor section== Section 2\n\ndef",
                     line: 1,
                     col: 1,


### PR DESCRIPTION
## Summary

Resolves #655. After tracing the code and comparing against Asciidoctor 2.0.26, the section `source` span flagged by the `TO DO` at `parser/src/blocks/tests/mod.rs` is **already correct** — there is no blank-line trim bug to fix. This PR just removes the stale comment.

## Why the span is correct

- **Trailing whitespace is already trimmed.** `SectionBlock::parse` applies `source.trim_trailing_whitespace()` (added in #228, *after* this TO DO was written in #158). Probing many inputs at both the `SectionBlock::parse` and full-`Document` level, no leading/trailing blank lines leak into any section span.
- **Asciidoctor agrees on the extent.** For the test input, the `sect2` section spans the heading through the final `def` paragraph, so `"=== Section Title\n\nabc\n\n.ancestor section== Section 2\n\ndef"` is the correct extent.
- **Interior separators can't be stripped.** The `\n\n` between the section's child blocks (`abc`, the middle paragraph, `def`) are inherent to a contiguous compound-block source. The TO DO's premise — that they should be trimmed — isn't achievable while `def` is a child of the section.

## Follow-up

A genuine divergence surfaced during this investigation (tracked in #664, **not** addressed here): a block title separated from its block by a blank line (`.ancestor section== Section 2` then a blank line then `def`) is not attached to `def`. This crate demotes the title line to a paragraph and emits a `MissingBlockAfterTitleOrAttributeList` warning (3 blocks), whereas Asciidoctor attaches the title to `def` (2 blocks, no warning). This does not affect the section source span.

## Testing

- `cargo test -p asciidoc-parser blocks::` — 718 passed, 0 failed.
- `missing_block_after_title_line` still passes (the asserted value is unchanged; only the comment was removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
