### PR TITLE
feat: Render [open] styled paragraph as an open block (#679)

### DIFF
--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -2496,7 +2496,16 @@ mod special {
         let doc = Parser::default().parse("[open]\nMake it what you want.");
         assert_css(&doc, ".openblock", 1);
         assert_css(&doc, ".openblock p", 0);
-        assert_rendered_contains(&doc, "Make it what you want.");
+
+        // The inline content sits directly in the `div.content` wrapper (no
+        // wrapping `<p>`), so assert the wrapper structure and that the text
+        // lives inside it — not merely somewhere in the rendered tree.
+        assert_css(&doc, "div.openblock > div.content", 1);
+        assert_xpath(
+            &doc,
+            "//div[@class = \"openblock\"]/div[@class = \"content\"][contains(text(), \"Make it what you want.\")]",
+            1,
+        );
     }
 
     // Ported from Ruby Asciidoctor's paragraphs_test.rb ('note inline syntax').

--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -2487,6 +2487,18 @@ mod special {
         }
     }
 
+    // Ported from Ruby Asciidoctor's paragraphs_test.rb ('Styled Paragraphs' >
+    // 'should convert open paragraph to open block'). An `[open]` styled
+    // paragraph renders as an open block whose inline content sits directly in
+    // the content wrapper, with no wrapping `<p>`.
+    #[test]
+    fn should_convert_open_paragraph_to_open_block() {
+        let doc = Parser::default().parse("[open]\nMake it what you want.");
+        assert_css(&doc, ".openblock", 1);
+        assert_css(&doc, ".openblock p", 0);
+        assert_rendered_contains(&doc, "Make it what you want.");
+    }
+
     // Ported from Ruby Asciidoctor's paragraphs_test.rb ('note inline syntax').
     // The inline label form (e.g. `NOTE: ...`) renders as an admonition block.
     #[test]
@@ -2521,10 +2533,13 @@ fn port_from_ruby() {
     # been ported to `mod special` below now that conditional preprocessor
     # directives are implemented.
 
+    # NOTE: '[open]' styled paragraph -> open block (#679) has been ported to
+    # `mod special` below.
+
     # NOTE: the remaining un-ported tests below are tracked by dedicated
-    # issues: '[open]' styled paragraph -> open block (#679), inline doctype
-    # (#680), and unknown/custom paragraph style logging (#681). The DocBook
-    # 'simpara' styled-paragraph tests are out of scope (no DocBook backend).
+    # issues: inline doctype (#680) and unknown/custom paragraph style logging
+    # (#681). The DocBook 'simpara' styled-paragraph tests are out of scope (no
+    # DocBook backend).
 
     context 'Styled Paragraphs' do
       test 'should wrap text in simpara for styled paragraphs when converted to DocBook' do
@@ -2567,16 +2582,8 @@ fn port_from_ruby() {
         assert_css 'chapter > simpara', output, 1
       end
 
-      test 'should convert open paragraph to open block' do
-        input = <<~'EOS'
-        [open]
-        Make it what you want.
-        EOS
-
-        output = convert_string_to_embedded input
-        assert_css '.openblock', output, 1
-        assert_css '.openblock p', output, 0
-      end
+      # NOTE: 'should convert open paragraph to open block' has been ported to
+      # `mod special` below.
 
       test 'should wrap text in simpara for styled paragraphs with title when converted to DocBook' do
         input = <<~'EOS'

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -697,6 +697,14 @@ impl ToVirtualDom for Block<'_> {
             return example_to_node(self);
         }
 
+        // An `[open]` styled paragraph renders as an open block
+        // (`div.openblock > div.content`), with its inline content placed
+        // directly in the content wrapper and no `<p>`. The delimited `--` open
+        // block is a `Block::CompoundDelimited` handled by the match below.
+        if matches!(self, Block::Simple(_)) && is_open(self) {
+            return open_paragraph_to_node(self);
+        }
+
         match self {
             Block::Simple(simple) => {
                 // Comment blocks should not be rendered.
@@ -1421,6 +1429,42 @@ fn compound_delimited_to_node<'a>(compound: &'a CompoundDelimitedBlock<'a>) -> V
     node
 }
 
+/// Renders an `[open]` styled paragraph as an open block, matching
+/// Asciidoctor's HTML output.
+///
+/// The paragraph form of an open block (`[open]` over a single paragraph)
+/// produces the same `div.openblock > div.content` structure as the delimited
+/// `--` form in [`compound_delimited_to_node`], but its inline content is
+/// rendered directly inside the content wrapper without a wrapping `<p>` —
+/// mirroring the `[example]` and `[sidebar]` paragraph styles. The outer
+/// `div.openblock` carries the block's id and roles, and a title, when present,
+/// is rendered as a `div.title` *before* the content wrapper.
+fn open_paragraph_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
+    let mut node = VirtualNode::new("div").with_class("openblock");
+
+    for role in block.roles() {
+        node = node.with_class(role);
+    }
+
+    if let Some(id) = block.id() {
+        node = node.with_id(id);
+    }
+
+    // The title, when present, precedes the content wrapper.
+    if let Some(title) = block.title() {
+        node.children
+            .push(VirtualNode::new("div").with_class("title").with_text(title));
+    }
+
+    let mut content = VirtualNode::new("div").with_class("content");
+    if let Some(rendered) = block.rendered_content() {
+        content = content.with_html_content(rendered);
+    }
+    node.children.push(content);
+
+    node
+}
+
 /// Returns `true` if `block` is a collapsible block: an example block (or
 /// example-styled paragraph) carrying the `collapsible` option.
 ///
@@ -1499,18 +1543,20 @@ fn is_sidebar<'a>(block: &'a Block<'a>) -> bool {
     block.resolved_context().as_ref() == "sidebar"
 }
 
-/// Returns `true` if `block` is an open block: the `--` structural container,
-/// rendered by [`compound_delimited_to_node`] as `div.openblock`.
+/// Returns `true` if `block` is an open block: the `--` structural container
+/// or a paragraph carrying the `[open]` style, both of which resolve to the
+/// `open` context and render as `div.openblock`.
 ///
-/// Only a delimited open block (a [`Block::CompoundDelimited`] resolving to the
-/// `open` context) qualifies. Every masquerade style on a `--` block is
-/// intercepted earlier — by [`is_sidebar`], [`is_example`], `QuoteBlock`,
-/// `AdmonitionBlock`, or `RawDelimitedBlock` — so a `CompoundDelimited` block
-/// that reaches here always resolves to `open`. Like a sidebar, an open block
-/// renders its own title (as a `div.title` before its content wrapper), so
-/// [`add_block_with_title`] must not also emit one.
+/// The delimited form is a [`Block::CompoundDelimited`] rendered by
+/// [`compound_delimited_to_node`]; the paragraph form is a [`Block::Simple`]
+/// rendered by [`open_paragraph_to_node`]. Every masquerade style on a `--`
+/// block is intercepted earlier — by [`is_sidebar`], [`is_example`],
+/// `QuoteBlock`, `AdmonitionBlock`, or `RawDelimitedBlock` — so a
+/// `CompoundDelimited` block that reaches here always resolves to `open`. Like
+/// a sidebar, an open block renders its own title (as a `div.title` before its
+/// content wrapper), so [`add_block_with_title`] must not also emit one.
 fn is_open<'a>(block: &'a Block<'a>) -> bool {
-    matches!(block, Block::CompoundDelimited(_)) && block.resolved_context().as_ref() == "open"
+    block.resolved_context().as_ref() == "open"
 }
 
 /// Renders a sidebar block, matching Asciidoctor's HTML output.


### PR DESCRIPTION
Ports the stubbed Asciidoctor test _"should convert open paragraph to open block"_ (`Styled Paragraphs`) to an executable Rust test and implements the rendering.

## Problem

An `[open]` styled paragraph fell through to the plain simple-block renderer, which emitted an empty `<div class="openblock">` — the paragraph's content was dropped from the open-block output.

## Fix

In the test virtual-DOM renderer (`assert_dom/virtual_dom.rs`), an `[open]` paragraph now renders as `div.openblock > div.content` with its inline content placed **directly** in the content wrapper (no wrapping `<p>`), matching Asciidoctor and mirroring the existing `[example]` and `[sidebar]` paragraph styles:

- `is_open` now matches both the `--` delimited block and the `[open]` paragraph (both resolve to the `open` context), so `add_block_with_title` lets the open block own its title.
- `Block::to_virtual_dom` routes an `[open]` paragraph to a new `open_paragraph_to_node`.
- The delimited `--` open-block path (`compound_delimited_to_node`) is unchanged.

## Test

Ported to `mod special` in `paragraphs_test.rs`:

```
[open]
Make it what you want.
```
- `assert_css('.openblock', 1)`
- `assert_css('.openblock p', 0)`

The DocBook `simpara` styled-paragraph tests in the same context remain out of scope (no DocBook backend).

Closes #679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)