### PR TITLE
doc: Resolve spec question on delimited block marker char matching (#145)

### DIFF
--- a/parser/src/blocks/compound_delimited.rs
+++ b/parser/src/blocks/compound_delimited.rs
@@ -49,9 +49,12 @@ impl<'src> CompoundDelimitedBlock<'src> {
             return true;
         }
 
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/145):
-        // Seek spec clarity: Do the characters after the fourth char
-        // have to match the first four?
+        // Every character after the initial four must match the fourth
+        // (delimiter) character. This matches Asciidoctor, whose
+        // `is_delimited_block?` requires the run following the leading char to
+        // be uniform (see https://github.com/asciidoc-rs/asciidoc-parser/issues/145
+        // and https://gitlab.eclipse.org/eclipse/asciidoc-lang/asciidoc-lang/-/issues/56):
+        // `====xyz` is not a delimiter, but `====` plus any number of `=` is.
 
         if data.len() >= 4 {
             if data.starts_with("====") {

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -66,9 +66,12 @@ impl<'src> RawDelimitedBlock<'src> {
             return true;
         }
 
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/145):
-        // Seek spec clarity: Do the characters after the fourth char
-        // have to match the first four?
+        // Every character after the initial four must match the fourth
+        // (delimiter) character. This matches Asciidoctor, whose
+        // `is_delimited_block?` requires the run following the leading char to
+        // be uniform (see https://github.com/asciidoc-rs/asciidoc-parser/issues/145
+        // and https://gitlab.eclipse.org/eclipse/asciidoc-lang/asciidoc-lang/-/issues/56):
+        // `----xyz` is not a delimiter, but `----` plus any number of `-` is.
 
         if data.len() >= 4 {
             if data.starts_with("////") {


### PR DESCRIPTION
## Summary

Resolves the spec-clarity question in #145: **must the fifth and successive characters in a delimited block marker match the fourth character?**

**Answer: Yes.** Asciidoctor enforces it. `====xyz` is *not* a valid example-block delimiter; only `====` followed by additional `=` characters (`=====`, `========`, …) is accepted.

## Evidence

Verified against the installed Asciidoctor 2.0.26 source (`Parser.is_delimited_block?`):

```ruby
context, masq = DELIMITED_BLOCKS[tip]
if context && (line_len == tip_len ||
    (uniform? (line.slice 1, line_len), DELIMITED_BLOCK_TAILS[tip], (line_len - 1)))
```

- `DELIMITED_BLOCK_TAILS[tip]` is the fourth/last char of the canonical delimiter (`=` for `====`).
- `uniform?(str, chr, len)` is `str.count(chr) == len` — i.e. **every** character after the first must equal the tail char.

Empirical check via `Asciidoctor::Parser.is_delimited_block?`:

| Line | Result |
|------|--------|
| `====` | delimiter (example) |
| `=====` | delimiter (example) |
| `====xyz` | not a delimiter |
| `====-` | not a delimiter |
| `----------` | delimiter (listing) |

This agrees with the Eclipse asciidoc-lang answer in [asciidoc-lang#56](https://gitlab.eclipse.org/eclipse/asciidoc-lang/asciidoc-lang/-/issues/56).

## Changes

The parser **already** enforces this rule (`is_valid_delimiter` in both files, with existing tests covering mixed-char rejection such as `----/` and `----------x`). This PR only replaces the two "seek spec clarity" `TO DO` comments with a note recording the resolved rule and its source:

- `parser/src/blocks/raw_delimited.rs`
- `parser/src/blocks/compound_delimited.rs`

No behavior or test changes. Closes #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)