### PR TITLE
chore: Re-point prevent.rs TO DO from #316 to #667

### DIFF
--- a/parser/src/tests/asciidoc_lang/subs/prevent.rs
+++ b/parser/src/tests/asciidoc_lang/subs/prevent.rs
@@ -24,9 +24,9 @@ mod escape_with_backslashes {
     #[ignore]
     #[test]
     fn punctuation() {
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/316):
-        // Some of the macros described here are not yet implemented, so this test can't
-        // work properly.
+        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/667):
+        // Backslash-escaping of attribute references (`\{id}`) and special characters
+        // (`\&sect;`) isn't implemented yet, so this test can't work properly.
         to_do_verifies!(
             r#"
 To prevent a punctuation character from being interpreted as an attribute reference or formatting syntax (e.g., `+_+`, `+^+`) in normal content, prepend the character with a backslash (`\`).


### PR DESCRIPTION
The lone `TO DO` comment referencing #316 (on the `#[ignore]`d `punctuation()` test in `parser/src/tests/asciidoc_lang/subs/prevent.rs`) was stale and misattributed.

## What changed

- The `http`/`link` macros tracked by #316 **are** now implemented (`link:` macros via #330, plus URL autolinks). The autolink assertion inside that test already passes.
- But the test stays `#[ignore]`d for an **unrelated** reason: backslash-escaping of attribute references (`\{id}`) and special characters (`\&sect;`) isn't implemented yet. The old comment wrongly blamed unimplemented macros and pointed at the wrong tracking issue.
- Filed #667 to track the actual blocker (accurately scoped, following the sibling-test pattern of #305/#307/#308) and re-pointed the comment to it.

No behavior change — comment/tracking hygiene only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)