### PR TITLE
chore: Enable nested-cell unterminated-block cursor test (#542)

### DIFF
--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1676,13 +1676,12 @@ mod psv {
 
         assert_xpath(&doc, "//ul//table", 1);
 
+        // Exactly one warning is expected: the unterminated example block,
+        // attributed to line 9 (where `====` opens inside the cell).
         let warnings: Vec<_> = doc.warnings().collect();
-        assert!(
-            warnings
-                .iter()
-                .any(|w| w.warning == WarningType::UnterminatedDelimitedBlock
-                    && w.source.line() == 9)
-        );
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].warning, WarningType::UnterminatedDelimitedBlock);
+        assert_eq!(warnings[0].source.line(), 9);
     }
 
     #[test]

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -1664,12 +1664,10 @@ mod psv {
     }
 
     #[test]
-    #[ignore]
-    // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/542): an
-    // unterminated example block inside an AsciiDoc table cell that is itself
+    // An unterminated example block inside an AsciiDoc table cell that is itself
     // attached to a list item — Asciidoctor reports the warning at the inner
-    // block's line (9). Enable once the cursor/line of nested-cell warnings is
-    // tracked (same nested-cell source-map work as #542).
+    // block's line (9). The cursor/line of nested-cell warnings is tracked via
+    // the nested-cell source-map work landed for #542.
     fn should_show_correct_line_number_in_warning_about_unterminated_block_inside_asciidoc_table_cell()
      {
         let doc = Parser::default().parse(


### PR DESCRIPTION
## Summary

Closes the remaining work tracked in #542.

The two behaviors #542 asked for — mapping a nested AsciiDoc-table-cell's error/warning cursor back to its originating `(file, line)` — are already implemented:

- The unresolved-`include::`-in-a-cell cursor test landed via #639 and #641/#651 (already un-ignored and passing).
- That same nested-cell source-map machinery also fixes the companion case: an **unterminated example block inside an AsciiDoc table cell attached to a list item**, whose warning must be reported at the inner block's originating line.

The only outstanding item was the `#[ignore]`d regression test for that second case. It now passes and is not vacuous: the document produces exactly one `UnterminatedDelimitedBlock` warning at line 9, matching Asciidoctor.

## Change

Test-only: remove `#[ignore]` from `should_show_correct_line_number_in_warning_about_unterminated_block_inside_asciidoc_table_cell` and refresh its stale TODO comment.

## Verification

- Targeted test passes (previously `--ignored`).
- Full `tables_test` module: 117 passed, 0 ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)