### PR TITLE
fix: Implement the abstract block style (close #783)

### DIFF
--- a/parser/src/blocks/is_block.rs
+++ b/parser/src/blocks/is_block.rs
@@ -69,6 +69,16 @@ pub trait IsBlock<'src>: Debug + Eq + PartialEq {
             if declared_style == "source" {
                 return "listing".into();
             }
+
+            // The `abstract` style is not itself a context; it specializes the
+            // `open` context. Asciidoctor rebuilds an `[abstract]` paragraph as
+            // an open block (keeping the simple content model), so the style
+            // resolves a paragraph's context to `open`. On any other context
+            // (including the `--` delimited form, which is already `open`), the
+            // declared style is preserved without changing the context.
+            if declared_style == "abstract" && self.raw_context().as_ref() == "paragraph" {
+                return "open".into();
+            }
         }
 
         self.raw_context()

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -184,6 +184,29 @@ impl<'src> Document<'src> {
                 blocks = section_blocks;
             }
 
+            // An abstract block is not permitted as a direct child of a book
+            // document without a doctitle. Asciidoctor's converter excludes
+            // such a block's content and warns; the parser keeps the block in
+            // the AST (as Asciidoctor does) and records the warning here, for
+            // a renderer to act on.
+            if matches!(
+                parser.attribute_value("doctype"),
+                InterpretedValue::Value(ref v) if v == "book"
+            ) && header.title().is_none()
+            {
+                for block in &blocks {
+                    if block.declared_style() == Some("abstract")
+                        && block.resolved_context().as_ref() == "open"
+                    {
+                        warnings.push(Warning {
+                            source: block.span(),
+                            warning: WarningType::AbstractBlockInBookWithoutDoctitle,
+                            origin: None,
+                        });
+                    }
+                }
+            }
+
             // Under `doctype: inline`, only the first eligible block is converted,
             // as bare inline content, and everything after it is dropped (the
             // rendering lives on the embed path). A compound or empty candidate

--- a/parser/src/tests/asciidoctor_rb/blocks_test.rs
+++ b/parser/src/tests/asciidoctor_rb/blocks_test.rs
@@ -7448,7 +7448,7 @@ mod abstract_and_part_intro {
     // errors are not emitted; those tests are kept `#[ignore]`d with the
     // Ruby-intended assertions. The DocBook variants are reproduced as
     // `non_normative`.
-    // TODO: implement the partintro block style.
+    // TODO: implement the partintro block style (#794).
 
     #[test]
     fn should_make_abstract_on_open_block_without_title_a_quote_block_for_article() {

--- a/parser/src/tests/asciidoctor_rb/blocks_test.rs
+++ b/parser/src/tests/asciidoctor_rb/blocks_test.rs
@@ -7439,17 +7439,17 @@ mod abstract_and_part_intro {
 "#
     );
 
-    // NOTE: divergence from Asciidoctor pervasive to this context. This crate
-    // does not model the `abstract` and `partintro` block styles: an
-    // `[abstract]` open block is not converted to a `quoteblock.abstract` (nor
-    // does an `[abstract]` paragraph gain the `abstract` class), a `[partintro]`
-    // open block does not gain the `partintro` class, and the associated
-    // validation warnings/errors are not emitted. The HTML tests are kept
-    // `#[ignore]`d with the Ruby-intended assertions; the DocBook variants are
-    // reproduced as `non_normative`.
-    // TODO: implement the abstract (#783) and partintro block styles.
+    // NOTE: the `abstract` block style (#783) is modeled: an `[abstract]` open
+    // block (or paragraph) resolves to the `open` context with the `abstract`
+    // declared style, renders as `quoteblock.abstract`, and an abstract used as
+    // a direct child of a doctitle-less book document is excluded with a
+    // warning. The `partintro` block style is still unmodeled: a `[partintro]`
+    // open block does not gain the `partintro` class, and its validation
+    // errors are not emitted; those tests are kept `#[ignore]`d with the
+    // Ruby-intended assertions. The DocBook variants are reproduced as
+    // `non_normative`.
+    // TODO: implement the partintro block style.
 
-    #[ignore]
     #[test]
     fn should_make_abstract_on_open_block_without_title_a_quote_block_for_article() {
         verifies!(
@@ -7488,7 +7488,6 @@ mod abstract_and_part_intro {
         assert_css(&doc, ".quoteblock > blockquote > .paragraph", 2);
     }
 
-    #[ignore]
     #[test]
     fn should_make_abstract_on_open_block_with_title_a_quote_block_with_title_for_article() {
         verifies!(
@@ -7527,7 +7526,6 @@ mod abstract_and_part_intro {
         assert_css(&doc, ".quoteblock > .title", 1);
     }
 
-    #[ignore]
     #[test]
     fn should_allow_abstract_in_document_with_title_if_doctype_is_book() {
         verifies!(
@@ -7551,9 +7549,9 @@ mod abstract_and_part_intro {
         let doc = Parser::default()
             .parse("= Book\n:doctype: book\n\n[abstract]\nAbstract for book with title is valid\n");
         assert_css(&doc, ".abstract", 1);
+        assert!(doc.warnings().next().is_none());
     }
 
-    #[ignore]
     #[test]
     fn should_not_allow_abstract_as_direct_child_of_document_if_doctype_is_book() {
         verifies!(
@@ -7577,6 +7575,13 @@ mod abstract_and_part_intro {
         let doc = Parser::default()
             .parse(":doctype: book\n\n[abstract]\nAbstract for book without title is invalid.\n");
         assert_css(&doc, ".abstract", 0);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert!(matches!(
+            warnings[0].warning,
+            WarningType::AbstractBlockInBookWithoutDoctitle
+        ));
     }
 
     // The DocBook abstract variants are backend-specific and out of scope.

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -622,8 +622,21 @@ impl ToVirtualDom for Document<'_> {
             TocMode::Disabled => {}
         }
 
+        // An abstract block is not permitted as a direct child of a book
+        // document without a doctitle: Asciidoctor's converter excludes the
+        // block's content (a warning was recorded at parse time). With a
+        // doctitle, pre-section content lands inside the preamble instead, so
+        // this exclusion never applies.
+        let exclude_abstracts = matches!(
+            self.attribute_value("doctype"),
+            InterpretedValue::Value(ref v) if v == "book"
+        ) && self.doctitle().is_none();
+
         // Add child blocks, including block titles as separate siblings.
         for block in self.nested_blocks() {
+            if exclude_abstracts && is_abstract(block) {
+                continue;
+            }
             add_block_with_title(&mut node, block);
         }
 
@@ -714,6 +727,15 @@ impl ToVirtualDom for Block<'_> {
         // numbered caption preceding the content wrapper.
         if is_example(self) {
             return example_to_node(self);
+        }
+
+        // An `[abstract]` open block (the `--` structural container or the
+        // `[abstract]` paragraph style) renders as a quote block carrying the
+        // `abstract` class rather than as `div.openblock`. This check must
+        // precede the `is_open` routing below, since an abstract block also
+        // resolves to the `open` context.
+        if is_abstract(self) {
+            return abstract_to_node(self);
         }
 
         // An `[open]` styled paragraph renders as an open block
@@ -1690,6 +1712,65 @@ fn open_paragraph_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
     node
 }
 
+/// Returns `true` if `block` is an abstract block: the `--` structural
+/// container or a paragraph carrying the `abstract` style, both of which
+/// resolve to the `open` context with the `abstract` declared style.
+fn is_abstract<'a>(block: &'a Block<'a>) -> bool {
+    block.declared_style() == Some("abstract") && block.resolved_context().as_ref() == "open"
+}
+
+/// Renders an abstract block, matching Asciidoctor's HTML output for the
+/// `abstract` style on an open block (`convert_open`).
+///
+/// The block renders as `div.quoteblock.abstract`, carrying the block's id and
+/// roles, with the body wrapped in a `<blockquote>`. A title, when present, is
+/// rendered as a `div.title` placed *before* the blockquote. The delimited `--`
+/// form encloses other blocks (rendered through [`add_block_with_title`] so
+/// their own titles and paragraph wrappers surface); the paragraph form holds
+/// inline content rendered directly inside the blockquote without a `<p>`
+/// wrapper.
+fn abstract_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
+    let mut node = VirtualNode::new("div")
+        .with_class("quoteblock")
+        .with_class("abstract");
+
+    for role in block.roles() {
+        node = node.with_class(role);
+    }
+
+    if let Some(id) = block.id() {
+        node = node.with_id(id);
+    }
+
+    // The title, when present, precedes the blockquote.
+    if let Some(title) = block.title() {
+        node.children
+            .push(VirtualNode::new("div").with_class("title").with_text(title));
+    }
+
+    let mut blockquote = VirtualNode::new("blockquote");
+
+    match block.content_model() {
+        // A delimited abstract encloses other blocks.
+        ContentModel::Compound => {
+            for child in block.nested_blocks() {
+                add_block_with_title(&mut blockquote, child);
+            }
+        }
+
+        // An abstract paragraph holds inline content, rendered directly inside
+        // the blockquote without a wrapping paragraph.
+        _ => {
+            if let Some(rendered) = block.rendered_content() {
+                blockquote = blockquote.with_html_content(rendered);
+            }
+        }
+    }
+
+    node.children.push(blockquote);
+    node
+}
+
 /// Returns `true` if `block` is a collapsible block: an example block (or
 /// example-styled paragraph) carrying the `collapsible` option.
 ///
@@ -1776,8 +1857,9 @@ fn is_sidebar<'a>(block: &'a Block<'a>) -> bool {
 /// [`compound_delimited_to_node`]; the paragraph form is a [`Block::Simple`]
 /// rendered by [`open_paragraph_to_node`]. Every masquerade style on a `--`
 /// block is intercepted earlier — by [`is_sidebar`], [`is_example`],
-/// `QuoteBlock`, `AdmonitionBlock`, or `RawDelimitedBlock` — so a
-/// `CompoundDelimited` block that reaches here always resolves to `open`. Like
+/// [`is_abstract`], `QuoteBlock`, `AdmonitionBlock`, or `RawDelimitedBlock` —
+/// so a `CompoundDelimited` block that reaches here always resolves to `open`
+/// with no abstract styling. Like
 /// a sidebar, an open block renders its own title (as a `div.title` before its
 /// content wrapper), so [`add_block_with_title`] must not also emit one.
 fn is_open<'a>(block: &'a Block<'a>) -> bool {

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -206,6 +206,14 @@ pub enum WarningType {
     /// corresponding open region. The field is the unexpected tag name.
     #[error("unexpected end tag in include file: {0}")]
     IncludeTagUnexpectedEnd(String),
+
+    /// An `[abstract]` block was found as a direct child of a document without
+    /// a doctitle when the doctype is `book`. Asciidoctor excludes such a
+    /// block's content from the converted output.
+    #[error(
+        "abstract block cannot be used in a document without a doctitle when doctype is book. Excluding block content."
+    )]
+    AbstractBlockInBookWithoutDoctitle,
 }
 
 impl std::fmt::Debug for WarningType {
@@ -398,6 +406,10 @@ impl std::fmt::Debug for WarningType {
                 .debug_tuple("WarningType::IncludeTagUnexpectedEnd")
                 .field(tag)
                 .finish(),
+
+            WarningType::AbstractBlockInBookWithoutDoctitle => {
+                write!(f, "WarningType::AbstractBlockInBookWithoutDoctitle")
+            }
         }
     }
 }
@@ -858,6 +870,16 @@ mod tests {
                 assert_eq!(
                     debug_output,
                     "WarningType::IncludeTagUnexpectedEnd(\"'a'\")"
+                );
+            }
+
+            #[test]
+            fn abstract_block_in_book_without_doctitle() {
+                let warning = WarningType::AbstractBlockInBookWithoutDoctitle;
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(
+                    debug_output,
+                    "WarningType::AbstractBlockInBookWithoutDoctitle"
                 );
             }
         }


### PR DESCRIPTION
Closes #783.

This crate previously rendered an `[abstract]` open block as a plain `openblock` and left `[abstract]` paragraphs untouched. This PR models the `abstract` block style end to end, verified against Asciidoctor 2.0.26's actual AST and HTML output:

## Parser changes

- **`resolved_context()`** (`is_block.rs`): an `abstract`-styled paragraph now resolves to the `open` context, matching Asciidoctor's AST (its parser rebuilds an abstract paragraph as an open block with a simple content model). The `--` delimited form already resolved to `open`; on any other container (e.g. a sidebar) the declared style is preserved without changing the context, which also matches Asciidoctor.
- **New warning** (`warnings.rs`, `document.rs`): `WarningType::AbstractBlockInBookWithoutDoctitle`, with Asciidoctor's exact message text (`abstract block cannot be used in a document without a doctitle when doctype is book. Excluding block content.`). It is recorded post-parse when the doctype is `book`, the document has no doctitle, and an abstract open block is a direct child of the document. The block stays in the AST — as it does in Asciidoctor, where exclusion is converter behavior — for a renderer to act on.

## Test-infrastructure changes

- **Virtual DOM** (`virtual_dom.rs`): mirrors Asciidoctor's `convert_open` for the `abstract` style — `div.quoteblock.abstract > blockquote`, with the title as a `div.title` before the blockquote, compound children rendered as `div.paragraph` wrappers, and the paragraph form's inline content placed directly in the blockquote. A top-level abstract in a doctitle-less book document is excluded from the rendered output.
- **`blocks_test.rs`**: un-ignores the four abstract tests and adds the warning assertion the Ruby test makes (`assert_message @logger, :WARN, …`). The `partintro` style remains unmodeled; its tests stay ignored with an updated TODO.

## Verification

- All four previously-ignored abstract tests pass; full workspace suite passes (3819 tests), `cargo +nightly fmt --check` and clippy clean.
- Behavior cross-checked against Ruby Asciidoctor 2.0.26 (HTML output and `Asciidoctor.load` AST) for: both delimited-form article tests, the paragraph form in an article, book-with-doctitle (allowed), book-without-doctitle (excluded + warning), and `[abstract]` on a sidebar container (style preserved, context unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)