### PR TITLE
chore: Port admonition tests from the paragraphs port_from_ruby stub (#456)

### DIFF
--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -2445,6 +2445,62 @@ mod special {
         assert_output_contains(&doc, "The backend is html5.");
         assert_output_contains(&doc, "Last line of sidebar.");
     }
+
+    // Asciidoctor's `ADMONITION_STYLES`: the five built-in admonition labels.
+    const ADMONITION_STYLES: [&str; 5] = ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"];
+
+    // Ported from Ruby Asciidoctor's paragraphs_test.rb ('note multiline
+    // syntax'). A styled paragraph whose style is an admonition label renders as
+    // an admonition block.
+    #[test]
+    fn note_multiline_syntax() {
+        for style in ADMONITION_STYLES {
+            let doc = Parser::default().parse(&format!("[{style}]\nThis is a winner."));
+            assert_xpath(
+                &doc,
+                &format!(
+                    "//div[@class = \"admonitionblock {}\"]",
+                    style.to_lowercase()
+                ),
+                1,
+            );
+        }
+    }
+
+    // Ported from Ruby Asciidoctor's paragraphs_test.rb ('note block syntax').
+    // An example-delimited block carrying an admonition style renders as an
+    // admonition block.
+    #[test]
+    fn note_block_syntax() {
+        for style in ADMONITION_STYLES {
+            let doc = Parser::default().parse(&format!("[{style}]\n====\nThis is a winner.\n===="));
+            assert_xpath(
+                &doc,
+                &format!(
+                    "//div[@class = \"admonitionblock {}\"]",
+                    style.to_lowercase()
+                ),
+                1,
+            );
+        }
+    }
+
+    // Ported from Ruby Asciidoctor's paragraphs_test.rb ('note inline syntax').
+    // The inline label form (e.g. `NOTE: ...`) renders as an admonition block.
+    #[test]
+    fn note_inline_syntax() {
+        for style in ADMONITION_STYLES {
+            let doc = Parser::default().parse(&format!("{style}: This is important, fool!"));
+            assert_xpath(
+                &doc,
+                &format!(
+                    "//div[@class = \"admonitionblock {}\"]",
+                    style.to_lowercase()
+                ),
+                1,
+            );
+        }
+    }
 }
 
 #[ignore]
@@ -2454,23 +2510,9 @@ fn port_from_ruby() {
         "Port this: {}",
         r###"
   context 'special' do
-    test 'note multiline syntax' do
-      Asciidoctor::ADMONITION_STYLES.each do |style|
-        assert_xpath %(//div[@class='admonitionblock #{style.downcase}']), convert_string(%([#{style}]\nThis is a winner.))
-      end
-    end
-
-    test 'note block syntax' do
-      Asciidoctor::ADMONITION_STYLES.each do |style|
-        assert_xpath %(//div[@class='admonitionblock #{style.downcase}']), convert_string(%([#{style}]\n====\nThis is a winner.\n====))
-      end
-    end
-
-    test 'note inline syntax' do
-      Asciidoctor::ADMONITION_STYLES.each do |style|
-        assert_xpath %(//div[@class='admonitionblock #{style.downcase}']), convert_string(%(#{style}: This is important, fool!))
-      end
-    end
+    # NOTE: 'note multiline syntax', 'note block syntax', and 'note inline
+    # syntax' have been ported to `mod special` now that admonitions are
+    # implemented.
 
     # NOTE: 'should process preprocessor conditional in paragraph content' has
     # been ported to `mod special` below now that conditional preprocessor

--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -2464,6 +2464,7 @@ mod special {
                 ),
                 1,
             );
+            assert_rendered_contains(&doc, "This is a winner.");
         }
     }
 
@@ -2482,6 +2483,7 @@ mod special {
                 ),
                 1,
             );
+            assert_rendered_contains(&doc, "This is a winner.");
         }
     }
 
@@ -2499,6 +2501,7 @@ mod special {
                 ),
                 1,
             );
+            assert_rendered_contains(&doc, "This is important, fool!");
         }
     }
 }


### PR DESCRIPTION
Resolves the admonition portion of issue #456. Admonition parsing is already implemented; the reopening audit flagged that the `#[ignore]`d `port_from_ruby` stub in `paragraphs_test.rs` still held the unported Ruby admonition tests.

## Changes

- Ported the three Ruby admonition tests — `note multiline syntax`, `note block syntax`, `note inline syntax` — into `mod special` (Asciidoctor's `context 'special'`) as executable tests. Each drives `Parser` + `assert_xpath` over all five `ADMONITION_STYLES` (NOTE/TIP/IMPORTANT/WARNING/CAUTION) for the multiline (`[NOTE]`), block (`[NOTE]\n====`), and inline (`NOTE:`) forms.
- Removed them from the `port_from_ruby` stub, leaving a breadcrumb matching the adjacent preprocessor-conditional note.

This follows the established pattern in this file, where `mod quote` and `mod special` were extracted from the same stub as their features landed.

The remaining stub content (DocBook styled paragraphs, inline doctype, custom paragraph styles) is unrelated to #456 and stays.

## Verification

- The 3 new tests pass; full `paragraphs_test` module green (34 passed, 1 ignored — the remaining stub).
- `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)