### PR TITLE
feat: Handle unknown/custom paragraph styles (#681)

### DIFF
--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -2506,6 +2506,39 @@ mod special {
     }
 }
 
+// Ported from Ruby Asciidoctor's paragraphs_test.rb (`context 'Custom'`),
+// covering how an unregistered (unknown) paragraph style is handled.
+mod custom {
+    use crate::tests::prelude::*;
+
+    // Ported from Ruby Asciidoctor's paragraphs_test.rb ('should not warn if
+    // paragraph style is unregisted'). An unknown block style such as `[foo]`
+    // on a paragraph is accepted silently: the style is retained on the block,
+    // the content is parsed as an ordinary paragraph, and no warning is
+    // emitted.
+    #[test]
+    fn should_not_warn_if_paragraph_style_is_unregistered() {
+        let doc = Parser::default().parse("[foo]\nbar");
+
+        // The unknown style is retained on the block, and its content is parsed
+        // as an ordinary paragraph.
+        let block = doc.nested_blocks().next().unwrap();
+        assert_eq!(block.declared_style(), Some("foo"));
+        assert_eq!(block.rendered_content(), Some("bar"));
+
+        // No warning is produced.
+        assert_eq!(doc.warnings().count(), 0);
+    }
+
+    // Not ported: 'should log debug message if paragraph style is unknown and
+    // debug level is enabled'. Asciidoctor logs `unknown style for paragraph:
+    // foo` only at DEBUG severity. This crate has no debug-severity logging
+    // channel — its `Warning` mechanism conveys WARN-level possible parse
+    // errors only (see `crate::warnings`) — so there is no equivalent behavior
+    // to assert. The observable behavior at default severity (no warning) is
+    // covered by `should_not_warn_if_paragraph_style_is_unregistered` above.
+}
+
 #[ignore]
 #[test]
 fn port_from_ruby() {
@@ -2521,10 +2554,13 @@ fn port_from_ruby() {
     # been ported to `mod special` below now that conditional preprocessor
     # directives are implemented.
 
+    # NOTE: 'context Custom' (unknown/custom paragraph style handling, #681)
+    # has been ported to `mod custom` below.
+
     # NOTE: the remaining un-ported tests below are tracked by dedicated
-    # issues: '[open]' styled paragraph -> open block (#679), inline doctype
-    # (#680), and unknown/custom paragraph style logging (#681). The DocBook
-    # 'simpara' styled-paragraph tests are out of scope (no DocBook backend).
+    # issues: '[open]' styled paragraph -> open block (#679) and inline doctype
+    # (#680). The DocBook 'simpara' styled-paragraph tests are out of scope (no
+    # DocBook backend).
 
     context 'Styled Paragraphs' do
       test 'should wrap text in simpara for styled paragraphs when converted to DocBook' do
@@ -2648,29 +2684,7 @@ fn port_from_ruby() {
     end
   end
 
-  context 'Custom' do
-    test 'should not warn if paragraph style is unregisted' do
-      input = <<~'EOS'
-      [foo]
-      bar
-      EOS
-      using_memory_logger do |logger|
-        convert_string_to_embedded input
-        assert_empty logger.messages
-      end
-    end
-
-    test 'should log debug message if paragraph style is unknown and debug level is enabled' do
-      input = <<~'EOS'
-      [foo]
-      bar
-      EOS
-      using_memory_logger Logger::Severity::DEBUG do |logger|
-        convert_string_to_embedded input
-        assert_message logger, :DEBUG, '<stdin>: line 2: unknown style for paragraph: foo', Hash
-      end
-    end
-  end
+  # NOTE: 'context Custom' has been ported to `mod custom` above.
 
 "###
     );


### PR DESCRIPTION
Fixes #681.

Ports Asciidoctor's `paragraphs_test.rb` `context 'Custom'` tests, which cover how an unregistered (unknown) paragraph style such as `[foo]` is handled.

## What changed

- **`should not warn if paragraph style is unregisted`** → ported as an executable Rust test in a new `mod custom`. It asserts the crate's behavior for `[foo]\nbar`: the unknown style is retained on the block (`declared_style() == Some("foo")`), the content is parsed as an ordinary paragraph (`bar`), and **no warning** is emitted. This is already the crate's behavior; the test locks it in.

- **`should log debug message if paragraph style is unknown and debug level is enabled`** → **intentionally not ported.** Asciidoctor emits `unknown style for paragraph: foo` only at `DEBUG` severity. This crate has no debug-severity logging channel — its `Warning` mechanism conveys WARN-level possible parse errors only — so there is no equivalent behavior to assert. The observable behavior at default severity (no warning) is the one covered above. This decision is documented inline next to the ported test.

The `port_from_ruby` breadcrumb is updated and the now-ported `context 'Custom'` block removed from the stub.

## Note for reviewer

The DEBUG-logging half of the issue asks to "implement the behavior," but the only faithful way to reproduce it would be to introduce a severity/debug-logging subsystem that doesn't exist in this crate (there is no `log`/`tracing` dependency, and `Warning` is WARN-only). That felt out of scope for this port, so I documented it as not-applicable rather than build a logging channel for a single diagnostic message. Happy to reconsider if you'd prefer a debug-logging mechanism instead.

## Testing

- `cargo test -p asciidoc-parser --lib` — 3148 passed, 0 failed.
- `cargo clippy -p asciidoc-parser --all-targets` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)