### PR TITLE
feat: Track Asciidoctor's paragraphs_test.rb via SDD

### DIFF
--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -1668,9 +1668,18 @@ mod normal {
         );
     }
 
+    // This test stays `non_normative!`: the upstream `input` ends with the
+    // single-line paragraph `roll it back`, which renders no `<br>` regardless
+    // of the `hardbreaks` setting, so the upstream `(//p)[2]/br == 0` assertion
+    // can't actually demonstrate that `:!hardbreaks:` took effect (see
+    // https://github.com/asciidoctor/asciidoctor/issues/4818). The Rust test
+    // below instead feeds a multi-line final paragraph (`roll\nit\nback`), so
+    // the absence of `<br>` genuinely proves the toggle. Because the parser
+    // never receives the verbatim upstream input, we don't claim line coverage
+    // of it.
     #[test]
     fn should_be_able_to_toggle_hardbreaks_by_setting_hardbreaks_option_on_document() {
-        verifies!(
+        non_normative!(
             r#"
     test 'should be able to toggle hardbreaks by setting hardbreaks-option on document' do
       input = <<~'EOS'
@@ -1691,9 +1700,6 @@ mod normal {
     end
 "#
         );
-
-        // NOTE: I substituted different test material in this test.
-        // See https://github.com/asciidoctor/asciidoctor/issues/4818 for why.
 
         let doc = Parser::default()
             .parse(":hardbreaks-option:\n\nmake\nit\nso\n\n:!hardbreaks:\n\nroll\nit\nback");

--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -1,14 +1,83 @@
 // Adapted from Asciidoctor's paragraphs test suite, found in
 // https://github.com/asciidoctor/asciidoctor/blob/main/test/paragraphs_test.rb.
 //
-// IMPORTANT: In porting this, I've disregarded compatibility mode (stated
-// limitation of `asciidoc-parser` crate) and alternate (non-HTML) back ends.
+// The tests in this tree are adapted from the Ruby implementation of
+// Asciidoctor, which comes with the following license:
+//
+// MIT License
+//
+// Copyright (C) 2012-present Dan Allen, Sarah White, Ryan Waldron, and the
+// individual contributors to Asciidoctor.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//! Port of Asciidoctor's `paragraphs_test.rb`.
+//!
+//! Each Ruby `context` becomes a Rust `mod` and each `test '..'` becomes a
+//! `#[test] fn`, driven through [`Parser`](crate::Parser) and asserted with the
+//! `assert_*` DOM helpers (or a full-AST `assert_eq!`) — the same conventions
+//! documented in [`super`].
+//!
+//! Compatibility mode and non-HTML backends are out of scope for this crate, so
+//! the DocBook `simpara`/`indexterm` tests and the DEBUG-severity
+//! unknown-style-logging test are reproduced verbatim in `non_normative!`
+//! blocks (they account for those Ruby lines without asserting behavior this
+//! crate does not model). A handful of `inline_doctype` tests have no Ruby
+//! counterpart in v2.0.26 — they extend coverage of the boundary cases and so
+//! carry no `verifies!` block.
+
+use crate::tests::sdd::*;
+
+track_file!("ref/asciidoctor/test/paragraphs_test.rb");
+
+non_normative!(
+    r#"
+# frozen_string_literal: true
+require_relative 'test_helper'
+
+context 'Paragraphs' do
+  context 'Normal' do
+"#
+);
 
 mod normal {
     use crate::{document::RefType, tests::prelude::*};
 
     #[test]
     fn should_treat_plain_text_separated_by_blank_lines_as_paragraphs() {
+        verifies!(
+            r#"
+    test 'should treat plain text separated by blank lines as paragraphs' do
+      input = <<~'EOS'
+      Plain text for the win!
+
+      Yep. Text. Plain and simple.
+      EOS
+      output = convert_string_to_embedded input
+      assert_css 'p', output, 2
+      assert_xpath '(//p)[1][text() = "Plain text for the win!"]', output, 1
+      assert_xpath '(//p)[2][text() = "Yep. Text. Plain and simple."]', output, 1
+    end
+
+"#
+        );
+
         let doc =
             Parser::default().parse("Plain text for the win!\n\nYep. Text. Plain and simple.");
 
@@ -99,6 +168,26 @@ mod normal {
 
     #[test]
     fn should_associate_block_title_with_paragraph() {
+        verifies!(
+            r#"
+    test 'should associate block title with paragraph' do
+      input = <<~'EOS'
+      .Titled
+      Paragraph.
+
+      Winning.
+      EOS
+      output = convert_string_to_embedded input
+
+      assert_css 'p', output, 2
+      assert_xpath '(//p)[1]/preceding-sibling::*[@class = "title"]', output, 1
+      assert_xpath '(//p)[1]/preceding-sibling::*[@class = "title"][text() = "Titled"]', output, 1
+      assert_xpath '(//p)[2]/preceding-sibling::*[@class = "title"]', output, 0
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse(".Titled\nParagraph.\n\nWinning.");
 
         assert_eq!(
@@ -193,6 +282,32 @@ mod normal {
 
     #[test]
     fn no_duplicate_block_before_next_section() {
+        verifies!(
+            r#"
+    test 'no duplicate block before next section' do
+      input = <<~'EOS'
+      = Title
+
+      Preamble
+
+      == First Section
+
+      Paragraph 1
+
+      Paragraph 2
+
+      == Second Section
+
+      Last words
+      EOS
+
+      output = convert_string input
+      assert_xpath '//p[text() = "Paragraph 2"]', output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("= Title\n\nPreamble\n\n== First Section\n\nParagraph 1\n\nParagraph 2\n\n== Second Section\n\nLast words");
 
         assert_eq!(
@@ -421,6 +536,22 @@ mod normal {
 
     #[test]
     fn does_not_treat_wrapped_line_as_a_list_item() {
+        verifies!(
+            r#"
+    test 'does not treat wrapped line as a list item' do
+      input = <<~'EOS'
+      paragraph
+      . wrapped line
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_css 'p', output, 1
+      assert_xpath %(//p[text()="paragraph\n. wrapped line"]), output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("paragraph\n. wrapped line");
 
         assert_eq!(
@@ -483,6 +614,22 @@ mod normal {
 
     #[test]
     fn does_not_treat_wrapped_line_as_a_block_title() {
+        verifies!(
+            r#"
+    test 'does not treat wrapped line as a block title' do
+      input = <<~'EOS'
+      paragraph
+      .wrapped line
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_css 'p', output, 1
+      assert_xpath %(//p[text()="paragraph\n.wrapped line"]), output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("paragraph\n.wrapped line");
 
         assert_eq!(
@@ -545,6 +692,22 @@ mod normal {
 
     #[test]
     fn interprets_normal_paragraph_style_as_normal_paragraph() {
+        verifies!(
+            r#"
+    test 'interprets normal paragraph style as normal paragraph' do
+      input = <<~'EOS'
+      [normal]
+      Normal paragraph.
+      Nothing special.
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_css 'p', output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("[normal]\nNormal paragraph.\nNothing special.");
 
         assert_eq!(
@@ -620,6 +783,25 @@ mod normal {
 
     #[test]
     fn removes_indentation_from_literal_paragraph_marked_as_normal() {
+        verifies!(
+            r#"
+    test 'removes indentation from literal paragraph marked as normal' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
+      input = <<~EOS
+      [normal]
+        Normal paragraph.
+          Nothing special.
+        Last line.
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_css 'p', output, 1
+      assert_xpath %(//p[text()="Normal paragraph.\n  Nothing special.\nLast line."]), output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default()
             .parse("[normal]\n Normal paragraph.\n  Nothing special.\n Last line.");
 
@@ -696,6 +878,22 @@ mod normal {
 
     #[test]
     fn normal_paragraph_terminates_at_block_attribute_list() {
+        verifies!(
+            r#"
+    test 'normal paragraph terminates at block attribute list' do
+      input = <<~'EOS'
+      normal text
+      [literal]
+      literal text
+      EOS
+      output = convert_string_to_embedded input
+      assert_css '.paragraph:root', output, 1
+      assert_css '.literalblock:root', output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("normal text\n[literal]\nliteral text");
 
         assert_eq!(
@@ -798,6 +996,23 @@ mod normal {
 
     #[test]
     fn normal_paragraph_terminates_at_block_delimiter() {
+        verifies!(
+            r#"
+    test 'normal paragraph terminates at block delimiter' do
+      input = <<~'EOS'
+      normal text
+      --
+      text in open block
+      --
+      EOS
+      output = convert_string_to_embedded input
+      assert_css '.paragraph:root', output, 1
+      assert_css '.openblock:root', output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("normal text\n--\ntext in open block\n--");
 
         assert_eq!(
@@ -903,6 +1118,22 @@ mod normal {
 
     #[test]
     fn normal_paragraph_terminates_at_list_continuation() {
+        verifies!(
+            r#"
+    test 'normal paragraph terminates at list continuation' do
+      input = <<~'EOS'
+      normal text
+      +
+      EOS
+      output = convert_string_to_embedded input
+      assert_css '.paragraph:root', output, 2
+      assert_xpath %((/*[@class="paragraph"])[1]/p[text() = "normal text"]), output, 1
+      assert_xpath %((/*[@class="paragraph"])[2]/p[text() = "+"]), output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("normal text\n+");
 
         assert_eq!(
@@ -992,6 +1223,22 @@ mod normal {
 
     #[test]
     fn normal_style_turns_literal_paragraph_into_normal_paragraph() {
+        verifies!(
+            r#"
+    test 'normal style turns literal paragraph into normal paragraph' do
+      input = <<~'EOS'
+      [normal]
+       normal paragraph,
+       despite the leading indent
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_css '.paragraph:root > p', output, 1
+    end
+
+"#
+        );
+
         let doc =
             Parser::default().parse("[normal]\n normal paragraph,\n despite the leading indent");
 
@@ -1074,8 +1321,96 @@ mod normal {
     // * test 'does not automatically promote index terms in DocBook output if
     //   indexterm-promotion-option is not set'
 
+    // Backend-specific tests omitted: DocBook index-term promotion.
+    non_normative!(
+        r#"
+    test 'automatically promotes index terms in DocBook output if indexterm-promotion-option is set' do
+      input = <<~'EOS'
+      Here is an index entry for ((tigers)).
+      indexterm:[Big cats,Tigers,Siberian Tiger]
+      Here is an index entry for indexterm2:[Linux].
+      (((Operating Systems,Linux)))
+      Note that multi-entry terms generate separate index entries.
+      EOS
+
+      output = convert_string_to_embedded input, backend: 'docbook', attributes: { 'indexterm-promotion-option' => '' }
+      assert_xpath '/simpara', output, 1
+      term1 = xmlnodes_at_xpath '(//indexterm)[1]', output, 1
+      assert_equal %(<indexterm>\n<primary>tigers</primary>\n</indexterm>), term1.to_s
+      assert term1.next.content.start_with?('tigers')
+
+      term2 = xmlnodes_at_xpath '(//indexterm)[2]', output, 1
+      term2_elements = term2.elements
+      assert_equal 3, term2_elements.size
+      assert_equal '<primary>Big cats</primary>', term2_elements[0].to_s
+      assert_equal '<secondary>Tigers</secondary>', term2_elements[1].to_s
+      assert_equal '<tertiary>Siberian Tiger</tertiary>', term2_elements[2].to_s
+
+      term3 = xmlnodes_at_xpath '(//indexterm)[3]', output, 1
+      term3_elements = term3.elements
+      assert_equal 2, term3_elements.size
+      assert_equal '<primary>Tigers</primary>', term3_elements[0].to_s
+      assert_equal '<secondary>Siberian Tiger</secondary>', term3_elements[1].to_s
+
+      term4 = xmlnodes_at_xpath '(//indexterm)[4]', output, 1
+      term4_elements = term4.elements
+      assert_equal 1, term4_elements.size
+      assert_equal '<primary>Siberian Tiger</primary>', term4_elements[0].to_s
+
+      term5 = xmlnodes_at_xpath '(//indexterm)[5]', output, 1
+      assert_equal %(<indexterm>\n<primary>Linux</primary>\n</indexterm>), term5.to_s
+      assert term5.next.content.start_with?('Linux')
+
+      assert_xpath '(//indexterm)[6]/*', output, 2
+      assert_xpath '(//indexterm)[7]/*', output, 1
+    end
+
+    test 'does not automatically promote index terms in DocBook output if indexterm-promotion-option is not set' do
+      input = <<~'EOS'
+      The Siberian Tiger is one of the biggest living cats.
+      indexterm:[Big cats,Tigers,Siberian Tiger]
+      Note that multi-entry terms generate separate index entries.
+      (((Operating Systems,Linux)))
+      EOS
+
+      output = convert_string_to_embedded input, backend: 'docbook'
+
+      assert_css 'indexterm', output, 2
+
+      terms = xmlnodes_at_css 'indexterm', output, 2
+      term1 = terms[0]
+      term1_elements = term1.elements
+      assert_equal 3, term1_elements.size
+      assert_equal '<primary>Big cats</primary>', term1_elements[0].to_s
+      assert_equal '<secondary>Tigers</secondary>', term1_elements[1].to_s
+      assert_equal '<tertiary>Siberian Tiger</tertiary>', term1_elements[2].to_s
+      term2 = terms[1]
+      term2_elements = term2.elements
+      assert_equal 2, term2_elements.size
+      assert_equal '<primary>Operating Systems</primary>', term2_elements[0].to_s
+      assert_equal '<secondary>Linux</secondary>', term2_elements[1].to_s
+    end
+
+"#
+    );
+
     #[test]
     fn normal_paragraph_should_honor_explicit_subs_list() {
+        verifies!(
+            r#"
+    test 'normal paragraph should honor explicit subs list' do
+      input = <<~'EOS'
+      [subs="specialcharacters"]
+      *<Hey Jude>*
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_includes output, '*&lt;Hey Jude&gt;*'
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("[subs=\"specialcharacters\"]\n*<Hey Jude>*");
 
         assert_eq!(
@@ -1151,6 +1486,21 @@ mod normal {
 
     #[test]
     fn normal_paragraph_should_honor_specialchars_shorthand() {
+        verifies!(
+            r#"
+    test 'normal paragraph should honor specialchars shorthand' do
+      input = <<~'EOS'
+      [subs="specialchars"]
+      *<Hey Jude>*
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_includes output, '*&lt;Hey Jude&gt;*'
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("[subs=\"specialchars\"]\n*<Hey Jude>*");
 
         assert_eq!(
@@ -1226,6 +1576,25 @@ mod normal {
 
     #[test]
     fn should_add_a_hardbreak_at_end_of_each_line_when_hardbreaks_option_is_set() {
+        verifies!(
+            r#"
+    test 'should add a hardbreak at end of each line when hardbreaks option is set' do
+      input = <<~'EOS'
+      [%hardbreaks]
+      read
+      my
+      lips
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_css 'br', output, 2
+      assert_xpath '//p', output, 1
+      assert_includes output, "<p>read<br>\nmy<br>\nlips</p>"
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("[%hardbreaks]\nread\nmy\nlips");
 
         assert_eq!(
@@ -1301,6 +1670,28 @@ mod normal {
 
     #[test]
     fn should_be_able_to_toggle_hardbreaks_by_setting_hardbreaks_option_on_document() {
+        verifies!(
+            r#"
+    test 'should be able to toggle hardbreaks by setting hardbreaks-option on document' do
+      input = <<~'EOS'
+      :hardbreaks-option:
+
+      make
+      it
+      so
+
+      :!hardbreaks:
+
+      roll it back
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_xpath '(//p)[1]/br', output, 2
+      assert_xpath '(//p)[2]/br', output, 0
+    end
+"#
+        );
+
         // NOTE: I substituted different test material in this test.
         // See https://github.com/asciidoctor/asciidoctor/issues/4818 for why.
 
@@ -1424,11 +1815,39 @@ mod normal {
     }
 }
 
+non_normative!(
+    r#"
+  end
+
+  context 'Literal' do
+"#
+);
+
 mod literal {
     use crate::tests::prelude::*;
 
     #[test]
     fn single_line_literal_paragraphs() {
+        verifies!(
+            r#"
+    test 'single-line literal paragraphs' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
+      input = <<~EOS
+      you know what?
+
+       LITERALS
+
+       ARE LITERALLY
+
+       AWESOME!
+      EOS
+      output = convert_string_to_embedded input
+      assert_xpath '//pre', output, 3
+    end
+
+"#
+        );
+
         let doc =
             Parser::default().parse("you know what?\n\n LITERALS\n\n ARE LITERALLY\n\n AWESOME!");
 
@@ -1569,6 +1988,27 @@ mod literal {
 
     #[test]
     fn multi_line_literal_paragraphs() {
+        verifies!(
+            r#"
+    test 'multi-line literal paragraph' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
+      input = <<~EOS
+      Install instructions:
+
+       yum install ruby rubygems
+       gem install asciidoctor
+
+      You're good to go!
+      EOS
+      output = convert_string_to_embedded input
+      assert_xpath '//pre', output, 1
+      # indentation should be trimmed from literal block
+      assert_xpath %(//pre[text() = "yum install ruby rubygems\ngem install asciidoctor"]), output, 1
+    end
+
+"#
+        );
+
         let doc =
             Parser::default().parse("Install instructions:\n\n yum install ruby rubygems\n gem install asciidoctor\n\nYou're good to go!");
 
@@ -1684,6 +2124,20 @@ mod literal {
 
     #[test]
     fn literal_paragraph() {
+        verifies!(
+            r#"
+    test 'literal paragraph' do
+      input = <<~'EOS'
+      [literal]
+      this text is literally literal
+      EOS
+      output = convert_string_to_embedded input
+      assert_xpath %(/*[@class="literalblock"]//pre[text()="this text is literally literal"]), output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("[literal]\nthis text is literally literal");
 
         assert_eq!(
@@ -1759,6 +2213,21 @@ mod literal {
 
     #[test]
     fn should_read_content_below_literal_style_verbatim() {
+        verifies!(
+            r#"
+    test 'should read content below literal style verbatim' do
+      input = <<~'EOS'
+      [literal]
+      image::not-an-image-block[]
+      EOS
+      output = convert_string_to_embedded input
+      assert_xpath %(/*[@class="literalblock"]//pre[text()="image::not-an-image-block[]"]), output, 1
+      assert_css 'img', output, 0
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("[literal]\nimage::not-an-image-block[]");
 
         assert_eq!(
@@ -1834,6 +2303,20 @@ mod literal {
 
     #[test]
     fn listing_paragraph() {
+        verifies!(
+            r#"
+    test 'listing paragraph' do
+      input = <<~'EOS'
+      [listing]
+      this text is a listing
+      EOS
+      output = convert_string_to_embedded input
+      assert_xpath %(/*[@class="listingblock"]//pre[text()="this text is a listing"]), output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("[listing]\nthis text is a listing");
 
         assert_eq!(
@@ -1909,6 +2392,25 @@ mod literal {
 
     #[test]
     fn source_paragraph() {
+        verifies!(
+            r#"
+    test 'source paragraph' do
+      input = <<~'EOS'
+      [source]
+      use the source, luke!
+      EOS
+      block = block_from_string input
+      assert_equal :listing, block.context
+      assert_equal 'source', (block.attr 'style')
+      assert_equal :paragraph, (block.attr 'cloaked-context')
+      assert_nil (block.attr 'language')
+      output = convert_string_to_embedded input
+      assert_xpath %(/*[@class="listingblock"]//pre[@class="highlight"]/code[text()="use the source, luke!"]), output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("[source]\nuse the source, luke!");
 
         assert_eq!(
@@ -1984,6 +2486,25 @@ mod literal {
 
     #[test]
     fn source_code_paragraph_with_language() {
+        verifies!(
+            r#"
+    test 'source code paragraph with language' do
+      input = <<~'EOS'
+      [source, perl]
+      die 'zomg perl is tough';
+      EOS
+      block = block_from_string input
+      assert_equal :listing, block.context
+      assert_equal 'source', (block.attr 'style')
+      assert_equal :paragraph, (block.attr 'cloaked-context')
+      assert_equal 'perl', (block.attr 'language')
+      output = convert_string_to_embedded input
+      assert_xpath %(/*[@class="listingblock"]//pre[@class="highlight"]/code[@class="language-perl"][@data-lang="perl"][text()="die 'zomg perl is tough';"]), output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("[source, perl]\ndie 'zomg perl is tough';");
 
         assert_eq!(
@@ -2066,6 +2587,23 @@ mod literal {
 
     #[test]
     fn literal_paragraph_terminates_at_block_attribute_list() {
+        verifies!(
+            r#"
+    test 'literal paragraph terminates at block attribute list' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
+      input = <<~EOS
+       literal text
+      [normal]
+      normal text
+      EOS
+      output = convert_string_to_embedded input
+      assert_xpath %(/*[@class="literalblock"]), output, 1
+      assert_xpath %(/*[@class="paragraph"]), output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse(" literal text\n[normal]\nnormal text");
 
         assert_eq!(
@@ -2168,6 +2706,24 @@ mod literal {
 
     #[test]
     fn literal_paragraph_terminates_at_block_delimiter() {
+        verifies!(
+            r#"
+    test 'literal paragraph terminates at block delimiter' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
+      input = <<~EOS
+       literal text
+      --
+      normal text
+      --
+      EOS
+      output = convert_string_to_embedded input
+      assert_xpath %(/*[@class="literalblock"]), output, 1
+      assert_xpath %(/*[@class="openblock"]), output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse(" literal text\n--\nnormal text\n--");
 
         assert_eq!(
@@ -2273,6 +2829,23 @@ mod literal {
 
     #[test]
     fn literal_paragraph_terminates_at_list_continuation() {
+        verifies!(
+            r#"
+    test 'literal paragraph terminates at list continuation' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
+      input = <<~EOS
+       literal text
+      +
+      EOS
+      output = convert_string_to_embedded input
+      assert_xpath %(/*[@class="literalblock"]), output, 1
+      assert_xpath %(/*[@class="literalblock"]//pre[text() = "literal text"]), output, 1
+      assert_xpath %(/*[@class="paragraph"]), output, 1
+      assert_xpath %(/*[@class="paragraph"]/p[text() = "+"]), output, 1
+    end
+"#
+        );
+
         let doc = Parser::default().parse(" literal text\n+");
 
         assert_eq!(
@@ -2361,14 +2934,35 @@ mod literal {
     }
 }
 
-// Adapted from the `context 'Quote'` section of Asciidoctor's paragraphs test
-// suite. The blockquote feature was unimplemented when the rest of this file
-// was first ported, so these were left in the `port_from_ruby` stub below.
+non_normative!(
+    r#"
+  end
+
+  context 'Quote' do
+"#
+);
+
 mod quote {
     use crate::tests::prelude::*;
 
     #[test]
     fn single_line_quote_paragraph() {
+        verifies!(
+            r#"
+    test "single-line quote paragraph" do
+      input = <<~'EOS'
+      [quote]
+      Famous quote.
+      EOS
+      output = convert_string input
+      assert_xpath '//*[@class = "quoteblock"]', output, 1
+      assert_xpath '//*[@class = "quoteblock"]//p', output, 0
+      assert_xpath '//*[@class = "quoteblock"]//*[contains(text(), "Famous quote.")]', output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("[quote]\nFamous quote.");
         assert_xpath(&doc, "//*[@class = \"quoteblock\"]", 1);
         // A styled quote paragraph renders its text directly inside the
@@ -2379,6 +2973,23 @@ mod quote {
 
     #[test]
     fn quote_paragraph_terminates_at_list_continuation() {
+        verifies!(
+            r#"
+    test 'quote paragraph terminates at list continuation' do
+      input = <<~'EOS'
+      [quote]
+      A famouse quote.
+      +
+      EOS
+      output = convert_string_to_embedded input
+      assert_css '.quoteblock:root', output, 1
+      assert_css '.paragraph:root', output, 1
+      assert_xpath %(/*[@class="paragraph"]/p[text() = "+"]), output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("[quote]\nA famouse quote.\n+");
         assert_css(&doc, ".quoteblock", 1);
         // The list-continuation marker (`+`) terminates the quote paragraph and
@@ -2389,6 +3000,19 @@ mod quote {
 
     #[test]
     fn verse_paragraph() {
+        verifies!(
+            r#"
+    test "verse paragraph" do
+      output = convert_string("[verse]\nFamous verse.")
+      assert_xpath '//*[@class = "verseblock"]', output, 1
+      assert_xpath '//*[@class = "verseblock"]/pre', output, 1
+      assert_xpath '//*[@class = "verseblock"]//p', output, 0
+      assert_xpath '//*[@class = "verseblock"]/pre[normalize-space(text()) = "Famous verse."]', output, 1
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("[verse]\nFamous verse.");
         assert_xpath(&doc, "//*[@class = \"verseblock\"]", 1);
         assert_xpath(&doc, "//*[@class = \"verseblock\"]/pre", 1);
@@ -2402,6 +3026,21 @@ mod quote {
 
     #[test]
     fn should_perform_normal_subs_on_a_verse_paragraph() {
+        verifies!(
+            r##"
+    test 'should perform normal subs on a verse paragraph' do
+      input = <<~'EOS'
+      [verse]
+      _GET /groups/link:#group-id[\{group-id\}]_
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_includes output, '<pre class="content"><em>GET /groups/<a href="#group-id">{group-id}</a></em></pre>'
+    end
+
+"##
+        );
+
         let doc = Parser::default().parse("[verse]\n_GET /groups/link:#group-id[{group-id}]_");
         let block = doc.nested_blocks().next().unwrap();
         assert_eq!(
@@ -2412,6 +3051,21 @@ mod quote {
 
     #[test]
     fn quote_paragraph_should_honor_explicit_subs_list() {
+        verifies!(
+            r#"
+    test 'quote paragraph should honor explicit subs list' do
+      input = <<~'EOS'
+      [subs="specialcharacters"]
+      [quote]
+      *Hey Jude*
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_includes output, '*Hey Jude*'
+    end
+"#
+        );
+
         let doc = Parser::default().parse("[subs=\"specialcharacters\"]\n[quote]\n*Hey Jude*");
         // Only special-character substitution runs, so the `*` is left intact
         // (not converted to a `<strong>`).
@@ -2419,13 +3073,137 @@ mod quote {
     }
 }
 
+non_normative!(
+    r#"
+  end
+
+  context "special" do
+"#
+);
+
 mod special {
     use crate::tests::prelude::*;
 
-    // Ported from Ruby Asciidoctor's paragraphs_test.rb
-    // ('should process preprocessor conditional in paragraph content').
+    // Asciidoctor's `ADMONITION_STYLES`: the five built-in admonition labels.
+    const ADMONITION_STYLES: [&str; 5] = ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"];
+
+    // A styled paragraph whose style is an admonition label renders as an
+    // admonition block.
+    #[test]
+    fn note_multiline_syntax() {
+        verifies!(
+            r#"
+    test "note multiline syntax" do
+      Asciidoctor::ADMONITION_STYLES.each do |style|
+        assert_xpath "//div[@class='admonitionblock #{style.downcase}']", convert_string("[#{style}]\nThis is a winner.")
+      end
+    end
+
+"#
+        );
+
+        for style in ADMONITION_STYLES {
+            let doc = Parser::default().parse(&format!("[{style}]\nThis is a winner."));
+            assert_xpath(
+                &doc,
+                &format!(
+                    "//div[@class = \"admonitionblock {}\"]",
+                    style.to_lowercase()
+                ),
+                1,
+            );
+            assert_rendered_contains(&doc, "This is a winner.");
+        }
+    }
+
+    // An example-delimited block carrying an admonition style renders as an
+    // admonition block.
+    #[test]
+    fn note_block_syntax() {
+        verifies!(
+            r#"
+    test "note block syntax" do
+      Asciidoctor::ADMONITION_STYLES.each do |style|
+        assert_xpath "//div[@class='admonitionblock #{style.downcase}']", convert_string("[#{style}]\n====\nThis is a winner.\n====")
+      end
+    end
+
+"#
+        );
+
+        for style in ADMONITION_STYLES {
+            let doc = Parser::default().parse(&format!("[{style}]\n====\nThis is a winner.\n===="));
+            assert_xpath(
+                &doc,
+                &format!(
+                    "//div[@class = \"admonitionblock {}\"]",
+                    style.to_lowercase()
+                ),
+                1,
+            );
+            assert_rendered_contains(&doc, "This is a winner.");
+        }
+    }
+
+    // The inline label form (e.g. `NOTE: ...`) renders as an admonition block.
+    #[test]
+    fn note_inline_syntax() {
+        verifies!(
+            r##"
+    test "note inline syntax" do
+      Asciidoctor::ADMONITION_STYLES.each do |style|
+        assert_xpath "//div[@class='admonitionblock #{style.downcase}']", convert_string("#{style}: This is important, fool!")
+      end
+    end
+
+"##
+        );
+
+        for style in ADMONITION_STYLES {
+            let doc = Parser::default().parse(&format!("{style}: This is important, fool!"));
+            assert_xpath(
+                &doc,
+                &format!(
+                    "//div[@class = \"admonitionblock {}\"]",
+                    style.to_lowercase()
+                ),
+                1,
+            );
+            assert_rendered_contains(&doc, "This is important, fool!");
+        }
+    }
+
     #[test]
     fn should_process_preprocessor_conditional_in_paragraph_content() {
+        verifies!(
+            r#"
+    test 'should process preprocessor conditional in paragraph content' do
+      input = <<~'EOS'
+      ifdef::asciidoctor-version[]
+      [sidebar]
+      First line of sidebar.
+      ifdef::backend[The backend is {backend}.]
+      Last line of sidebar.
+      endif::[]
+      EOS
+
+      expected = <<~'EOS'.chop
+      <div class="sidebarblock">
+      <div class="content">
+      First line of sidebar.
+      The backend is html5.
+      Last line of sidebar.
+      </div>
+      </div>
+      EOS
+
+      result = convert_string_to_embedded input
+      assert_equal expected, result
+    end
+
+"#
+        );
+
         // `asciidoctor-version` and `backend` are not set by default in this
         // crate, so they are supplied explicitly to mirror the Ruby environment.
         let doc = Parser::default()
@@ -2446,53 +3224,74 @@ mod special {
         assert_output_contains(&doc, "Last line of sidebar.");
     }
 
-    // Asciidoctor's `ADMONITION_STYLES`: the five built-in admonition labels.
-    const ADMONITION_STYLES: [&str; 5] = ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"];
+    // Backend-specific test omitted: DocBook `simpara` wrapping of styled
+    // paragraphs.
+    non_normative!(
+        r#"
+    context 'Styled Paragraphs' do
+      test 'should wrap text in simpara for styled paragraphs when converted to DocBook' do
+        input = <<~'EOS'
+        = Book
+        :doctype: book
 
-    // Ported from Ruby Asciidoctor's paragraphs_test.rb ('note multiline
-    // syntax'). A styled paragraph whose style is an admonition label renders as
-    // an admonition block.
-    #[test]
-    fn note_multiline_syntax() {
-        for style in ADMONITION_STYLES {
-            let doc = Parser::default().parse(&format!("[{style}]\nThis is a winner."));
-            assert_xpath(
-                &doc,
-                &format!(
-                    "//div[@class = \"admonitionblock {}\"]",
-                    style.to_lowercase()
-                ),
-                1,
-            );
-            assert_rendered_contains(&doc, "This is a winner.");
-        }
-    }
+        [preface]
+        = About this book
 
-    // Ported from Ruby Asciidoctor's paragraphs_test.rb ('note block syntax').
-    // An example-delimited block carrying an admonition style renders as an
-    // admonition block.
-    #[test]
-    fn note_block_syntax() {
-        for style in ADMONITION_STYLES {
-            let doc = Parser::default().parse(&format!("[{style}]\n====\nThis is a winner.\n===="));
-            assert_xpath(
-                &doc,
-                &format!(
-                    "//div[@class = \"admonitionblock {}\"]",
-                    style.to_lowercase()
-                ),
-                1,
-            );
-            assert_rendered_contains(&doc, "This is a winner.");
-        }
-    }
+        [abstract]
+        An abstract for the book.
 
-    // Ported from Ruby Asciidoctor's paragraphs_test.rb ('Styled Paragraphs' >
-    // 'should convert open paragraph to open block'). An `[open]` styled
-    // paragraph renders as an open block whose inline content sits directly in
-    // the content wrapper, with no wrapping `<p>`.
+        = Part 1
+
+        [partintro]
+        An intro to this part.
+
+        == Chapter 1
+
+        [sidebar]
+        Just a side note.
+
+        [example]
+        As you can see here.
+
+        [quote]
+        Wise words from a wise person.
+
+        [open]
+        Make it what you want.
+        EOS
+
+        output = convert_string input, backend: 'docbook'
+        assert_css 'abstract > simpara', output, 1
+        assert_css 'partintro > simpara', output, 1
+        assert_css 'sidebar > simpara', output, 1
+        assert_css 'informalexample > simpara', output, 1
+        assert_css 'blockquote > simpara', output, 1
+        assert_css 'chapter > simpara', output, 1
+      end
+
+"#
+    );
+
+    // An `[open]` styled paragraph renders as an open block whose inline content
+    // sits directly in the content wrapper, with no wrapping `<p>`.
     #[test]
     fn should_convert_open_paragraph_to_open_block() {
+        verifies!(
+            r#"
+      test 'should convert open paragraph to open block' do
+        input = <<~'EOS'
+        [open]
+        Make it what you want.
+        EOS
+
+        output = convert_string_to_embedded input
+        assert_css '.openblock', output, 1
+        assert_css '.openblock p', output, 0
+      end
+
+"#
+        );
+
         let doc = Parser::default().parse("[open]\nMake it what you want.");
         assert_css(&doc, ".openblock", 1);
         assert_css(&doc, ".openblock p", 0);
@@ -2508,23 +3307,66 @@ mod special {
         );
     }
 
-    // Ported from Ruby Asciidoctor's paragraphs_test.rb ('note inline syntax').
-    // The inline label form (e.g. `NOTE: ...`) renders as an admonition block.
-    #[test]
-    fn note_inline_syntax() {
-        for style in ADMONITION_STYLES {
-            let doc = Parser::default().parse(&format!("{style}: This is important, fool!"));
-            assert_xpath(
-                &doc,
-                &format!(
-                    "//div[@class = \"admonitionblock {}\"]",
-                    style.to_lowercase()
-                ),
-                1,
-            );
-            assert_rendered_contains(&doc, "This is important, fool!");
-        }
-    }
+    // Backend-specific test omitted: DocBook `simpara` wrapping of titled styled
+    // paragraphs. (This block also closes the Ruby `Styled Paragraphs` context
+    // and opens `Inline doctype`.)
+    non_normative!(
+        r#"
+      test 'should wrap text in simpara for styled paragraphs with title when converted to DocBook' do
+        input = <<~'EOS'
+        = Book
+        :doctype: book
+
+        [preface]
+        = About this book
+
+        [abstract]
+        .Abstract title
+        An abstract for the book.
+
+        = Part 1
+
+        [partintro]
+        .Part intro title
+        An intro to this part.
+
+        == Chapter 1
+
+        [sidebar]
+        .Sidebar title
+        Just a side note.
+
+        [example]
+        .Example title
+        As you can see here.
+
+        [quote]
+        .Quote title
+        Wise words from a wise person.
+        EOS
+
+        output = convert_string input, backend: 'docbook'
+        assert_css 'abstract > title', output, 1
+        assert_xpath '//abstract/title[text() = "Abstract title"]', output, 1
+        assert_css 'abstract > title + simpara', output, 1
+        assert_css 'partintro > title', output, 1
+        assert_xpath '//partintro/title[text() = "Part intro title"]', output, 1
+        assert_css 'partintro > title + simpara', output, 1
+        assert_css 'sidebar > title', output, 1
+        assert_xpath '//sidebar/title[text() = "Sidebar title"]', output, 1
+        assert_css 'sidebar > title + simpara', output, 1
+        assert_css 'example > title', output, 1
+        assert_xpath '//example/title[text() = "Example title"]', output, 1
+        assert_css 'example > title + simpara', output, 1
+        assert_css 'blockquote > title', output, 1
+        assert_xpath '//blockquote/title[text() = "Quote title"]', output, 1
+        assert_css 'blockquote > title + simpara', output, 1
+      end
+    end
+
+    context 'Inline doctype' do
+"#
+    );
 
     // Ported from Ruby Asciidoctor's paragraphs_test.rb, `context 'Inline
     // doctype'`. Under `doctype: inline` the document converts only its first
@@ -2537,6 +3379,17 @@ mod special {
         // when doctype is inline'.
         #[test]
         fn should_only_output_first_paragraph() {
+            verifies!(
+                r#"
+      test 'should only format and output text in first paragraph when doctype is inline' do
+        input = "http://asciidoc.org[AsciiDoc] is a _lightweight_ markup language...\n\nignored"
+        output = convert_string input, doctype: 'inline'
+        assert_equal '<a href="http://asciidoc.org">AsciiDoc</a> is a <em>lightweight</em> markup language&#8230;&#8203;', output
+      end
+
+"#
+            );
+
             let doc = Parser::default()
                 .with_intrinsic_attribute("doctype", "inline", ModificationContext::Anywhere)
                 .parse(
@@ -2569,6 +3422,19 @@ mod special {
         // candidate: nothing is emitted and a warning is logged.
         #[test]
         fn should_warn_if_first_block_is_not_a_paragraph() {
+            verifies!(
+                r#"
+      test 'should output nil and warn if first block is not a paragraph' do
+        input = '* bullet'
+        using_memory_logger do |logger|
+          output = convert_string input, doctype: 'inline'
+          assert_nil output
+          assert_message logger, :WARN, '~no inline candidate'
+        end
+      end
+"#
+            );
+
             let doc = Parser::default()
                 .with_intrinsic_attribute("doctype", "inline", ModificationContext::Anywhere)
                 .parse("* bullet");
@@ -2653,18 +3519,40 @@ mod special {
     }
 }
 
-// Ported from Ruby Asciidoctor's paragraphs_test.rb (`context 'Custom'`),
-// covering how an unregistered (unknown) paragraph style is handled.
+non_normative!(
+    r#"
+    end
+  end
+
+  context 'Custom' do
+"#
+);
+
+// Covers how an unregistered (unknown) paragraph style is handled.
 mod custom {
     use crate::tests::prelude::*;
 
-    // Ported from Ruby Asciidoctor's paragraphs_test.rb ('should not warn if
-    // paragraph style is unregisted'). An unknown block style such as `[foo]`
-    // on a paragraph is accepted silently: the style is retained on the block,
-    // the content is parsed as an ordinary paragraph, and no warning is
-    // emitted.
+    // An unknown block style such as `[foo]` on a paragraph is accepted
+    // silently: the style is retained on the block, the content is parsed as an
+    // ordinary paragraph, and no warning is emitted.
     #[test]
     fn should_not_warn_if_paragraph_style_is_unregistered() {
+        verifies!(
+            r#"
+    test 'should not warn if paragraph style is unregisted' do
+      input = <<~'EOS'
+      [foo]
+      bar
+      EOS
+      using_memory_logger do |logger|
+        convert_string_to_embedded input
+        assert_empty logger.messages
+      end
+    end
+
+"#
+        );
+
         let doc = Parser::default().parse("[foo]\nbar");
 
         // The unknown style is retained on the block, and its content is parsed
@@ -2684,134 +3572,25 @@ mod custom {
     // errors only (see `crate::warnings`) — so there is no equivalent behavior
     // to assert. The observable behavior at default severity (no warning) is
     // covered by `should_not_warn_if_paragraph_style_is_unregistered` above.
-}
-
-#[ignore]
-#[test]
-fn port_from_ruby() {
-    todo!(
-        "Port this: {}",
-        r###"
-  context 'special' do
-    # NOTE: 'note multiline syntax', 'note block syntax', and 'note inline
-    # syntax' have been ported to `mod special` now that admonitions are
-    # implemented.
-
-    # NOTE: 'should process preprocessor conditional in paragraph content' has
-    # been ported to `mod special` below now that conditional preprocessor
-    # directives are implemented.
-
-    # NOTE: '[open]' styled paragraph -> open block (#679) has been ported to
-    # `mod special` below.
-
-    # NOTE: 'context Custom' (unknown/custom paragraph style handling, #681)
-    # has been ported to `mod custom` below.
-
-    # NOTE: the 'Inline doctype' tests (#680) have been ported to
-    # `mod special::inline_doctype` below.
-
-    # NOTE: the remaining DocBook 'simpara' styled-paragraph tests below are out
-    # of scope (no DocBook backend).
-
-    context 'Styled Paragraphs' do
-      test 'should wrap text in simpara for styled paragraphs when converted to DocBook' do
-        input = <<~'EOS'
-        = Book
-        :doctype: book
-
-        [preface]
-        = About this book
-
-        [abstract]
-        An abstract for the book.
-
-        = Part 1
-
-        [partintro]
-        An intro to this part.
-
-        == Chapter 1
-
-        [sidebar]
-        Just a side note.
-
-        [example]
-        As you can see here.
-
-        [quote]
-        Wise words from a wise person.
-
-        [open]
-        Make it what you want.
-        EOS
-
-        output = convert_string input, backend: 'docbook'
-        assert_css 'abstract > simpara', output, 1
-        assert_css 'partintro > simpara', output, 1
-        assert_css 'sidebar > simpara', output, 1
-        assert_css 'informalexample > simpara', output, 1
-        assert_css 'blockquote > simpara', output, 1
-        assert_css 'chapter > simpara', output, 1
-      end
-
-      # NOTE: 'should convert open paragraph to open block' has been ported to
-      # `mod special` below.
-
-      test 'should wrap text in simpara for styled paragraphs with title when converted to DocBook' do
-        input = <<~'EOS'
-        = Book
-        :doctype: book
-
-        [preface]
-        = About this book
-
-        [abstract]
-        .Abstract title
-        An abstract for the book.
-
-        = Part 1
-
-        [partintro]
-        .Part intro title
-        An intro to this part.
-
-        == Chapter 1
-
-        [sidebar]
-        .Sidebar title
-        Just a side note.
-
-        [example]
-        .Example title
-        As you can see here.
-
-        [quote]
-        .Quote title
-        Wise words from a wise person.
-        EOS
-
-        output = convert_string input, backend: 'docbook'
-        assert_css 'abstract > title', output, 1
-        assert_xpath '//abstract/title[text() = "Abstract title"]', output, 1
-        assert_css 'abstract > title + simpara', output, 1
-        assert_css 'partintro > title', output, 1
-        assert_xpath '//partintro/title[text() = "Part intro title"]', output, 1
-        assert_css 'partintro > title + simpara', output, 1
-        assert_css 'sidebar > title', output, 1
-        assert_xpath '//sidebar/title[text() = "Sidebar title"]', output, 1
-        assert_css 'sidebar > title + simpara', output, 1
-        assert_css 'example > title', output, 1
-        assert_xpath '//example/title[text() = "Example title"]', output, 1
-        assert_css 'example > title + simpara', output, 1
-        assert_css 'blockquote > title', output, 1
-        assert_xpath '//blockquote/title[text() = "Quote title"]', output, 1
-        assert_css 'blockquote > title + simpara', output, 1
+    non_normative!(
+        r#"
+    test 'should log debug message if paragraph style is unknown and debug level is enabled' do
+      input = <<~'EOS'
+      [foo]
+      bar
+      EOS
+      using_memory_logger Logger::Severity::DEBUG do |logger|
+        convert_string_to_embedded input
+        assert_message logger, :DEBUG, '<stdin>: line 2: unknown style for paragraph: foo', Hash
       end
     end
-  end
-
-  # NOTE: 'context Custom' has been ported to `mod custom` above.
-
-"###
+"#
     );
 }
+
+non_normative!(
+    r#"
+  end
+end
+"#
+);

--- a/ref/asciidoctor/test/paragraphs_test.rb
+++ b/ref/asciidoctor/test/paragraphs_test.rb
@@ -1,0 +1,635 @@
+# frozen_string_literal: true
+require_relative 'test_helper'
+
+context 'Paragraphs' do
+  context 'Normal' do
+    test 'should treat plain text separated by blank lines as paragraphs' do
+      input = <<~'EOS'
+      Plain text for the win!
+
+      Yep. Text. Plain and simple.
+      EOS
+      output = convert_string_to_embedded input
+      assert_css 'p', output, 2
+      assert_xpath '(//p)[1][text() = "Plain text for the win!"]', output, 1
+      assert_xpath '(//p)[2][text() = "Yep. Text. Plain and simple."]', output, 1
+    end
+
+    test 'should associate block title with paragraph' do
+      input = <<~'EOS'
+      .Titled
+      Paragraph.
+
+      Winning.
+      EOS
+      output = convert_string_to_embedded input
+
+      assert_css 'p', output, 2
+      assert_xpath '(//p)[1]/preceding-sibling::*[@class = "title"]', output, 1
+      assert_xpath '(//p)[1]/preceding-sibling::*[@class = "title"][text() = "Titled"]', output, 1
+      assert_xpath '(//p)[2]/preceding-sibling::*[@class = "title"]', output, 0
+    end
+
+    test 'no duplicate block before next section' do
+      input = <<~'EOS'
+      = Title
+
+      Preamble
+
+      == First Section
+
+      Paragraph 1
+
+      Paragraph 2
+
+      == Second Section
+
+      Last words
+      EOS
+
+      output = convert_string input
+      assert_xpath '//p[text() = "Paragraph 2"]', output, 1
+    end
+
+    test 'does not treat wrapped line as a list item' do
+      input = <<~'EOS'
+      paragraph
+      . wrapped line
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_css 'p', output, 1
+      assert_xpath %(//p[text()="paragraph\n. wrapped line"]), output, 1
+    end
+
+    test 'does not treat wrapped line as a block title' do
+      input = <<~'EOS'
+      paragraph
+      .wrapped line
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_css 'p', output, 1
+      assert_xpath %(//p[text()="paragraph\n.wrapped line"]), output, 1
+    end
+
+    test 'interprets normal paragraph style as normal paragraph' do
+      input = <<~'EOS'
+      [normal]
+      Normal paragraph.
+      Nothing special.
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_css 'p', output, 1
+    end
+
+    test 'removes indentation from literal paragraph marked as normal' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
+      input = <<~EOS
+      [normal]
+        Normal paragraph.
+          Nothing special.
+        Last line.
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_css 'p', output, 1
+      assert_xpath %(//p[text()="Normal paragraph.\n  Nothing special.\nLast line."]), output, 1
+    end
+
+    test 'normal paragraph terminates at block attribute list' do
+      input = <<~'EOS'
+      normal text
+      [literal]
+      literal text
+      EOS
+      output = convert_string_to_embedded input
+      assert_css '.paragraph:root', output, 1
+      assert_css '.literalblock:root', output, 1
+    end
+
+    test 'normal paragraph terminates at block delimiter' do
+      input = <<~'EOS'
+      normal text
+      --
+      text in open block
+      --
+      EOS
+      output = convert_string_to_embedded input
+      assert_css '.paragraph:root', output, 1
+      assert_css '.openblock:root', output, 1
+    end
+
+    test 'normal paragraph terminates at list continuation' do
+      input = <<~'EOS'
+      normal text
+      +
+      EOS
+      output = convert_string_to_embedded input
+      assert_css '.paragraph:root', output, 2
+      assert_xpath %((/*[@class="paragraph"])[1]/p[text() = "normal text"]), output, 1
+      assert_xpath %((/*[@class="paragraph"])[2]/p[text() = "+"]), output, 1
+    end
+
+    test 'normal style turns literal paragraph into normal paragraph' do
+      input = <<~'EOS'
+      [normal]
+       normal paragraph,
+       despite the leading indent
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_css '.paragraph:root > p', output, 1
+    end
+
+    test 'automatically promotes index terms in DocBook output if indexterm-promotion-option is set' do
+      input = <<~'EOS'
+      Here is an index entry for ((tigers)).
+      indexterm:[Big cats,Tigers,Siberian Tiger]
+      Here is an index entry for indexterm2:[Linux].
+      (((Operating Systems,Linux)))
+      Note that multi-entry terms generate separate index entries.
+      EOS
+
+      output = convert_string_to_embedded input, backend: 'docbook', attributes: { 'indexterm-promotion-option' => '' }
+      assert_xpath '/simpara', output, 1
+      term1 = xmlnodes_at_xpath '(//indexterm)[1]', output, 1
+      assert_equal %(<indexterm>\n<primary>tigers</primary>\n</indexterm>), term1.to_s
+      assert term1.next.content.start_with?('tigers')
+
+      term2 = xmlnodes_at_xpath '(//indexterm)[2]', output, 1
+      term2_elements = term2.elements
+      assert_equal 3, term2_elements.size
+      assert_equal '<primary>Big cats</primary>', term2_elements[0].to_s
+      assert_equal '<secondary>Tigers</secondary>', term2_elements[1].to_s
+      assert_equal '<tertiary>Siberian Tiger</tertiary>', term2_elements[2].to_s
+
+      term3 = xmlnodes_at_xpath '(//indexterm)[3]', output, 1
+      term3_elements = term3.elements
+      assert_equal 2, term3_elements.size
+      assert_equal '<primary>Tigers</primary>', term3_elements[0].to_s
+      assert_equal '<secondary>Siberian Tiger</secondary>', term3_elements[1].to_s
+
+      term4 = xmlnodes_at_xpath '(//indexterm)[4]', output, 1
+      term4_elements = term4.elements
+      assert_equal 1, term4_elements.size
+      assert_equal '<primary>Siberian Tiger</primary>', term4_elements[0].to_s
+
+      term5 = xmlnodes_at_xpath '(//indexterm)[5]', output, 1
+      assert_equal %(<indexterm>\n<primary>Linux</primary>\n</indexterm>), term5.to_s
+      assert term5.next.content.start_with?('Linux')
+
+      assert_xpath '(//indexterm)[6]/*', output, 2
+      assert_xpath '(//indexterm)[7]/*', output, 1
+    end
+
+    test 'does not automatically promote index terms in DocBook output if indexterm-promotion-option is not set' do
+      input = <<~'EOS'
+      The Siberian Tiger is one of the biggest living cats.
+      indexterm:[Big cats,Tigers,Siberian Tiger]
+      Note that multi-entry terms generate separate index entries.
+      (((Operating Systems,Linux)))
+      EOS
+
+      output = convert_string_to_embedded input, backend: 'docbook'
+
+      assert_css 'indexterm', output, 2
+
+      terms = xmlnodes_at_css 'indexterm', output, 2
+      term1 = terms[0]
+      term1_elements = term1.elements
+      assert_equal 3, term1_elements.size
+      assert_equal '<primary>Big cats</primary>', term1_elements[0].to_s
+      assert_equal '<secondary>Tigers</secondary>', term1_elements[1].to_s
+      assert_equal '<tertiary>Siberian Tiger</tertiary>', term1_elements[2].to_s
+      term2 = terms[1]
+      term2_elements = term2.elements
+      assert_equal 2, term2_elements.size
+      assert_equal '<primary>Operating Systems</primary>', term2_elements[0].to_s
+      assert_equal '<secondary>Linux</secondary>', term2_elements[1].to_s
+    end
+
+    test 'normal paragraph should honor explicit subs list' do
+      input = <<~'EOS'
+      [subs="specialcharacters"]
+      *<Hey Jude>*
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_includes output, '*&lt;Hey Jude&gt;*'
+    end
+
+    test 'normal paragraph should honor specialchars shorthand' do
+      input = <<~'EOS'
+      [subs="specialchars"]
+      *<Hey Jude>*
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_includes output, '*&lt;Hey Jude&gt;*'
+    end
+
+    test 'should add a hardbreak at end of each line when hardbreaks option is set' do
+      input = <<~'EOS'
+      [%hardbreaks]
+      read
+      my
+      lips
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_css 'br', output, 2
+      assert_xpath '//p', output, 1
+      assert_includes output, "<p>read<br>\nmy<br>\nlips</p>"
+    end
+
+    test 'should be able to toggle hardbreaks by setting hardbreaks-option on document' do
+      input = <<~'EOS'
+      :hardbreaks-option:
+
+      make
+      it
+      so
+
+      :!hardbreaks:
+
+      roll it back
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_xpath '(//p)[1]/br', output, 2
+      assert_xpath '(//p)[2]/br', output, 0
+    end
+  end
+
+  context 'Literal' do
+    test 'single-line literal paragraphs' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
+      input = <<~EOS
+      you know what?
+
+       LITERALS
+
+       ARE LITERALLY
+
+       AWESOME!
+      EOS
+      output = convert_string_to_embedded input
+      assert_xpath '//pre', output, 3
+    end
+
+    test 'multi-line literal paragraph' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
+      input = <<~EOS
+      Install instructions:
+
+       yum install ruby rubygems
+       gem install asciidoctor
+
+      You're good to go!
+      EOS
+      output = convert_string_to_embedded input
+      assert_xpath '//pre', output, 1
+      # indentation should be trimmed from literal block
+      assert_xpath %(//pre[text() = "yum install ruby rubygems\ngem install asciidoctor"]), output, 1
+    end
+
+    test 'literal paragraph' do
+      input = <<~'EOS'
+      [literal]
+      this text is literally literal
+      EOS
+      output = convert_string_to_embedded input
+      assert_xpath %(/*[@class="literalblock"]//pre[text()="this text is literally literal"]), output, 1
+    end
+
+    test 'should read content below literal style verbatim' do
+      input = <<~'EOS'
+      [literal]
+      image::not-an-image-block[]
+      EOS
+      output = convert_string_to_embedded input
+      assert_xpath %(/*[@class="literalblock"]//pre[text()="image::not-an-image-block[]"]), output, 1
+      assert_css 'img', output, 0
+    end
+
+    test 'listing paragraph' do
+      input = <<~'EOS'
+      [listing]
+      this text is a listing
+      EOS
+      output = convert_string_to_embedded input
+      assert_xpath %(/*[@class="listingblock"]//pre[text()="this text is a listing"]), output, 1
+    end
+
+    test 'source paragraph' do
+      input = <<~'EOS'
+      [source]
+      use the source, luke!
+      EOS
+      block = block_from_string input
+      assert_equal :listing, block.context
+      assert_equal 'source', (block.attr 'style')
+      assert_equal :paragraph, (block.attr 'cloaked-context')
+      assert_nil (block.attr 'language')
+      output = convert_string_to_embedded input
+      assert_xpath %(/*[@class="listingblock"]//pre[@class="highlight"]/code[text()="use the source, luke!"]), output, 1
+    end
+
+    test 'source code paragraph with language' do
+      input = <<~'EOS'
+      [source, perl]
+      die 'zomg perl is tough';
+      EOS
+      block = block_from_string input
+      assert_equal :listing, block.context
+      assert_equal 'source', (block.attr 'style')
+      assert_equal :paragraph, (block.attr 'cloaked-context')
+      assert_equal 'perl', (block.attr 'language')
+      output = convert_string_to_embedded input
+      assert_xpath %(/*[@class="listingblock"]//pre[@class="highlight"]/code[@class="language-perl"][@data-lang="perl"][text()="die 'zomg perl is tough';"]), output, 1
+    end
+
+    test 'literal paragraph terminates at block attribute list' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
+      input = <<~EOS
+       literal text
+      [normal]
+      normal text
+      EOS
+      output = convert_string_to_embedded input
+      assert_xpath %(/*[@class="literalblock"]), output, 1
+      assert_xpath %(/*[@class="paragraph"]), output, 1
+    end
+
+    test 'literal paragraph terminates at block delimiter' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
+      input = <<~EOS
+       literal text
+      --
+      normal text
+      --
+      EOS
+      output = convert_string_to_embedded input
+      assert_xpath %(/*[@class="literalblock"]), output, 1
+      assert_xpath %(/*[@class="openblock"]), output, 1
+    end
+
+    test 'literal paragraph terminates at list continuation' do
+      # NOTE cannot use single-quoted heredoc because of https://github.com/jruby/jruby/issues/4260
+      input = <<~EOS
+       literal text
+      +
+      EOS
+      output = convert_string_to_embedded input
+      assert_xpath %(/*[@class="literalblock"]), output, 1
+      assert_xpath %(/*[@class="literalblock"]//pre[text() = "literal text"]), output, 1
+      assert_xpath %(/*[@class="paragraph"]), output, 1
+      assert_xpath %(/*[@class="paragraph"]/p[text() = "+"]), output, 1
+    end
+  end
+
+  context 'Quote' do
+    test "single-line quote paragraph" do
+      input = <<~'EOS'
+      [quote]
+      Famous quote.
+      EOS
+      output = convert_string input
+      assert_xpath '//*[@class = "quoteblock"]', output, 1
+      assert_xpath '//*[@class = "quoteblock"]//p', output, 0
+      assert_xpath '//*[@class = "quoteblock"]//*[contains(text(), "Famous quote.")]', output, 1
+    end
+
+    test 'quote paragraph terminates at list continuation' do
+      input = <<~'EOS'
+      [quote]
+      A famouse quote.
+      +
+      EOS
+      output = convert_string_to_embedded input
+      assert_css '.quoteblock:root', output, 1
+      assert_css '.paragraph:root', output, 1
+      assert_xpath %(/*[@class="paragraph"]/p[text() = "+"]), output, 1
+    end
+
+    test "verse paragraph" do
+      output = convert_string("[verse]\nFamous verse.")
+      assert_xpath '//*[@class = "verseblock"]', output, 1
+      assert_xpath '//*[@class = "verseblock"]/pre', output, 1
+      assert_xpath '//*[@class = "verseblock"]//p', output, 0
+      assert_xpath '//*[@class = "verseblock"]/pre[normalize-space(text()) = "Famous verse."]', output, 1
+    end
+
+    test 'should perform normal subs on a verse paragraph' do
+      input = <<~'EOS'
+      [verse]
+      _GET /groups/link:#group-id[\{group-id\}]_
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_includes output, '<pre class="content"><em>GET /groups/<a href="#group-id">{group-id}</a></em></pre>'
+    end
+
+    test 'quote paragraph should honor explicit subs list' do
+      input = <<~'EOS'
+      [subs="specialcharacters"]
+      [quote]
+      *Hey Jude*
+      EOS
+
+      output = convert_string_to_embedded input
+      assert_includes output, '*Hey Jude*'
+    end
+  end
+
+  context "special" do
+    test "note multiline syntax" do
+      Asciidoctor::ADMONITION_STYLES.each do |style|
+        assert_xpath "//div[@class='admonitionblock #{style.downcase}']", convert_string("[#{style}]\nThis is a winner.")
+      end
+    end
+
+    test "note block syntax" do
+      Asciidoctor::ADMONITION_STYLES.each do |style|
+        assert_xpath "//div[@class='admonitionblock #{style.downcase}']", convert_string("[#{style}]\n====\nThis is a winner.\n====")
+      end
+    end
+
+    test "note inline syntax" do
+      Asciidoctor::ADMONITION_STYLES.each do |style|
+        assert_xpath "//div[@class='admonitionblock #{style.downcase}']", convert_string("#{style}: This is important, fool!")
+      end
+    end
+
+    test 'should process preprocessor conditional in paragraph content' do
+      input = <<~'EOS'
+      ifdef::asciidoctor-version[]
+      [sidebar]
+      First line of sidebar.
+      ifdef::backend[The backend is {backend}.]
+      Last line of sidebar.
+      endif::[]
+      EOS
+
+      expected = <<~'EOS'.chop
+      <div class="sidebarblock">
+      <div class="content">
+      First line of sidebar.
+      The backend is html5.
+      Last line of sidebar.
+      </div>
+      </div>
+      EOS
+
+      result = convert_string_to_embedded input
+      assert_equal expected, result
+    end
+
+    context 'Styled Paragraphs' do
+      test 'should wrap text in simpara for styled paragraphs when converted to DocBook' do
+        input = <<~'EOS'
+        = Book
+        :doctype: book
+
+        [preface]
+        = About this book
+
+        [abstract]
+        An abstract for the book.
+
+        = Part 1
+
+        [partintro]
+        An intro to this part.
+
+        == Chapter 1
+
+        [sidebar]
+        Just a side note.
+
+        [example]
+        As you can see here.
+
+        [quote]
+        Wise words from a wise person.
+
+        [open]
+        Make it what you want.
+        EOS
+
+        output = convert_string input, backend: 'docbook'
+        assert_css 'abstract > simpara', output, 1
+        assert_css 'partintro > simpara', output, 1
+        assert_css 'sidebar > simpara', output, 1
+        assert_css 'informalexample > simpara', output, 1
+        assert_css 'blockquote > simpara', output, 1
+        assert_css 'chapter > simpara', output, 1
+      end
+
+      test 'should convert open paragraph to open block' do
+        input = <<~'EOS'
+        [open]
+        Make it what you want.
+        EOS
+
+        output = convert_string_to_embedded input
+        assert_css '.openblock', output, 1
+        assert_css '.openblock p', output, 0
+      end
+
+      test 'should wrap text in simpara for styled paragraphs with title when converted to DocBook' do
+        input = <<~'EOS'
+        = Book
+        :doctype: book
+
+        [preface]
+        = About this book
+
+        [abstract]
+        .Abstract title
+        An abstract for the book.
+
+        = Part 1
+
+        [partintro]
+        .Part intro title
+        An intro to this part.
+
+        == Chapter 1
+
+        [sidebar]
+        .Sidebar title
+        Just a side note.
+
+        [example]
+        .Example title
+        As you can see here.
+
+        [quote]
+        .Quote title
+        Wise words from a wise person.
+        EOS
+
+        output = convert_string input, backend: 'docbook'
+        assert_css 'abstract > title', output, 1
+        assert_xpath '//abstract/title[text() = "Abstract title"]', output, 1
+        assert_css 'abstract > title + simpara', output, 1
+        assert_css 'partintro > title', output, 1
+        assert_xpath '//partintro/title[text() = "Part intro title"]', output, 1
+        assert_css 'partintro > title + simpara', output, 1
+        assert_css 'sidebar > title', output, 1
+        assert_xpath '//sidebar/title[text() = "Sidebar title"]', output, 1
+        assert_css 'sidebar > title + simpara', output, 1
+        assert_css 'example > title', output, 1
+        assert_xpath '//example/title[text() = "Example title"]', output, 1
+        assert_css 'example > title + simpara', output, 1
+        assert_css 'blockquote > title', output, 1
+        assert_xpath '//blockquote/title[text() = "Quote title"]', output, 1
+        assert_css 'blockquote > title + simpara', output, 1
+      end
+    end
+
+    context 'Inline doctype' do
+      test 'should only format and output text in first paragraph when doctype is inline' do
+        input = "http://asciidoc.org[AsciiDoc] is a _lightweight_ markup language...\n\nignored"
+        output = convert_string input, doctype: 'inline'
+        assert_equal '<a href="http://asciidoc.org">AsciiDoc</a> is a <em>lightweight</em> markup language&#8230;&#8203;', output
+      end
+
+      test 'should output nil and warn if first block is not a paragraph' do
+        input = '* bullet'
+        using_memory_logger do |logger|
+          output = convert_string input, doctype: 'inline'
+          assert_nil output
+          assert_message logger, :WARN, '~no inline candidate'
+        end
+      end
+    end
+  end
+
+  context 'Custom' do
+    test 'should not warn if paragraph style is unregisted' do
+      input = <<~'EOS'
+      [foo]
+      bar
+      EOS
+      using_memory_logger do |logger|
+        convert_string_to_embedded input
+        assert_empty logger.messages
+      end
+    end
+
+    test 'should log debug message if paragraph style is unknown and debug level is enabled' do
+      input = <<~'EOS'
+      [foo]
+      bar
+      EOS
+      using_memory_logger Logger::Severity::DEBUG do |logger|
+        convert_string_to_embedded input
+        assert_message logger, :DEBUG, '<stdin>: line 2: unknown style for paragraph: foo', Hash
+      end
+    end
+  end
+end


### PR DESCRIPTION
Vendor Asciidoctor's `paragraphs_test.rb` under `ref/asciidoctor/test/` (taken verbatim from **v2.0.26**) and migrate the pre-existing hand-port in `parser/src/tests/asciidoctor_rb/paragraphs_test.rs` to the line-by-line spec-driven-development approach established in #693, so the `sdd` coverage tool measures exactly which lines of the Ruby suite are verified.

This is the second file ported under `ref/asciidoctor/README.md`'s one-file-at-a-time plan (after `attribute_list_test.rb`).

## What changed

- **Vendored** `ref/asciidoctor/test/paragraphs_test.rb`, byte-identical to the upstream v2.0.26 tag.
- **Migrated** the existing `paragraphs_test.rs` to the SDD convention: license header, module doc, `track_file!`, and each Ruby `test '..'` wrapped in a `verifies!` block reproducing its source verbatim (**38 blocks**).
- Every remaining Ruby line is accounted for by a `non_normative!` block (**10 blocks**): the `context` wrappers, the DocBook `simpara`/`indexterm` tests, and the DEBUG-severity unknown-style logging test — all out of scope for this crate (no DocBook backend; no debug-level logging channel).
- **Reordered `mod special`** to match the Ruby file's order, which the coverage tool requires (the `verifies!` blocks must appear in source order).
- **Removed** the old `port_from_ruby` `#[ignore]`/`todo!` stub, now superseded by the non-normative blocks.

No tooling changes are needed: the `sdd` tool and the Codecov `asciidoctor` component already pick up every `.rb` file under `ref/asciidoctor/test`.

## Notes

Unlike the `attribute_list_test.rb` port, this surfaced **no parser behavior differences** — the existing test assertions were preserved unchanged and all pass. It's a pure test-infrastructure migration.

## Verification

- `sdd` reports **378 normative lines covered, 0 uncovered** (every non-blank Ruby line reproduced verbatim and in order).
- **42 `paragraphs_test` tests pass** (down from 43 items: the sole `#[ignore]` stub is removed); full parser suite **3189 passed, 0 failed**.
- `cargo +nightly fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)