### PR TITLE
chore: Verify section numbering on/off for sectnums unset in body (#328)

### DIFF
--- a/parser/src/tests/asciidoc_lang/attributes/unset_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/unset_attributes.rs
@@ -127,10 +127,9 @@ mod unset_in_body {
 "#
     );
 
-    #[ignore]
     #[test]
     fn sectnums_example() {
-        to_do_verifies!(
+        verifies!(
             r#"
 == Unset a document attribute in the body
 
@@ -164,14 +163,46 @@ All of the sections below where the attribute is unset will not be numbered.
 
         let mut parser = Parser::default();
 
-        parser.parse("= Title\n:sectnums:\n\n== Section Title\n\nsectnums = {sectnums}\n\n:!sectnums:\n\nsectnums = {sectnums}\n\n== Section Title\n\n=== Section Title\n\n:sectnums:\n\n== Section Title\n\nsectnums = {sectnums}");
+        let document = parser.parse("= Title\n:sectnums:\n\n== Section Title\n\nsectnums = {sectnums}\n\n:!sectnums:\n\nsectnums = {sectnums}\n\n== Section Title\n\n=== Section Title\n\n:sectnums:\n\n== Section Title\n\nsectnums = {sectnums}");
 
         assert_eq!(
             parser.attribute_value("sectnums"),
             InterpretedValue::Value("all".to_owned())
         );
 
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/328):
-        // Differentiate between numbers on and numbers off when we can.
+        // The sections before `sectnums` is unset are numbered; the sections
+        // where it is unset are not; and numbering resumes once it is reset.
+        let mut top_sections = document.nested_blocks().filter_map(|block| {
+            if let crate::blocks::Block::Section(section) = block {
+                Some(section)
+            } else {
+                None
+            }
+        });
+
+        // First section: `sectnums` is active, so it is numbered.
+        let first = top_sections.next().unwrap();
+        assert_eq!(first.section_number().unwrap().to_string(), "1");
+
+        // Second section: `sectnums` was unset in the first section's body, so
+        // neither it nor its nested subsection is numbered.
+        let second = top_sections.next().unwrap();
+        assert!(second.section_number().is_none());
+
+        let nested = second
+            .nested_blocks()
+            .find_map(|block| {
+                if let crate::blocks::Block::Section(section) = block {
+                    Some(section)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+        assert!(nested.section_number().is_none());
+
+        // Third section: `sectnums` was reset, so numbering resumes.
+        let third = top_sections.next().unwrap();
+        assert_eq!(third.section_number().unwrap().to_string(), "2");
     }
 }


### PR DESCRIPTION
## Summary

Issue #328 ("Implement section numbering") is resolved — section numbering is fully implemented in `parser/src/blocks/section.rs`. This PR clears the one lingering `TO DO (#328)` comment, which was in the `sectnums_example` test.

Rather than just deleting the stale comment, this does what it asked ("Differentiate between numbers on and numbers off when we can"): now that numbering exists, the test verifies the behavior directly.

## Changes

In `parser/src/tests/asciidoc_lang/attributes/unset_attributes.rs`:

- Removed the `#[ignore]` and the `TO DO (#328)` comment.
- Promoted `to_do_verifies!` → `verifies!` (the normative spec text is now actually verified).
- Added assertions matching the spec's described behavior: the first section is numbered `1`; the section (and its nested subsection) where `sectnums` is unset are unnumbered; numbering resumes at `2` after `sectnums` is reset.

## Verification

- `sectnums_example` passes (no longer ignored).
- The existing `section_numbering` tests still pass.
- `cargo clippy --lib` is clean.
- No `#328` references remain in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)