### PR TITLE
feat: Honor the appendix-number attribute for appendix lettering

### DIFF
--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -109,9 +109,19 @@ impl<'src> SectionBlock<'src> {
             || metadata.anchor_reftext.is_some();
 
         let (section_number, caption, xref_signifier) = if is_appendix_root {
+            // The appendix letter is resolved through the `appendix-number`
+            // counter (mirroring Ruby Asciidoctor's `Document#counter
+            // 'appendix-number', 'A'`): each appendix advances the counter, so
+            // a document-set `appendix-number` value is the letter *before* the
+            // first appendix (`:appendix-number: α` letters the appendices β,
+            // γ, …) and the attribute always reads back as the current letter.
+            let letter = parser.counter("appendix-number", Some("A"));
+
             parser
                 .last_appendix_section_number
                 .assign_next_number(level);
+            parser.last_appendix_section_number.appendix_letter = Some(letter);
+
             let number = parser.last_appendix_section_number.clone();
             let caption = appendix_caption(parser, &number);
 
@@ -783,6 +793,13 @@ impl std::fmt::Debug for SectionType {
 pub struct SectionNumber {
     pub(crate) section_type: SectionType,
     pub(crate) components: Vec<usize>,
+
+    // The letter (or, more generally, counter value) assigned to the appendix
+    // this number belongs to, resolved from the `appendix-number` counter
+    // (e.g. `"A"`, or `"β"` when the document sets `:appendix-number: α`).
+    // Replaces the first component when the number is displayed. `None` for
+    // normal section numbers.
+    pub(crate) appendix_letter: Option<String>,
 }
 
 impl SectionNumber {
@@ -807,6 +824,15 @@ impl SectionNumber {
     pub fn components(&self) -> &[usize] {
         &self.components
     }
+
+    /// Return the letter (or, more generally, `appendix-number` counter value)
+    /// assigned to the appendix this number belongs to (e.g. `"A"`, or `"β"`
+    /// when the document sets `:appendix-number: α`).
+    ///
+    /// Returns `None` for normal section numbers.
+    pub fn appendix_letter(&self) -> Option<&str> {
+        self.appendix_letter.as_deref()
+    }
 }
 
 impl fmt::Display for SectionNumber {
@@ -818,9 +844,16 @@ impl fmt::Display for SectionNumber {
                 .enumerate()
                 .map(|(index, x)| {
                     if index == 0 && self.section_type == SectionType::Appendix {
-                        char::from_u32(b'A' as u32 + (x - 1) as u32)
-                            .unwrap_or('?')
-                            .to_string()
+                        // A parsed appendix number always carries its letter;
+                        // the A, B, … derivation covers directly-constructed
+                        // values that don't.
+                        if let Some(letter) = &self.appendix_letter {
+                            letter.clone()
+                        } else {
+                            char::from_u32(b'A' as u32 + (x - 1) as u32)
+                                .unwrap_or('?')
+                                .to_string()
+                        }
                     } else {
                         x.to_string()
                     }
@@ -836,6 +869,7 @@ impl fmt::Debug for SectionNumber {
         f.debug_struct("SectionNumber")
             .field("section_type", &self.section_type)
             .field("components", &DebugSliceReference(&self.components))
+            .field("appendix_letter", &self.appendix_letter)
             .finish()
     }
 }
@@ -3288,7 +3322,7 @@ mod tests {
                 assert_eq!(sn.to_string(), "");
                 assert_eq!(
                     format!("{sn:?}"),
-                    "SectionNumber { section_type: SectionType::Normal, components: &[] }"
+                    "SectionNumber { section_type: SectionType::Normal, components: &[], appendix_letter: None }"
                 );
             }
 
@@ -3300,7 +3334,7 @@ mod tests {
                 assert_eq!(sn.to_string(), "1");
                 assert_eq!(
                     format!("{sn:?}"),
-                    "SectionNumber { section_type: SectionType::Normal, components: &[1] }"
+                    "SectionNumber { section_type: SectionType::Normal, components: &[1], appendix_letter: None }"
                 );
             }
 
@@ -3312,7 +3346,7 @@ mod tests {
                 assert_eq!(sn.to_string(), "1.1.1");
                 assert_eq!(
                     format!("{sn:?}"),
-                    "SectionNumber { section_type: SectionType::Normal, components: &[1, 1, 1] }"
+                    "SectionNumber { section_type: SectionType::Normal, components: &[1, 1, 1], appendix_letter: None }"
                 );
             }
 
@@ -3325,7 +3359,7 @@ mod tests {
                 assert_eq!(sn.to_string(), "2");
                 assert_eq!(
                     format!("{sn:?}"),
-                    "SectionNumber { section_type: SectionType::Normal, components: &[2] }"
+                    "SectionNumber { section_type: SectionType::Normal, components: &[2], appendix_letter: None }"
                 );
             }
 
@@ -3339,7 +3373,7 @@ mod tests {
                 assert_eq!(sn.to_string(), "2.1");
                 assert_eq!(
                     format!("{sn:?}"),
-                    "SectionNumber { section_type: SectionType::Normal, components: &[2, 1] }"
+                    "SectionNumber { section_type: SectionType::Normal, components: &[2, 1], appendix_letter: None }"
                 );
             }
         }
@@ -3352,12 +3386,13 @@ mod tests {
                 let sn = SectionNumber {
                     section_type: SectionType::Appendix,
                     components: vec![],
+                    appendix_letter: None,
                 };
                 assert_eq!(sn.components(), []);
                 assert_eq!(sn.to_string(), "");
                 assert_eq!(
                     format!("{sn:?}"),
-                    "SectionNumber { section_type: SectionType::Appendix, components: &[] }"
+                    "SectionNumber { section_type: SectionType::Appendix, components: &[], appendix_letter: None }"
                 );
             }
 
@@ -3366,13 +3401,14 @@ mod tests {
                 let mut sn = SectionNumber {
                     section_type: SectionType::Appendix,
                     components: vec![],
+                    appendix_letter: None,
                 };
                 sn.assign_next_number(1);
                 assert_eq!(sn.components(), [1]);
                 assert_eq!(sn.to_string(), "A");
                 assert_eq!(
                     format!("{sn:?}"),
-                    "SectionNumber { section_type: SectionType::Appendix, components: &[1] }"
+                    "SectionNumber { section_type: SectionType::Appendix, components: &[1], appendix_letter: None }"
                 );
             }
 
@@ -3381,13 +3417,14 @@ mod tests {
                 let mut sn = SectionNumber {
                     section_type: SectionType::Appendix,
                     components: vec![],
+                    appendix_letter: None,
                 };
                 sn.assign_next_number(3);
                 assert_eq!(sn.components(), [1, 1, 1]);
                 assert_eq!(sn.to_string(), "A.1.1");
                 assert_eq!(
                     format!("{sn:?}"),
-                    "SectionNumber { section_type: SectionType::Appendix, components: &[1, 1, 1] }"
+                    "SectionNumber { section_type: SectionType::Appendix, components: &[1, 1, 1], appendix_letter: None }"
                 );
             }
 
@@ -3396,6 +3433,7 @@ mod tests {
                 let mut sn = SectionNumber {
                     section_type: SectionType::Appendix,
                     components: vec![],
+                    appendix_letter: None,
                 };
                 sn.assign_next_number(3);
                 sn.assign_next_number(1);
@@ -3403,7 +3441,7 @@ mod tests {
                 assert_eq!(sn.to_string(), "B");
                 assert_eq!(
                     format!("{sn:?}"),
-                    "SectionNumber { section_type: SectionType::Appendix, components: &[2] }"
+                    "SectionNumber { section_type: SectionType::Appendix, components: &[2], appendix_letter: None }"
                 );
             }
 
@@ -3412,6 +3450,7 @@ mod tests {
                 let mut sn = SectionNumber {
                     section_type: SectionType::Appendix,
                     components: vec![],
+                    appendix_letter: None,
                 };
                 sn.assign_next_number(3);
                 sn.assign_next_number(1);
@@ -3420,9 +3459,92 @@ mod tests {
                 assert_eq!(sn.to_string(), "B.1");
                 assert_eq!(
                     format!("{sn:?}"),
-                    "SectionNumber { section_type: SectionType::Appendix, components: &[2, 1] }"
+                    "SectionNumber { section_type: SectionType::Appendix, components: &[2, 1], appendix_letter: None }"
                 );
             }
+
+            #[test]
+            fn appendix_letter_overrides_first_component() {
+                let mut sn = SectionNumber {
+                    section_type: SectionType::Appendix,
+                    components: vec![],
+                    appendix_letter: Some("\u{3b2}".to_owned()),
+                };
+                sn.assign_next_number(1);
+                sn.assign_next_number(2);
+                assert_eq!(sn.components(), [1, 1]);
+                assert_eq!(sn.appendix_letter(), Some("\u{3b2}"));
+                assert_eq!(sn.to_string(), "\u{3b2}.1");
+                assert_eq!(
+                    format!("{sn:?}"),
+                    "SectionNumber { section_type: SectionType::Appendix, components: &[1, 1], appendix_letter: Some(\"\u{3b2}\") }"
+                );
+            }
+        }
+    }
+
+    mod appendix_number_attribute {
+        use crate::{blocks::Block, tests::prelude::*};
+
+        // The `appendix-number` attribute is resolved as a counter (mirroring
+        // Ruby Asciidoctor), so its value is the letter *before* the first
+        // appendix and each appendix advances it.
+
+        #[test]
+        fn seeds_lettering_from_the_attribute() {
+            let doc = Parser::default()
+                .parse(":appendix-number: M\n\n[appendix]\n== One\n\n[appendix]\n== Two\n");
+
+            let caps: Vec<Option<&str>> = all_sections(&doc).iter().map(|s| s.caption()).collect();
+            assert_eq!(caps, vec![Some("Appendix N: "), Some("Appendix O: ")]);
+        }
+
+        #[test]
+        fn increments_a_numeric_value_numerically() {
+            let doc = Parser::default()
+                .parse(":appendix-number: 9\n\n[appendix]\n== One\n\n[appendix]\n== Two\n");
+
+            let caps: Vec<Option<&str>> = all_sections(&doc).iter().map(|s| s.caption()).collect();
+            assert_eq!(caps, vec![Some("Appendix 10: "), Some("Appendix 11: ")]);
+        }
+
+        #[test]
+        fn bare_attribute_resolves_to_default_seed() {
+            // A bare `:appendix-number:` takes the built-in default `@`, the
+            // character before `A`, so lettering still starts at `A`.
+            let doc = Parser::default()
+                .parse(":appendix-number:\n\n[appendix]\n== One\n\n[appendix]\n== Two\n");
+
+            let caps: Vec<Option<&str>> = all_sections(&doc).iter().map(|s| s.caption()).collect();
+            assert_eq!(caps, vec![Some("Appendix A: "), Some("Appendix B: ")]);
+        }
+
+        #[test]
+        fn letters_section_numbers_of_appendix_and_subsections() {
+            let doc = Parser::default()
+                .parse(":sectnums:\n:appendix-number: \u{3b1}\n\n[appendix]\n== One\n\n=== Sub\n");
+
+            let nums: Vec<Option<String>> = all_sections(&doc)
+                .iter()
+                .map(|s| s.section_number().map(|n| n.to_string()))
+                .collect();
+            assert_eq!(
+                nums,
+                vec![Some("\u{3b2}".to_owned()), Some("\u{3b2}.1".to_owned())]
+            );
+        }
+
+        #[test]
+        fn attribute_reads_back_as_the_current_letter() {
+            // Advancing the counter stores the new value back into the
+            // attribute, so a reference inside the appendix sees its letter.
+            let doc = Parser::default().parse("[appendix]\n== One\n\nLetter {appendix-number}.\n");
+
+            let section = first_section(&doc);
+            let Some(Block::Simple(paragraph)) = section.nested_blocks().next() else {
+                panic!("expected a simple block");
+            };
+            assert_eq!(paragraph.content().rendered(), "Letter A.");
         }
     }
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -343,6 +343,7 @@ impl Default for Parser {
             last_appendix_section_number: SectionNumber {
                 section_type: SectionType::Appendix,
                 components: vec![],
+                appendix_letter: None,
             },
             sectnumlevels: 3,
             topmost_section_type: SectionType::Normal,

--- a/parser/src/tests/asciidoc_lang/sections/appendix.rs
+++ b/parser/src/tests/asciidoc_lang/sections/appendix.rs
@@ -121,6 +121,7 @@ include::example$appendix.adoc[tag=appx-article-out]
                         section_number: Some(SectionNumber {
                             section_type: SectionType::Normal,
                             components: &[1, 1,],
+                            appendix_letter: None,
                         },),
                     },),],
                     source: Span {
@@ -140,6 +141,7 @@ include::example$appendix.adoc[tag=appx-article-out]
                     section_number: Some(SectionNumber {
                         section_type: SectionType::Normal,
                         components: &[1,],
+                        appendix_letter: None,
                     },),
                 },),
                 Block::Section(SectionBlock {
@@ -183,6 +185,7 @@ include::example$appendix.adoc[tag=appx-article-out]
                             section_number: Some(SectionNumber {
                                 section_type: SectionType::Appendix,
                                 components: &[1, 1,],
+                                appendix_letter: Some("A"),
                             },),
                         },),
                         Block::Section(SectionBlock {
@@ -214,6 +217,7 @@ include::example$appendix.adoc[tag=appx-article-out]
                             section_number: Some(SectionNumber {
                                 section_type: SectionType::Appendix,
                                 components: &[1, 2,],
+                                appendix_letter: Some("A"),
                             },),
                         },),
                     ],
@@ -247,6 +251,7 @@ include::example$appendix.adoc[tag=appx-article-out]
                     section_number: Some(SectionNumber {
                         section_type: SectionType::Appendix,
                         components: &[1,],
+                        appendix_letter: Some("A"),
                     },),
                 },),
                 Block::Section(SectionBlock {
@@ -291,6 +296,7 @@ include::example$appendix.adoc[tag=appx-article-out]
                     section_number: Some(SectionNumber {
                         section_type: SectionType::Appendix,
                         components: &[2,],
+                        appendix_letter: Some("B"),
                     },),
                 },),
             ],

--- a/parser/src/tests/asciidoc_lang/sections/numbers.rs
+++ b/parser/src/tests/asciidoc_lang/sections/numbers.rs
@@ -147,6 +147,7 @@ When `sectnums` is set, level 1 (`==`) through level 3 (`====`) section titles a
                         section_number: Some(SectionNumber {
                             section_type: SectionType::Normal,
                             components: &[1, 1, 1,],
+                            appendix_letter: None,
                         },),
                     },),],
                     source: Span {
@@ -166,6 +167,7 @@ When `sectnums` is set, level 1 (`==`) through level 3 (`====`) section titles a
                     section_number: Some(SectionNumber {
                         section_type: SectionType::Normal,
                         components: &[1, 1,],
+                        appendix_letter: None,
                     },),
                 },),],
                 source: Span {
@@ -184,7 +186,8 @@ When `sectnums` is set, level 1 (`==`) through level 3 (`====`) section titles a
                 caption: None,
                 section_number: Some(SectionNumber {
                     section_type: SectionType::Normal,
-                    components: &[1,]
+                    components: &[1,],
+                    appendix_letter: None,
                 },),
             },),],
             source: Span {
@@ -365,7 +368,8 @@ The section number does not increment in regions of the document where section n
                     caption: None,
                     section_number: Some(SectionNumber {
                         section_type: SectionType::Normal,
-                        components: &[1,]
+                        components: &[1,],
+                        appendix_letter: None,
                     },),
                 },),
                 Block::Section(SectionBlock {
@@ -494,7 +498,8 @@ The section number does not increment in regions of the document where section n
                     caption: None,
                     section_number: Some(SectionNumber {
                         section_type: SectionType::Normal,
-                        components: &[2,]
+                        components: &[2,],
+                        appendix_letter: None,
                     },),
                 },),
             ],
@@ -600,7 +605,8 @@ If it is unset (`sectnums!`) on the command line or API, then the numbers are di
         sb.section_number().unwrap(),
         &SectionNumber {
             section_type: SectionType::Normal,
-            components: &[1]
+            components: &[1],
+            appendix_letter: None,
         }
     );
 
@@ -759,6 +765,7 @@ include::example$section.adoc[tag=sectnuml]
                     section_number: Some(SectionNumber {
                         section_type: SectionType::Normal,
                         components: &[1, 1,],
+                        appendix_letter: None,
                     },),
                 },),],
                 source: Span {
@@ -777,7 +784,8 @@ include::example$section.adoc[tag=sectnuml]
                 caption: None,
                 section_number: Some(SectionNumber {
                     section_type: SectionType::Normal,
-                    components: &[1,]
+                    components: &[1,],
+                    appendix_letter: None,
                 },),
             },),],
             source: Span {

--- a/parser/src/tests/asciidoctor_rb/sections_test.rs
+++ b/parser/src/tests/asciidoctor_rb/sections_test.rs
@@ -3838,11 +3838,15 @@ mod special_sections {
         assert_eq!(sec.section_title(), "Attribute Options");
     }
 
-    // NOTE: The `appendix-number` attribute (to start appendix lettering at a
-    // custom value) is not honored — the crate always letters appendices A, B, …
-    // Out of scope (see #780).
-    non_normative!(
-        r##"
+    // The caption prefix is verified via `caption()` (see the note above about
+    // captions being computed on the AST). `decode_char 946` is β (U+03B2) and
+    // `decode_char 947` is γ (U+03B3): the `appendix-number` value is the letter
+    // *before* the first appendix, so `:appendix-number: α` letters the
+    // appendices β and γ.
+    #[test]
+    fn should_allow_appendix_number_to_be_controlled_using_appendix_number_attribute() {
+        verifies!(
+            r##"
     test 'should allow appendix number to be controlled using appendix-number attribute' do
       input = <<~'EOS'
       :appendix-number: α
@@ -3864,7 +3868,21 @@ mod special_sections {
     end
 
 "##
-    );
+        );
+
+        let doc = Parser::default().parse(
+            ":appendix-number: \u{3b1}\n\n[appendix]\n== Attribute Options\n\nDetails\n\n[appendix]\n== All the Other Stuff\n\nDetails\n",
+        );
+
+        let sections = all_sections(&doc);
+        assert_eq!(sections.len(), 2);
+
+        assert_eq!(sections[0].caption(), Some("Appendix \u{3b2}: "));
+        assert_eq!(sections[0].section_title(), "Attribute Options");
+
+        assert_eq!(sections[1].caption(), Some("Appendix \u{3b3}: "));
+        assert_eq!(sections[1].section_title(), "All the Other Stuff");
+    }
 
     #[test]
     fn should_use_style_from_last_block_attribute_line_above_section_that_defines_a_style() {

--- a/parser/src/tests/fixtures/blocks/section_number.rs
+++ b/parser/src/tests/fixtures/blocks/section_number.rs
@@ -6,6 +6,7 @@ use crate::{blocks::SectionType, internal::debug::DebugSliceReference};
 pub(crate) struct SectionNumber {
     pub section_type: SectionType,
     pub components: &'static [usize],
+    pub appendix_letter: Option<&'static str>,
 }
 
 impl fmt::Debug for SectionNumber {
@@ -13,6 +14,7 @@ impl fmt::Debug for SectionNumber {
         f.debug_struct("SectionNumber")
             .field("section_type", &self.section_type)
             .field("components", &DebugSliceReference(self.components))
+            .field("appendix_letter", &self.appendix_letter)
             .finish()
     }
 }
@@ -30,5 +32,7 @@ impl PartialEq<SectionNumber> for crate::blocks::SectionNumber {
 }
 
 fn fixture_eq_observed(fixture: &SectionNumber, observed: &crate::blocks::SectionNumber) -> bool {
-    fixture.section_type == observed.section_type && fixture.components == observed.components()
+    fixture.section_type == observed.section_type
+        && fixture.components == observed.components()
+        && fixture.appendix_letter == observed.appendix_letter()
 }


### PR DESCRIPTION
Fixes #780.

Appendix lettering is now resolved through the existing counter mechanism, mirroring Ruby Asciidoctor's `Document#counter 'appendix-number', 'A'`: each appendix advances the `appendix-number` counter, so a document-set value is the letter *before* the first appendix (`:appendix-number: α` letters the appendices β, γ, …), and the attribute reads back as the current letter as the document is parsed.

## Changes

- `SectionBlock::parse` resolves the appendix letter via `Parser::counter("appendix-number", Some("A"))` instead of deriving it purely from the A, B, … ordinal. The crate's counter already mirrors Ruby's `Helpers.nextval` (numeric increment, `String#succ`-style successor otherwise), so `α` → `β`, `9` → `10`, and a bare `:appendix-number:` resolves through its built-in `@` default to `A`.
- `SectionNumber` carries the resolved letter (new `appendix_letter()` accessor); `Display` uses it for the first component, so the caption, the xref signifier, and the section numbers of the appendix and its subsections (e.g. `β.1` under `:sectnums:`) all render it. Directly-constructed values without a letter still fall back to the A, B, … derivation.
- The `SectionNumber` test fixture gained the matching field, so existing fixture tests now also pin the letter.

## Tests

- Converted the Ruby test `should allow appendix number to be controlled using appendix-number attribute` from `non_normative!` to a verifying SDD test in `sections_test.rs`.
- New behavior tests in `section.rs`: custom letter start, numeric values, bare-attribute default seed, subsection numbering with a custom letter, and the attribute reading back as the current letter.

## Out of scope

The analogous `chapter-number` attribute (mentioned as *Related* in #780) depends on book-doctype chapter modeling, which the crate doesn't have yet; its Ruby test remains `non_normative!` with the other book-doctype tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)