### PR TITLE
fix: Resolve unset attribute references to empty in `ifeval` expressions

### DIFF
--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -245,7 +245,7 @@ impl<'p> PreprocessorState<'p> {
             } else if line.starts_with("include::")
                 && let Some(caps) = INCLUDE_DIRECTIVE.captures(line.data())
             {
-                let target = self.substitute_attributes(&caps[1]);
+                let target = self.substitute_attributes(&caps[1], MissingAttribute::KeepLiteral);
 
                 if self.parser.safe >= SafeMode::Secure {
                     // The include directive is disabled at `SafeMode::Secure`
@@ -503,14 +503,15 @@ impl<'p> PreprocessorState<'p> {
     }
 
     /// Apply attribute substitution to a string, replacing {attribute-name}
-    /// patterns with their corresponding values from the parser.
-    fn substitute_attributes(&self, input: &str) -> String {
+    /// patterns with their corresponding values from the parser. A reference to
+    /// an unset attribute is handled per `missing`.
+    fn substitute_attributes(&self, input: &str, missing: MissingAttribute) -> String {
         if !input.contains('{') {
             return input.to_string();
         }
 
         #[derive(Debug)]
-        struct AttributeReplacer<'p>(&'p Parser);
+        struct AttributeReplacer<'p>(&'p Parser, MissingAttribute);
 
         impl Replacer for AttributeReplacer<'_> {
             fn replace_append(&mut self, caps: &regex::Captures<'_>, dest: &mut String) {
@@ -526,7 +527,9 @@ impl<'p> PreprocessorState<'p> {
                 }
 
                 if !self.0.has_attribute(attr_name) {
-                    dest.push_str(&caps[0]);
+                    if matches!(self.1, MissingAttribute::KeepLiteral) {
+                        dest.push_str(&caps[0]);
+                    }
                     return;
                 }
 
@@ -539,7 +542,7 @@ impl<'p> PreprocessorState<'p> {
         let result: Cow<'_, str> = input.into();
 
         if let Cow::Owned(new_result) =
-            ATTRIBUTE_REFERENCE.replace_all(&result, AttributeReplacer(self.parser))
+            ATTRIBUTE_REFERENCE.replace_all(&result, AttributeReplacer(self.parser, missing))
         {
             new_result
         } else {
@@ -940,10 +943,11 @@ impl<'p> PreprocessorState<'p> {
 
     /// Resolve one side of an `ifeval` expression to a typed [`Value`].
     ///
-    /// Attribute references are substituted first. A value enclosed in single
-    /// or double quotes is always a string; otherwise it is coerced per the
-    /// documented rules (empty → nil, `true`/`false` → boolean, a value with a
-    /// period → float, anything else → integer).
+    /// Attribute references are substituted first; a reference to an unset
+    /// attribute resolves to the empty string, as in Asciidoctor. A value
+    /// enclosed in single or double quotes is always a string; otherwise it is
+    /// coerced per the documented rules (empty → nil, `true`/`false` →
+    /// boolean, a value with a period → float, anything else → integer).
     fn resolve_expr_val(&self, raw: &str) -> Value {
         let raw = raw.trim();
 
@@ -954,10 +958,24 @@ impl<'p> PreprocessorState<'p> {
             .or_else(|| raw.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')));
 
         match quoted_inner {
-            Some(inner) => Value::Str(self.substitute_attributes(inner)),
-            None => coerce_unquoted(&self.substitute_attributes(raw)),
+            Some(inner) => Value::Str(self.substitute_attributes(inner, MissingAttribute::Drop)),
+            None => coerce_unquoted(&self.substitute_attributes(raw, MissingAttribute::Drop)),
         }
     }
+}
+
+/// How attribute substitution treats a reference to an unset attribute.
+#[derive(Clone, Copy, Debug)]
+enum MissingAttribute {
+    /// Leave the `{name}` reference in place unchanged, deferring to normal
+    /// content parsing (and its `attribute-missing` handling) downstream.
+    KeepLiteral,
+
+    /// Resolve the reference to the empty string. This mirrors Asciidoctor's
+    /// `attribute_missing: 'drop'` option, which its `ifeval` operand
+    /// resolution always applies regardless of the `attribute-missing`
+    /// document attribute (see issue #779).
+    Drop,
 }
 
 /// A value that one side of an `ifeval` expression has been coerced to.

--- a/parser/src/tests/asciidoc_lang/attributes/unresolved_references.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/unresolved_references.rs
@@ -200,9 +200,37 @@ There are a few cases where the `attribute-missing` attribute is not strictly ho
 One of those cases is the include directive.
 If a missing attribute is found in the target of an include directive, the processor will issue a warning about the missing attribute and leave behind the same warning message in the converted document.
 
+"#
+);
+
+#[test]
+fn ifeval_ignores_attribute_missing() {
+    verifies!(
+        r#"
 Another case is the `ifeval` directive.
 A missing attribute reference can safely be used in the clause of the `ifeval` directive without any side effects (i.e., `drop`) since the purpose of that statement is to determine whether an attribute resolves to a value.
 
+"#
+    );
+
+    // A missing reference in an `ifeval` clause resolves to empty (`drop`)
+    // regardless of the `attribute-missing` setting: even with `drop-line`,
+    // the directive itself is not dropped — it evaluates normally.
+    for setting in ["skip", "drop", "drop-line", "warn"] {
+        let source = format!(
+            ":attribute-missing: {setting}\n\nifeval::['{{name}}' == '']\nIncluded.\nendif::[]"
+        );
+        let doc = Parser::default().parse(&source);
+        assert_eq!(
+            rendered_paragraphs(&doc),
+            vec!["Included."],
+            "attribute-missing: {setting}"
+        );
+    }
+}
+
+non_normative!(
+    r#"
 === Forcing failure
 
 If you want the processor to fail when the document contains a missing attribute, set the `attribute-missing` attribute to `warn` and pass the `--failure-level=WARN` option to the CLI.

--- a/parser/src/tests/asciidoctor_rb/reader_test.rs
+++ b/parser/src/tests/asciidoctor_rb/reader_test.rs
@@ -5370,17 +5370,13 @@ fn escaped_ifdef_is_unescaped_and_ignored() {
     );
 }
 
-// Divergent behavior — left non-normative. In an `ifeval` expression this
-// crate keeps an *unset* attribute reference literal (`{foo}` stays `{foo}`),
-// whereas Asciidoctor resolves a missing reference to the empty string. So
-// `'{foo}' == ''` is false here (the content is dropped) but true in
-// Asciidoctor (the content is included). Matching Asciidoctor would require
-// resolving missing references to empty in `ifeval` *and* defining the
-// `asciidoctor-version` intrinsic that the sibling version-comparison cases
-// rely on — out of scope for this crate today. Tracked by
-// https://github.com/asciidoc-rs/asciidoc-parser/issues/779.
-non_normative!(
-    r#"
+// A reference to an unset attribute resolves to the empty string in an
+// `ifeval` operand (see issue #779), so `'{foo}' == ''` is true and the
+// content is included.
+#[test]
+fn ifeval_comparing_missing_attribute_to_nil_includes_content() {
+    verifies!(
+        r#"
       test 'ifeval comparing missing attribute to nil includes content' do
         input = <<~'EOS'
         ifeval::['{foo}' == '']
@@ -5398,15 +5394,24 @@ non_normative!(
       end
 
 "#
-);
+    );
 
-// Divergent behavior — left non-normative, same root cause as the previous
-// case (see issue #779): an unset `{leveloffset}` stays literal, so
-// `{leveloffset} == 0` coerces `"{leveloffset}"` to the integer 0 and compares
-// equal (content *included*), whereas Asciidoctor resolves the missing
-// reference to nil, which is not equal to 0 (content dropped).
-non_normative!(
-    r#"
+    let parser = Parser::default();
+    assert_eq!(
+        reader_read(
+            &parser,
+            "ifeval::['{foo}' == '']\nNo foo for you!\nendif::[]"
+        ),
+        "No foo for you!"
+    );
+}
+
+// The unset (and unquoted) `{leveloffset}` reference resolves to empty and
+// thus coerces to nil, which is not equal to 0, so the content is dropped.
+#[test]
+fn ifeval_comparing_missing_attribute_to_0_drops_content() {
+    verifies!(
+        r#"
       test 'ifeval comparing missing attribute to 0 drops content' do
         input = <<~'EOS'
         ifeval::[{leveloffset} == 0]
@@ -5424,7 +5429,17 @@ non_normative!(
       end
 
 "#
-);
+    );
+
+    let parser = Parser::default();
+    assert_eq!(
+        reader_read(
+            &parser,
+            "ifeval::[{leveloffset} == 0]\nI didn't make the cut!\nendif::[]"
+        ),
+        ""
+    );
+}
 
 #[test]
 fn ifeval_running_unsupported_operation_on_missing_attribute_drops_content() {
@@ -5482,7 +5497,14 @@ fn ifeval_running_invalid_operation_drops_content() {
 "#
     );
 
-    let parser = Parser::default();
+    // The test supplies the `asciidoctor-version` value this crate does not
+    // define (see issue #778) so that, as in Ruby, the invalid operation is a
+    // number compared against a boolean.
+    let parser = Parser::default().with_intrinsic_attribute(
+        "asciidoctor-version",
+        "2.0.26",
+        ModificationContext::Anywhere,
+    );
     assert_eq!(
         reader_read(
             &parser,
@@ -5600,9 +5622,10 @@ fn ifeval_comparing_quoted_attribute_to_non_matching_string_drops_content() {
     );
 }
 
-// (This crate does not define the `asciidoctor-version` intrinsic, so the
-// reference is compared as a literal string; the comparison holds either
-// way for these inputs.)
+// This crate does not define the `asciidoctor-version` intrinsic (see issue
+// #778), and a reference to an unset attribute resolves to empty in an
+// `ifeval` operand (see issue #779), so the test supplies a version value for
+// the comparison to hold against.
 #[test]
 fn ifeval_comparing_attribute_to_lower_version_number_includes_content() {
     verifies!(
@@ -5626,7 +5649,11 @@ fn ifeval_comparing_attribute_to_lower_version_number_includes_content() {
 "#
     );
 
-    let parser = Parser::default();
+    let parser = Parser::default().with_intrinsic_attribute(
+        "asciidoctor-version",
+        "2.0.26",
+        ModificationContext::Anywhere,
+    );
     assert_eq!(
         reader_read(
             &parser,
@@ -5636,7 +5663,8 @@ fn ifeval_comparing_attribute_to_lower_version_number_includes_content() {
     );
 }
 
-// A reference always equals itself, so the content is included.
+// A reference always equals itself, so the content is included. (Here the
+// attribute is unset, so both sides resolve to the empty string.)
 #[test]
 fn ifeval_comparing_attribute_to_self_includes_content() {
     verifies!(
@@ -5670,7 +5698,8 @@ fn ifeval_comparing_attribute_to_self_includes_content() {
     );
 }
 
-// The operands may be given in either order.
+// The operands may be given in either order. (As above, the test supplies the
+// `asciidoctor-version` value this crate does not define — see issue #778.)
 #[test]
 fn ifeval_arguments_can_be_transposed() {
     verifies!(
@@ -5694,7 +5723,11 @@ fn ifeval_arguments_can_be_transposed() {
 "#
     );
 
-    let parser = Parser::default();
+    let parser = Parser::default().with_intrinsic_attribute(
+        "asciidoctor-version",
+        "2.0.26",
+        ModificationContext::Anywhere,
+    );
     assert_eq!(
         reader_read(
             &parser,


### PR DESCRIPTION
Fixes #779.

## What changed

When evaluating an `ifeval` expression, a reference to an **unset** attribute now resolves to the empty string, matching Asciidoctor (whose `resolve_expr_val` substitutes with `attribute_missing: 'drop'` regardless of the `attribute-missing` document attribute). Previously the reference stayed literal (`{leveloffset}` stayed `{leveloffset}`), which inverted comparisons involving missing attributes:

- `ifeval::[{leveloffset} == 0]` — literal `"{leveloffset}"` coerced to integer `0`, so content was wrongly **included**; it now resolves to nil, which is not equal to `0`, so content is dropped.
- `ifeval::['{foo}' == '']` — literal `"{foo}"` was not equal to `""`, so content was wrongly **dropped**; it now resolves to `''`, so content is included.

`substitute_attributes` in the preprocessor now takes a `MissingAttribute` mode; `ifeval` operands use `Drop` while include targets keep the existing `KeepLiteral` behavior.

## Tests

- The two `reader_test.rb` cases deferred on #779 (`ifeval comparing missing attribute to nil includes content` and `... to 0 drops content`) are converted from `non_normative!` to passing `verifies!` tests.
- The `ifeval` paragraph of `unresolved-references.adoc` ("A missing attribute reference can safely be used in the clause of the `ifeval` directive without any side effects (i.e., `drop`)") is now verified across all four `attribute-missing` settings.
- As anticipated in the issue, the sibling version-comparison cases (`'{asciidoctor-version}' >= '0.1.0'`, transposed variant, and `{asciidoctor-version} > true`) previously passed only because the reference stayed literal. Those tests now supply an `asciidoctor-version` value via `with_intrinsic_attribute`, since this crate does not define the intrinsic — see #778.

SDD coverage of both tracked files remains complete (`cargo run -p sdd` reports no uncovered lines). Full suite: 3817 passed, 0 failed. Clippy clean; formatted with nightly rustfmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)