### PR TITLE
fix: Support macros nested in link/xref text (close #305)

### DIFF
--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -1149,8 +1149,7 @@ fn extract_attributes_from_text<'src>(
         // `extract_attributes_from_text` (substitutors.rb) and is what makes a
         // macro nested inside a link/xref's text (e.g. `link[image:...[]]`)
         // survive intact: the already-rendered inner macro output happens to
-        // contain `=` and `"` characters, but is not a real attribute list. See
-        // https://github.com/asciidoc-rs/asciidoc-parser/issues/305.
+        // contain `=` and `"` characters, but is not a real attribute list.
         if resolved_text.value() == text.data() {
             let empty_attrs = Attrlist::parse(Span::default(), parser, AttrlistContext::Inline)
                 .item
@@ -1529,8 +1528,7 @@ impl Replacer for InlineXrefReplacer<'_, '_> {
                 // such as `xref:sec[image:...[]]`, whose HTML contains `=` and
                 // `"`), not a real attribute list. Treat the text as plain link
                 // text and honor no named attributes, matching Asciidoctor's
-                // `extract_attributes_from_text`. See
-                // https://github.com/asciidoc-rs/asciidoc-parser/issues/305.
+                // `extract_attributes_from_text`.
                 let first = attrlist.nth_attribute(1).map(|a| a.value().to_string());
 
                 if first.as_deref() == Some(normalized.as_str()) {

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -1142,17 +1142,23 @@ fn extract_attributes_from_text<'src>(
     let attrs = attrlist_maw.item.item;
 
     if let Some(resolved_text) = attrs.nth_attribute(1) {
-        // NOTE: If resolved text remains unchanged, return an empty attribute list and
-        // return unparsed text. Commented out because I haven't seen an example of this
-        // happening in practice. Each of the call sites for this function introduces a
-        // constraint that should make this impossible.
-
-        /* if resolved_text.value() == text.data() {
-            let empty_attrs = Attrlist::parse(Span::default(), parser, AttrlistContext::Inline).item.item;
+        // If the resolved text is unchanged from the input — i.e. the attribute
+        // list parse produced a single positional value equal to the whole text
+        // and split nothing off as a named attribute — clear the attributes and
+        // return the text unparsed. This matches Asciidoctor's
+        // `extract_attributes_from_text` (substitutors.rb) and is what makes a
+        // macro nested inside a link/xref's text (e.g. `link[image:...[]]`)
+        // survive intact: the already-rendered inner macro output happens to
+        // contain `=` and `"` characters, but is not a real attribute list. See
+        // https://github.com/asciidoc-rs/asciidoc-parser/issues/305.
+        if resolved_text.value() == text.data() {
+            let empty_attrs = Attrlist::parse(Span::default(), parser, AttrlistContext::Inline)
+                .item
+                .item;
             (text.data().to_owned(), empty_attrs)
-        } else { */
-        (resolved_text.value().to_owned(), attrs)
-        /* } */
+        } else {
+            (resolved_text.value().to_owned(), attrs)
+        }
     } else {
         let default_text = default_text.map(|s| s.to_string());
         (default_text.unwrap_or_default(), attrs)
@@ -1517,18 +1523,29 @@ impl Replacer for InlineXrefReplacer<'_, '_> {
                         .item
                         .item;
 
-                window = attrlist
-                    .named_attribute("window")
-                    .map(|a| a.value().to_string());
-                roles = attrlist.roles().iter().map(|r| r.to_string()).collect();
-                xrefstyle_override = attrlist
-                    .named_attribute("xrefstyle")
-                    .map(|a| XrefStyle::parse(a.value()));
+                // If the attribute-list parse split nothing off as a named
+                // attribute — the sole positional value is the whole text —
+                // the `=` was incidental (e.g. an already-rendered inner macro
+                // such as `xref:sec[image:...[]]`, whose HTML contains `=` and
+                // `"`), not a real attribute list. Treat the text as plain link
+                // text and honor no named attributes, matching Asciidoctor's
+                // `extract_attributes_from_text`. See
+                // https://github.com/asciidoc-rs/asciidoc-parser/issues/305.
+                let first = attrlist.nth_attribute(1).map(|a| a.value().to_string());
 
-                attrlist
-                    .nth_attribute(1)
-                    .map(|a| a.value().to_string())
-                    .filter(|s| !s.is_empty())
+                if first.as_deref() == Some(normalized.as_str()) {
+                    Some(raw_text.replace("\\]", "]"))
+                } else {
+                    window = attrlist
+                        .named_attribute("window")
+                        .map(|a| a.value().to_string());
+                    roles = attrlist.roles().iter().map(|r| r.to_string()).collect();
+                    xrefstyle_override = attrlist
+                        .named_attribute("xrefstyle")
+                        .map(|a| XrefStyle::parse(a.value()));
+
+                    first.filter(|s| !s.is_empty())
+                }
             } else {
                 Some(raw_text.replace("\\]", "]"))
             };

--- a/parser/src/tests/asciidoc_lang/subs/macros.rs
+++ b/parser/src/tests/asciidoc_lang/subs/macros.rs
@@ -152,14 +152,11 @@ mod default_macros_substitution {
 "#
         );
 
-        // Resolves https://github.com/asciidoc-rs/asciidoc-parser/issues/305:
-        // "Does Asciidoctor allow one macro to contain another?"
-        //
-        // Yes. The macros substitution step is applied to the *positional text*
-        // of a macro, so a macro nested in that text is itself processed. The
-        // canonical example is an inline image in the text of a link: the link
-        // text `image:logo.png[Logo]` is substituted into an image span, which
-        // then becomes the link's content.
+        // Can one macro contain another? Yes. The macros substitution step is
+        // applied to the *positional text* of a macro, so a macro nested in that
+        // text is itself processed. The canonical example is an inline image in
+        // the text of a link: the link text `image:logo.png[Logo]` is
+        // substituted into an image span, which then becomes the link's content.
         let doc = Parser::default().parse("https://example.org[image:logo.png[Logo]]");
 
         let block1 = doc.nested_blocks().next().unwrap();

--- a/parser/src/tests/asciidoc_lang/subs/macros.rs
+++ b/parser/src/tests/asciidoc_lang/subs/macros.rs
@@ -143,13 +143,8 @@ mod default_macros_substitution {
         assert_eq!(block1.content().rendered(), "foo icon:heart[] bar");
     }
 
-    #[ignore]
     #[test]
     fn macros() {
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/305):
-        // I can't concieve of how macro substitutions can be applied _within_
-        // macros. Deferring for now.
-
         verifies!(
             r#"
 |Macros |{y}
@@ -157,8 +152,15 @@ mod default_macros_substitution {
 "#
         );
 
-        let doc = Parser::default()
-            .parse(":icons:\n:heart: icon:heart[]\n\nClick image:pause.png[title=Pause pass:a[{heart}] Resume] when you need a break.");
+        // Resolves https://github.com/asciidoc-rs/asciidoc-parser/issues/305:
+        // "Does Asciidoctor allow one macro to contain another?"
+        //
+        // Yes. The macros substitution step is applied to the *positional text*
+        // of a macro, so a macro nested in that text is itself processed. The
+        // canonical example is an inline image in the text of a link: the link
+        // text `image:logo.png[Logo]` is substituted into an image span, which
+        // then becomes the link's content.
+        let doc = Parser::default().parse("https://example.org[image:logo.png[Logo]]");
 
         let block1 = doc.nested_blocks().next().unwrap();
 
@@ -168,7 +170,23 @@ mod default_macros_substitution {
 
         assert_eq!(
             block1.content().rendered(),
-            r#"Click <span class="image"><img src="pause.png" alt="pause" title="Pause &#169; Resume"></span> when you need a break."#
+            r#"<a href="https://example.org"><span class="image"><img src="logo.png" alt="Logo"></span></a>"#
+        );
+
+        // The same nesting works when the inner macro appears mid-sentence in
+        // the outer link's text.
+        let doc =
+            Parser::default().parse("See https://example.org[the image:logo.png[Logo] here].");
+
+        let block1 = doc.nested_blocks().next().unwrap();
+
+        let Block::Simple(block1) = block1 else {
+            panic!("Unexpected block type: {block1:?}");
+        };
+
+        assert_eq!(
+            block1.content().rendered(),
+            r#"See <a href="https://example.org">the <span class="image"><img src="logo.png" alt="Logo"></span> here</a>."#
         );
     }
 

--- a/parser/src/tests/asciidoc_lang/subs/macros.rs
+++ b/parser/src/tests/asciidoc_lang/subs/macros.rs
@@ -188,6 +188,22 @@ mod default_macros_substitution {
             block1.content().rendered(),
             r#"See <a href="https://example.org">the <span class="image"><img src="logo.png" alt="Logo"></span> here</a>."#
         );
+
+        // Nesting also applies to the text of a cross-reference macro: the
+        // inner image is processed inside the `xref:` target's text.
+        let doc =
+            Parser::default().parse("[[sec]]Target.\n\nSee xref:sec[image:logo.png[Logo]] now.");
+
+        let block2 = doc.nested_blocks().nth(1).unwrap();
+
+        let Block::Simple(block2) = block2 else {
+            panic!("Unexpected block type: {block2:?}");
+        };
+
+        assert_eq!(
+            block2.content().rendered(),
+            r##"See <a href="#sec"><span class="image"><img src="logo.png" alt="Logo"></span></a> now."##
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Resolves #305 — *"Search for an example of macros inside macros. Does Asciidoctor allow one macro to contain another?"*

**Determination: yes.** Asciidoctor applies the macros substitution step to a macro's **positional text**, so a macro nested in that text (e.g. an inline image in a link's text) is itself processed — the "Macros | Yes" row of the [macros substitution table](https://docs.asciidoctor.org/asciidoc/latest/subs/macros/). Nesting happens in positional/text content, **not** in named-attribute values. Confirmed against Asciidoctor 2.0.26:

| Case | Behavior |
|---|---|
| `https://example.org[image:logo.png[Logo]]` | image nests inside the link |
| `See https://…[the image:logo.png[Logo] here]` | image nests mid-sentence |
| `xref:sec[image:logo.png[Logo]]` | image nests inside the xref |
| `image:pause.png[title=icon:heart[]…]` (named attr value) | inner macro **not** processed |

We previously produced garbled HTML for the nesting cases.

## Root cause

Inline images are substituted to HTML before links/xrefs (matching Asciidoctor's ordering), so the link/xref handlers receive already-rendered image HTML in their bracket text. That HTML contains `=` and `"`, which our extractors mistook for an attribute list.

Asciidoctor's `extract_attributes_from_text` guards against this: if parsing the text yields a lone positional value equal to the whole input (nothing split off as a named attribute), it discards the attrs and returns the text untouched. That guard was **present but commented out** in `macros.rs`, with a note that no real example was known — the nested-macro case is exactly that example.

## Changes

- Enable the guard in `extract_attributes_from_text` (fixes URL links, the `link:` macro, and mailto text).
- Apply the same guard in `InlineXrefReplacer`, which reimplements the extraction inline.
- Replace the `#[ignore]`d `macros()` spec test — whose example was a named-attribute case with a guessed-wrong expected value — with passing tests using the canonical link-containing-image examples.

## Out of scope

The `xref:target.adoc[…]` **inter-document** case still resolves the href to `#target.adoc` where Asciidoctor emits `target.html`. That's a separate xref path-resolution gap unrelated to macro nesting; the nesting itself now works for it.

## Verification

- Full parser suite: `3190 passed, 0 failed` (26 ignored, down from 27 — `macros()` is no longer ignored)
- `cargo +nightly fmt --check` clean
- `cargo clippy -p asciidoc-parser --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)