### PR TITLE
feat: Track Asciidoctor's preamble_test.rb via SDD

### DIFF
--- a/parser/src/document/toc.rs
+++ b/parser/src/document/toc.rs
@@ -4,12 +4,13 @@
 use crate::{Parser, document::InterpretedValue};
 
 /// Where (and whether) a document's table of contents (TOC) is generated,
-/// resolved from the [`toc` attribute].
+/// resolved from the [`toc` attribute] and, when `toc` carries no placement
+/// keyword, the `toc-placement` attribute.
 ///
-/// The `toc` attribute is header-only, so this value is fixed once a document's
-/// header has been processed. A nested [AsciiDoc table cell] behaves as its own
-/// standalone document and resolves its own [`TocMode`] independently — it does
-/// **not** inherit the parent document's setting.
+/// The `toc`/`toc-placement` attributes are header-only, so this value is fixed
+/// once a document's header has been processed. A nested [AsciiDoc table cell]
+/// behaves as its own standalone document and resolves its own [`TocMode`]
+/// independently — it does **not** inherit the parent document's setting.
 ///
 /// The `auto`, `left`, and `right` placements all render the TOC automatically
 /// near the top of the document; `left` and `right` additionally request a
@@ -37,12 +38,14 @@ pub enum TocMode {
     /// in standalone HTML, is rendered as a fixed right-hand side column.
     Right,
 
-    /// The `toc` attribute is set to `preamble`: the TOC is generated
-    /// immediately below the document's preamble.
+    /// The placement resolves to `preamble` (via `:toc: preamble` or
+    /// `:toc-placement: preamble`): the TOC is generated immediately below the
+    /// document's preamble.
     Preamble,
 
-    /// The `toc` attribute is set to `macro`: the table of contents is
-    /// generated only where a `toc::[]` block macro appears.
+    /// The placement resolves to `macro` (via `:toc: macro` or
+    /// `:toc-placement: macro`): the table of contents is generated only where
+    /// a `toc::[]` block macro appears.
     Macro,
 }
 
@@ -56,16 +59,29 @@ impl TocMode {
         }
 
         // `toc` has a built-in default of `auto`, so a bare `:toc:` resolves to
-        // `Value("auto")` (never `Set`). An explicit `auto`, or any other
-        // (unrecognized) value, is treated as an automatic placement, matching
-        // Asciidoctor (which renders an auto-placed TOC for any non-positional
-        // value).
+        // `Value("auto")` (never `Set`). A placement keyword in the `toc` value
+        // itself is a shorthand that wins outright. Otherwise (`auto`, empty, or
+        // any unrecognized value) the placement comes from the separate
+        // `toc-placement` attribute, matching Asciidoctor, which folds the `toc`
+        // shorthand into `toc-placement` and treats the latter as the source of
+        // truth. A bogus `toc-placement` — like a bogus `toc` — falls back to an
+        // automatic placement.
         match value.as_maybe_str().map(str::trim) {
             Some("macro") => Self::Macro,
             Some("left") => Self::Left,
             Some("right") => Self::Right,
             Some("preamble") => Self::Preamble,
-            _ => Self::Auto,
+            _ => match parser
+                .attribute_value("toc-placement")
+                .as_maybe_str()
+                .map(str::trim)
+            {
+                Some("macro") => Self::Macro,
+                Some("left") => Self::Left,
+                Some("right") => Self::Right,
+                Some("preamble") => Self::Preamble,
+                _ => Self::Auto,
+            },
         }
     }
 
@@ -212,6 +228,34 @@ mod tests {
     #[test]
     fn unrecognized_mode_is_treated_as_auto() {
         assert_eq!(doc_with(":toc: bogus").toc_mode(), TocMode::Auto);
+    }
+
+    #[test]
+    fn placement_falls_back_to_toc_placement_attribute() {
+        // When the `toc` value carries no placement keyword, the separate
+        // `toc-placement` attribute determines the placement.
+        assert_eq!(
+            doc_with(":toc:\n:toc-placement: preamble").toc_mode(),
+            TocMode::Preamble
+        );
+        assert_eq!(
+            doc_with(":toc:\n:toc-placement: macro").toc_mode(),
+            TocMode::Macro
+        );
+        assert_eq!(
+            doc_with(":toc: auto\n:toc-placement: preamble").toc_mode(),
+            TocMode::Preamble
+        );
+        // A placement keyword in the `toc` value wins over `toc-placement`.
+        assert_eq!(
+            doc_with(":toc: macro\n:toc-placement: preamble").toc_mode(),
+            TocMode::Macro
+        );
+        // A bogus `toc-placement` falls back to an automatic placement.
+        assert_eq!(
+            doc_with(":toc:\n:toc-placement: bogus").toc_mode(),
+            TocMode::Auto
+        );
     }
 
     #[test]

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -1540,11 +1540,11 @@ mod assignment {
         //
         // Three rows still diverge from Asciidoctor's matrix (and are asserted
         // as this crate's actual behavior): the `toc2` alias is not recognized
-        // (it resolves to `Disabled`, not a left-placed TOC); `toc-class` is
-        // never switched to `toc2`; and a soft-unset `toc-placement!` (with
-        // `toc` set) resolves to `Auto` here rather than Asciidoctor's `macro`.
-        // The `toc toc-placement=macro` row, by contrast, now matches
-        // Asciidoctor (`macro`) since this crate honors an explicit
+        // (it resolves to `Disabled`, not a left-placed TOC — #748); `toc-class`
+        // is never switched to `toc2` (#749); and a soft-unset `toc-placement!`
+        // (with `toc` set) resolves to `Auto` here rather than Asciidoctor's
+        // `macro` (#750). The `toc toc-placement=macro` row, by contrast, now
+        // matches Asciidoctor (`macro`) since this crate honors an explicit
         // `toc-placement`.
         use crate::document::TocMode;
         // Each row is the raw attribute spec (as it appears in the vendored
@@ -1556,11 +1556,13 @@ mod assignment {
             ("toc=header", TocMode::Auto),
             ("toc=beeboo", TocMode::Auto),
             ("toc=left", TocMode::Left),
+            // `toc2` alias unrecognized (#748); Asciidoctor: left-placed TOC.
             ("toc2", TocMode::Disabled),
             ("toc=right", TocMode::Right),
             ("toc=preamble", TocMode::Preamble),
             ("toc=macro", TocMode::Macro),
             ("toc toc-placement=macro toc-position=left", TocMode::Macro),
+            // Soft-unset `toc-placement!` (#750); Asciidoctor: `macro`.
             ("toc toc-placement!", TocMode::Auto),
         ];
         for (spec, expected_mode) in rows {
@@ -1576,7 +1578,8 @@ mod assignment {
             }
             let doc = parser.parse("");
             assert_eq!(doc.toc_mode(), *expected_mode, "toc_mode for {spec:?}");
-            // `toc-class` is never materialized as `toc2`; it stays the default.
+            // `toc-class` is never switched to `toc2`; it stays the default
+            // (#749); Asciidoctor sets `toc2` for left/right placement.
             assert_eq!(doc.toc_class(), "toc", "toc_class for {spec:?}");
         }
     }

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -1532,17 +1532,20 @@ mod assignment {
         // `Document::toc_*` accessors rather than materializing the
         // `toc-position` / `toc-placement` / `toc-class` document attributes
         // that Asciidoctor's matrix inspects. It also folds Asciidoctor's
-        // separate `toc-position` and `toc-placement` into a single `TocMode`
-        // that is resolved from the `toc` value alone. So each matrix row is
-        // exercised here through `toc_mode()` / `toc_class()`, asserting this
-        // crate's actual behavior.
+        // separate `toc-position` and `toc-placement` into a single `TocMode`,
+        // resolved from the `toc` value with a fallback to the `toc-placement`
+        // attribute when the `toc` value carries no placement keyword. So each
+        // matrix row is exercised here through `toc_mode()` / `toc_class()`,
+        // asserting this crate's actual behavior.
         //
-        // Three rows diverge from Asciidoctor's matrix (and are asserted as this
-        // crate's actual behavior): the `toc2` alias is not recognized (it
-        // resolves to `Disabled`, not a left-placed TOC); explicit
-        // `toc-placement` / `toc-position` attributes are not honored (only the
-        // `toc` value drives the mode); and `toc-class` is never switched to
-        // `toc2`.
+        // Three rows still diverge from Asciidoctor's matrix (and are asserted
+        // as this crate's actual behavior): the `toc2` alias is not recognized
+        // (it resolves to `Disabled`, not a left-placed TOC); `toc-class` is
+        // never switched to `toc2`; and a soft-unset `toc-placement!` (with
+        // `toc` set) resolves to `Auto` here rather than Asciidoctor's `macro`.
+        // The `toc toc-placement=macro` row, by contrast, now matches
+        // Asciidoctor (`macro`) since this crate honors an explicit
+        // `toc-placement`.
         use crate::document::TocMode;
         // Each row is the raw attribute spec (as it appears in the vendored
         // matrix, parsed the same way Ruby does — space-separated entries,
@@ -1557,7 +1560,7 @@ mod assignment {
             ("toc=right", TocMode::Right),
             ("toc=preamble", TocMode::Preamble),
             ("toc=macro", TocMode::Macro),
-            ("toc toc-placement=macro toc-position=left", TocMode::Auto),
+            ("toc toc-placement=macro toc-position=left", TocMode::Macro),
             ("toc toc-placement!", TocMode::Auto),
         ];
         for (spec, expected_mode) in rows {

--- a/parser/src/tests/asciidoctor_rb/mod.rs
+++ b/parser/src/tests/asciidoctor_rb/mod.rs
@@ -50,5 +50,6 @@ mod attribute_list_test;
 mod converter_test;
 mod lists_test;
 mod paragraphs_test;
+mod preamble_test;
 mod substitutions_test;
 mod tables_test;

--- a/parser/src/tests/asciidoctor_rb/preamble_test.rs
+++ b/parser/src/tests/asciidoctor_rb/preamble_test.rs
@@ -1,0 +1,406 @@
+// Adapted from Asciidoctor's preamble test suite, found in
+// https://github.com/asciidoctor/asciidoctor/blob/main/test/preamble_test.rb.
+//
+// The tests in this tree are adapted from the Ruby implementation of
+// Asciidoctor, which comes with the following license:
+//
+// MIT License
+//
+// Copyright (C) 2012-present Dan Allen, Sarah White, Ryan Waldron, and the
+// individual contributors to Asciidoctor.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//! Port of Asciidoctor's `preamble_test.rb`.
+//!
+//! Each Ruby `test '..'` becomes a `#[test] fn`, driven through
+//! [`Parser`](crate::Parser) and asserted with the `assert_xpath` DOM helper
+//! against [`to_virtual_dom`](crate::Document::to_virtual_dom) — the same
+//! conventions documented in [`super`]. The preamble tests are all about
+//! rendered structure (the `id="preamble"` wrapper, section siblings, generated
+//! section ids), so `assert_xpath` is the natural fit here.
+//!
+//! **Embedded-output model.** This crate's virtual DOM models Asciidoctor's
+//! *embedded* output, whose root `<div class="document">` plays the role of the
+//! standalone document's `<div id="content">` body wrapper. The Ruby tests use
+//! `convert_string` (standalone output), so their `//*[@id="content"]/...`
+//! assertions are translated to the equivalent `//*[@class="document"]/...`
+//! here (noted inline where it applies).
+//!
+//! Non-HTML backends and multiple level-0 headings are out of scope for this
+//! crate, so the five DocBook `preface`/`abstract` tests and the book-doctype
+//! multi-part test are reproduced verbatim in `non_normative!` blocks (see
+//! #380 for level-0 sections). Each such block is annotated inline.
+
+use crate::tests::prelude::*;
+
+track_file!("ref/asciidoctor/test/preamble_test.rb");
+
+non_normative!(
+    r#"
+# frozen_string_literal: true
+require_relative 'test_helper'
+
+context 'Preamble' do
+"#
+);
+
+#[test]
+fn title_and_single_paragraph_preamble_before_section() {
+    verifies!(
+        r#"
+  test 'title and single paragraph preamble before section' do
+    input = <<~'EOS'
+    = Title
+
+    Preamble paragraph 1.
+
+    == First Section
+
+    Section paragraph 1.
+    EOS
+    result = convert_string(input)
+    assert_xpath '//p', result, 2
+    assert_xpath '//*[@id="preamble"]', result, 1
+    assert_xpath '//*[@id="preamble"]//p', result, 1
+    assert_xpath '//*[@id="preamble"]/following-sibling::*//h2[@id="_first_section"]', result, 1
+    assert_xpath '//*[@id="preamble"]/following-sibling::*//p', result, 1
+  end
+
+"#
+    );
+
+    let doc = Parser::default()
+        .parse("= Title\n\nPreamble paragraph 1.\n\n== First Section\n\nSection paragraph 1.");
+
+    assert_xpath(&doc, "//p", 2);
+    assert_xpath(&doc, r#"//*[@id="preamble"]"#, 1);
+    assert_xpath(&doc, r#"//*[@id="preamble"]//p"#, 1);
+    assert_xpath(
+        &doc,
+        r#"//*[@id="preamble"]/following-sibling::*//h2[@id="_first_section"]"#,
+        1,
+    );
+    assert_xpath(&doc, r#"//*[@id="preamble"]/following-sibling::*//p"#, 1);
+}
+
+non_normative!(
+    r#"
+  test 'title of preface is blank by default in DocBook output' do
+    input = <<~'EOS'
+    = Document Title
+    :doctype: book
+
+    Preface content.
+
+    == First Section
+
+    Section content.
+    EOS
+    result = convert_string input, backend: :docbook
+    assert_xpath '//preface/title', result, 1
+    title_node = xmlnodes_at_xpath '//preface/title', result, 1
+    assert_equal '', title_node.text
+  end
+
+  test 'preface-title attribute is assigned as title of preface in DocBook output' do
+    input = <<~'EOS'
+    = Document Title
+    :doctype: book
+    :preface-title: Preface
+
+    Preface content.
+
+    == First Section
+
+    Section content.
+    EOS
+    result = convert_string input, backend: :docbook
+    assert_xpath '//preface/title[text()="Preface"]', result, 1
+  end
+
+"#
+);
+
+#[test]
+fn title_and_multi_paragraph_preamble_before_section() {
+    verifies!(
+        r#"
+  test 'title and multi-paragraph preamble before section' do
+    input = <<~'EOS'
+    = Title
+
+    Preamble paragraph 1.
+
+    Preamble paragraph 2.
+
+    == First Section
+
+    Section paragraph 1.
+    EOS
+    result = convert_string(input)
+    assert_xpath '//p', result, 3
+    assert_xpath '//*[@id="preamble"]', result, 1
+    assert_xpath '//*[@id="preamble"]//p', result, 2
+    assert_xpath '//*[@id="preamble"]/following-sibling::*//h2[@id="_first_section"]', result, 1
+    assert_xpath '//*[@id="preamble"]/following-sibling::*//p', result, 1
+  end
+
+"#
+    );
+
+    let doc = Parser::default().parse(
+        "= Title\n\nPreamble paragraph 1.\n\nPreamble paragraph 2.\n\n== First Section\n\nSection paragraph 1.",
+    );
+
+    assert_xpath(&doc, "//p", 3);
+    assert_xpath(&doc, r#"//*[@id="preamble"]"#, 1);
+    assert_xpath(&doc, r#"//*[@id="preamble"]//p"#, 2);
+    assert_xpath(
+        &doc,
+        r#"//*[@id="preamble"]/following-sibling::*//h2[@id="_first_section"]"#,
+        1,
+    );
+    assert_xpath(&doc, r#"//*[@id="preamble"]/following-sibling::*//p"#, 1);
+}
+
+#[test]
+fn should_not_wrap_content_in_preamble_if_document_has_title_but_no_sections() {
+    verifies!(
+        r#"
+  test 'should not wrap content in preamble if document has title but no sections' do
+    input = <<~'EOS'
+    = Title
+
+    paragraph
+    EOS
+    result = convert_string(input)
+    assert_xpath '//p', result, 1
+    assert_xpath '//*[@id="content"]/*[@class="paragraph"]/p', result, 1
+    assert_xpath '//*[@id="content"]/*[@class="paragraph"]/following-sibling::*', result, 0
+  end
+
+"#
+    );
+
+    let doc = Parser::default().parse("= Title\n\nparagraph");
+
+    assert_xpath(&doc, "//p", 1);
+
+    // In the embedded model the `<div class="document">` root is the content
+    // body wrapper (Ruby's `id="content"`): the lone paragraph is a direct
+    // child of it, not wrapped in a preamble, and has no following sibling.
+    assert_xpath(&doc, r#"//*[@id="preamble"]"#, 0);
+    assert_xpath(&doc, r#"//*[@class="paragraph"]/p"#, 1);
+    assert_xpath(&doc, r#"//*[@class="paragraph"]/following-sibling::*"#, 0);
+}
+
+#[test]
+fn title_and_section_without_preamble() {
+    verifies!(
+        r#"
+  test 'title and section without preamble' do
+    input = <<~'EOS'
+    = Title
+
+    == First Section
+
+    Section paragraph 1.
+    EOS
+    result = convert_string(input)
+    assert_xpath '//p', result, 1
+    assert_xpath '//*[@id="preamble"]', result, 0
+    assert_xpath '//h2[@id="_first_section"]', result, 1
+  end
+
+"#
+    );
+
+    let doc = Parser::default().parse("= Title\n\n== First Section\n\nSection paragraph 1.");
+
+    assert_xpath(&doc, "//p", 1);
+    assert_xpath(&doc, r#"//*[@id="preamble"]"#, 0);
+    assert_xpath(&doc, r#"//h2[@id="_first_section"]"#, 1);
+}
+
+#[test]
+fn no_title_with_preamble_and_section() {
+    verifies!(
+        r#"
+  test 'no title with preamble and section' do
+    input = <<~'EOS'
+    Preamble paragraph 1.
+
+    == First Section
+
+    Section paragraph 1.
+    EOS
+    result = convert_string(input)
+    assert_xpath '//p', result, 2
+    assert_xpath '//*[@id="preamble"]', result, 0
+    assert_xpath '//h2[@id="_first_section"]/preceding::p', result, 1
+  end
+
+"#
+    );
+
+    let doc = Parser::default()
+        .parse("Preamble paragraph 1.\n\n== First Section\n\nSection paragraph 1.");
+
+    assert_xpath(&doc, "//p", 2);
+    assert_xpath(&doc, r#"//*[@id="preamble"]"#, 0);
+
+    // Ruby's `preceding::p` (all paragraphs before the heading in document
+    // order) counts the single top-level paragraph that precedes the section.
+    // With no document title it is a plain paragraph, not a preamble, so it is
+    // a preceding *sibling* of the section div here.
+    assert_xpath(&doc, r#"//*[@class="sect1"]/preceding-sibling::*//p"#, 1);
+}
+
+non_normative!(
+    r#"
+  test 'preamble in book doctype' do
+      input = <<~'EOS'
+      = Book
+      :doctype: book
+
+      Back then...
+
+      = Chapter One
+
+      [partintro]
+      It was a dark and stormy night...
+
+      == Scene One
+
+      Someone's gonna get axed.
+
+      = Chapter Two
+
+      [partintro]
+      They couldn't believe their eyes when...
+
+      == Scene One
+
+      The axe came swinging.
+      EOS
+
+      d = document_from_string(input)
+      assert_equal 'book', d.doctype
+      output = d.convert
+      assert_xpath '//h1', output, 3
+      assert_xpath %{//*[@id="preamble"]//p[text() = "Back then#{decode_char 8230}#{decode_char 8203}"]}, output, 1
+  end
+
+"#
+);
+
+#[test]
+fn should_output_table_of_contents_in_preamble_if_toc_placement_attribute_value_is_preamble() {
+    verifies!(
+        r#"
+  test 'should output table of contents in preamble if toc-placement attribute value is preamble' do
+    input = <<~'EOS'
+    = Article
+    :toc:
+    :toc-placement: preamble
+
+    Once upon a time...
+
+    == Section One
+
+    It was a dark and stormy night...
+
+    == Section Two
+
+    They couldn't believe their eyes when...
+    EOS
+
+    output = convert_string input
+    assert_xpath '//*[@id="preamble"]/*[@id="toc"]', output, 1
+  end
+
+"#
+    );
+
+    let doc = Parser::default().parse(
+        "= Article\n:toc:\n:toc-placement: preamble\n\nOnce upon a time...\n\n== Section One\n\nIt was a dark and stormy night...\n\n== Section Two\n\nThey couldn't believe their eyes when...",
+    );
+
+    assert_xpath(&doc, r#"//*[@id="preamble"]/*[@id="toc"]"#, 1);
+}
+
+non_normative!(
+    r#"
+  test 'should move abstract in implicit preface to info tag when converting to DocBook' do
+    input = <<~'EOS'
+    = Document Title
+
+    [abstract]
+    This is the abstract.
+
+    == Fin
+    EOS
+
+    %w(article book).each do |doctype|
+      output = convert_string input, backend: 'docbook', doctype: doctype
+      assert_xpath '//abstract', output, 1
+      assert_xpath %(/#{doctype}/info/abstract), output, 1
+    end
+  end
+
+  test 'should move abstract as first section to info tag when converting to DocBook' do
+    input = <<~'EOS'
+    = Document Title
+
+    [abstract]
+    == Abstract
+
+    This is the abstract.
+
+    == Fin
+    EOS
+
+    output = convert_string input, backend: 'docbook'
+    assert_xpath '//abstract', output, 1
+    assert_xpath '/article/info/abstract', output, 1
+  end
+
+  test 'should move abstract in preface section to info tag when converting to DocBook' do
+    input = <<~'EOS'
+    = Document Title
+    :doctype: book
+
+    [preface]
+    == Preface
+
+    [abstract]
+    This is the abstract.
+
+    == Fin
+    EOS
+
+    output = convert_string input, backend: 'docbook'
+    assert_xpath '//abstract', output, 1
+    assert_xpath '/book/info/abstract', output, 1
+    assert_xpath '//preface', output, 0
+  end
+end
+"#
+);

--- a/ref/asciidoctor/test/preamble_test.rb
+++ b/ref/asciidoctor/test/preamble_test.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+require_relative 'test_helper'
+
+context 'Preamble' do
+  test 'title and single paragraph preamble before section' do
+    input = <<~'EOS'
+    = Title
+
+    Preamble paragraph 1.
+
+    == First Section
+
+    Section paragraph 1.
+    EOS
+    result = convert_string(input)
+    assert_xpath '//p', result, 2
+    assert_xpath '//*[@id="preamble"]', result, 1
+    assert_xpath '//*[@id="preamble"]//p', result, 1
+    assert_xpath '//*[@id="preamble"]/following-sibling::*//h2[@id="_first_section"]', result, 1
+    assert_xpath '//*[@id="preamble"]/following-sibling::*//p', result, 1
+  end
+
+  test 'title of preface is blank by default in DocBook output' do
+    input = <<~'EOS'
+    = Document Title
+    :doctype: book
+
+    Preface content.
+
+    == First Section
+
+    Section content.
+    EOS
+    result = convert_string input, backend: :docbook
+    assert_xpath '//preface/title', result, 1
+    title_node = xmlnodes_at_xpath '//preface/title', result, 1
+    assert_equal '', title_node.text
+  end
+
+  test 'preface-title attribute is assigned as title of preface in DocBook output' do
+    input = <<~'EOS'
+    = Document Title
+    :doctype: book
+    :preface-title: Preface
+
+    Preface content.
+
+    == First Section
+
+    Section content.
+    EOS
+    result = convert_string input, backend: :docbook
+    assert_xpath '//preface/title[text()="Preface"]', result, 1
+  end
+
+  test 'title and multi-paragraph preamble before section' do
+    input = <<~'EOS'
+    = Title
+
+    Preamble paragraph 1.
+
+    Preamble paragraph 2.
+
+    == First Section
+
+    Section paragraph 1.
+    EOS
+    result = convert_string(input)
+    assert_xpath '//p', result, 3
+    assert_xpath '//*[@id="preamble"]', result, 1
+    assert_xpath '//*[@id="preamble"]//p', result, 2
+    assert_xpath '//*[@id="preamble"]/following-sibling::*//h2[@id="_first_section"]', result, 1
+    assert_xpath '//*[@id="preamble"]/following-sibling::*//p', result, 1
+  end
+
+  test 'should not wrap content in preamble if document has title but no sections' do
+    input = <<~'EOS'
+    = Title
+
+    paragraph
+    EOS
+    result = convert_string(input)
+    assert_xpath '//p', result, 1
+    assert_xpath '//*[@id="content"]/*[@class="paragraph"]/p', result, 1
+    assert_xpath '//*[@id="content"]/*[@class="paragraph"]/following-sibling::*', result, 0
+  end
+
+  test 'title and section without preamble' do
+    input = <<~'EOS'
+    = Title
+
+    == First Section
+
+    Section paragraph 1.
+    EOS
+    result = convert_string(input)
+    assert_xpath '//p', result, 1
+    assert_xpath '//*[@id="preamble"]', result, 0
+    assert_xpath '//h2[@id="_first_section"]', result, 1
+  end
+
+  test 'no title with preamble and section' do
+    input = <<~'EOS'
+    Preamble paragraph 1.
+
+    == First Section
+
+    Section paragraph 1.
+    EOS
+    result = convert_string(input)
+    assert_xpath '//p', result, 2
+    assert_xpath '//*[@id="preamble"]', result, 0
+    assert_xpath '//h2[@id="_first_section"]/preceding::p', result, 1
+  end
+
+  test 'preamble in book doctype' do
+      input = <<~'EOS'
+      = Book
+      :doctype: book
+
+      Back then...
+
+      = Chapter One
+
+      [partintro]
+      It was a dark and stormy night...
+
+      == Scene One
+
+      Someone's gonna get axed.
+
+      = Chapter Two
+
+      [partintro]
+      They couldn't believe their eyes when...
+
+      == Scene One
+
+      The axe came swinging.
+      EOS
+
+      d = document_from_string(input)
+      assert_equal 'book', d.doctype
+      output = d.convert
+      assert_xpath '//h1', output, 3
+      assert_xpath %{//*[@id="preamble"]//p[text() = "Back then#{decode_char 8230}#{decode_char 8203}"]}, output, 1
+  end
+
+  test 'should output table of contents in preamble if toc-placement attribute value is preamble' do
+    input = <<~'EOS'
+    = Article
+    :toc:
+    :toc-placement: preamble
+
+    Once upon a time...
+
+    == Section One
+
+    It was a dark and stormy night...
+
+    == Section Two
+
+    They couldn't believe their eyes when...
+    EOS
+
+    output = convert_string input
+    assert_xpath '//*[@id="preamble"]/*[@id="toc"]', output, 1
+  end
+
+  test 'should move abstract in implicit preface to info tag when converting to DocBook' do
+    input = <<~'EOS'
+    = Document Title
+
+    [abstract]
+    This is the abstract.
+
+    == Fin
+    EOS
+
+    %w(article book).each do |doctype|
+      output = convert_string input, backend: 'docbook', doctype: doctype
+      assert_xpath '//abstract', output, 1
+      assert_xpath %(/#{doctype}/info/abstract), output, 1
+    end
+  end
+
+  test 'should move abstract as first section to info tag when converting to DocBook' do
+    input = <<~'EOS'
+    = Document Title
+
+    [abstract]
+    == Abstract
+
+    This is the abstract.
+
+    == Fin
+    EOS
+
+    output = convert_string input, backend: 'docbook'
+    assert_xpath '//abstract', output, 1
+    assert_xpath '/article/info/abstract', output, 1
+  end
+
+  test 'should move abstract in preface section to info tag when converting to DocBook' do
+    input = <<~'EOS'
+    = Document Title
+    :doctype: book
+
+    [preface]
+    == Preface
+
+    [abstract]
+    This is the abstract.
+
+    == Fin
+    EOS
+
+    output = convert_string input, backend: 'docbook'
+    assert_xpath '//abstract', output, 1
+    assert_xpath '/book/info/abstract', output, 1
+    assert_xpath '//preface', output, 0
+  end
+end


### PR DESCRIPTION
Vendor Asciidoctor's `preamble_test.rb` (verbatim from **v2.0.26**) under
`ref/asciidoctor/test/` and port it line-by-line via the spec-driven-development
approach established in #693 and continued through #710, so the `sdd` coverage
tool measures exactly which lines of the Ruby suite are verified.

This is the next file ported under `ref/asciidoctor/README.md`'s
one-file-at-a-time plan. The `sdd` tool and the Codecov `asciidoctor` component
already pick up every `.rb` file under `ref/asciidoctor/test`, so no tooling
changes are needed.

## What changed

- **6 in-scope HTML tests** are wrapped in `verifies!` blocks that reproduce
  their Ruby source verbatim, driven through the parser and asserted with
  `assert_xpath` against `doc.to_virtual_dom()`.
- **6 out-of-scope tests** are reproduced verbatim in annotated `non_normative!`
  blocks:
  - five DocBook `preface`/`abstract` tests (non-HTML backend), and
  - the book-doctype multi-part test (multiple level-0 headings, out of scope
    per #380).
- Two assertions are adapted to this crate's *embedded*-output virtual DOM
  (which has no standalone `id="content"` body wrapper — the root
  `div.document` plays that role), noted inline.

## Incompatibility surfaced — and fixed

The `toc-placement: preamble` test failed because `TocMode::from_parser` read
only the `toc` attribute and ignored `toc-placement` entirely, so the TOC
rendered at the top of the document (as `auto`) instead of inside the preamble.

Asciidoctor folds the `toc` placement shorthand into `toc-placement` and treats
the latter as the source of truth. The fix (first commit) matches that: a
placement keyword in the `toc` value still wins, but otherwise (`auto`, empty,
or unrecognized) the placement now comes from `toc-placement`, falling back to
`auto`. A unit test covers the interaction and the doc comments were updated.

## Verification

- `sdd` reports **75 normative lines covered, 0 uncovered** for
  `preamble_test.rb`, and a reconstruct-and-diff confirms the blocks reproduce
  the vendored `.rb` exactly (223/223 lines).
- `cargo test -p asciidoc-parser --lib`: full crate suite green
  (**3,212 passed, 0 failed, 16 ignored**).
- `cargo +nightly fmt --check` clean; `cargo clippy -p asciidoc-parser --tests`
  reports 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)