### PR TITLE
fix: Expand mid-list subs group name in place and de-duplicate

### DIFF
--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -97,23 +97,27 @@ impl SubstitutionGroup {
         for (count, mut step) in custom.split(",").enumerate() {
             step = step.trim();
 
+            // A group name (`normal`/`verbatim`) is expanded *in place*: its
+            // constituent steps are appended to the running list rather than
+            // replacing it. This matches Asciidoctor's `resolve_subs`, where a
+            // group name mid-list contributes its steps like any other token.
             if step == "n" || step == "normal" {
-                steps = vec![
+                steps.extend([
                     SubstitutionStep::SpecialCharacters,
                     SubstitutionStep::Quotes,
                     SubstitutionStep::AttributeReferences,
                     SubstitutionStep::CharacterReplacements,
                     SubstitutionStep::Macros,
                     SubstitutionStep::PostReplacement,
-                ];
+                ]);
                 continue;
             }
 
             if step == "v" || step == "verbatim" {
-                steps = vec![
+                steps.extend([
                     SubstitutionStep::SpecialCharacters,
                     SubstitutionStep::Callouts,
-                ];
+                ]);
                 continue;
             }
 
@@ -169,7 +173,18 @@ impl SubstitutionGroup {
             }
         }
 
-        Some(Self::Custom(steps))
+        // De-duplicate the final list, first occurrence winning. Asciidoctor
+        // ensures each substitution runs at most once, so a step contributed by
+        // more than one token (e.g. the `quotes` in `quotes,normal`) is kept
+        // only in its earliest position.
+        let mut deduped: Vec<SubstitutionStep> = Vec::with_capacity(steps.len());
+        for step in steps {
+            if !deduped.contains(&step) {
+                deduped.push(step);
+            }
+        }
+
+        Some(Self::Custom(deduped))
     }
 
     pub(crate) fn apply(
@@ -505,6 +520,9 @@ mod tests {
 
         #[test]
         fn addition() {
+            // `n` expands to normal's steps (which already include
+            // replacements); the trailing `r` is de-duplicated away, matching
+            // Asciidoctor.
             assert_eq!(
                 SubstitutionGroup::from_custom_string(None, "n,r"),
                 Some(SubstitutionGroup::Custom(vec![
@@ -514,7 +532,6 @@ mod tests {
                     SubstitutionStep::CharacterReplacements,
                     SubstitutionStep::Macros,
                     SubstitutionStep::PostReplacement,
-                    SubstitutionStep::CharacterReplacements,
                 ]))
             );
 
@@ -530,6 +547,9 @@ mod tests {
 
         #[test]
         fn incremental() {
+            // `n` expands to normal's steps (which already include
+            // replacements); the trailing `r` is de-duplicated away, matching
+            // Asciidoctor.
             assert_eq!(
                 SubstitutionGroup::from_custom_string(None, "n,r"),
                 Some(SubstitutionGroup::Custom(vec![
@@ -539,7 +559,6 @@ mod tests {
                     SubstitutionStep::CharacterReplacements,
                     SubstitutionStep::Macros,
                     SubstitutionStep::PostReplacement,
-                    SubstitutionStep::CharacterReplacements,
                 ]))
             );
 
@@ -549,6 +568,36 @@ mod tests {
                     SubstitutionStep::SpecialCharacters,
                     SubstitutionStep::Callouts,
                     SubstitutionStep::Macros,
+                ]))
+            );
+        }
+
+        #[test]
+        fn group_name_mid_list_expands_in_place_and_dedups() {
+            // A group name (`normal`) appearing mid-list is expanded in place
+            // and appended to what came before, rather than resetting the
+            // accumulated steps. The leading `quotes` is preserved, and the
+            // redundant `quotes` from `normal`'s expansion is de-duplicated
+            // away, matching Asciidoctor's `resolve_subs`.
+            assert_eq!(
+                SubstitutionGroup::from_custom_string(None, "quotes,normal"),
+                Some(SubstitutionGroup::Custom(vec![
+                    SubstitutionStep::Quotes,
+                    SubstitutionStep::SpecialCharacters,
+                    SubstitutionStep::AttributeReferences,
+                    SubstitutionStep::CharacterReplacements,
+                    SubstitutionStep::Macros,
+                    SubstitutionStep::PostReplacement,
+                ]))
+            );
+
+            // Same behavior for the shorthand `v` group name mid-list.
+            assert_eq!(
+                SubstitutionGroup::from_custom_string(None, "m,v"),
+                Some(SubstitutionGroup::Custom(vec![
+                    SubstitutionStep::Macros,
+                    SubstitutionStep::SpecialCharacters,
+                    SubstitutionStep::Callouts,
                 ]))
             );
         }

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -7104,16 +7104,12 @@ mod post_replacements {
 //
 // * "should resolve subs for block" (`subs = 'quotes,normal'`) — the closest
 //   analogue is `SubstitutionGroup::from_custom_string(None, "quotes,normal")`.
-//   The two implementations diverge here: Asciidoctor expands `normal` in place
-//   and de-duplicates, yielding `[quotes, specialcharacters, attributes,
-//   replacements, macros, post_replacements]`, whereas this crate treats a
-//   mid-list group name as a reset, yielding `[specialcharacters, quotes,
-//   attributes, replacements, macros, post_replacements]` (the leading `quotes`
-//   is dropped, no de-duplication). This is a substitution-resolution behavior
-//   difference, not a missing test, and is tracked separately in
-//   https://github.com/asciidoc-rs/asciidoc-parser/issues/663 rather than by
-//   asserting the current output here. Once that is fixed, this case becomes
-//   portable as an executable test.
+//   Both implementations now expand `normal` in place and de-duplicate,
+//   yielding `[quotes, specialcharacters, attributes, replacements, macros,
+//   post_replacements]`. This is covered by the executable
+//   `from_custom_string::group_name_mid_list_expands_in_place_and_dedups` test
+//   in `content::substitution_group` (see
+//   https://github.com/asciidoc-rs/asciidoc-parser/issues/663).
 //
 // * The `coderay` / `pygments` cases resolve `specialcharacters` to a
 //   `:highlight` sub driven by a source highlighter. Source highlighting is out


### PR DESCRIPTION
Fixes #663.

## Problem

`SubstitutionGroup::from_custom_string` diverged from Asciidoctor's `resolve_subs` when a substitution **group name** (`normal` / `verbatim`) appeared mid-list, and it never de-duplicated the resulting step list.

For `subs = "quotes,normal"`:

- **Before** — the mid-list `normal` token *reset* the accumulated steps, dropping the leading `quotes`, and no de-duplication was applied → `[specialcharacters, quotes, attributes, replacements, macros, post_replacements]`.
- **Asciidoctor** — expands `normal` *in place* and de-duplicates → `[quotes, specialcharacters, attributes, replacements, macros, post_replacements]`.

## Fix

- Expand `normal` / `verbatim` group tokens in place (append their constituent steps to the running list) instead of resetting it.
- De-duplicate the final step list, first occurrence winning, so each substitution runs at most once — matching Asciidoctor.

## Tests

- Added `from_custom_string::group_name_mid_list_expands_in_place_and_dedups` covering `quotes,normal` and `m,v`.
- Re-derived the `addition` / `incremental` `n,r` expectation: `n` already expands to normal's steps (which include `replacements`), so the trailing `r` is now de-duplicated away.
- Updated the `substitutions_test.rs` tombstone note now that the "should resolve subs for block" (`quotes,normal`) case is portable and covered.

All existing `+`/`-` operator and subtraction cases are unaffected (they had no duplicates and their group tokens were already at position 0). Full parser suite (`3112` tests), clippy, and fmt are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)