### PR TITLE
fix: Treat a bare trailing backslash as literal, not a line continuation (#666)

### DIFF
--- a/parser/src/document/attribute.rs
+++ b/parser/src/document/attribute.rs
@@ -188,11 +188,17 @@ impl InterpretedValue {
                         line
                     };
 
-                    let line = line
-                        .trim_start_matches('\r')
-                        .trim_end_matches(' ')
-                        .trim_end_matches('\\')
-                        .trim_end_matches(' ');
+                    let line = line.trim_start_matches('\r').trim_end_matches(' ');
+
+                    // Strip the soft-wrap line continuation marker (a space
+                    // followed by a backslash). Only non-final lines carry a
+                    // continuation; a trailing backslash on the final line is a
+                    // literal character and is preserved.
+                    let line = if count < last_count {
+                        line.trim_end_matches('\\').trim_end_matches(' ')
+                    } else {
+                        line
+                    };
 
                     if line.ends_with('+') {
                         format!("{}\n", line.trim_end_matches('+').trim_end_matches(' '))
@@ -531,6 +537,72 @@ mod tests {
                 offset: 17
             }
         );
+    }
+
+    #[test]
+    fn bare_trailing_backslash_is_literal() {
+        // A bare trailing backslash (no preceding space) is not a soft-wrap line
+        // continuation; it is a literal character and the value ends at that line.
+        // See https://github.com/asciidoc-rs/asciidoc-parser/issues/666.
+        let mi = crate::document::Attribute::parse(
+            crate::Span::new(":longpath: very/long/path/to/some/\\\nsubdirectory"),
+            &Parser::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            mi.item,
+            Attribute {
+                name: Span {
+                    data: "longpath",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+                value_source: Some(Span {
+                    data: "very/long/path/to/some/\\",
+                    line: 1,
+                    col: 12,
+                    offset: 11,
+                }),
+                value: InterpretedValue::Value("very/long/path/to/some/\\"),
+                source: Span {
+                    data: ":longpath: very/long/path/to/some/\\",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                }
+            }
+        );
+
+        assert_eq!(
+            mi.item.value(),
+            InterpretedValue::Value("very/long/path/to/some/\\")
+        );
+
+        // `subdirectory` is left as a separate line, not folded into the value.
+        assert_eq!(
+            mi.after,
+            Span {
+                data: "subdirectory",
+                line: 2,
+                col: 1,
+                offset: 36
+            }
+        );
+    }
+
+    #[test]
+    fn literal_trailing_backslash_on_final_line() {
+        // The soft-wrap continuation on the first line is folded, but the bare
+        // trailing backslash on the final line is kept as a literal character.
+        let mi = crate::document::Attribute::parse(
+            crate::Span::new(":foo: bar \\\nbaz\\"),
+            &Parser::default(),
+        )
+        .unwrap();
+
+        assert_eq!(mi.item.value(), InterpretedValue::Value("bar baz\\"));
     }
 
     #[test]

--- a/parser/src/span/line.rs
+++ b/parser/src/span/line.rs
@@ -119,11 +119,10 @@ impl<'src> Span<'src> {
     fn one_line_with_continuation(self) -> Option<MatchedItem<'src, Self>> {
         let line = self.take_normalized_line();
 
-        // TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/666): The spec
-        // requires a *space* before the backslash for a soft-wrap line continuation.
-        // This accepts a bare trailing `\`, so `foo\` (no space) is wrongly folded
-        // instead of being kept literal (Asciidoctor keeps it literal).
-        if line.item.ends_with('\\') {
+        // A soft-wrap line continuation is a *space* immediately followed by a
+        // trailing backslash. A bare trailing backslash (no preceding space) is a
+        // literal character and does not continue the line (matching Asciidoctor).
+        if line.item.ends_with(" \\") {
             Some(line)
         } else {
             None
@@ -1339,7 +1338,7 @@ mod tests {
 
         #[test]
         fn multiple_continuations() {
-            let span = crate::Span::new("abc \\\ndef\\\nghi");
+            let span = crate::Span::new("abc \\\ndef \\\nghi");
             let line = span.take_line_with_continuation().unwrap();
 
             assert_eq!(
@@ -1348,14 +1347,44 @@ mod tests {
                     data: "",
                     line: 3,
                     col: 4,
-                    offset: 14
+                    offset: 15
                 }
             );
 
             assert_eq!(
                 line.item,
                 Span {
-                    data: "abc \\\ndef\\\nghi",
+                    data: "abc \\\ndef \\\nghi",
+                    line: 1,
+                    col: 1,
+                    offset: 0
+                }
+            );
+        }
+
+        #[test]
+        fn bare_backslash_is_not_a_continuation() {
+            // A soft-wrap line continuation requires a *space* before the trailing
+            // backslash. A bare `\` (no preceding space) is a literal character and
+            // terminates the line; the next line is not folded in.
+            // See https://github.com/asciidoc-rs/asciidoc-parser/issues/666.
+            let span = crate::Span::new("abc\\\ndef");
+            let line = span.take_line_with_continuation().unwrap();
+
+            assert_eq!(
+                line.after,
+                Span {
+                    data: "def",
+                    line: 2,
+                    col: 1,
+                    offset: 5
+                }
+            );
+
+            assert_eq!(
+                line.item,
+                Span {
+                    data: "abc\\",
                     line: 1,
                     col: 1,
                     offset: 0


### PR DESCRIPTION
Fixes #666.

## Problem

`one_line_with_continuation` treated **any** trailing backslash as a soft-wrap line continuation, but the AsciiDoc spec (and Asciidoctor) require **a space immediately before** the backslash. A bare `\` at the end of an attribute-value line (no preceding space) was wrongly folded into a continuation instead of being kept as a literal character.

Reproduction:

```
:longpath: very/long/path/to/some/\
subdirectory

{longpath}
```

- **Asciidoctor:** `{longpath}` → `very/long/path/to/some/\` (literal backslash; `subdirectory` is a separate paragraph).
- **asciidoc-parser (before):** folded the two lines into `very/long/path/to/some/ subdirectory`.

## Fix

- `parser/src/span/line.rs` — `one_line_with_continuation` now requires the line to end with `" \"` (space + backslash) to be treated as a continuation.
- `parser/src/document/attribute.rs` — `InterpretedValue::from_raw_value` now strips the continuation marker only from non-final lines, so a literal trailing backslash on the **final** line of a multiline value is preserved. (Given the `line.rs` fix, every non-final line in a folded value is guaranteed to end with a genuine `" \"` marker.)

## Tests

- `span::line`: added `bare_backslash_is_not_a_continuation`; updated `multiple_continuations` to use a genuine ` \` marker on each continued line.
- `document::attribute`: added `bare_trailing_backslash_is_literal` (the issue's reproduction) and `literal_trailing_backslash_on_final_line`.

Full test suite, `clippy`, and nightly `rustfmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)