### PR TITLE
feat: Define a predefined `asciidoc-parser-version` attribute

### DIFF
--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -321,6 +321,20 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
     // ### Security attributes
     attrs.insert("max-include-depth".to_owned(), set(ApiOnly, "64"));
 
+    // ### Parser intrinsic attributes
+    //
+    // The version of this crate, so documents can reference the parser version
+    // (e.g. in `ifeval` expressions). This is the parser-specific counterpart
+    // of Ruby Asciidoctor's `asciidoctor-version` intrinsic; that name (and the
+    // companion `asciidoctor` flag) is intentionally *not* defined, so
+    // documents can distinguish the two processors. Like the safe-mode
+    // intrinsics below, it describes the processor itself, so it is locked
+    // against document assignment (`ApiOnly`).
+    attrs.insert(
+        "asciidoc-parser-version".to_owned(),
+        set(ApiOnly, env!("CARGO_PKG_VERSION")),
+    );
+
     // ### Safe-mode intrinsic attributes
     //
     // These describe the default safe mode (`SafeMode::Secure`).

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2018,6 +2018,54 @@ mod tests {
     }
 
     #[test]
+    fn asciidoc_parser_version_is_predefined() {
+        // The crate predefines `asciidoc-parser-version` with its own version
+        // (the parser-specific counterpart of Ruby Asciidoctor's
+        // `asciidoctor-version` intrinsic).
+        let mut parser = Parser::default();
+
+        assert_eq!(
+            parser.attribute_value("asciidoc-parser-version"),
+            InterpretedValue::Value(env!("CARGO_PKG_VERSION"))
+        );
+
+        // The value is available to attribute references and `ifeval`
+        // expressions in document content.
+        let doc = parser.parse(concat!(
+            "= Title\n",
+            "\n",
+            "ifeval::['{asciidoc-parser-version}' >= '0.1.0']\n",
+            "v{asciidoc-parser-version}\n",
+            "endif::[]\n",
+        ));
+
+        assert_eq!(
+            rendered_paragraphs(&doc),
+            vec![format!("v{}", env!("CARGO_PKG_VERSION"))]
+        );
+    }
+
+    #[test]
+    fn asciidoc_parser_version_is_locked() {
+        // The parser version describes the processor itself, so a document
+        // assignment is rejected with a warning and the built-in value stays
+        // in place.
+        let mut parser = Parser::default();
+
+        let doc = parser.parse(":asciidoc-parser-version: 99.99.99");
+
+        assert_eq!(
+            doc.warnings().next().unwrap().warning,
+            WarningType::AttributeValueIsLocked("asciidoc-parser-version".to_owned())
+        );
+
+        assert_eq!(
+            parser.attribute_value("asciidoc-parser-version"),
+            InterpretedValue::Value(env!("CARGO_PKG_VERSION"))
+        );
+    }
+
+    #[test]
     fn silently_locked_intrinsic_rejects_header_and_body_without_warning() {
         // A silently-locked `ApiOnly` intrinsic (as a converter would seed a
         // safe-mode-restricted attribute) rejects both a header assignment and a


### PR DESCRIPTION
Fixes #778.

## What this does

Predefines an `asciidoc-parser-version` built-in attribute set to the crate
version (`env!("CARGO_PKG_VERSION")`), so documents can reference the parser
version and use it in expressions, e.g.:

```asciidoc
ifeval::['{asciidoc-parser-version}' >= '0.1.0']
That version will do!
endif::[]
```

It is registered in `built_in_attrs.rs` under a new "Parser intrinsic
attributes" section, alongside the other processor-describing intrinsics.

## Decisions on the issue's open questions

- **Modifiable vs. locked:** locked (`ApiOnly`), matching this crate's
  treatment of the other processor intrinsics (`safe-mode-level`,
  `safe-mode-name`, `max-include-depth`). A document assignment records an
  `AttributeValueIsLocked` warning and is ignored, so an attempt to shadow the
  parser version is surfaced rather than silently honored. (Ruby Asciidoctor
  soft-sets its intrinsics, but since this is a new parser-specific name there
  is no compatibility constraint; happy to switch to a soft set if preferred.)
- **Asciidoctor-compatibility aliases:** not added. `asciidoctor` /
  `asciidoctor-version` remain undefined, so documents can distinguish the two
  processors (e.g. via `ifdef::asciidoctor[]`). This keeps the ported
  `reader_test.rb` cases that reference `{asciidoctor-version}` behaving as
  before. Can be added as a follow-up if we decide we want them.

## Tests

- `asciidoc_parser_version_is_predefined` — a pristine parser resolves the
  attribute to the crate version, and the value is usable in attribute
  references and `ifeval` expressions in document content.
- `asciidoc_parser_version_is_locked` — a document assignment warns and leaves
  the built-in value in place.

Full suite passes (`cargo test`), clippy clean, formatted with
`cargo +nightly fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)