### PR TITLE
fix: Preserve hard line break marker in attribute entry values (close #307)

### DIFF
--- a/parser/src/document/attribute.rs
+++ b/parser/src/document/attribute.rs
@@ -200,8 +200,15 @@ impl InterpretedValue {
                         line
                     };
 
-                    if line.ends_with('+') {
-                        format!("{}\n", line.trim_end_matches('+').trim_end_matches(' '))
+                    // A hard line break marker (a space followed by `+`) before
+                    // a line continuation preserves the newline instead of
+                    // folding it into a space. The `+` itself is left in the
+                    // value verbatim: the post_replacements substitution step is
+                    // not applied to attribute entry values, so the `+` is only
+                    // interpreted as a line break later, when the value is used
+                    // in a block whose substitutions include post_replacements.
+                    if line.ends_with(" +") {
+                        format!("{line}\n")
                     } else if count < last_count {
                         format!("{line} ")
                     } else {
@@ -628,7 +635,7 @@ mod tests {
                     col: 7,
                     offset: 6,
                 }),
-                value: InterpretedValue::Value("bar\nblah"),
+                value: InterpretedValue::Value("bar +\nblah"),
                 source: Span {
                     data: ":foo: bar + \\\n blah",
                     line: 1,
@@ -638,7 +645,7 @@ mod tests {
             }
         );
 
-        assert_eq!(mi.item.value(), InterpretedValue::Value("bar\nblah"));
+        assert_eq!(mi.item.value(), InterpretedValue::Value("bar +\nblah"));
 
         assert_eq!(
             mi.after,

--- a/parser/src/tests/asciidoc_lang/attributes/wrap_values.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/wrap_values.rs
@@ -125,7 +125,7 @@ This syntax ensures that the newlines are preserved in the output as hard line b
                 offset: 8,
             }),
             value: InterpretedValue::Value(
-                "Write your docs in text,\nAsciiDoc makes it easy,\nNow get back to work!"
+                "Write your docs in text, +\nAsciiDoc makes it easy, +\nNow get back to work!"
             ),
             source: Span {
                 data: ":haiku: Write your docs in text, + \\\nAsciiDoc makes it easy, + \\\nNow get back to work!",
@@ -139,7 +139,8 @@ This syntax ensures that the newlines are preserved in the output as hard line b
     assert_eq!(
         mi.item.value(),
         &crate::document::InterpretedValue::Value(
-            "Write your docs in text,\nAsciiDoc makes it easy,\nNow get back to work!".to_string()
+            "Write your docs in text, +\nAsciiDoc makes it easy, +\nNow get back to work!"
+                .to_string()
         ),
     );
 }

--- a/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
+++ b/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
@@ -52,18 +52,58 @@ mod default_post_replacements_substitution {
 "#
     );
 
-    #[ignore]
     #[test]
     fn attribute_entry_values() {
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/307):
-        // Search for an example of post-replacement mattering for attribute values.
-        //
-        // No test here because I don't know how to test this.
-        to_do_verifies!(
+        verifies!(
             r#"
 |Attribute entry values |{n}
 
 "#
+        );
+
+        // The post replacements step is _not_ applied when an attribute entry
+        // value is parsed. A xref:attributes:wrap-values.adoc#hard[hard-wrapped]
+        // attribute value therefore stores the line-break marker (` +`)
+        // verbatim rather than converting it to a `<br>`. The marker is only
+        // interpreted as a line break later, if and when the value is used in a
+        // block whose substitutions include post_replacements.
+        //
+        // A passthrough block with `subs=attributes` resolves the attribute
+        // reference but does not run post_replacements, so the stored ` +`
+        // survives verbatim. This demonstrates the step was not applied to the
+        // attribute value itself.
+        let doc = Parser::default().parse(
+            ":haiku: Write your docs in text, + \\\nAsciiDoc makes it easy, + \\\nNow get back to work!\n\n[subs=attributes]\n++++\n{haiku}\n++++",
+        );
+
+        let block1 = doc.nested_blocks().next().unwrap();
+
+        let Block::RawDelimited(block1) = block1 else {
+            panic!("Unexpected block type: {block1:?}");
+        };
+
+        assert_eq!(
+            block1.content().rendered(),
+            "Write your docs in text, +\nAsciiDoc makes it easy, +\nNow get back to work!"
+        );
+
+        // By contrast, referencing the same attribute in a normal paragraph
+        // _does_ produce line breaks, because post_replacements is applied to
+        // the paragraph (not to the attribute value). This confirms the `<br>`
+        // comes from the containing block, not from the attribute entry value.
+        let doc = Parser::default().parse(
+            ":haiku: Write your docs in text, + \\\nAsciiDoc makes it easy, + \\\nNow get back to work!\n\n{haiku}",
+        );
+
+        let block1 = doc.nested_blocks().next().unwrap();
+
+        let Block::Simple(block1) = block1 else {
+            panic!("Unexpected block type: {block1:?}");
+        };
+
+        assert_eq!(
+            block1.content().rendered(),
+            "Write your docs in text,<br>\nAsciiDoc makes it easy,<br>\nNow get back to work!"
         );
     }
 


### PR DESCRIPTION
## Summary

Resolves #307, which asked for an observable example of the post_replacements substitution step "mattering" for attribute entry values (the [spec table](https://github.com/asciidoc-rs/asciidoc-parser/blob/main/ref/asciidoc-lang/docs/modules/subs/pages/post-replacements.adoc) says it is **not** applied to them).

## What the investigation found

The observable example is a **hard-wrapped attribute value**. Verified against locally installed Asciidoctor 2.0.26:

```adoc
:haiku: Write your docs in text, + \
AsciiDoc makes it easy, + \
Now get back to work!

{haiku}
```

Asciidoctor stores the value with the line-break marker **verbatim** — `"Write your docs in text, +\n..."` — *not* as `<br>`. The `+` is only interpreted as a `<br>` later, when the value is substituted into a block whose subs include post_replacements. This proves post_replacements is a property of the containing block, not the attribute value.

## The incompatibility (fixed here)

The parser was **stripping** the ` +` marker at attribute-parse time, storing `"...text,\n..."`. Hard line breaks were therefore silently lost: `{haiku}` in a paragraph rendered with **no** `<br>`, where Asciidoctor renders `<br>`.

`InterpretedValue::from_raw_value` now preserves the ` +` marker verbatim (guarded on ` +` so a no-space `a+` still folds to a space, matching Asciidoctor).

## Tests

- Replaced the ignored `attribute_entry_values` placeholder (the one that referenced this issue) with a real test that demonstrates "No" both ways: a `subs=attributes` passthrough block keeps the literal ` +`, while a normal paragraph renders `<br>`.
- Updated `wrap_values::hard_wrap_attribute_values` and `attribute::value_with_hard_wrap` to assert the Asciidoctor-matching values.

All 3202 parser tests pass; `cargo +nightly fmt` and clippy clean. No references to issue #307 remain in source.

## Out of scope (flagged separately)

Single-line attribute values ending in ` +` differ too — Asciidoctor strips `:foo: bar +` to `"bar"`, the parser keeps `"bar +"`. That's a distinct code path and is being handled in a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)