### PR TITLE
fix: Attach block metadata separated from its block by a blank line (#664)

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -288,6 +288,27 @@ impl<'src> Block<'src> {
             mut warnings,
         } = BlockMetadata::parse(source, parser);
 
+        // Tolerate a blank line between a block's metadata (title, anchor, or
+        // attribute list) and the block it decorates. Asciidoctor's
+        // `parse_block_metadata_lines` skips blank lines after each metadata
+        // line, so metadata separated from its block by one or more blank lines
+        // still attaches to that block rather than dangling as a spurious
+        // `MissingBlockAfterTitleOrAttributeList`. Advancing `block_start` past
+        // the gap lets the block-type dispatch below see the content directly.
+        //
+        // This applies at the block level only. Inside a list item,
+        // blank-separated metadata follows the list-continuation rules handled
+        // in `ListItem::parse` (where such metadata is discarded), so leave
+        // `block_start` pointing at the blank line for those callers. Likewise,
+        // if only blank lines follow (no block content), leave it untouched so
+        // the genuinely-dangling-metadata warning still fires.
+        if parent_list_markers.is_none() && !metadata.is_empty() {
+            let after_blanks = metadata.block_start.discard_empty_lines();
+            if after_blanks != metadata.block_start && !after_blanks.is_empty() {
+                metadata.block_start = after_blanks;
+            }
+        }
+
         // The `[literal]` block style normally marks a literal *paragraph*,
         // which is handled directly as a simple (literal) block below, bypassing
         // the delimited-block parsers. The exception is when `[literal]` is set

--- a/parser/src/blocks/tests/mod.rs
+++ b/parser/src/blocks/tests/mod.rs
@@ -248,7 +248,12 @@ mod error_cases {
     };
 
     #[test]
-    fn missing_block_after_title_line() {
+    fn title_line_separated_from_block_by_blank_line_attaches() {
+        // Regression test for issue #664: a block title (`.title`) separated
+        // from its block by a blank line attaches to the following block,
+        // matching Asciidoctor (which tolerates the intervening blank line).
+        // The title line is *not* demoted to a standalone paragraph and no
+        // spurious `MissingBlockAfterTitleOrAttributeList` warning is emitted.
         let mut parser = Parser::default();
         let mut warnings: Vec<crate::warnings::Warning<'_>> = vec![];
 
@@ -317,31 +322,6 @@ mod error_cases {
                     Block::Simple(SimpleBlock {
                         content: Content {
                             original: Span {
-                                data: ".ancestor section== Section 2",
-                                line: 5,
-                                col: 1,
-                                offset: 24,
-                            },
-                            rendered: ".ancestor section== Section 2",
-                        },
-                        source: Span {
-                            data: ".ancestor section== Section 2",
-                            line: 5,
-                            col: 1,
-                            offset: 24,
-                        },
-                        style: SimpleBlockStyle::Paragraph,
-                        title_source: None,
-                        title: None,
-                        caption: None,
-                        number: None,
-                        anchor: None,
-                        anchor_reftext: None,
-                        attrlist: None,
-                    },),
-                    Block::Simple(SimpleBlock {
-                        content: Content {
-                            original: Span {
                                 data: "def",
                                 line: 7,
                                 col: 1,
@@ -350,14 +330,19 @@ mod error_cases {
                             rendered: "def",
                         },
                         source: Span {
-                            data: "def",
-                            line: 7,
+                            data: ".ancestor section== Section 2\n\ndef",
+                            line: 5,
                             col: 1,
-                            offset: 55,
+                            offset: 24,
                         },
                         style: SimpleBlockStyle::Paragraph,
-                        title_source: None,
-                        title: None,
+                        title_source: Some(Span {
+                            data: "ancestor section== Section 2",
+                            line: 5,
+                            col: 2,
+                            offset: 25,
+                        }),
+                        title: Some("ancestor section== Section 2"),
                         caption: None,
                         number: None,
                         anchor: None,
@@ -393,17 +378,52 @@ mod error_cases {
             }
         );
 
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn attribute_list_separated_from_block_by_blank_line_attaches() {
+        // Issue #664 (generalized): the blank-line tolerance applies to any
+        // block metadata, not just titles. A block attribute list separated
+        // from its block by a blank line attaches to the following block (its
+        // role is applied here) rather than dangling with a warning.
+        let doc = Parser::default().parse("[.myrole]\n\ndef");
+
+        let blocks: Vec<_> = doc.nested_blocks().collect();
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].roles(), vec!["myrole"]);
+        assert_eq!(blocks[0].rendered_content(), Some("def"));
+        assert!(doc.warnings().next().is_none());
+    }
+
+    #[test]
+    fn multiple_blank_lines_between_title_and_block_are_tolerated() {
+        // More than one blank line between the metadata and its block is also
+        // tolerated, matching Asciidoctor's `skip_blank_lines`.
+        let doc = Parser::default().parse(".My Title\n\n\ndef");
+
+        let blocks: Vec<_> = doc.nested_blocks().collect();
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].title(), Some("My Title"));
+        assert_eq!(blocks[0].rendered_content(), Some("def"));
+        assert!(doc.warnings().next().is_none());
+    }
+
+    #[test]
+    fn title_with_only_blank_lines_after_still_warns() {
+        // A title followed by nothing but blank lines has no block to attach to,
+        // so the `MissingBlockAfterTitleOrAttributeList` warning still fires and
+        // the title line is demoted to paragraph content.
+        let doc = Parser::default().parse(".My Title\n\n");
+
+        let blocks: Vec<_> = doc.nested_blocks().collect();
+        assert_eq!(blocks.len(), 1);
+        assert!(blocks[0].title().is_none());
         assert_eq!(
-            warnings,
-            vec![Warning {
-                source: Span {
-                    data: ".ancestor section== Section 2\n\ndef",
-                    line: 5,
-                    col: 1,
-                    offset: 24,
-                },
-                warning: WarningType::MissingBlockAfterTitleOrAttributeList,
-            },]
+            doc.warnings()
+                .map(|w| w.warning.clone())
+                .collect::<Vec<_>>(),
+            vec![WarningType::MissingBlockAfterTitleOrAttributeList]
         );
     }
 


### PR DESCRIPTION
Fixes #664.

## Summary

A block title (`.title`) — and, generalizing, any block metadata (anchor or attribute list) — separated from its block by a blank line was not attached to the following block. Asciidoctor tolerates the intervening blank line (its `parse_block_metadata_lines` calls `skip_blank_lines` after each metadata line), so it attaches the metadata; this crate instead demoted the metadata line to a standalone paragraph and emitted a spurious `MissingBlockAfterTitleOrAttributeList` warning.

### Before

```asciidoc
=== Section Title

abc

.ancestor section== Section 2

def
```

parsed to **three** blocks in the section (`abc`, `.ancestor section== Section 2` demoted to a paragraph, and `def`) plus a `MissingBlockAfterTitleOrAttributeList` warning.

### After

**Two** blocks (`abc`, and a `def` paragraph whose title is `ancestor section== Section 2`), no warning — matching Asciidoctor 2.0.26.

## Approach

`Block::parse_internal` now advances `block_start` past a blank-line gap after parsing block metadata, so the existing block-type dispatch sees the block content directly and attaches the metadata to it.

The change is deliberately scoped to the **block level** (`parent_list_markers.is_none()`):

- **Inside a list item**, blank-separated metadata keeps following the list-continuation rules in `ListItem::parse` (where such metadata is discarded). This preserves the ported Asciidoctor behaviors in `trailing_block_attribute_line_attached_by_continuation_should_not_create_block` and `trailing_block_title_line_attached_by_continuation_should_not_create_block`, where metadata + blank line + a sibling list marker is dropped rather than re-associated.
- **Genuinely dangling metadata** (a title/attrlist followed by nothing but blank lines) still points `block_start` at the blank line, so the `MissingBlockAfterTitleOrAttributeList` warning continues to fire.

The fix generalizes to all metadata kinds and to any following block type (paragraph, delimited block, list, …) and tolerates multiple blank lines.

## Tests

- Rewrote the former `missing_block_after_title_line` test (which encoded the old three-block behavior) as `title_line_separated_from_block_by_blank_line_attaches`, asserting the two-block, no-warning result.
- Added `attribute_list_separated_from_block_by_blank_line_attaches`, `multiple_blank_lines_between_title_and_block_are_tolerated`, and `title_with_only_blank_lines_after_still_warns`.

Full parser test suite passes (`cargo test -p asciidoc-parser`), clippy clean, nightly `rustfmt` applied.

## Known limitation (out of scope for #664)

A blank line *between two metadata items* (e.g. `.Title` + blank line + `[source]` + content) is not merged into a single metadata set — only the first item attaches and the later line is read as content. This is a rarer edge case than the reported title-then-block scenario and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)