### PR TITLE
fix: Safe-mode handling in `InlineSubstitutionRenderer` is complete (close #277)

### DIFF
--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -65,12 +65,13 @@ pub trait InlineSubstitutionRenderer: Debug {
     /// The `target_image_path` is resolved relative to the directory retrieved
     /// from the specified document-scoped attribute key, if provided.
     ///
-    /// NOT YET IMPLEMENTED:
-    /// If the `data-uri` attribute is set on the document, and the safe mode
-    /// level is less than `SafeMode::SECURE`, the image will be safely
-    /// converted to a data URI by reading it from the same directory. If
-    /// neither of these conditions are satisfied, a relative path (i.e., URL)
-    /// will be returned.
+    /// In Asciidoctor, if the `data-uri` attribute is set on the document and
+    /// the safe mode is below `SafeMode::Secure`, the image is converted to a
+    /// data URI by reading its bytes from the same directory; otherwise a
+    /// relative path (i.e., URL) is returned. The `data-uri` embedding path is
+    /// not yet implemented in this crate (tracked by
+    /// <https://github.com/asciidoc-rs/asciidoc-parser/issues/697>), so a
+    /// normalized web path is always returned.
     ///
     /// ## Parameters
     ///
@@ -791,9 +792,11 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
         // attribute is set and the safe mode is below `SafeMode::Secure`. That
         // requires reading the image's bytes, which this crate leaves to the
         // caller rather than performing file/network access itself; the
-        // `data-uri` attribute is therefore not implemented and the image is
-        // always emitted as a normalized web path. Because data-uri embedding is
-        // absent, there is no safe-mode-sensitive behavior to gate here.
+        // `data-uri` attribute is therefore not yet implemented (tracked by
+        // https://github.com/asciidoc-rs/asciidoc-parser/issues/697) and the
+        // image is always emitted as a normalized web path. Because data-uri
+        // embedding is absent, there is no safe-mode-sensitive behavior to gate
+        // here.
         let asset_dir = parser
             .attribute_value(asset_dir_key)
             .as_maybe_str()

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -3043,7 +3043,7 @@ mod macros {
     #[test]
     fn should_link_to_data_uri_if_value_of_link_attribute_is_self_and_inline_image_is_embedded() {
         todo!(
-            "Port when server safe modes are implemented: {}",
+            "Port when `data-uri` image embedding is implemented (asciidoc-rs/asciidoc-parser#697): {}",
             r###"
         test 'should link to data URI if value of link attribute is self and inline image is embedded' do
             para = block_from_string 'image:circle.svg[Tiger,100,link=self]', safe: Asciidoctor::SafeMode::SERVER, attributes: { 'data-uri' => '', 'imagesdir' => 'fixtures', 'docdir' => testdir }
@@ -3657,7 +3657,7 @@ mod macros {
     #[test]
     fn should_substitute_attributes_in_target_of_inline_image_in_section_title() {
         todo!(
-            "Port this test when implementing safe modes: {}",
+            "Port when `data-uri` embedding and `catalog_assets` are implemented (asciidoc-rs/asciidoc-parser#697): {}",
             r###"
             # NOTE this test verifies attributes get substituted eagerly in target of image in title
             test 'should substitute attributes in target of inline image in section title' do

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -3043,7 +3043,7 @@ mod macros {
     #[test]
     fn should_link_to_data_uri_if_value_of_link_attribute_is_self_and_inline_image_is_embedded() {
         todo!(
-            "Port when `data-uri` image embedding is implemented (asciidoc-rs/asciidoc-parser#697): {}",
+            "Port when `data-uri` image embedding and `link=self` data-URI resolution are implemented (asciidoc-rs/asciidoc-parser#697): {}",
             r###"
         test 'should link to data URI if value of link attribute is self and inline image is embedded' do
             para = block_from_string 'image:circle.svg[Tiger,100,link=self]', safe: Asciidoctor::SafeMode::SERVER, attributes: { 'data-uri' => '', 'imagesdir' => 'fixtures', 'docdir' => testdir }


### PR DESCRIPTION
Closes #277.

## Summary

Safe-mode handling in `InlineSubstitutionRenderer` is already fully implemented and tested (delivered in #598): `safe_mode()` is plumbed through the parser and gates the security-sensitive SVG `inline`/`interactive` options (they render as a plain `<img>` at `Secure`), the `safe-mode-*` attributes exist, and `with_safe_mode()` is wired throughout. So the parser work #277 asked for is done.

#277 was reopened during the pre-1.0 `TO DO` audit, citing two `#[ignore]`d Asciidoctor-ported tests. On inspection, those tests are **not** blocked on safe mode — they need the separate **`data-uri` image-embedding** feature (read image bytes + base64 + MIME detection), and one also needs **`catalog_assets`**. Their `#[ignore]` messages ("when safe modes are implemented") were therefore stale and misleading now that safe modes exist.

Rather than conflate that asset-embedding work with safe-mode handling, it's now tracked separately in #697.

## Changes

- Re-point the two tests' `#[ignore]` messages to the `data-uri` feature (#697):
  - `should_link_to_data_uri_if_value_of_link_attribute_is_self_and_inline_image_is_embedded`
  - `should_substitute_attributes_in_target_of_inline_image_in_section_title`
- Fix the stale `image_uri` doc comment and inline comment in `inline_substitution_renderer.rs` that described the unimplemented `data-uri` path as if safe-mode handling were missing.

No behavioral change; documentation/test-annotation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)