### PR TITLE
fix: Default `relfilesuffix` to `outfilesuffix` instead of hardcoded `.html` (#657)

### DIFF
--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -290,10 +290,14 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
         any(ApiOrHeader, Value(".html".into())),
     );
 
-    // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/657): `relfilesuffix` should default to the current value of
-    // `outfilesuffix` rather than a hardcoded `.html`; they diverge for
-    // non-HTML backends (e.g. `.xml` for DocBook).
-    attrs.insert("relfilesuffix".to_owned(), set(Anywhere, ".html"));
+    // `relfilesuffix` — the path suffix added to relative (inter-document)
+    // xrefs — is intentionally *not* registered here. When it has not been
+    // explicitly set it tracks the current value of `outfilesuffix` rather than
+    // a hardcoded `.html`, since the two diverge for non-HTML backends (e.g.
+    // `.xml` for DocBook). That read-only default is resolved on the fly by the
+    // attribute readers (see `Parser::effective_attribute_for_read`); it stays
+    // absent from this table so that, like Asciidoctor, it is genuinely unset
+    // (and hence freely modifiable anywhere) until an author assigns it.
     attrs.insert("webfonts".to_owned(), empty(ApiOrHeader, Set));
 
     // ### Image and icon attributes

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -497,8 +497,8 @@ impl Parser {
     /// materialized in either table.
     ///
     /// This is the *raw* lookup used by the attribute writers to decide whether
-    /// a name is locked against modification. The attribute *readers* additionally
-    /// resolve the read-only default of `relfilesuffix` (see
+    /// a name is locked against modification. The attribute *readers*
+    /// additionally resolve the read-only default of `relfilesuffix` (see
     /// [`tracks_outfilesuffix`](Self::tracks_outfilesuffix)).
     ///
     /// [unset]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unset-attributes/
@@ -517,15 +517,15 @@ impl Parser {
     /// two diverge for non-HTML backends, e.g. `.xml` for DocBook — see
     /// [issue #657](https://github.com/asciidoc-rs/asciidoc-parser/issues/657)).
     ///
-    /// Returns `false` once `relfilesuffix` is explicitly set or unset (an entry
-    /// — a value or an [unset] tombstone — then lives in the per-parser map),
-    /// and for every other name. The redirect is deliberately confined to the
-    /// value *readers*: the attribute *writers* consult
-    /// [`effective_attribute`](Self::effective_attribute) directly, so
-    /// `relfilesuffix` stays modifiable anywhere rather than inheriting the
-    /// header-only modification context of `outfilesuffix`. Callers must apply a
-    /// like-named counter overlay first, so a `{counter:relfilesuffix}` still
-    /// wins over the tracked default.
+    /// Returns `false` once `relfilesuffix` is explicitly set or unset (an
+    /// entry — a value or an [unset] tombstone — then lives in the
+    /// per-parser map), and for every other name. The redirect is
+    /// deliberately confined to the value *readers*: the attribute
+    /// *writers* consult [`effective_attribute`](Self::effective_attribute)
+    /// directly, so `relfilesuffix` stays modifiable anywhere rather than
+    /// inheriting the header-only modification context of `outfilesuffix`.
+    /// Callers must apply a like-named counter overlay first, so a
+    /// `{counter:relfilesuffix}` still wins over the tracked default.
     ///
     /// [unset]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unset-attributes/
     pub(crate) fn tracks_outfilesuffix(&self, name: &str) -> bool {

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -467,7 +467,7 @@ impl Parser {
             return InterpretedValue::Value(value.clone());
         }
 
-        match self.effective_attribute(name) {
+        match self.effective_attribute_for_read(name) {
             Some(av) => {
                 if let InterpretedValue::Set = av.value
                     && let Some(default) = self.default_attribute_values.get(name)
@@ -488,6 +488,11 @@ impl Parser {
     /// `safe-mode-*` flags). The synthesized attributes are never
     /// materialized in either table.
     ///
+    /// This is the *raw* lookup used by the attribute writers to decide whether
+    /// a name is locked against modification. The attribute *readers* use
+    /// [`effective_attribute_for_read`](Self::effective_attribute_for_read),
+    /// which additionally resolves the read-only default of `relfilesuffix`.
+    ///
     /// [unset]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unset-attributes/
     pub(crate) fn effective_attribute(&self, name: &str) -> Option<&AttributeValue> {
         if let Some(av) = self.attribute_values.get(name) {
@@ -499,12 +504,30 @@ impl Parser {
         synthesized_attr(name, &self.attribute_values)
     }
 
+    /// Like [`effective_attribute`](Self::effective_attribute), but
+    /// additionally resolves the read-only default of `relfilesuffix`: when
+    /// it has not been explicitly set, it tracks the current value of
+    /// `outfilesuffix` (the two diverge for non-HTML backends, e.g. `.xml`
+    /// for DocBook). See [issue #657](https://github.com/asciidoc-rs/asciidoc-parser/issues/657).
+    ///
+    /// Only the value *readers* use this. The attribute *writers* deliberately
+    /// consult [`effective_attribute`](Self::effective_attribute) instead, so
+    /// `relfilesuffix` stays modifiable anywhere rather than inheriting the
+    /// header-only modification context of `outfilesuffix`.
+    pub(crate) fn effective_attribute_for_read(&self, name: &str) -> Option<&AttributeValue> {
+        if name == "relfilesuffix" && !self.attribute_values.contains_key(name) {
+            return self.effective_attribute("outfilesuffix");
+        }
+        self.effective_attribute(name)
+    }
+
     /// Returns `true` if the parser has a [document attribute] by this name.
     ///
     /// [document attribute]: https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes/
     pub fn has_attribute<N: AsRef<str>>(&self, name: N) -> bool {
         let name = name.as_ref();
-        self.counter_values.borrow().contains_key(name) || self.effective_attribute(name).is_some()
+        self.counter_values.borrow().contains_key(name)
+            || self.effective_attribute_for_read(name).is_some()
     }
 
     /// Returns `true` if the parser has a [document attribute] by this name
@@ -520,7 +543,7 @@ impl Parser {
             return true;
         }
 
-        self.effective_attribute(name)
+        self.effective_attribute_for_read(name)
             .map(|a| a.value != InterpretedValue::Unset)
             .unwrap_or(false)
     }

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -467,7 +467,15 @@ impl Parser {
             return InterpretedValue::Value(value.clone());
         }
 
-        match self.effective_attribute_for_read(name) {
+        // An unset `relfilesuffix` reads as the *effective* value of
+        // `outfilesuffix` — routed through this same reader so an
+        // `outfilesuffix` counter overlay is honored too (see
+        // [`tracks_outfilesuffix`](Self::tracks_outfilesuffix)).
+        if self.tracks_outfilesuffix(name) {
+            return self.attribute_value("outfilesuffix");
+        }
+
+        match self.effective_attribute(name) {
             Some(av) => {
                 if let InterpretedValue::Set = av.value
                     && let Some(default) = self.default_attribute_values.get(name)
@@ -489,9 +497,9 @@ impl Parser {
     /// materialized in either table.
     ///
     /// This is the *raw* lookup used by the attribute writers to decide whether
-    /// a name is locked against modification. The attribute *readers* use
-    /// [`effective_attribute_for_read`](Self::effective_attribute_for_read),
-    /// which additionally resolves the read-only default of `relfilesuffix`.
+    /// a name is locked against modification. The attribute *readers* additionally
+    /// resolve the read-only default of `relfilesuffix` (see
+    /// [`tracks_outfilesuffix`](Self::tracks_outfilesuffix)).
     ///
     /// [unset]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unset-attributes/
     pub(crate) fn effective_attribute(&self, name: &str) -> Option<&AttributeValue> {
@@ -504,21 +512,24 @@ impl Parser {
         synthesized_attr(name, &self.attribute_values)
     }
 
-    /// Like [`effective_attribute`](Self::effective_attribute), but
-    /// additionally resolves the read-only default of `relfilesuffix`: when
-    /// it has not been explicitly set, it tracks the current value of
-    /// `outfilesuffix` (the two diverge for non-HTML backends, e.g. `.xml`
-    /// for DocBook). See [issue #657](https://github.com/asciidoc-rs/asciidoc-parser/issues/657).
+    /// Reports whether `name` is `relfilesuffix` in its unset state, in which
+    /// case a *read* resolves it to the current value of `outfilesuffix` (the
+    /// two diverge for non-HTML backends, e.g. `.xml` for DocBook — see
+    /// [issue #657](https://github.com/asciidoc-rs/asciidoc-parser/issues/657)).
     ///
-    /// Only the value *readers* use this. The attribute *writers* deliberately
-    /// consult [`effective_attribute`](Self::effective_attribute) instead, so
+    /// Returns `false` once `relfilesuffix` is explicitly set or unset (an entry
+    /// — a value or an [unset] tombstone — then lives in the per-parser map),
+    /// and for every other name. The redirect is deliberately confined to the
+    /// value *readers*: the attribute *writers* consult
+    /// [`effective_attribute`](Self::effective_attribute) directly, so
     /// `relfilesuffix` stays modifiable anywhere rather than inheriting the
-    /// header-only modification context of `outfilesuffix`.
-    pub(crate) fn effective_attribute_for_read(&self, name: &str) -> Option<&AttributeValue> {
-        if name == "relfilesuffix" && !self.attribute_values.contains_key(name) {
-            return self.effective_attribute("outfilesuffix");
-        }
-        self.effective_attribute(name)
+    /// header-only modification context of `outfilesuffix`. Callers must apply a
+    /// like-named counter overlay first, so a `{counter:relfilesuffix}` still
+    /// wins over the tracked default.
+    ///
+    /// [unset]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unset-attributes/
+    pub(crate) fn tracks_outfilesuffix(&self, name: &str) -> bool {
+        name == "relfilesuffix" && !self.attribute_values.contains_key(name)
     }
 
     /// Returns `true` if the parser has a [document attribute] by this name.
@@ -526,8 +537,13 @@ impl Parser {
     /// [document attribute]: https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes/
     pub fn has_attribute<N: AsRef<str>>(&self, name: N) -> bool {
         let name = name.as_ref();
-        self.counter_values.borrow().contains_key(name)
-            || self.effective_attribute_for_read(name).is_some()
+        if self.counter_values.borrow().contains_key(name) {
+            return true;
+        }
+        if self.tracks_outfilesuffix(name) {
+            return self.has_attribute("outfilesuffix");
+        }
+        self.effective_attribute(name).is_some()
     }
 
     /// Returns `true` if the parser has a [document attribute] by this name
@@ -543,7 +559,11 @@ impl Parser {
             return true;
         }
 
-        self.effective_attribute_for_read(name)
+        if self.tracks_outfilesuffix(name) {
+            return self.is_attribute_set("outfilesuffix");
+        }
+
+        self.effective_attribute(name)
             .map(|a| a.value != InterpretedValue::Unset)
             .unwrap_or(false)
     }

--- a/parser/src/parser/resolved_attributes.rs
+++ b/parser/src/parser/resolved_attributes.rs
@@ -64,7 +64,7 @@ impl ResolvedAttributes {
             return InterpretedValue::Value(value.clone());
         }
 
-        match self.effective_attribute(name) {
+        match self.effective_attribute_for_read(name) {
             Some(av) => {
                 if let InterpretedValue::Set = av.value
                     && let Some(default) = self.default_attribute_values.get(name)
@@ -93,13 +93,28 @@ impl ResolvedAttributes {
         synthesized_attr(name, &self.attribute_values)
     }
 
+    /// Like [`effective_attribute`](Self::effective_attribute), but
+    /// additionally resolves the read-only default of `relfilesuffix`: when
+    /// it has not been explicitly set, it tracks the current value of
+    /// `outfilesuffix`. Mirrors [`Parser::effective_attribute_for_read`],
+    /// so a lookup here returns the same value the parser would report
+    /// after `parse`.
+    ///
+    /// [`Parser::effective_attribute_for_read`]: crate::Parser::effective_attribute_for_read
+    fn effective_attribute_for_read(&self, name: &str) -> Option<&AttributeValue> {
+        if name == "relfilesuffix" && !self.attribute_values.contains_key(name) {
+            return self.effective_attribute("outfilesuffix");
+        }
+        self.effective_attribute(name)
+    }
+
     /// Returns `true` if the named document attribute is present (whether or
     /// not it is set).
     ///
     /// Mirrors [`Parser::has_attribute`](crate::Parser::has_attribute).
     pub(crate) fn has_attribute<N: AsRef<str>>(&self, name: N) -> bool {
         let name = name.as_ref();
-        self.counter_values.contains_key(name) || self.effective_attribute(name).is_some()
+        self.counter_values.contains_key(name) || self.effective_attribute_for_read(name).is_some()
     }
 
     /// Returns `true` if the named document attribute is present and set (i.e.
@@ -116,7 +131,7 @@ impl ResolvedAttributes {
             return true;
         }
 
-        self.effective_attribute(name)
+        self.effective_attribute_for_read(name)
             .map(|a| a.value != InterpretedValue::Unset)
             .unwrap_or(false)
     }

--- a/parser/src/parser/resolved_attributes.rs
+++ b/parser/src/parser/resolved_attributes.rs
@@ -64,7 +64,15 @@ impl ResolvedAttributes {
             return InterpretedValue::Value(value.clone());
         }
 
-        match self.effective_attribute_for_read(name) {
+        // An unset `relfilesuffix` reads as the *effective* value of
+        // `outfilesuffix` — routed through this same reader so an
+        // `outfilesuffix` counter overlay is honored too (see
+        // [`tracks_outfilesuffix`](Self::tracks_outfilesuffix)).
+        if self.tracks_outfilesuffix(name) {
+            return self.attribute_value("outfilesuffix");
+        }
+
+        match self.effective_attribute(name) {
             Some(av) => {
                 if let InterpretedValue::Set = av.value
                     && let Some(default) = self.default_attribute_values.get(name)
@@ -93,19 +101,16 @@ impl ResolvedAttributes {
         synthesized_attr(name, &self.attribute_values)
     }
 
-    /// Like [`effective_attribute`](Self::effective_attribute), but
-    /// additionally resolves the read-only default of `relfilesuffix`: when
-    /// it has not been explicitly set, it tracks the current value of
-    /// `outfilesuffix`. Mirrors [`Parser::effective_attribute_for_read`],
-    /// so a lookup here returns the same value the parser would report
-    /// after `parse`.
+    /// Reports whether `name` is `relfilesuffix` in its unset state, in which
+    /// case a *read* resolves it to the current value of `outfilesuffix`.
+    /// Mirrors [`Parser::tracks_outfilesuffix`], so a lookup here returns the
+    /// same value the parser would report after `parse`. Callers apply a
+    /// like-named counter overlay first, so a `{counter:relfilesuffix}` still
+    /// wins over the tracked default.
     ///
-    /// [`Parser::effective_attribute_for_read`]: crate::Parser::effective_attribute_for_read
-    fn effective_attribute_for_read(&self, name: &str) -> Option<&AttributeValue> {
-        if name == "relfilesuffix" && !self.attribute_values.contains_key(name) {
-            return self.effective_attribute("outfilesuffix");
-        }
-        self.effective_attribute(name)
+    /// [`Parser::tracks_outfilesuffix`]: crate::Parser::tracks_outfilesuffix
+    fn tracks_outfilesuffix(&self, name: &str) -> bool {
+        name == "relfilesuffix" && !self.attribute_values.contains_key(name)
     }
 
     /// Returns `true` if the named document attribute is present (whether or
@@ -114,7 +119,13 @@ impl ResolvedAttributes {
     /// Mirrors [`Parser::has_attribute`](crate::Parser::has_attribute).
     pub(crate) fn has_attribute<N: AsRef<str>>(&self, name: N) -> bool {
         let name = name.as_ref();
-        self.counter_values.contains_key(name) || self.effective_attribute_for_read(name).is_some()
+        if self.counter_values.contains_key(name) {
+            return true;
+        }
+        if self.tracks_outfilesuffix(name) {
+            return self.has_attribute("outfilesuffix");
+        }
+        self.effective_attribute(name).is_some()
     }
 
     /// Returns `true` if the named document attribute is present and set (i.e.
@@ -131,7 +142,11 @@ impl ResolvedAttributes {
             return true;
         }
 
-        self.effective_attribute_for_read(name)
+        if self.tracks_outfilesuffix(name) {
+            return self.is_attribute_set("outfilesuffix");
+        }
+
+        self.effective_attribute(name)
             .map(|a| a.value != InterpretedValue::Unset)
             .unwrap_or(false)
     }

--- a/parser/src/tests/asciidoc_lang/attributes/document_attributes_ref.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/document_attributes_ref.rs
@@ -1333,12 +1333,15 @@ A non-empty value replaces the `family` query string parameter in the Google Fon
 /// <https://github.com/asciidoc-rs/asciidoc-parser/issues/657>.
 #[test]
 fn relfilesuffix_tracks_outfilesuffix() {
-    // On a pristine parser `relfilesuffix` reports the `outfilesuffix` default.
+    // On a pristine parser `relfilesuffix` reports the `outfilesuffix` default,
+    // and reads as present and set (like the header-only `outfilesuffix` it
+    // tracks) even though it is not stored.
     let parser = Parser::default();
     assert_eq!(
         parser.attribute_value("relfilesuffix").as_maybe_str(),
         Some(".html")
     );
+    assert!(parser.has_attribute("relfilesuffix"));
     assert!(parser.is_attribute_set("relfilesuffix"));
 
     // Changing `outfilesuffix` (here, to a DocBook-style suffix) moves
@@ -1372,6 +1375,56 @@ fn relfilesuffix_tracks_outfilesuffix() {
         Some(".adoc")
     );
     assert_eq!(doc.warnings().count(), 0);
+}
+
+/// The read-only default resolves the *effective* value of `outfilesuffix`,
+/// including a counter overlay: a counter takes precedence over a like-named
+/// attribute, so a `{counter:outfilesuffix}` must move `relfilesuffix` with it
+/// rather than leaving it reading the underlying attribute. Regression test for
+/// the counter-overlay gap in the issue #657 fix.
+#[test]
+fn relfilesuffix_tracks_outfilesuffix_counter_overlay() {
+    let mut parser = Parser::default();
+    parser.parse("= Title\n\nSuffix is {counter:outfilesuffix}.\n");
+
+    // Resolving the counter overlays `outfilesuffix`: the counter increments its
+    // last character, so `.html` becomes `.htmm`. An unset `relfilesuffix` must
+    // read that overlaid value, not the raw `.html` attribute underneath it.
+    let outfilesuffix = parser.attribute_value("outfilesuffix");
+    assert_eq!(outfilesuffix.as_maybe_str(), Some(".htmm"));
+    assert_eq!(parser.attribute_value("relfilesuffix"), outfilesuffix);
+}
+
+/// The same tracking applies to a parsed [`Document`]'s attribute snapshot
+/// (`ResolvedAttributes`), which mirrors the parser: querying `relfilesuffix`
+/// on the document reports the `outfilesuffix` in effect at the end of parsing.
+///
+/// [`Document`]: crate::Document
+#[test]
+fn relfilesuffix_tracks_outfilesuffix_on_document() {
+    // Default backend: the snapshot reports the `.html` default, present/set.
+    let doc = Parser::default().parse("= Title\n\nBody.\n");
+    assert_eq!(
+        doc.attribute_value("relfilesuffix").as_maybe_str(),
+        Some(".html")
+    );
+    assert!(doc.has_attribute("relfilesuffix"));
+    assert!(doc.is_attribute_set("relfilesuffix"));
+
+    // A header-set `outfilesuffix` carries into the snapshot's `relfilesuffix`.
+    let doc = Parser::default().parse("= Title\n:outfilesuffix: .xml\n\nBody.\n");
+    assert_eq!(
+        doc.attribute_value("relfilesuffix").as_maybe_str(),
+        Some(".xml")
+    );
+
+    // An explicit `relfilesuffix` in the document wins in the snapshot too.
+    let doc =
+        Parser::default().parse("= Title\n:outfilesuffix: .xml\n:relfilesuffix: .adoc\n\nBody.\n");
+    assert_eq!(
+        doc.attribute_value("relfilesuffix").as_maybe_str(),
+        Some(".adoc")
+    );
 }
 
 #[test]

--- a/parser/src/tests/asciidoc_lang/attributes/document_attributes_ref.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/document_attributes_ref.rs
@@ -1324,6 +1324,56 @@ A non-empty value replaces the `family` query string parameter in the Google Fon
     }
 }
 
+/// The reference page describes `relfilesuffix` as defaulting to `.html`, but
+/// that default is really "the value of `outfilesuffix`" — the two diverge for
+/// non-HTML backends (e.g. `.xml` for DocBook). `relfilesuffix` is not stored
+/// by default: when it has not been explicitly set it tracks the current value
+/// of `outfilesuffix`, yet it remains freely modifiable (it is not header-only
+/// like `outfilesuffix`). See
+/// <https://github.com/asciidoc-rs/asciidoc-parser/issues/657>.
+#[test]
+fn relfilesuffix_tracks_outfilesuffix() {
+    // On a pristine parser `relfilesuffix` reports the `outfilesuffix` default.
+    let parser = Parser::default();
+    assert_eq!(
+        parser.attribute_value("relfilesuffix").as_maybe_str(),
+        Some(".html")
+    );
+    assert!(parser.is_attribute_set("relfilesuffix"));
+
+    // Changing `outfilesuffix` (here, to a DocBook-style suffix) moves
+    // `relfilesuffix` with it, rather than leaving it pinned at `.html`.
+    let mut parser = Parser::default();
+    parser.parse("= Title\n:outfilesuffix: .xml\n");
+    assert_eq!(
+        parser.attribute_value("outfilesuffix").as_maybe_str(),
+        Some(".xml")
+    );
+    assert_eq!(
+        parser.attribute_value("relfilesuffix").as_maybe_str(),
+        Some(".xml")
+    );
+
+    // An explicit `relfilesuffix` wins and no longer tracks `outfilesuffix`.
+    let mut parser = Parser::default();
+    parser.parse("= Title\n:outfilesuffix: .xml\n:relfilesuffix: .adoc\n");
+    assert_eq!(
+        parser.attribute_value("relfilesuffix").as_maybe_str(),
+        Some(".adoc")
+    );
+
+    // Unlike `outfilesuffix` (header-only), `relfilesuffix` may be set from the
+    // document body: the assignment is honored without an
+    // `AttributeValueIsLocked` warning.
+    let mut parser = Parser::default();
+    let doc = parser.parse("= Title\n\nSome text.\n\n:relfilesuffix: .adoc\n");
+    assert_eq!(
+        parser.attribute_value("relfilesuffix").as_maybe_str(),
+        Some(".adoc")
+    );
+    assert_eq!(doc.warnings().count(), 0);
+}
+
 #[test]
 fn image_and_icon_attributes() {
     verifies!(


### PR DESCRIPTION
Fixes #657.

## Problem

`parser/src/parser/built_in_attrs.rs` registered `relfilesuffix` as a
built-in attribute hardcoded to `.html`. Per Asciidoctor, `relfilesuffix`
(the path suffix added to relative / inter-document xrefs) is **not**
actually set by default: when it has not been explicitly set, it tracks
the current value of `outfilesuffix`. The two diverge for non-HTML
backends (e.g. `.xml` for DocBook), so pinning it to `.html` produced the
wrong suffix whenever `outfilesuffix` was changed.

## Fix

- Remove the built-in `relfilesuffix` entry so it is genuinely unset by
  default (and therefore freely modifiable anywhere, matching its
  non-header-only status).
- Resolve it on the fly: the attribute **readers** (`attribute_value`,
  `has_attribute`, `is_attribute_set`, plus their `ResolvedAttributes`
  mirrors) now fall through to `outfilesuffix` when `relfilesuffix` has
  not been explicitly set, via a new `effective_attribute_for_read`.
- The attribute **writers** deliberately keep using the raw
  `effective_attribute`, so `relfilesuffix` stays modifiable anywhere
  rather than inheriting the header-only modification context of
  `outfilesuffix`. An explicit assignment (in the header or body) still
  wins and stops tracking.

## Tests

Adds `relfilesuffix_tracks_outfilesuffix`, covering: the pristine default,
tracking a changed `outfilesuffix` (`.xml`), an explicit override winning,
and a body-level assignment being honored without an
`AttributeValueIsLocked` warning. The existing
`assert_default("relfilesuffix", ".html")` continues to pass. Full parser
suite green (`cargo test -p asciidoc-parser`), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)