### PR TITLE
feat: Port system-path root handling in PathResolver::partition_path (#653)

### DIFF
--- a/parser/src/parser/path_resolver.rs
+++ b/parser/src/parser/path_resolver.rs
@@ -25,8 +25,10 @@ pub struct PathResolver {
     /// File separator to use for path operations. (Defaults to
     /// platform-appropriate separator.)
     pub file_separator: char,
-    // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/653): Port this from Ruby?
-    // attr_accessor :working_dir
+    // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/653): Ruby's
+    // `PathResolver` also carries a `working_dir`, but it is only consumed by
+    // `system_path` / `relative_path`, neither of which is ported yet. Add this
+    // field when the first consumer lands rather than as an unused field now.
 }
 
 impl Default for PathResolver {
@@ -122,8 +124,11 @@ impl PathResolver {
     /// an optional path root (e.g., `/`, `./`, `c:/`, or `//`), which is only
     /// present if the path is absolute.
     fn partition_path(&self, path: &str, web: WebPath) -> (Vec<String>, Option<String>) {
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/653): Add cache implementation?
-
+        // Ruby memoizes partition results per (path, web) in a hash. That cache
+        // exists to avoid Ruby's comparatively expensive string work; here the
+        // partitioning is cheap and the resolver takes `&self`, so caching would
+        // require interior mutability that the derived `Clone`/`Eq` would then
+        // have to skip. Deliberately not ported.
         let posix_path = self.posixify(path);
 
         let root: Option<String> = if web.0 {
@@ -134,32 +139,29 @@ impl PathResolver {
             } else {
                 None
             }
+        } else if self.is_root(&posix_path) {
+            if self.is_unc(&posix_path) {
+                // ex. //sample/path
+                Some(DOUBLE_SLASH.to_owned())
+            } else if posix_path.starts_with('/') {
+                // ex. /sample/path
+                Some("/".to_owned())
+            } else if posix_path.starts_with(URI_CLASSLOADER) {
+                // ex. uri:classloader:sample/path (or uri:classloader:/sample/path)
+                Some(URI_CLASSLOADER.to_owned())
+            } else {
+                // ex. C:/sample/path (or file:///sample/path in browser
+                // environment). The root is everything up to and including the
+                // first slash. `is_root` guarantees a slash for the drive-letter
+                // case, so `None` here is unreachable in practice.
+                posix_path.find('/').map(|slash| posix_path[..=slash].to_owned())
+            }
+        } else if posix_path.starts_with("./") {
+            // ex. ./sample/path
+            Some("./".to_owned())
         } else {
-            // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/653):
-            todo!(
-                "Port this: {}",
-                r#"
-				elsif root? posix_path
-				  # ex. //sample/path
-				  if unc? posix_path
-					root = DOUBLE_SLASH
-				  # ex. /sample/path
-				  elsif posix_path.start_with? SLASH
-					root = SLASH
-				  # ex. uri:classloader:sample/path (or uri:classloader:/sample/path)
-				  elsif posix_path.start_with? URI_CLASSLOADER
-					root = posix_path.slice 0, URI_CLASSLOADER.length
-				  # ex. C:/sample/path (or file:///sample/path in browser environment)
-				  else
-					root = posix_path.slice 0, (posix_path.index SLASH) + 1
-				  end
-				# ex. ./sample/path
-				elsif posix_path.start_with? DOT_SLASH
-				  root = DOT_SLASH
-				end
-				# otherwise ex. sample/path
-                "#
-            );
+            // otherwise ex. sample/path
+            None
         };
 
         let path_after_root = if let Some(root) = &root {
@@ -173,8 +175,6 @@ impl PathResolver {
             .filter(|s| *s != ".")
             .map(|s| s.to_owned())
             .collect();
-
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/653): Add cache write?
 
         (path_segments, root)
     }
@@ -195,6 +195,24 @@ impl PathResolver {
     /// with a `'/'`.
     pub fn is_web_root(&self, path: &str) -> bool {
         path.starts_with('/')
+    }
+
+    /// Return `true` if the path is an absolute (rooted) system path. A path is
+    /// absolute if it starts with `'/'` or, on a Windows-style resolver, if it
+    /// starts with a drive letter or slash root (e.g. `C:/` or `\`).
+    fn is_absolute_path(&self, path: &str) -> bool {
+        path.starts_with('/') || (self.file_separator == '\\' && WINDOWS_ROOT.is_match(path))
+    }
+
+    /// Return `true` if the path has a root, meaning it is either an absolute
+    /// path or a `uri:classloader:` path.
+    fn is_root(&self, path: &str) -> bool {
+        self.is_absolute_path(path) || path.starts_with(URI_CLASSLOADER)
+    }
+
+    /// Return `true` if the path is a UNC path (i.e. starts with `'//'`).
+    fn is_unc(&self, path: &str) -> bool {
+        path.starts_with(DOUBLE_SLASH)
     }
 }
 
@@ -240,6 +258,21 @@ static URI_SNIFF: LazyLock<Regex> = LazyLock::new(|| {
     "#,
     )
     .unwrap()
+});
+
+/// Path root marker for a UNC path (e.g. `//sample/path`).
+const DOUBLE_SLASH: &str = "//";
+
+/// Path root marker for a JRuby classloader URI (e.g.
+/// `uri:classloader:/sample/path`).
+const URI_CLASSLOADER: &str = "uri:classloader:";
+
+/// Matches the root of a Windows-style path: an optional drive letter followed
+/// by a leading slash (either separator). Mirrors Ruby Asciidoctor's
+/// `WindowsRootRx`.
+static WINDOWS_ROOT: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(r"^(?:[a-zA-Z]:)?[\\/]").unwrap()
 });
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -457,5 +490,115 @@ mod tests {
         assert!(pr.is_web_root("/blah"));
         assert!(!pr.is_web_root(""));
         assert!(!pr.is_web_root("./blah"));
+    }
+
+    mod partition_path {
+        use super::super::WebPath;
+        use crate::parser::PathResolver;
+
+        fn seg(items: &[&str]) -> Vec<String> {
+            items.iter().map(|s| (*s).to_owned()).collect()
+        }
+
+        #[test]
+        fn relative_system_path() {
+            let pr = PathResolver::default();
+            assert_eq!(
+                pr.partition_path("sample/path", WebPath(false)),
+                (seg(&["sample", "path"]), None)
+            );
+        }
+
+        #[test]
+        fn dot_slash_system_path() {
+            let pr = PathResolver::default();
+            assert_eq!(
+                pr.partition_path("./sample/path", WebPath(false)),
+                (seg(&["sample", "path"]), Some("./".to_owned()))
+            );
+        }
+
+        #[test]
+        fn self_references_are_removed() {
+            let pr = PathResolver::default();
+            assert_eq!(
+                pr.partition_path("sample/./path", WebPath(false)),
+                (seg(&["sample", "path"]), None)
+            );
+        }
+
+        #[test]
+        fn absolute_system_path() {
+            let pr = PathResolver::default();
+            assert_eq!(
+                pr.partition_path("/sample/path", WebPath(false)),
+                (seg(&["sample", "path"]), Some("/".to_owned()))
+            );
+        }
+
+        #[test]
+        fn unc_path() {
+            let pr = PathResolver::default();
+            assert_eq!(
+                pr.partition_path("//server/share/path", WebPath(false)),
+                (seg(&["server", "share", "path"]), Some("//".to_owned()))
+            );
+        }
+
+        #[test]
+        fn uri_classloader_rooted() {
+            let pr = PathResolver::default();
+            assert_eq!(
+                pr.partition_path("uri:classloader:/sample/path", WebPath(false)),
+                (
+                    seg(&["", "sample", "path"]),
+                    Some("uri:classloader:".to_owned())
+                )
+            );
+        }
+
+        #[test]
+        fn uri_classloader_relative() {
+            let pr = PathResolver::default();
+            assert_eq!(
+                pr.partition_path("uri:classloader:sample/path", WebPath(false)),
+                (seg(&["sample", "path"]), Some("uri:classloader:".to_owned()))
+            );
+        }
+
+        #[test]
+        fn windows_drive_letter() {
+            let pr = PathResolver {
+                file_separator: '\\',
+            };
+
+            assert_eq!(
+                pr.partition_path("C:\\sample\\path", WebPath(false)),
+                (seg(&["sample", "path"]), Some("C:/".to_owned()))
+            );
+        }
+
+        #[test]
+        fn windows_drive_letter_forward_slashes() {
+            let pr = PathResolver {
+                file_separator: '\\',
+            };
+
+            assert_eq!(
+                pr.partition_path("C:/sample/path", WebPath(false)),
+                (seg(&["sample", "path"]), Some("C:/".to_owned()))
+            );
+        }
+
+        #[test]
+        fn drive_letter_is_relative_on_posix_resolver() {
+            // Without a Windows-style separator, a drive-letter prefix is not
+            // treated as a root.
+            let pr = PathResolver::default();
+            assert_eq!(
+                pr.partition_path("C:/sample/path", WebPath(false)),
+                (seg(&["C:", "sample", "path"]), None)
+            );
+        }
     }
 }

--- a/parser/src/parser/path_resolver.rs
+++ b/parser/src/parser/path_resolver.rs
@@ -25,10 +25,15 @@ pub struct PathResolver {
     /// File separator to use for path operations. (Defaults to
     /// platform-appropriate separator.)
     pub file_separator: char,
-    // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/653): Ruby's
-    // `PathResolver` also carries a `working_dir`, but it is only consumed by
-    // `system_path` / `relative_path`, neither of which is ported yet. Add this
-    // field when the first consumer lands rather than as an unused field now.
+    // Ruby's `PathResolver` also carries a `working_dir`, but it is read only by
+    // `system_path` — the filesystem-resolution + safe-mode-jail routine — as a
+    // fallback base directory, and Ruby always seeds it from `Dir.pwd`. This
+    // crate performs no filesystem I/O: `include::` and asset resolution are
+    // delegated to the client via `IncludeFileHandler`, so there is no consumer
+    // for `working_dir`, and a `Dir.pwd`-derived base would contradict this
+    // type's deterministic, OS-independent design. Intentionally not ported; if
+    // a built-in filesystem handler ever ports `system_path`, prefer an explicit
+    // caller-supplied base over an implicit working directory.
 }
 
 impl Default for PathResolver {

--- a/parser/src/parser/path_resolver.rs
+++ b/parser/src/parser/path_resolver.rs
@@ -154,7 +154,9 @@ impl PathResolver {
                 // environment). The root is everything up to and including the
                 // first slash. `is_root` guarantees a slash for the drive-letter
                 // case, so `None` here is unreachable in practice.
-                posix_path.find('/').map(|slash| posix_path[..=slash].to_owned())
+                posix_path
+                    .find('/')
+                    .map(|slash| posix_path[..=slash].to_owned())
             }
         } else if posix_path.starts_with("./") {
             // ex. ./sample/path
@@ -562,7 +564,10 @@ mod tests {
             let pr = PathResolver::default();
             assert_eq!(
                 pr.partition_path("uri:classloader:sample/path", WebPath(false)),
-                (seg(&["sample", "path"]), Some("uri:classloader:".to_owned()))
+                (
+                    seg(&["sample", "path"]),
+                    Some("uri:classloader:".to_owned())
+                )
             );
         }
 
@@ -593,8 +598,12 @@ mod tests {
         #[test]
         fn drive_letter_is_relative_on_posix_resolver() {
             // Without a Windows-style separator, a drive-letter prefix is not
-            // treated as a root.
-            let pr = PathResolver::default();
+            // treated as a root. (Constructed explicitly rather than via
+            // `default()`, whose separator is platform-dependent.)
+            let pr = PathResolver {
+                file_separator: '/',
+            };
+
             assert_eq!(
                 pr.partition_path("C:/sample/path", WebPath(false)),
                 (seg(&["C:", "sample", "path"]), None)


### PR DESCRIPTION
## What

Resolves the `todo!` panic-in-waiting in `PathResolver::partition_path`'s non-web branch by porting Ruby Asciidoctor's system-path root handling, and makes a deliberate call on the other two TO DOs tracked in #653.

Closes #653.

## Changes

- **Port system-path roots** (`path_resolver.rs:138`): the `else` (non-web) branch of `partition_path` now resolves UNC (`//`), absolute (`/`), `uri:classloader:`, and Windows drive-letter (`C:/`) roots, plus the `./` and bare-relative cases — a faithful translation of the Ruby source.
- **New predicates** mirroring Ruby: `is_absolute_path` (`absolute_path?`), `is_root` (`root?`), `is_unc` (`unc?`); constants `DOUBLE_SLASH` / `URI_CLASSLOADER`; and a `WINDOWS_ROOT` regex mirroring `WindowsRootRx`.
- **Tests**: 10 new `partition_path` unit tests covering relative, `./`, self-reference removal, absolute, UNC, `uri:classloader:` (rooted + relative), Windows drive letters (back- and forward-slash), and the posix-resolver-treats-drive-letter-as-relative case.

## Deliberately *not* ported (documented in-code)

- **`partition_path` cache** (`path_resolver.rs:125,176`): Ruby memoizes results to dodge its expensive string work. Here partitioning is cheap and the resolver takes `&self`, so a cache would require interior mutability that the derived `Clone`/`Eq`/`PartialEq` would then have to skip — not worth it. The TO DOs are replaced with a comment explaining this.
- **`working_dir` field** (`path_resolver.rs:28`): only consumed by `system_path` / `relative_path` in Ruby, neither of which is ported yet. Better added alongside its first consumer than as an unused field now.

If you'd rather keep #653 open to track the cache / `working_dir` follow-ups separately, say the word and I'll drop the `Closes` and narrow the scope note.

## Testing

- `cargo test -p asciidoc-parser` — 3121 passed, 0 failed
- `cargo clippy -p asciidoc-parser --all-targets` — clean (crate denies `unwrap_used`/`expect_used`/`panic`/`indexing_slicing`; the new code stays within those)

🤖 Generated with [Claude Code](https://claude.com/claude-code)