### PR TITLE
feat: Honor cell-level alignment in table header row (#654)

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1982,7 +1982,10 @@ impl<'src> TableCell<'src> {
     /// specifier overrides the column's [style](ColumnStyle); with no cell
     /// style operator, the cell is processed with the column's style. A
     /// header cell (`is_header`) is always processed as plain header
-    /// content, regardless of any style operator on the column or the cell.
+    /// content, regardless of any style operator on the column or the cell, and
+    /// it ignores the column's alignment operators: with no operator on its own
+    /// specifier, a header cell falls back to the default alignment rather than
+    /// inheriting the column's.
     ///
     /// Leading and trailing whitespace is always stripped. For every style but
     /// [`AsciiDoc`](ColumnStyle::AsciiDoc) the cell holds inline
@@ -2001,9 +2004,21 @@ impl<'src> TableCell<'src> {
         warnings: &mut Vec<Warning<'src>>,
     ) -> Self {
         // A cell's own alignment operator overrides the column's alignment; with
-        // no operator, the cell inherits the column's alignment.
-        let h_align = raw.spec.h_align.unwrap_or(column.h_align);
-        let v_align = raw.spec.v_align.unwrap_or(column.v_align);
+        // no operator, the cell inherits the column's alignment. The header row
+        // ignores alignment operators on the column specifier, so a header cell
+        // with no operator of its own falls back to the default alignment rather
+        // than the column's; a cell specifier's own operator is still applied.
+        let (h_align, v_align) = if is_header {
+            (
+                raw.spec.h_align.unwrap_or(HorizontalAlignment::Left),
+                raw.spec.v_align.unwrap_or(VerticalAlignment::Top),
+            )
+        } else {
+            (
+                raw.spec.h_align.unwrap_or(column.h_align),
+                raw.spec.v_align.unwrap_or(column.v_align),
+            )
+        };
 
         // A cell's own style operator overrides the column's style; with no
         // operator, the cell is processed with the column's style. The header
@@ -2069,12 +2084,21 @@ impl<'src> TableCell<'src> {
             column.style
         };
 
+        // A data field carries no cell specifier, so its alignment comes from the
+        // column — except in the header row, which ignores the column's alignment
+        // operators and falls back to the default alignment.
+        let (h_align, v_align) = if is_header {
+            (HorizontalAlignment::Left, VerticalAlignment::Top)
+        } else {
+            (column.h_align, column.v_align)
+        };
+
         let source = field.content;
         let content = process_content(field.content, field.replacement, style, parser, warnings);
 
         Self {
-            h_align: column.h_align,
-            v_align: column.v_align,
+            h_align,
+            v_align,
             style,
             colspan: 1,
             rowspan: 1,

--- a/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
@@ -117,7 +117,7 @@ It also ignores alignment operators assigned to the table's column specifiers; h
     // The columns carry alignment operators (`^` centers, `.>` bottom-aligns),
     // and the first row is promoted to the header. The header row ignores the
     // column alignment operators, so its cells fall back to the default
-    // alignment (left, top)...
+    // alignment (left, top) ...
     let table = parse_table(
         "[cols=\"^.>,^.>\",options=\"header\"]\n|===\n|Column 1 |Column 2\n\n|Cell 1 |Cell 2\n|===",
     );
@@ -129,7 +129,7 @@ It also ignores alignment operators assigned to the table's column specifiers; h
         ]
     );
 
-    // ...while the body cells in the same columns *do* honor the column
+    // ... while the body cells in the same columns *do* honor the column
     // alignment operators.
     assert_eq!(
         table.body_rows()[0]

--- a/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
@@ -38,6 +38,20 @@ fn header_texts(table: &crate::blocks::TableBlock<'_>) -> Vec<String> {
         .collect()
 }
 
+/// Return the `(horizontal, vertical)` alignment of each cell in the table's
+/// header row, panicking if the table has no header row.
+fn header_alignments(
+    table: &crate::blocks::TableBlock<'_>,
+) -> Vec<(HorizontalAlignment, VerticalAlignment)> {
+    table
+        .header_row()
+        .expect("expected a header row")
+        .cells()
+        .iter()
+        .map(|cell| (cell.h_align(), cell.v_align()))
+        .collect()
+}
+
 non_normative!(
     r#"
 = Create a Header Row
@@ -93,19 +107,72 @@ TIP: The header row ignores any style operators assigned via column and cell spe
         crate::blocks::TableCellContent::AsciiDoc(_)
     ));
 
-    to_do_verifies!(
+    verifies!(
         r#"
 It also ignores alignment operators assigned to the table's column specifiers; however, any alignment operators assigned to a cell specifier in the header row are applied.
 
 "#
     );
 
-    // The interaction between the header row and alignment operators on a cell
-    // specifier depends on cell specifiers, which are not yet implemented.
-    if false {
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/654):
-        todo!("cell specifiers and cell-level alignment for the header row");
-    }
+    // The columns carry alignment operators (`^` centers, `.>` bottom-aligns),
+    // and the first row is promoted to the header. The header row ignores the
+    // column alignment operators, so its cells fall back to the default
+    // alignment (left, top)...
+    let table = parse_table(
+        "[cols=\"^.>,^.>\",options=\"header\"]\n|===\n|Column 1 |Column 2\n\n|Cell 1 |Cell 2\n|===",
+    );
+    assert_eq!(
+        header_alignments(&table),
+        vec![
+            (HorizontalAlignment::Left, VerticalAlignment::Top),
+            (HorizontalAlignment::Left, VerticalAlignment::Top),
+        ]
+    );
+
+    // ...while the body cells in the same columns *do* honor the column
+    // alignment operators.
+    assert_eq!(
+        table.body_rows()[0]
+            .cells()
+            .iter()
+            .map(|cell| (cell.h_align(), cell.v_align()))
+            .collect::<Vec<_>>(),
+        vec![
+            (HorizontalAlignment::Center, VerticalAlignment::Bottom),
+            (HorizontalAlignment::Center, VerticalAlignment::Bottom),
+        ]
+    );
+
+    // Alignment operators on a cell specifier *in the header row* are applied.
+    // Here the columns are centered (`^`), but the header cells carry their own
+    // operators (`>` right, `.>` bottom), which override the ignored column
+    // alignment; the horizontal alignment of the second header cell has no cell
+    // operator, so it falls back to the default (left) rather than the column's
+    // center.
+    let table = parse_table(
+        "[cols=\"2*^\",options=\"header\"]\n|===\n>|Column 1 .>|Column 2\n\n|Cell 1 |Cell 2\n|===",
+    );
+    assert_eq!(
+        header_alignments(&table),
+        vec![
+            (HorizontalAlignment::Right, VerticalAlignment::Top),
+            (HorizontalAlignment::Left, VerticalAlignment::Bottom),
+        ]
+    );
+
+    // The body cells, which have no cell specifier, still honor the column's
+    // center alignment.
+    assert_eq!(
+        table.body_rows()[0]
+            .cells()
+            .iter()
+            .map(|cell| (cell.h_align(), cell.v_align()))
+            .collect::<Vec<_>>(),
+        vec![
+            (HorizontalAlignment::Center, VerticalAlignment::Top),
+            (HorizontalAlignment::Center, VerticalAlignment::Top),
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #654.

## Summary

The table header row now honors per-cell alignment while continuing to ignore alignment operators from column specifiers, matching the normative text in `add-header-row.adoc`:

> The header row ignores any style operators assigned via column and cell specifiers. It also ignores alignment operators assigned to the table's column specifiers; however, any alignment operators assigned to a cell specifier in the header row are applied.

## The bug

Previously, a header cell with no alignment operator of its own inherited its **column's** alignment (`raw.spec.h_align.unwrap_or(column.h_align)`). That contradicts the spec: the header row must ignore column alignment operators. Style was already correctly forced to `Default` for header cells; only alignment was wrong.

## The fix

In `TableCell::parse` (PSV cells), a header cell now falls back to the **default** alignment (left, top) when its own specifier carries no operator, while a cell-level operator (e.g. `^|`, `.>|`) is still applied. Body cells are unchanged — they continue to inherit the column's alignment.

The same correction is applied to `TableCell::parse_data` (CSV/TSV/DSV tables): a data field has no cell specifier, so header cells there fall back to the default alignment instead of the column's.

## Tests

`add_header_row.rs::header_ignores_operators` had its normative paragraph marked `to_do_verifies!` and a `todo!()` stub (tracked by this issue). Both are now real:

- Columns with alignment operators + a header row → header cells fall back to (left, top); body cells still honor the column alignment.
- Header cells carrying their own operators (`>|`, `.>|`) over centered columns → the cell operators are applied and the un-operated axis falls back to the default (not the column's).

All existing table tests, clippy, and `cargo +nightly fmt` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)