### PR TITLE
feat: Render document-level `doctype: inline` (#680)

### DIFF
--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -132,32 +132,6 @@ impl<'src> Document<'src> {
             }
 
             let mut blocks = maw_blocks.item.item;
-
-            // Under `doctype: inline`, only the first block is converted, as bare
-            // inline content, and everything after it is dropped (the rendering
-            // lives on the embed path). A compound or empty first block has no
-            // inline content to emit, so warn here — matching Asciidoctor's
-            // `Document#convert` — and let the embed path render nothing. The
-            // rendered inline output of a valid candidate is read back from the
-            // first block's own content.
-            if matches!(
-                parser.attribute_value("doctype"),
-                InterpretedValue::Value(ref v) if v == "inline"
-            ) && let Some(first) = blocks
-                .iter()
-                .find(|b| !matches!(b, Block::DocumentAttribute(_)))
-                && matches!(
-                    first.content_model(),
-                    ContentModel::Compound | ContentModel::Empty
-                )
-            {
-                warnings.push(Warning {
-                    source: first.span(),
-                    warning: WarningType::NoInlineDoctypeCandidate,
-                    origin: None,
-                });
-            }
-
             let mut has_content_blocks = false;
             let mut preamble_split_index: Option<usize> = None;
 
@@ -187,6 +161,30 @@ impl<'src> Document<'src> {
 
                 section_blocks.insert(0, Block::Preamble(preamble));
                 blocks = section_blocks;
+            }
+
+            // Under `doctype: inline`, only the first eligible block is converted,
+            // as bare inline content, and everything after it is dropped (the
+            // rendering lives on the embed path). A compound or empty candidate
+            // has no inline content to emit, so warn here — matching
+            // Asciidoctor's `Document#convert` — and let the embed path render
+            // nothing. This runs on the final block list (after any preamble
+            // split) and uses the same candidate selection as the renderer, so
+            // the two always agree on which block is the candidate.
+            if matches!(
+                parser.attribute_value("doctype"),
+                InterpretedValue::Value(ref v) if v == "inline"
+            ) && let Some(first) = first_inline_candidate(blocks.iter())
+                && matches!(
+                    first.content_model(),
+                    ContentModel::Compound | ContentModel::Empty
+                )
+            {
+                warnings.push(Warning {
+                    source: first.span(),
+                    warning: WarningType::NoInlineDoctypeCandidate,
+                    origin: None,
+                });
             }
 
             // Capture the parser's fully-resolved attribute state so it can be
@@ -511,6 +509,32 @@ impl std::fmt::Debug for Document<'_> {
             .field("catalog", &dependent.catalog)
             .finish()
     }
+}
+
+/// Returns the first block eligible to be the sole rendered block of an
+/// `inline` document.
+///
+/// A document-attribute entry and a comment (either a `[comment]`-styled block
+/// or a `////` comment block) produce no output, so they are transparent here
+/// and skipped, mirroring how Asciidoctor drops them before taking `blocks[0]`.
+/// The returned block is the one an `inline` document renders (when it holds
+/// inline content) or reports as having *no inline candidate* (when it is
+/// compound or empty).
+///
+/// Both the parse-time `no inline candidate` check and the embed-path renderer
+/// select the candidate through this function so the two never disagree about
+/// which block is the candidate.
+pub(crate) fn first_inline_candidate<'a, 'src>(
+    blocks: impl Iterator<Item = &'a Block<'src>>,
+) -> Option<&'a Block<'src>>
+where
+    'src: 'a,
+{
+    blocks.into_iter().find(|b| {
+        !matches!(b, Block::DocumentAttribute(_))
+            && b.resolved_context().as_ref() != "comment"
+            && b.declared_style() != Some("comment")
+    })
 }
 
 #[cfg(test)]

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -5,7 +5,7 @@ use std::{marker::PhantomData, rc::Rc, slice::Iter};
 use self_cell::self_cell;
 
 use crate::{
-    Parser, Span,
+    HasSpan, Parser, Span,
     attributes::Attrlist,
     blocks::{Block, ContentModel, IsBlock, Preamble, parse_utils::parse_blocks_until},
     document::{Catalog, Docinfo, DocinfoLocation, Header, InterpretedValue, TocConfig, TocMode},
@@ -15,7 +15,7 @@ use crate::{
         ReferenceWarning, ResolvedAttributes, SourceMap,
     },
     strings::CowStr,
-    warnings::Warning,
+    warnings::{Warning, WarningType},
 };
 
 /// A document represents the top-level block element in AsciiDoc. It consists
@@ -132,6 +132,32 @@ impl<'src> Document<'src> {
             }
 
             let mut blocks = maw_blocks.item.item;
+
+            // Under `doctype: inline`, only the first block is converted, as bare
+            // inline content, and everything after it is dropped (the rendering
+            // lives on the embed path). A compound or empty first block has no
+            // inline content to emit, so warn here — matching Asciidoctor's
+            // `Document#convert` — and let the embed path render nothing. The
+            // rendered inline output of a valid candidate is read back from the
+            // first block's own content.
+            if matches!(
+                parser.attribute_value("doctype"),
+                InterpretedValue::Value(ref v) if v == "inline"
+            ) && let Some(first) = blocks
+                .iter()
+                .find(|b| !matches!(b, Block::DocumentAttribute(_)))
+                && matches!(
+                    first.content_model(),
+                    ContentModel::Compound | ContentModel::Empty
+                )
+            {
+                warnings.push(Warning {
+                    source: first.span(),
+                    warning: WarningType::NoInlineDoctypeCandidate,
+                    origin: None,
+                });
+            }
+
             let mut has_content_blocks = false;
             let mut preamble_split_index: Option<usize> = None;
 

--- a/parser/src/document/mod.rs
+++ b/parser/src/document/mod.rs
@@ -20,6 +20,8 @@ pub use docinfo::DocinfoLocation;
 
 mod document;
 pub use document::Document;
+#[cfg(test)]
+pub(crate) use document::first_inline_candidate;
 
 mod header;
 pub use header::Header;

--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -2504,6 +2504,62 @@ mod special {
             assert_rendered_contains(&doc, "This is important, fool!");
         }
     }
+
+    // Ported from Ruby Asciidoctor's paragraphs_test.rb, `context 'Inline
+    // doctype'`. Under `doctype: inline` the document converts only its first
+    // block, as bare inline content; a compound (or empty) first block has no
+    // inline candidate and is reported.
+    mod inline_doctype {
+        use crate::tests::prelude::*;
+
+        // Ported from 'should only format and output text in first paragraph
+        // when doctype is inline'.
+        #[test]
+        fn should_only_output_first_paragraph() {
+            let doc = Parser::default()
+                .with_intrinsic_attribute("doctype", "inline", ModificationContext::Anywhere)
+                .parse(
+                    "http://asciidoc.org[AsciiDoc] is a _lightweight_ markup language...\n\nignored",
+                );
+
+            // The first paragraph is rendered as bare inline content, with the
+            // full inline substitutions applied and no `<div class="paragraph">
+            // <p>` wrapper.
+            let first = doc.nested_blocks().next().unwrap();
+            assert_eq!(
+                first.rendered_content(),
+                Some(
+                    "<a href=\"http://asciidoc.org\">AsciiDoc</a> is a <em>lightweight</em> markup language&#8230;&#8203;"
+                )
+            );
+            assert_css(&doc, ".paragraph", 0);
+            assert_xpath(&doc, "//a[@href = \"http://asciidoc.org\"]", 1);
+            assert_xpath(&doc, "//em[text() = \"lightweight\"]", 1);
+
+            // The second paragraph (`ignored`) is dropped from the output.
+            refute_rendered_contains(&doc, "ignored");
+
+            // A valid inline candidate produces no warning.
+            assert!(doc.warnings().next().is_none());
+        }
+
+        // Ported from 'should output nil and warn if first block is not a
+        // paragraph'. A list is a compound block, so it is not an inline
+        // candidate: nothing is emitted and a warning is logged.
+        #[test]
+        fn should_warn_if_first_block_is_not_a_paragraph() {
+            let doc = Parser::default()
+                .with_intrinsic_attribute("doctype", "inline", ModificationContext::Anywhere)
+                .parse("* bullet");
+
+            let warnings: Vec<_> = doc.warnings().collect();
+            assert_eq!(warnings.len(), 1);
+            assert_eq!(warnings[0].warning, WarningType::NoInlineDoctypeCandidate);
+
+            // Nothing is rendered (the list is not an inline candidate).
+            refute_rendered_contains(&doc, "bullet");
+        }
+    }
 }
 
 #[ignore]
@@ -2521,10 +2577,13 @@ fn port_from_ruby() {
     # been ported to `mod special` below now that conditional preprocessor
     # directives are implemented.
 
+    # NOTE: the 'Inline doctype' tests (#680) have been ported to
+    # `mod special::inline_doctype` below.
+
     # NOTE: the remaining un-ported tests below are tracked by dedicated
-    # issues: '[open]' styled paragraph -> open block (#679), inline doctype
-    # (#680), and unknown/custom paragraph style logging (#681). The DocBook
-    # 'simpara' styled-paragraph tests are out of scope (no DocBook backend).
+    # issues: '[open]' styled paragraph -> open block (#679) and
+    # unknown/custom paragraph style logging (#681). The DocBook 'simpara'
+    # styled-paragraph tests are out of scope (no DocBook backend).
 
     context 'Styled Paragraphs' do
       test 'should wrap text in simpara for styled paragraphs when converted to DocBook' do
@@ -2627,23 +2686,6 @@ fn port_from_ruby() {
         assert_css 'blockquote > title', output, 1
         assert_xpath '//blockquote/title[text() = "Quote title"]', output, 1
         assert_css 'blockquote > title + simpara', output, 1
-      end
-    end
-
-    context 'Inline doctype' do
-      test 'should only format and output text in first paragraph when doctype is inline' do
-        input = "http://asciidoc.org[AsciiDoc] is a _lightweight_ markup language...\n\nignored"
-        output = convert_string input, doctype: 'inline'
-        assert_equal '<a href="http://asciidoc.org">AsciiDoc</a> is a <em>lightweight</em> markup language&#8230;&#8203;', output
-      end
-
-      test 'should output nil and warn if first block is not a paragraph' do
-        input = '* bullet'
-        using_memory_logger do |logger|
-          output = convert_string input, doctype: 'inline'
-          assert_nil output
-          assert_message logger, :WARN, '~no inline candidate'
-        end
       end
     end
   end

--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -2614,6 +2614,12 @@ mod special {
         // candidate has no inline content, so the parse-time warning and the
         // (empty) rendered output stay in agreement — the preamble never masks a
         // silently-dropped candidate.
+        //
+        // This matches Asciidoctor 2.0.26 exactly: `= Title\n\nfirst
+        // paragraph\n\n== Section` under `-d inline` logs `no inline candidate`
+        // and emits nothing (the preamble is `@blocks[0]`, and its content model
+        // is compound). Rendering the inner paragraph instead would diverge from
+        // Asciidoctor.
         #[test]
         fn preamble_is_a_compound_candidate() {
             let doc = Parser::default()
@@ -2626,6 +2632,23 @@ mod special {
 
             refute_rendered_contains(&doc, "first paragraph");
             refute_rendered_contains(&doc, "body");
+        }
+
+        // A title with a paragraph but *no* section creates no preamble (this
+        // crate, like Asciidoctor, only wraps a preamble when a section follows),
+        // so the paragraph is itself the first block and is rendered as inline
+        // content with no warning. Asciidoctor 2.0.26 emits `first paragraph`
+        // for `= Title\n\nfirst paragraph` under `-d inline`. This is the
+        // boundary that distinguishes the candidate from the compound-preamble
+        // case above.
+        #[test]
+        fn titled_paragraph_without_section_is_rendered() {
+            let doc = Parser::default()
+                .with_intrinsic_attribute("doctype", "inline", ModificationContext::Anywhere)
+                .parse("= Title\n\nfirst paragraph");
+
+            assert!(doc.warnings().next().is_none());
+            assert_rendered_contains(&doc, "first paragraph");
         }
     }
 }

--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -2559,6 +2559,53 @@ mod special {
             // Nothing is rendered (the list is not an inline candidate).
             refute_rendered_contains(&doc, "bullet");
         }
+
+        // A leading `[comment]`-styled paragraph produces no output, so it is
+        // transparent: the inline candidate is the first *following* block, and
+        // the comment text is never emitted.
+        #[test]
+        fn should_skip_leading_comment_styled_paragraph() {
+            let doc = Parser::default()
+                .with_intrinsic_attribute("doctype", "inline", ModificationContext::Anywhere)
+                .parse("[comment]\nthis is a comment\n\nvisible text");
+
+            assert!(doc.warnings().next().is_none());
+            assert_rendered_contains(&doc, "visible text");
+            refute_rendered_contains(&doc, "this is a comment");
+        }
+
+        // A leading `////` comment block is likewise transparent: its raw
+        // content is never emitted, and the following paragraph is the
+        // candidate.
+        #[test]
+        fn should_skip_leading_comment_block() {
+            let doc = Parser::default()
+                .with_intrinsic_attribute("doctype", "inline", ModificationContext::Anywhere)
+                .parse("////\nhidden comment\n////\n\nvisible text");
+
+            assert!(doc.warnings().next().is_none());
+            assert_rendered_contains(&doc, "visible text");
+            refute_rendered_contains(&doc, "hidden comment");
+        }
+
+        // A document title followed by a paragraph and a section wraps the
+        // paragraph in a compound preamble, which is the first block. A compound
+        // candidate has no inline content, so the parse-time warning and the
+        // (empty) rendered output stay in agreement — the preamble never masks a
+        // silently-dropped candidate.
+        #[test]
+        fn preamble_is_a_compound_candidate() {
+            let doc = Parser::default()
+                .with_intrinsic_attribute("doctype", "inline", ModificationContext::Anywhere)
+                .parse("= Title\n\nfirst paragraph\n\n== Section\n\nbody");
+
+            let warnings: Vec<_> = doc.warnings().collect();
+            assert_eq!(warnings.len(), 1);
+            assert_eq!(warnings[0].warning, WarningType::NoInlineDoctypeCandidate);
+
+            refute_rendered_contains(&doc, "first paragraph");
+            refute_rendered_contains(&doc, "body");
+        }
     }
 }
 

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -21,7 +21,7 @@ use crate::{
         SimpleBlockStyle, Stripes, TableBlock, TableCellContent, TableColumn, TableRow,
         VerticalAlignment,
     },
-    document::{InterpretedValue, TocMode},
+    document::{InterpretedValue, TocMode, first_inline_candidate},
 };
 
 /// The document-wide `icons` mode, which controls how callouts and callout
@@ -555,19 +555,19 @@ impl ToVirtualDom for Document<'_> {
             node = node.with_id(id);
         }
 
-        // Under `doctype: inline`, the document renders only its first block, as
-        // bare inline content (no block wrappers), and drops everything after
-        // it. A compound or empty first block has no inline candidate (a
-        // `no inline candidate` warning was recorded at parse time), so the
-        // document renders as empty.
+        // Under `doctype: inline`, the document renders only its first eligible
+        // block, as bare inline content (no block wrappers), and drops
+        // everything after it. A compound or empty candidate has no inline
+        // content (a `no inline candidate` warning was recorded at parse time),
+        // so the document renders as empty. The candidate is selected the same
+        // way as the parse-time check (see [`first_inline_candidate`]), so a
+        // preamble, comment, or attribute entry never masks the real candidate.
         if matches!(
             self.attribute_value("doctype"),
             InterpretedValue::Value(ref v) if v == "inline"
         ) {
-            if let Some(rendered) = self
-                .nested_blocks()
-                .find(|b| !matches!(b, Block::DocumentAttribute(_)))
-                .and_then(|b| b.rendered_content())
+            if let Some(rendered) =
+                first_inline_candidate(self.nested_blocks()).and_then(|b| b.rendered_content())
             {
                 node.children.extend(parse_html_content(rendered));
             }

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -555,6 +555,25 @@ impl ToVirtualDom for Document<'_> {
             node = node.with_id(id);
         }
 
+        // Under `doctype: inline`, the document renders only its first block, as
+        // bare inline content (no block wrappers), and drops everything after
+        // it. A compound or empty first block has no inline candidate (a
+        // `no inline candidate` warning was recorded at parse time), so the
+        // document renders as empty.
+        if matches!(
+            self.attribute_value("doctype"),
+            InterpretedValue::Value(ref v) if v == "inline"
+        ) {
+            if let Some(rendered) = self
+                .nested_blocks()
+                .find(|b| !matches!(b, Block::DocumentAttribute(_)))
+                .and_then(|b| b.rendered_content())
+            {
+                node.children.extend(parse_html_content(rendered));
+            }
+            return node;
+        }
+
         // The document title renders as an `<h1>` when it is shown. This
         // virtual DOM models the *embedded* output, whose default is
         // title-hidden: the title shows only when `showtitle` is set, or (absent

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -47,6 +47,11 @@ pub enum WarningType {
     )]
     DocumentHeaderNotTerminated,
 
+    #[error(
+        "no inline candidate; use the inline doctype to convert a single paragraph, verbatim, or raw block"
+    )]
+    NoInlineDoctypeCandidate,
+
     #[error("An empty attribute value was detected")]
     EmptyAttributeValue,
 
@@ -160,6 +165,10 @@ impl std::fmt::Debug for WarningType {
 
             WarningType::DocumentHeaderNotTerminated => {
                 write!(f, "WarningType::DocumentHeaderNotTerminated")
+            }
+
+            WarningType::NoInlineDoctypeCandidate => {
+                write!(f, "WarningType::NoInlineDoctypeCandidate")
             }
 
             WarningType::EmptyAttributeValue => write!(f, "WarningType::EmptyAttributeValue"),
@@ -362,6 +371,13 @@ mod tests {
                 let warning = WarningType::DocumentHeaderNotTerminated;
                 let debug_output = format!("{:?}", warning);
                 assert_eq!(debug_output, "WarningType::DocumentHeaderNotTerminated");
+            }
+
+            #[test]
+            fn no_inline_doctype_candidate() {
+                let warning = WarningType::NoInlineDoctypeCandidate;
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(debug_output, "WarningType::NoInlineDoctypeCandidate");
             }
 
             #[test]


### PR DESCRIPTION
Fixes #680.

## What

Implements document-level `doctype: inline` rendering, matching Asciidoctor's `Document#convert`:

- Under `doctype: inline`, the document converts **only its first block**, as bare inline content (no `<div class="paragraph"><p>` wrapper), and drops every block after it.
- A **compound or empty** first block has no inline candidate. In that case a new `WarningType::NoInlineDoctypeCandidate` warning is recorded at parse time (surfaced via `Document::warnings()`), and the embed path renders nothing — mirroring Asciidoctor logging `no inline candidate` and returning `nil`.

## Where

- `parser/src/warnings.rs` — new `NoInlineDoctypeCandidate` warning variant (+ `Debug` arm and unit test).
- `parser/src/document/document.rs` — after block parsing, when `doctype` resolves to `inline` and the first non-attribute block is compound/empty, push the warning.
- `parser/src/tests/assert_dom/virtual_dom.rs` — `ToVirtualDom for Document` early-returns the first block's inline content under `doctype: inline` (parallels the existing table-cell inline-doctype handling).

## Tests

Ports the two `context 'Inline doctype'` tests from Asciidoctor's `paragraphs_test.rb` into executable Rust tests under `mod special::inline_doctype`, and clears the corresponding `port_from_ruby` stub:

1. `should_only_output_first_paragraph` — only the first paragraph is emitted as bare inline content; the trailing `ignored` paragraph is dropped; no warning.
2. `should_warn_if_first_block_is_not_a_paragraph` — a leading list (compound) yields no output and a single `NoInlineDoctypeCandidate` warning.

Full suite passes (`cargo test -p asciidoc-parser`), `cargo clippy` clean, `cargo +nightly fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)