### PR TITLE
chore: Clarify multi-line attribute soft-wrap folding is spec-correct (#658)

### DIFF
--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -2111,11 +2111,11 @@ mod tests {
     fn attribute_substitution_with_multiline_attribute() {
         let source = ":longpath: very/long/path/to/some/ \\\nsubdirectory\n:ext: adoc\n\ninclude::{longpath}/file.{ext}[]";
 
-        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/658): This should be
-        // "very/long/path/to/some/subdirectory/file.adoc" (without space) but the
-        // current Attribute::parse() incorrectly preserves the space before the
-        // backslash in multi-line attribute continuation. This is a bug that
-        // should be fixed.
+        // A soft-wrap line continuation folds the ` \` marker, the newline, and any
+        // ensuing indentation into a single space (see the `wrap_values` spec test).
+        // So `{longpath}` correctly resolves to "very/long/path/to/some/ subdirectory"
+        // *with* the space, matching Asciidoctor. The space is inherent to soft
+        // wrapping, not a stray artifact.
         let handler = InlineFileHandler::from_pairs([(
             "very/long/path/to/some/ subdirectory/file.adoc",
             "Multi-line attribute worked!",

--- a/parser/src/span/line.rs
+++ b/parser/src/span/line.rs
@@ -118,6 +118,11 @@ impl<'src> Span<'src> {
 
     fn one_line_with_continuation(self) -> Option<MatchedItem<'src, Self>> {
         let line = self.take_normalized_line();
+
+        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/666): The spec
+        // requires a *space* before the backslash for a soft-wrap line continuation.
+        // This accepts a bare trailing `\`, so `foo\` (no space) is wrongly folded
+        // instead of being kept literal (Asciidoctor keeps it literal).
         if line.item.ends_with('\\') {
             Some(line)
         } else {


### PR DESCRIPTION
## What

Resolves the confusion in #658 and flags a related, genuine bug (#666).

### #658 — not a bug; the space is spec-correct
The `attribute_substitution_with_multiline_attribute` test carried a TODO claiming that preserving the space before a line-continuation backslash was buggy. Verified against the vendored AsciiDoc spec and real Asciidoctor 2.x:

| Input | Asciidoctor | this parser |
|---|---|---|
| `some/ \` (space + backslash) | `very/long/path/to/some/ subdirectory` (**with** space) | same ✅ |

Per the soft-wrap spec (`wrap_values`), a line continuation is *a space followed by a backslash*, and the marker + newline + indentation fold into **a single space**. So the current output is correct; only the comment was wrong. This PR replaces the misleading TODO with an accurate note.

### #666 — genuine (opposite) divergence, flagged only
While confirming the above, I found that `one_line_with_continuation` accepts **any** bare trailing `\` as a continuation, but the spec/Asciidoctor require a preceding space. So `some/\` (no space) is wrongly folded here instead of kept literal. This PR does **not** fix that — it adds a `TODO` referencing the new tracking issue #666.

## Scope
Comments only — no value/parsing semantics change. Existing tests pass.

## Follow-ups
- Close #658 as works-as-designed.
- #666 tracks the bare-backslash fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
