### PR TITLE
doc: Resolve issue #146 — open blocks are delimited only by `--`

### DIFF
--- a/parser/src/blocks/compound_delimited.rs
+++ b/parser/src/blocks/compound_delimited.rs
@@ -97,9 +97,11 @@ impl<'src> CompoundDelimitedBlock<'src> {
         let delimiter = metadata.block_start.take_normalized_line();
         let maybe_delimiter_text = delimiter.item.data();
 
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/146):
-        // Seek spec clarity on whether three hyphens can be used to
-        // delimit an open block. Assuming yes for now.
+        // An open block is delimited by exactly two hyphens (`--`). Three or
+        // more hyphens do not delimit an open block: `---` is a thematic break
+        // (see `Break`), matching Asciidoctor, which renders a lone `---` as an
+        // `<hr>` and treats `---` inside an open block as literal text. This is
+        // enforced by `is_valid_delimiter`, which accepts only exactly `--`.
         let context = match maybe_delimiter_text
             .split_at_checked(maybe_delimiter_text.len().min(4))?
             .0


### PR DESCRIPTION
Resolves #146.

## Background

Issue #146 asked whether three hyphens (`---`) can be used to delimit/nest an open block, since the spec doesn't state this explicitly.

## Resolution

Compared to **Asciidoctor 2.0.26** in practice:

- A lone `---` renders as a thematic break (`<hr>`), **not** an open block.
- `---` inside an open block is treated as literal text — never a nested open block.
- Open blocks are delimited by **exactly `--`**.

## Changes

The parser already implemented this correctly, so this is cleanup only:

- `is_valid_delimiter` accepts only exactly `--` for open blocks, and `---` is parsed as a `Break` (thematic) — matching Asciidoctor. Behavior is already covered by the existing `compound_delimited::open::nested_blocks` test.
- Replaced the stale `TO DO` comment (which had assumed three hyphens *might* delimit an open block) with a note documenting the confirmed behavior.
- Removed the last in-code reference to issue #146.

All 12 compound-delimited tests pass; parser builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)