### PR TITLE
fix: Enforce max-include-depth in the preprocessor

### DIFF
--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -92,6 +92,11 @@ struct PreprocessorState<'p> {
     source_map: SourceMap,
     warnings: Vec<DeferredWarning>,
 
+    /// The include-depth limit currently in effect, or `None` when
+    /// `max-include-depth` is 0 — which disables the include directive
+    /// entirely. See [`MaxIncludeDepth`].
+    max_include_depth: Option<MaxIncludeDepth>,
+
     /// Stack of open conditional preprocessor directives (`ifdef`, `ifndef`,
     /// `ifeval`). Each entry records whether the lines it encloses are
     /// currently being skipped. See [`process_conditional_directive`].
@@ -126,8 +131,54 @@ struct Conditional {
     source_line: usize,
 }
 
+/// The include-depth limit in effect, mirroring Asciidoctor's `@maxdepth`
+/// state. Depths count the number of open includes: a directive in the root
+/// file is at depth 0, one in a file it includes is at depth 1, and so on.
+#[derive(Clone, Copy, Debug)]
+struct MaxIncludeDepth {
+    /// The absolute limit set by the `max-include-depth` attribute. A `depth`
+    /// attribute on an include directive can never raise the effective limit
+    /// above this.
+    abs: usize,
+
+    /// The depth at which further include directives are refused, compared
+    /// against the depth of the file containing the directive. Initially equal
+    /// to [`abs`](Self::abs); an include directive's `depth` attribute lowers
+    /// it for the span of that include.
+    curr: usize,
+
+    /// The limit relative to the file that established it, reported in the
+    /// "maximum include depth of N exceeded" diagnostic (matching
+    /// Asciidoctor, which reports the requested relative depth rather than
+    /// the absolute nesting level).
+    rel: usize,
+}
+
 impl<'p> PreprocessorState<'p> {
     fn new(parser: &'p mut Parser) -> Self {
+        // Asciidoctor reads `max-include-depth` once, when the reader is
+        // constructed, so the value in effect at the start of preprocessing
+        // governs the entire pass. (The attribute is API-only — see
+        // `built_in_attrs.rs` — so the document cannot change it anyway.) The
+        // value is coerced as Ruby's `to_i` would; a non-positive result
+        // disables the include directive entirely.
+        let max_include_depth = match parser.attribute_value("max-include-depth") {
+            InterpretedValue::Value(value) => ruby_to_i(&value),
+            // Set with an empty value coerces to 0 (disabled); unset falls
+            // back to Asciidoctor's default of 64.
+            InterpretedValue::Set => 0,
+            InterpretedValue::Unset => 64,
+        };
+
+        let max_include_depth = usize::try_from(max_include_depth)
+            .ok()
+            .filter(|&depth| depth > 0)
+            .map(|depth| MaxIncludeDepth {
+                abs: depth,
+                curr: depth,
+                rel: depth,
+            });
+
         Self {
             parser,
             in_document_header: true,
@@ -137,6 +188,7 @@ impl<'p> PreprocessorState<'p> {
             output: String::new(),
             source_map: SourceMap::default(),
             warnings: vec![],
+            max_include_depth,
             conditional_stack: vec![],
         }
     }
@@ -276,6 +328,45 @@ impl<'p> PreprocessorState<'p> {
                     continue;
                 }
 
+                // `max-include-depth=0` disables the include directive
+                // entirely: the directive line is left in the output verbatim,
+                // with no diagnostic, and the include file handler is never
+                // consulted (matching Asciidoctor).
+                let Some(max_depth) = self.max_include_depth else {
+                    self.emit_line(
+                        line.data(),
+                        file_name,
+                        source_line_number,
+                        &mut has_reported_file,
+                    );
+                    continue;
+                };
+
+                // When the file containing the directive already sits at the
+                // maximum include depth, the directive is likewise left
+                // verbatim, and a "maximum include depth exceeded" error is
+                // recorded at the directive's own file and line (matching
+                // Asciidoctor). `include_depth` counts the current file as 1,
+                // so the containing file's depth — which the limit is compared
+                // against — is `include_depth - 1`, making the depth-exceeded
+                // condition `include_depth - 1 >= curr`, i.e.:
+                if self.include_depth > max_depth.curr {
+                    self.warnings.push(DeferredWarning {
+                        offset: self.output.len(),
+                        len: line.data().len(),
+                        warning: WarningType::MaxIncludeDepthExceeded(max_depth.rel),
+                        origin: None,
+                    });
+
+                    self.emit_line(
+                        line.data(),
+                        file_name,
+                        source_line_number,
+                        &mut has_reported_file,
+                    );
+                    continue;
+                }
+
                 let attrlist = caps
                     .get(2)
                     .map(|attrlist| {
@@ -378,10 +469,43 @@ impl<'p> PreprocessorState<'p> {
                     let content_start = self.output.len();
 
                     if is_asciidoc_file(&target) {
+                        // The directive's `depth` attribute lowers the maximum
+                        // include depth while the included file (and anything
+                        // it includes) is processed; the previous limit is
+                        // restored once the include has been merged. A positive
+                        // value permits that many more levels below the
+                        // included file, clamped to the absolute
+                        // `max-include-depth` limit; zero (or a value that
+                        // coerces to zero) permits none. `include_depth` here
+                        // is the containing file's depth plus one — i.e. the
+                        // depth of the included file itself.
+                        let saved_max_depth = self.max_include_depth;
+
+                        if let Some(depth_attr) = attrlist.named_attribute("depth")
+                            && let Some(max_depth) = self.max_include_depth.as_mut()
+                        {
+                            let rel = ruby_to_i(depth_attr.value());
+                            if rel > 0 {
+                                let mut rel = rel as usize;
+                                let mut curr = self.include_depth + rel;
+                                if curr > max_depth.abs {
+                                    curr = max_depth.abs;
+                                    rel = max_depth.abs;
+                                }
+                                max_depth.curr = curr;
+                                max_depth.rel = rel;
+                            } else {
+                                max_depth.curr = self.include_depth;
+                                max_depth.rel = 0;
+                            }
+                        }
+
                         // AsciiDoc files are run through the preprocessor, so the
                         // include (and other) directives they contain are
                         // interpreted.
                         self.process_adoc_include(&selected, Some(&target));
+
+                        self.max_include_depth = saved_max_depth;
                     } else {
                         // Non-AsciiDoc files are merged verbatim; the preprocessor
                         // does not interpret any AsciiDoc directives within them
@@ -3170,5 +3294,31 @@ mod tests {
         // Tabs expand to the tab stop; the common indent is zero (the middle line
         // is flush left), so no further indentation change is made.
         assert_eq!(output, "----\n    a\nno-tab\n    b\n----\n");
+    }
+
+    #[test]
+    fn cyclic_include_is_bounded_by_max_include_depth() {
+        // A file that includes itself would recurse without limit if the
+        // include depth were not enforced. The default `max-include-depth` of
+        // 64 bounds the expansion: the directive at the 64th nesting level is
+        // left verbatim, with a "maximum include depth exceeded" error.
+        let handler = InlineFileHandler::from_pairs([("loop.adoc", "include::loop.adoc[]")]);
+
+        let parser = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_include_file_handler(handler);
+
+        let (output, _source_map, warnings) = preprocess("include::loop.adoc[]", &parser);
+
+        // Each nesting level's only line is the directive itself, which
+        // expands to the next level (contributing no output of its own) until
+        // the limit is reached and the directive survives verbatim.
+        assert_eq!(output, "include::loop.adoc[]\n");
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::MaxIncludeDepthExceeded(64)
+        );
     }
 }

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -3321,4 +3321,65 @@ mod tests {
             WarningType::MaxIncludeDepthExceeded(64)
         );
     }
+
+    #[test]
+    fn max_include_depth_set_with_no_value_disables_includes() {
+        // `max-include-depth` set as a boolean (no value) coerces like an
+        // empty string in Ruby (`''.to_i == 0`), so it disables the include
+        // directive just as an explicit 0 does: the directive is left
+        // verbatim, silently, and the handler is never consulted.
+        let handler = InlineFileHandler::from_pairs([("shared.adoc", "shared content")]);
+
+        let parser = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_intrinsic_attribute_bool("max-include-depth", true, ModificationContext::ApiOnly)
+            .with_include_file_handler(handler);
+
+        let (output, _source_map, warnings) = preprocess("include::shared.adoc[]", &parser);
+
+        assert_eq!(output, "include::shared.adoc[]\n");
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn max_include_depth_unset_falls_back_to_default() {
+        // With `max-include-depth` explicitly unset via the API, the
+        // preprocessor falls back to Asciidoctor's default of 64, so an
+        // ordinary include still expands.
+        let handler = InlineFileHandler::from_pairs([("shared.adoc", "shared content")]);
+
+        let parser = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_intrinsic_attribute_bool("max-include-depth", false, ModificationContext::ApiOnly)
+            .with_include_file_handler(handler);
+
+        let (output, _source_map, warnings) = preprocess("include::shared.adoc[]", &parser);
+
+        assert_eq!(output, "shared content\n");
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn depth_request_exceeding_max_include_depth_is_clamped() {
+        // A `depth` request larger than the absolute `max-include-depth` limit
+        // is clamped to it: with a limit of 2, `depth=10` still refuses the
+        // third nesting level, and the diagnostic reports the clamped limit
+        // (2), not the requested relative depth (10) — matching Asciidoctor.
+        let handler = InlineFileHandler::from_pairs([
+            ("a.adoc", "include::b.adoc[]"),
+            ("b.adoc", "include::c.adoc[]"),
+            ("c.adoc", "content of c"),
+        ]);
+
+        let parser = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_intrinsic_attribute("max-include-depth", "2", ModificationContext::ApiOnly)
+            .with_include_file_handler(handler);
+
+        let (output, _source_map, warnings) = preprocess("include::a.adoc[depth=10]", &parser);
+
+        assert_eq!(output, "include::c.adoc[]\n");
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].warning, WarningType::MaxIncludeDepthExceeded(2));
+    }
 }

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -170,14 +170,19 @@ impl<'p> PreprocessorState<'p> {
             InterpretedValue::Unset => 64,
         };
 
-        let max_include_depth = usize::try_from(max_include_depth)
-            .ok()
-            .filter(|&depth| depth > 0)
-            .map(|depth| MaxIncludeDepth {
+        // A positive value too large for `usize` (possible on 32-bit targets)
+        // saturates to an effectively unlimited depth rather than failing the
+        // conversion, which would otherwise be mistaken for the "disabled"
+        // sentinel. (Ruby's integers are unbounded, so Asciidoctor simply
+        // honors such a value as a very large limit.)
+        let max_include_depth = (max_include_depth > 0).then(|| {
+            let depth = usize::try_from(max_include_depth).unwrap_or(usize::MAX);
+            MaxIncludeDepth {
                 abs: depth,
                 curr: depth,
                 rel: depth,
-            });
+            }
+        });
 
         Self {
             parser,
@@ -486,8 +491,12 @@ impl<'p> PreprocessorState<'p> {
                         {
                             let rel = ruby_to_i(depth_attr.value());
                             if rel > 0 {
-                                let mut rel = rel as usize;
-                                let mut curr = self.include_depth + rel;
+                                // A request too large for `usize` (possible on
+                                // 32-bit targets) saturates rather than
+                                // wrapping into a restrictive value; the clamp
+                                // below then reduces it to the absolute limit.
+                                let mut rel = usize::try_from(rel).unwrap_or(usize::MAX);
+                                let mut curr = self.include_depth.saturating_add(rel);
                                 if curr > max_depth.abs {
                                     curr = max_depth.abs;
                                     rel = max_depth.abs;
@@ -3399,5 +3408,51 @@ mod tests {
         assert_eq!(output, "include::c.adoc[]\n");
         assert_eq!(warnings.len(), 1);
         assert_eq!(warnings[0].warning, WarningType::MaxIncludeDepthExceeded(2));
+    }
+
+    #[test]
+    fn huge_max_include_depth_acts_as_large_limit() {
+        // A positive `max-include-depth` too large to represent exactly (e.g.
+        // beyond `usize` on a 32-bit target) is a very large limit, not the
+        // 0 = disabled sentinel: an ordinary include still expands.
+        let handler = InlineFileHandler::from_pairs([("shared.adoc", "shared content")]);
+
+        let parser = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_intrinsic_attribute(
+                "max-include-depth",
+                "9223372036854775807",
+                ModificationContext::ApiOnly,
+            )
+            .with_include_file_handler(handler);
+
+        let (output, _source_map, warnings) = preprocess("include::shared.adoc[]", &parser);
+
+        assert_eq!(output, "shared content\n");
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn huge_depth_request_is_clamped_not_wrapped() {
+        // A huge positive `depth` request is treated like any other
+        // greater-than-the-limit request — clamped to the absolute
+        // `max-include-depth` — rather than wrapping into a small (or zero)
+        // value that would restrict nesting further than asked.
+        let handler = InlineFileHandler::from_pairs([
+            ("a.adoc", "include::b.adoc[]"),
+            ("b.adoc", "content of b"),
+        ]);
+
+        let parser = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_intrinsic_attribute("max-include-depth", "1", ModificationContext::ApiOnly)
+            .with_include_file_handler(handler);
+
+        let (output, _source_map, warnings) =
+            preprocess("include::a.adoc[depth=9223372036854775807]", &parser);
+
+        assert_eq!(output, "include::b.adoc[]\n");
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].warning, WarningType::MaxIncludeDepthExceeded(1));
     }
 }

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -1147,6 +1147,10 @@ fn coerce_unquoted(s: &str) -> Value {
 
 /// Parse the leading integer of a string, Ruby `String#to_i` style (a string
 /// with no leading numeric portion yields `0`).
+///
+/// Ruby's integers are unbounded; a value beyond the range of `i64` saturates
+/// to `i64::MIN`/`i64::MAX` (by sign) so that a very large magnitude is not
+/// mistaken for 0.
 fn ruby_to_i(s: &str) -> i64 {
     let mut digits = String::new();
 
@@ -1158,7 +1162,17 @@ fn ruby_to_i(s: &str) -> i64 {
         }
     }
 
-    digits.parse().unwrap_or(0)
+    digits.parse().unwrap_or_else(|_| {
+        if !digits.bytes().any(|b| b.is_ascii_digit()) {
+            // No numeric portion at all (empty, or a bare `+`/`-`): 0, as
+            // Ruby's `to_i` yields.
+            0
+        } else if digits.starts_with('-') {
+            i64::MIN
+        } else {
+            i64::MAX
+        }
+    })
 }
 
 /// Parse the leading float of a string, Ruby `String#to_f` style (a string with
@@ -3412,47 +3426,68 @@ mod tests {
 
     #[test]
     fn huge_max_include_depth_acts_as_large_limit() {
-        // A positive `max-include-depth` too large to represent exactly (e.g.
-        // beyond `usize` on a 32-bit target) is a very large limit, not the
-        // 0 = disabled sentinel: an ordinary include still expands.
-        let handler = InlineFileHandler::from_pairs([("shared.adoc", "shared content")]);
+        // A positive `max-include-depth` too large to represent exactly —
+        // whether beyond `usize` on a 32-bit target or beyond `i64` entirely —
+        // is a very large limit, not the 0 = disabled sentinel: an ordinary
+        // include still expands. (Ruby's integers are unbounded, so
+        // Asciidoctor honors any such value.)
+        for value in ["9223372036854775807", "9223372036854775808"] {
+            let handler = InlineFileHandler::from_pairs([("shared.adoc", "shared content")]);
 
-        let parser = Parser::default()
-            .with_safe_mode(SafeMode::Server)
-            .with_intrinsic_attribute(
-                "max-include-depth",
-                "9223372036854775807",
-                ModificationContext::ApiOnly,
-            )
-            .with_include_file_handler(handler);
+            let parser = Parser::default()
+                .with_safe_mode(SafeMode::Server)
+                .with_intrinsic_attribute("max-include-depth", value, ModificationContext::ApiOnly)
+                .with_include_file_handler(handler);
 
-        let (output, _source_map, warnings) = preprocess("include::shared.adoc[]", &parser);
+            let (output, _source_map, warnings) = preprocess("include::shared.adoc[]", &parser);
 
-        assert_eq!(output, "shared content\n");
-        assert!(warnings.is_empty());
+            assert_eq!(output, "shared content\n");
+            assert!(warnings.is_empty());
+        }
     }
 
     #[test]
     fn huge_depth_request_is_clamped_not_wrapped() {
-        // A huge positive `depth` request is treated like any other
-        // greater-than-the-limit request — clamped to the absolute
-        // `max-include-depth` — rather than wrapping into a small (or zero)
-        // value that would restrict nesting further than asked.
-        let handler = InlineFileHandler::from_pairs([
-            ("a.adoc", "include::b.adoc[]"),
-            ("b.adoc", "content of b"),
-        ]);
+        // A huge positive `depth` request — again, whether beyond `usize` on a
+        // 32-bit target or beyond `i64` entirely — is treated like any other
+        // greater-than-the-limit request, clamped to the absolute
+        // `max-include-depth`, rather than wrapping or collapsing into a small
+        // (or zero) value that would restrict nesting further than asked.
+        for value in ["9223372036854775807", "9223372036854775808"] {
+            let handler = InlineFileHandler::from_pairs([
+                ("a.adoc", "include::b.adoc[]"),
+                ("b.adoc", "content of b"),
+            ]);
 
-        let parser = Parser::default()
-            .with_safe_mode(SafeMode::Server)
-            .with_intrinsic_attribute("max-include-depth", "1", ModificationContext::ApiOnly)
-            .with_include_file_handler(handler);
+            let parser = Parser::default()
+                .with_safe_mode(SafeMode::Server)
+                .with_intrinsic_attribute("max-include-depth", "1", ModificationContext::ApiOnly)
+                .with_include_file_handler(handler);
 
-        let (output, _source_map, warnings) =
-            preprocess("include::a.adoc[depth=9223372036854775807]", &parser);
+            let (output, _source_map, warnings) =
+                preprocess(&format!("include::a.adoc[depth={value}]"), &parser);
 
-        assert_eq!(output, "include::b.adoc[]\n");
-        assert_eq!(warnings.len(), 1);
-        assert_eq!(warnings[0].warning, WarningType::MaxIncludeDepthExceeded(1));
+            assert_eq!(output, "include::b.adoc[]\n");
+            assert_eq!(warnings.len(), 1);
+            assert_eq!(warnings[0].warning, WarningType::MaxIncludeDepthExceeded(1));
+        }
+    }
+
+    #[test]
+    fn ruby_to_i_saturates_on_overflow() {
+        use super::ruby_to_i;
+
+        assert_eq!(ruby_to_i("42"), 42);
+        assert_eq!(ruby_to_i("42abc"), 42);
+
+        // Beyond `i64` in either direction saturates by sign (Ruby's unbounded
+        // integers keep the value's magnitude; 0 would invert its meaning).
+        assert_eq!(ruby_to_i("9223372036854775808"), i64::MAX);
+        assert_eq!(ruby_to_i("-9223372036854775809"), i64::MIN);
+
+        // No numeric portion at all still yields 0, as Ruby's `to_i` does.
+        assert_eq!(ruby_to_i("abc"), 0);
+        assert_eq!(ruby_to_i("-"), 0);
+        assert_eq!(ruby_to_i(""), 0);
     }
 }

--- a/parser/src/tests/asciidoctor_rb/reader_test.rs
+++ b/parser/src/tests/asciidoctor_rb/reader_test.rs
@@ -1061,9 +1061,8 @@ non_normative!(
 // `uri:classloader:` and remote (URL) includes; the `doc.catalog[:includes]`
 // registry; filesystem-relative / absolute-path / spaces-in-filename resolution
 // and the `base_dir` sandbox; non-UTF-8 `encoding` handling; the
-// `max-include-depth` bound; the `attribute-missing` / blank-target reader
-// diagnostics; and the Reader-object APIs (`read_lines_until`,
-// `skip_comment_lines`).
+// `attribute-missing` / blank-target reader diagnostics; and the Reader-object
+// APIs (`read_lines_until`, `skip_comment_lines`).
 
 // At the default safe mode (secure) the include directive is not expanded;
 // it is replaced with a link to the target carrying the `include` role.
@@ -4177,12 +4176,13 @@ fn include_directive_not_at_start_of_line_is_ignored() {
     );
 }
 
-// Out of scope: this crate does not implement the `max-include-depth`
-// attribute (nor the "maximum include depth exceeded" diagnostic), so it cannot
-// be used to disable or bound include expansion. Tracked by
-// https://github.com/asciidoc-rs/asciidoc-parser/issues/777.
-non_normative!(
-    r#"
+// `max-include-depth=0` disables the include directive entirely: the directive
+// line is left in the output verbatim, with no diagnostic, and the include
+// file handler is never consulted.
+#[test]
+fn include_directive_is_disabled_when_max_include_depth_attribute_is_0() {
+    verifies!(
+        r#"
       test 'include directive is disabled when max-include-depth attribute is 0' do
         input = 'include::include-file.adoc[]'
         para = block_from_string input, safe: :safe, attributes: { 'max-include-depth' => 0 }
@@ -4191,10 +4191,30 @@ non_normative!(
       end
 
 "#
-);
+    );
 
-non_normative!(
-    r#"
+    let handler = RecordingIncludeFileHandler::new("included content");
+    let probe = handler.clone();
+    let parser = Parser::default()
+        .with_safe_mode(SafeMode::Server)
+        .with_intrinsic_attribute("max-include-depth", "0", ModificationContext::ApiOnly)
+        .with_include_file_handler(handler);
+
+    let (output, _source_map, warnings) =
+        crate::parser::preprocessor::preprocess("include::include-file.adoc[]", &parser);
+
+    assert_eq!(output, "include::include-file.adoc[]\n");
+    assert!(probe.calls().is_empty());
+    assert!(warnings.is_empty());
+}
+
+// `max-include-depth` is an API-only attribute (see `built_in_attrs.rs`), so
+// the document's attempt to raise it to 1 is ignored and the API-set value of
+// 0 still disables the include directive.
+#[test]
+fn max_include_depth_cannot_be_set_by_document() {
+    verifies!(
+        r#"
       test 'max-include-depth cannot be set by document' do
         input = <<~'EOS'
         :max-include-depth: 1
@@ -4207,10 +4227,57 @@ non_normative!(
       end
 
 "#
-);
+    );
 
-non_normative!(
-    r#"
+    let handler = RecordingIncludeFileHandler::new("included content");
+    let probe = handler.clone();
+    let parser = Parser::default()
+        .with_safe_mode(SafeMode::Server)
+        .with_intrinsic_attribute("max-include-depth", "0", ModificationContext::ApiOnly)
+        .with_include_file_handler(handler);
+
+    let (output, _source_map, warnings) = crate::parser::preprocessor::preprocess(
+        ":max-include-depth: 1\n\ninclude::include-file.adoc[]",
+        &parser,
+    );
+
+    assert_eq!(
+        output,
+        ":max-include-depth: 1\n\ninclude::include-file.adoc[]\n"
+    );
+    assert!(probe.calls().is_empty());
+    assert!(warnings.is_empty());
+}
+
+/// Verbatim copy of Asciidoctor's `test/fixtures/parent-include.adoc`.
+const PARENT_INCLUDE_ADOC: &str =
+    "first line of parent\n\ninclude::child-include.adoc[]\n\nlast line of parent\n";
+
+/// Verbatim copy of Asciidoctor's
+/// `test/fixtures/parent-include-restricted.adoc`.
+const PARENT_INCLUDE_RESTRICTED_ADOC: &str =
+    "first line of parent\n\ninclude::child-include.adoc[depth=0]\n\nlast line of parent\n";
+
+/// Verbatim copy of Asciidoctor's `test/fixtures/child-include.adoc`.
+const CHILD_INCLUDE_ADOC: &str =
+    "first line of child\n\ninclude::grandchild-include.adoc[]\n\nlast line of child\n";
+
+/// Verbatim copy of Asciidoctor's `test/fixtures/grandchild-include.adoc`.
+const GRANDCHILD_INCLUDE_ADOC: &str = "first line of grandchild\n\nlast line of grandchild\n";
+
+// The `depth` attribute on an include directive bounds how many further levels
+// of include nesting are permitted beneath the included file. An include
+// directive in a file that already sits at the limit is left verbatim, with a
+// "maximum include depth exceeded" error at the directive's own file and line.
+//
+// (Asciidoctor resolves each nested target against the including file's
+// directory, so its message names `fixtures/child-include.adoc`; this crate
+// delegates path resolution to the include file handler and names the target
+// as written, `child-include.adoc`.)
+#[test]
+fn include_directive_should_be_disabled_if_max_include_depth_has_been_exceeded() {
+    verifies!(
+        r#"
       test 'include directive should be disabled if max include depth has been exceeded' do
         input = 'include::fixtures/parent-include.adoc[depth=1]'
         using_memory_logger do |logger|
@@ -4224,10 +4291,59 @@ non_normative!(
       end
 
 "#
-);
+    );
 
-non_normative!(
-    r#"
+    let parser = Parser::default()
+        .with_safe_mode(SafeMode::Server)
+        .with_include_file_handler(InlineFileHandler::from_pairs([
+            ("fixtures/parent-include.adoc", PARENT_INCLUDE_ADOC),
+            ("child-include.adoc", CHILD_INCLUDE_ADOC),
+            ("grandchild-include.adoc", GRANDCHILD_INCLUDE_ADOC),
+        ]));
+
+    let (output, source_map, warnings) = crate::parser::preprocessor::preprocess(
+        "include::fixtures/parent-include.adoc[depth=1]",
+        &parser,
+    );
+
+    assert_eq!(
+        output,
+        "first line of parent\n\nfirst line of child\n\ninclude::grandchild-include.adoc[]\n\nlast line of child\n\nlast line of parent\n"
+    );
+
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0].warning, WarningType::MaxIncludeDepthExceeded(1));
+
+    // The warning's span covers the verbatim directive line, which the source
+    // map places at line 3 of `child-include.adoc`.
+    assert_eq!(
+        &output[warnings[0].offset..(warnings[0].offset + warnings[0].len)],
+        "include::grandchild-include.adoc[]"
+    );
+
+    let output_line = output[..warnings[0].offset]
+        .bytes()
+        .filter(|&b| b == b'\n')
+        .count()
+        + 1;
+    assert_eq!(
+        source_map.original_file_and_line(output_line),
+        Some(crate::parser::SourceLine(
+            Some("child-include.adoc".to_owned()),
+            3
+        ))
+    );
+}
+
+// A `depth` limit established by a nested include directive (here `depth=0` on
+// the child include) is enforced within that include even though the outer
+// directive permitted more nesting, and is restored once the include has been
+// merged (so `last line of parent` still follows).
+#[test]
+fn include_directive_should_be_disabled_if_max_include_depth_set_in_nested_context_has_been_exceeded()
+ {
+    verifies!(
+        r#"
       test 'include directive should be disabled if max include depth set in nested context has been exceeded' do
         input = 'include::fixtures/parent-include-restricted.adoc[depth=3]'
         using_memory_logger do |logger|
@@ -4242,7 +4358,32 @@ non_normative!(
       end
 
 "#
-);
+    );
+
+    let parser = Parser::default()
+        .with_safe_mode(SafeMode::Server)
+        .with_include_file_handler(InlineFileHandler::from_pairs([
+            (
+                "fixtures/parent-include-restricted.adoc",
+                PARENT_INCLUDE_RESTRICTED_ADOC,
+            ),
+            ("child-include.adoc", CHILD_INCLUDE_ADOC),
+            ("grandchild-include.adoc", GRANDCHILD_INCLUDE_ADOC),
+        ]));
+
+    let (output, _source_map, warnings) = crate::parser::preprocessor::preprocess(
+        "include::fixtures/parent-include-restricted.adoc[depth=3]",
+        &parser,
+    );
+
+    assert_eq!(
+        output,
+        "first line of parent\n\nfirst line of child\n\ninclude::grandchild-include.adoc[]\n\nlast line of child\n\nlast line of parent\n"
+    );
+
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0].warning, WarningType::MaxIncludeDepthExceeded(0));
+}
 
 non_normative!(
     r#"

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -152,6 +152,15 @@ pub enum WarningType {
     #[error("include file not found: {0}")]
     IncludeFileNotFound(String),
 
+    /// An include directive was not expanded because the file containing it
+    /// already sits at the maximum include depth (the `max-include-depth`
+    /// attribute, possibly lowered by an enclosing include directive's `depth`
+    /// attribute). The field is the relative maximum in effect — the number of
+    /// levels that were permitted below the file that established the limit —
+    /// matching the number Asciidoctor reports.
+    #[error("maximum include depth of {0} exceeded")]
+    MaxIncludeDepthExceeded(usize),
+
     /// An include directive specified an `encoding` attribute whose value is
     /// not UTF-8. The parser only handles UTF-8 content, so the requested
     /// encoding cannot be honored.
@@ -350,6 +359,11 @@ impl std::fmt::Debug for WarningType {
             WarningType::IncludeFileNotFound(target) => f
                 .debug_tuple("WarningType::IncludeFileNotFound")
                 .field(target)
+                .finish(),
+
+            WarningType::MaxIncludeDepthExceeded(depth) => f
+                .debug_tuple("WarningType::MaxIncludeDepthExceeded")
+                .field(depth)
                 .finish(),
 
             WarningType::NonUtf8IncludeEncoding(encoding) => f
@@ -765,6 +779,13 @@ mod tests {
                     debug_output,
                     "WarningType::IncludeFileNotFound(\"content.adoc\")"
                 );
+            }
+
+            #[test]
+            fn max_include_depth_exceeded() {
+                let warning = WarningType::MaxIncludeDepthExceeded(64);
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(debug_output, "WarningType::MaxIncludeDepthExceeded(64)");
             }
 
             #[test]

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -772,6 +772,27 @@ mod tests {
             }
 
             #[test]
+            fn invalid_footnote_reference() {
+                let warning = WarningType::InvalidFootnoteReference("fn1".to_string());
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(
+                    debug_output,
+                    "WarningType::InvalidFootnoteReference(\"fn1\")"
+                );
+            }
+
+            #[test]
+            fn deprecated_footnoref_macro() {
+                let warning =
+                    WarningType::DeprecatedFootnorefMacro("footnoteref:[fn1]".to_string());
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(
+                    debug_output,
+                    "WarningType::DeprecatedFootnorefMacro(\"footnoteref:[fn1]\")"
+                );
+            }
+
+            #[test]
             fn include_file_not_found() {
                 let warning = WarningType::IncludeFileNotFound("content.adoc".to_string());
                 let debug_output = format!("{:?}", warning);


### PR DESCRIPTION
Fixes #777.

The preprocessor tracked `PreprocessorState::include_depth` but never compared it against any limit, so the `max-include-depth` attribute had no effect and include recursion had no bound at all.

This implements the attribute following Asciidoctor's `PreprocessorReader` semantics (`@maxdepth` with its `abs`/`curr`/`rel` components):

* **`max-include-depth` bounds include nesting** (default 64). It is read once when preprocessing starts, mirroring Asciidoctor reading it once at reader construction; the attribute itself was already API-only in `built_in_attrs.rs`, so the document cannot raise it.
* **`max-include-depth=0` disables the include directive entirely**: the directive line is left in the output verbatim, with no diagnostic and without consulting the include file handler.
* **Reaching the limit leaves the directive verbatim** and records a new `WarningType::MaxIncludeDepthExceeded` ("maximum include depth of N exceeded") whose span covers the verbatim line, so it resolves through the source map to the directive's own file and line. N is the *relative* limit in effect, matching the number Asciidoctor reports.
* **The `depth` attribute on an include directive** lowers the limit for the span of that include — a positive value permits that many more levels beneath the included file (clamped to the absolute `max-include-depth`); zero or a non-numeric value permits none. The previous limit is restored once the include has been merged.
* **Cyclic includes are now bounded**: a self-including file stops at depth 64 with the diagnostic instead of recursing without limit (new regression test in `preprocessor.rs`).

The four `max-include-depth` cases of Asciidoctor's `reader_test.rb` are promoted from `non_normative!` to `verifies!`, using the vendored fixture contents (`parent-include.adoc`, `parent-include-restricted.adoc`, `child-include.adoc`, `grandchild-include.adoc`) through `InlineFileHandler`. One documented divergence: Asciidoctor resolves nested targets against the including file's directory, so its message names `fixtures/child-include.adoc`; this crate delegates path resolution to the include file handler and names the target as written (`child-include.adoc`).

Verified with `cargo test -p asciidoc-parser` (3,820 + 4 doc tests passing), `cargo clippy --all-targets`, and `cargo +nightly fmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)