### PR TITLE
fix: Strip trailing ` +` from single-line attribute values

### DIFF
--- a/parser/src/document/attribute.rs
+++ b/parser/src/document/attribute.rs
@@ -219,7 +219,13 @@ impl InterpretedValue {
             // the remaining value is right-trimmed. Contrast with a multi-line
             // (continued) value, where the marker is preserved so it can drive
             // post_replacements when the value is later used.
-            content.rendered = stripped.trim_end().into();
+            //
+            // Trim only ASCII whitespace (matching Ruby's `rstrip`, which
+            // Asciidoctor applies here); Unicode whitespace such as a
+            // non-breaking space is significant and must be preserved.
+            content.rendered = stripped
+                .trim_end_matches([' ', '\t', '\n', '\r', '\x0C', '\x0B'])
+                .into();
         }
 
         SubstitutionGroup::Header.apply(&mut content, parser, None);
@@ -746,6 +752,13 @@ mod tests {
 
         // Only the final ` +` is stripped; an earlier ` +` remains literal.
         assert_eq!(value(":foo: bar + +\nx"), InterpretedValue::Value("bar +"));
+
+        // Trimming after the marker uses ASCII whitespace rules (Ruby `rstrip`);
+        // a preceding non-breaking space is significant and is preserved.
+        assert_eq!(
+            value(":foo: bar\u{00a0} +\nx"),
+            InterpretedValue::Value("bar\u{00a0}")
+        );
     }
 
     #[test]

--- a/parser/src/document/attribute.rs
+++ b/parser/src/document/attribute.rs
@@ -211,6 +211,15 @@ impl InterpretedValue {
                 .collect();
 
             content.rendered = CowStr::Boxed(value.join("").into_boxed_str());
+        } else if let Some(stripped) = data.strip_suffix(" +") {
+            // A single-line value ending in a bare hard line break marker (a
+            // space followed by a single `+`) has that marker stripped. This
+            // mirrors Asciidoctor, where ` +` at the end of an attribute value
+            // is treated as a legacy line-continuation marker: it is removed and
+            // the remaining value is right-trimmed. Contrast with a multi-line
+            // (continued) value, where the marker is preserved so it can drive
+            // post_replacements when the value is later used.
+            content.rendered = stripped.trim_end().into();
         }
 
         SubstitutionGroup::Header.apply(&mut content, parser, None);
@@ -649,6 +658,94 @@ mod tests {
                 offset: 19
             }
         );
+    }
+
+    #[test]
+    fn single_line_trailing_hard_break_marker_is_stripped() {
+        // A single-line value ending in a bare hard line break marker (a space
+        // followed by a single `+`) has that marker stripped from the
+        // interpreted value, matching Asciidoctor. The raw `value_source` still
+        // contains the literal ` +`. Contrast with `value_with_hard_wrap`, where
+        // a ` +` on a *continued* (multi-line) value is preserved as a newline.
+        let mi = crate::document::Attribute::parse(
+            crate::Span::new(":foo: bar +\nblah"),
+            &Parser::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            mi.item,
+            Attribute {
+                name: Span {
+                    data: "foo",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+                value_source: Some(Span {
+                    data: "bar +",
+                    line: 1,
+                    col: 7,
+                    offset: 6,
+                }),
+                value: InterpretedValue::Value("bar"),
+                source: Span {
+                    data: ":foo: bar +",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                }
+            }
+        );
+
+        assert_eq!(mi.item.value(), InterpretedValue::Value("bar"));
+
+        // `blah` is a separate line, not folded into the value (there is no line
+        // continuation).
+        assert_eq!(
+            mi.after,
+            Span {
+                data: "blah",
+                line: 2,
+                col: 1,
+                offset: 12
+            }
+        );
+    }
+
+    #[test]
+    fn single_line_hard_break_marker_edge_cases() {
+        // The marker is exactly a space followed by a single `+`. Any leading
+        // whitespace before the `+` (including tabs) is trimmed from the result,
+        // but only the single trailing ` +` is removed (not a repeated marker).
+        let value = |src| {
+            crate::document::Attribute::parse(crate::Span::new(src), &Parser::default())
+                .unwrap()
+                .item
+                .value()
+                .clone()
+        };
+
+        // Extra space(s) before the `+` are trimmed away with the marker.
+        assert_eq!(value(":foo: bar  +\nx"), InterpretedValue::Value("bar"));
+
+        // A tab preceding the marker's space is also trimmed.
+        assert_eq!(value(":foo: bar\t +\nx"), InterpretedValue::Value("bar"));
+
+        // `++` is not a hard line break marker; it is preserved verbatim.
+        assert_eq!(value(":foo: bar ++\nx"), InterpretedValue::Value("bar ++"));
+
+        // A `+` with no preceding space is a literal character.
+        assert_eq!(value(":foo: bar+\nx"), InterpretedValue::Value("bar+"));
+
+        // A tab (rather than a space) before the `+` does not form a marker.
+        assert_eq!(value(":foo: bar\t+\nx"), InterpretedValue::Value("bar\t+"));
+
+        // A lone `+` (nothing before the space) is preserved.
+        assert_eq!(value(":foo: +\nx"), InterpretedValue::Value("+"));
+
+        // Only the final ` +` is stripped; an earlier ` +` remains literal.
+        assert_eq!(value(":foo: bar + +\nx"), InterpretedValue::Value("bar +"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Asciidoctor and asciidoc-parser disagreed on how a single-line document attribute value ending in a hard line break marker (` +`) is stored.

For `:foo: bar +` followed by `{foo} more`:
- **Asciidoctor** renders `<p>bar more</p>` — the trailing ` +` is stripped at parse time (stored value is `"bar"`).
- **asciidoc-parser** (before) rendered `bar + more` — it kept the literal ` +`.

## The Asciidoctor rule

In `parser.rb`, `HARD_LINE_BREAK` and `LINE_CONTINUATION_LEGACY` are the same string (`' '` + `'+'`), so a single-line value ending in ` +` is run through the legacy line-continuation path: the marker is sliced off and the remainder right-trimmed. With no continuation line following, the value simply becomes `bar`.

Verified against locally installed Asciidoctor 2.0.26:

| Input value | Stored |
|---|---|
| `bar +` | `bar` (marker stripped) |
| `bar  +` (extra space) | `bar` |
| `bar\t +` (tab before marker) | `bar` |
| `bar ++` | `bar ++` (not a marker) |
| `bar+` (no space) | `bar+` |
| `bar\t+` (tab, not space) | `bar\t+` |
| `+` (lone) | `+` |
| `bar + +` | `bar +` (single pass only) |

Rule: strip exactly a trailing ` +` (space + single `+`), then right-trim; single pass, space-specific.

## Change

`InterpretedValue::from_raw_value` now handles the single-line branch: it strips a trailing `" +"` suffix and right-trims the remainder. The raw `value_source` span still exposes the literal ` +`; only the interpreted value is stripped.

This preserves the deliberate contrast with multi-line (continued) values fixed in #307, where the ` +` marker is *preserved* as a newline so it can drive post_replacements when the value is later used — that branch is untouched.

## Tests

Added two unit tests in the `attribute.rs` test module (alongside the existing `value_with_hard_wrap` / `bare_trailing_backslash_is_literal` tests — this is an undocumented Asciidoctor quirk not covered by any spec `.adoc`, so a `verifies!` SDD marker wasn't appropriate):

- `single_line_trailing_hard_break_marker_is_stripped` — full `Attribute` assertion for the canonical case.
- `single_line_hard_break_marker_edge_cases` — the edge cases in the table above.

All 3203 parser tests pass; `cargo +nightly fmt --check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)