### PR TITLE
chore: Mark multiple level-0 heading support as out of scope (#380)

### DIFF
--- a/parser/src/tests/asciidoc_lang/document/title.rs
+++ b/parser/src/tests/asciidoc_lang/document/title.rs
@@ -105,8 +105,11 @@ image::document-title.png[Title of document]
         );
     }
 
-    // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/380):
-    // Add option to support multiple level-0 headings.
+    // Out of scope (https://github.com/asciidoc-rs/asciidoc-parser/issues/380):
+    // multiple level-0 headings are only valid for the `book` doctype, where the
+    // additional level-0 titles are interpreted as parts of a multi-part book. We
+    // don't support the `book` doctype's parts, so this is treated as
+    // non-normative.
     non_normative!(
         r#"
 === Doctypes and titles

--- a/parser/src/tests/asciidoc_lang/root/syntax_quick_reference.rs
+++ b/parser/src/tests/asciidoc_lang/root/syntax_quick_reference.rs
@@ -450,17 +450,20 @@ include::sections:example$section.adoc[tag=b-base]
 "#
     );
 
-    to_do_verifies!(
+    // Out of scope (https://github.com/asciidoc-rs/asciidoc-parser/issues/380):
+    // multiple level-0 headings are only valid for the `book` doctype, where the
+    // additional level-0 titles are interpreted as parts of a multi-part book. We
+    // don't support the `book` doctype's parts, so this is treated as
+    // non-normative.
+    non_normative!(
         r#"
 The `book` document type can have additional level 0 section titles, which are interpreted as xref:sections:parts.adoc[parts].
 The presence of at least one part implicitly makes the document a multi-part book.
 "#
     );
 
-    // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/380): the
-    // `book` doctype's additional level-0 titles (parts) and multi-part books
-    // are not yet implemented. Today a second level-0 heading always warns,
-    // regardless of `:doctype: book`.
+    // The `book` doctype's parts are out of scope (see above): today a second
+    // level-0 heading always warns, regardless of `:doctype: book`.
     let doc = Parser::default()
         .parse("= Book Title\n:doctype: book\n\n== Chapter One\n\n= Part Two\n\n== Chapter Two");
     assert!(

--- a/parser/src/tests/asciidoc_lang/sections/titles_and_levels.rs
+++ b/parser/src/tests/asciidoc_lang/sections/titles_and_levels.rs
@@ -318,9 +318,11 @@ include::example$section.adoc[tag=b-base]
     );
 }
 
-// TODO (https://github.com/asciidoc-rs/asciidoc-parser/issues/380):
-// Option to support multiple level-0 headings.
-// Ignoring this rule for now.
+// Out of scope (https://github.com/asciidoc-rs/asciidoc-parser/issues/380):
+// multiple level-0 headings are only valid for the `book` doctype, where the
+// additional level-0 titles are interpreted as parts of a multi-part book. We
+// don't support the `book` doctype's parts, so this rule is treated as
+// non-normative.
 non_normative!(
     r#"
 Section levels must be nested logically.


### PR DESCRIPTION
## Summary

Issue #380 ("Option to support multiple level-0 headings") tracked support for the `book` doctype's multiple level-0 section titles — the extra level-0 titles that become *parts* of a multi-part book. This is valid AsciiDoc input for `:doctype: book` regardless of output backend (it is **not** a DocBook-only concern).

We've decided not to support the `book` doctype's parts, so this reclassifies the relevant spec quotations in the test suite as non-normative and closes #380 as not planned.

## Changes

- **`root/syntax_quick_reference.rs`** — convert the `to_do_verifies!` block for book parts to `non_normative!`; reframe the comment from "to-do / not yet implemented" to out of scope. The live assertion documenting current behavior (a second level-0 heading always warns, regardless of `:doctype: book`) is retained.
- **`sections/titles_and_levels.rs`** and **`document/title.rs`** — already `non_normative!`; update their comments from "TODO: add option to support" to the out-of-scope framing.

Each comment keeps the #380 link for traceability and accurately describes this as a `book`-doctype (parts) feature — no DocBook framing.

## Testing

- `cargo test --package asciidoc-parser --lib` for the affected modules — all passing.

Closes #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)