### PR TITLE
chore: Close out #456 and track remaining paragraph stubs

### DIFF
--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -2521,6 +2521,11 @@ fn port_from_ruby() {
     # been ported to `mod special` below now that conditional preprocessor
     # directives are implemented.
 
+    # NOTE: the remaining un-ported tests below are tracked by dedicated
+    # issues: '[open]' styled paragraph -> open block (#679), inline doctype
+    # (#680), and unknown/custom paragraph style logging (#681). The DocBook
+    # 'simpara' styled-paragraph tests are out of scope (no DocBook backend).
+
     context 'Styled Paragraphs' do
       test 'should wrap text in simpara for styled paragraphs when converted to DocBook' do
         input = <<~'EOS'


### PR DESCRIPTION
## Summary

Follow-up housekeeping after confirming issue #456 (*Implement admonition parsing*) can be closed.

- Verified no references to #456 remain in the code; admonition parsing is implemented and its tests were ported in #672 (commit 0e273941).
- Closed #456.
- Split the unrelated topics still sharing the `port_from_ruby` stub in [`paragraphs_test.rs`](parser/src/tests/asciidoctor_rb/paragraphs_test.rs) into dedicated tracking issues, and added a code breadcrumb mapping each remaining in-scope test to its issue:
  - #679 — `[open]` styled paragraph converts to an open block
  - #680 — inline doctype (`doctype: inline`) rendering
  - #681 — logging for unknown/custom paragraph styles
- The DocBook `simpara` styled-paragraph tests are declared out of scope (no DocBook backend).

## Changes

The only code change is a comment breadcrumb in the `port_from_ruby` stub — no behavior change. The substantive work (filing the three issues, closing #456) happened on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)