### PR TITLE
doc: Note extensions are not planned for 1.0 and remove #262 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ I’m reading page-by-page, line-by-line, and writing tests to verify that the i
 
 (*) Yes, I’m aware that the Asciidoc language authors consider this a “language description,” not a specification. I’m splitting the difference here.
 
+## Extensions
+
+Extensions (custom block, block macro, inline macro, and similar processors, as provided by the [Ruby implementation of Asciidoctor](https://github.com/asciidoctor/asciidoctor)) are not planned for the 1.0 release of this crate. They may be added in a subsequent version.
+
 ## No planned support for some AsciiDoc features
 
 The following features are supported in the [Ruby implementation of Asciidoctor](https://github.com/asciidoctor/asciidoctor), on which this project is based, but are not supported – and will likely never be supported – in this crate:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ I’m reading page-by-page, line-by-line, and writing tests to verify that the i
 
 ## Extensions
 
-Extensions (custom block, block macro, inline macro, and similar processors, as provided by the [Ruby implementation of Asciidoctor](https://github.com/asciidoctor/asciidoctor)) are not planned for the 1.0 release of this crate. They may be added in a subsequent version.
+Extensions – custom block, block macro, inline macro, and similar processors, as provided by the [Ruby implementation of Asciidoctor](https://github.com/asciidoctor/asciidoctor) – are not planned for the 1.0 release of this crate. They may be added in a subsequent version.
 
 ## No planned support for some AsciiDoc features
 

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -43,10 +43,6 @@ pub(super) fn apply_macros(content: &mut Content<'_>, parser: &Parser) {
         }
     }
 
-    // TO DO (#262): Implement extensions that can define macros.
-    // Port Ruby Asciidoctor's implementation from
-    // https://github.com/asciidoctor/asciidoctor/blob/main/lib/asciidoctor/substitutors.rb#L306-L347.
-
     // The UI macros (`kbd:`, `btn:`, and `menu:`) are recognized only when the
     // `experimental` document attribute is set. Although the UI macros are a
     // stable part of the AsciiDoc language, requiring the attribute is an


### PR DESCRIPTION
Sweeps the codebase for references to [issue #262](https://github.com/asciidoc-rs/asciidoc-parser/issues/262) and removes them:

- Removed the `TO DO (#262)` comment (and its now-orphaned Asciidoctor port note) from the inline macro substitution code in `parser/src/content/macros.rs`.
- Added an **Extensions** section to the README stating that extensions are not planned for the 1.0 release of this crate, though they may be added in a subsequent version.

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)