### PR TITLE
fix: Do not treat a numeric character reference as an xref path separator

### DIFF
--- a/parser/src/parser/reference_resolver.rs
+++ b/parser/src/parser/reference_resolver.rs
@@ -195,8 +195,9 @@ pub trait ReferenceResolver {
 /// `#id` fragments. Targets that carry a path component (detected by the
 /// presence of `#`, e.g. `other-page.adoc#frag`) are treated as inter-document
 /// references and left unresolved — resolving those is the responsibility of a
-/// host-supplied resolver. A `#` that introduces a numeric character reference
-/// (`&#8658;`) is not a path separator; see [`has_path_component`].
+/// host-supplied resolver. Only the first `#` is considered, and a `#` preceded
+/// by `&` is not a path separator, so a target carrying a numeric character
+/// reference (`Cub &#8658; Tiger`) still resolves as a same-document reference.
 #[derive(Clone, Copy, Debug)]
 pub struct CatalogResolver<'a> {
     catalog: &'a Catalog,

--- a/parser/src/parser/reference_resolver.rs
+++ b/parser/src/parser/reference_resolver.rs
@@ -195,7 +195,8 @@ pub trait ReferenceResolver {
 /// `#id` fragments. Targets that carry a path component (detected by the
 /// presence of `#`, e.g. `other-page.adoc#frag`) are treated as inter-document
 /// references and left unresolved — resolving those is the responsibility of a
-/// host-supplied resolver.
+/// host-supplied resolver. A `#` that introduces a numeric character reference
+/// (`&#8658;`) is not a path separator; see [`has_path_component`].
 #[derive(Clone, Copy, Debug)]
 pub struct CatalogResolver<'a> {
     catalog: &'a Catalog,
@@ -213,7 +214,7 @@ impl ReferenceResolver for CatalogResolver<'_> {
         let target = context.target;
 
         // Path-bearing (inter-document) targets are a host concern.
-        if target.contains('#') {
+        if has_path_component(target) {
             return None;
         }
 
@@ -231,6 +232,22 @@ impl ReferenceResolver for CatalogResolver<'_> {
         }
 
         None
+    }
+}
+
+/// Returns `true` if `target` names a document outside this one, i.e. it splits
+/// into a path and a fragment at a `#`.
+///
+/// By the time a cross-reference is resolved, the character-replacement
+/// substitution has already run over its target, so a target that contained
+/// `=>`, `->`, or `(C)` now carries a numeric character reference such as
+/// `&#8658;`. The `#` inside that entity is not a path separator, so only the
+/// *first* `#` is considered, and it is ignored when it is preceded by `&`
+/// (matching Asciidoctor's `refid[hash_idx - 1] != '&'` guard).
+fn has_path_component(target: &str) -> bool {
+    match target.find('#') {
+        Some(0) | None => false,
+        Some(index) => !target[..index].ends_with('&'),
     }
 }
 
@@ -307,5 +324,35 @@ mod tests {
                 })
                 .is_none()
         );
+    }
+
+    #[test]
+    fn numeric_character_reference_is_not_a_path_separator() {
+        let catalog = catalog_with("_cub_tiger", Some("Cub &#8658; Tiger"), RefType::Section);
+        let resolver = CatalogResolver::new(&catalog);
+
+        let resolved = resolver
+            .resolve(&ResolutionContext {
+                target: "Cub &#8658; Tiger",
+                provided_text: None,
+            })
+            .unwrap();
+
+        assert_eq!(resolved.href, "#_cub_tiger");
+        assert_eq!(resolved.text.as_deref(), Some("Cub &#8658; Tiger"));
+    }
+
+    #[test]
+    fn has_path_component_ignores_numeric_character_references() {
+        assert!(!has_path_component("plain-id"));
+        assert!(!has_path_component("Cub &#8658; Tiger"));
+        assert!(!has_path_component("C&#43;&#43;"));
+        assert!(!has_path_component("#frag"));
+        assert!(has_path_component("other-page.adoc#frag"));
+        assert!(has_path_component("other-page.adoc#"));
+
+        // Only the first `#` decides; a later path separator inside a target
+        // that opens with an entity is not reconsidered (matching Asciidoctor).
+        assert!(!has_path_component("&#43;.adoc#frag"));
     }
 }

--- a/parser/src/tests/asciidoctor_rb/links_test.rs
+++ b/parser/src/tests/asciidoctor_rb/links_test.rs
@@ -3481,11 +3481,10 @@ fn should_resolve_first_matching_natural_xref() {
     );
 }
 
-// Surfaced incompatibility: Asciidoctor resolves `<<Cub => Tiger>>` to the
-// section id `_cub_tiger`; this crate applies replacement subs to the target
-// and fails to match. Tracked in #771.
-non_normative!(
-    r###"
+#[test]
+fn should_not_match_numeric_character_references_while_searching_for_fragment_in_xref_target() {
+    verifies!(
+        r###"
   test 'should not match numeric character references while searching for fragment in xref target' do
     input = <<~'EOS'
     see <<Cub => Tiger>>
@@ -3498,7 +3497,14 @@ non_normative!(
   end
 
 "###
-);
+    );
+
+    let doc = Parser::default().parse("see <<Cub => Tiger>>\n\n== Cub => Tiger");
+    assert_eq!(
+        rendered_paragraphs(&doc)[0],
+        r##"see <a href="#_cub_tiger">Cub &#8658; Tiger</a>"##
+    );
+}
 
 #[test]
 fn should_not_match_numeric_character_references_in_path_of_interdocument_xref() {


### PR DESCRIPTION
`CatalogResolver` classified any target containing `#` as a path-bearing
(inter-document) reference and left it unresolved. By the time a cross-reference
resolves, the character-replacement substitution has already run over its target,
so `<<Cub => Tiger>>` arrives as `Cub &#8658; Tiger` — the `#` inside the entity
was mistaken for a path separator, and the natural xref never reached the reverse
reftext lookup.

Following Asciidoctor's `refid[hash_idx - 1] != '&'` guard in `sub_macros`, only
the first `#` decides, and it is ignored when preceded by `&`.

Before: `see <a href="#Cub &#8658; Tiger">[Cub &#8658; Tiger]</a>`
After:  `see <a href="#_cub_tiger">Cub &#8658; Tiger</a>` (matches Asciidoctor 2.0.26)

Note: the issue text attributes this to substitution ordering in `content/macros.rs`,
but the ordering already matches Asciidoctor — replacements run before macros on
*both* sides, so the section reftext and the xref target both arrive as
`Cub &#8658; Tiger` and would have matched. The single-line `#` check in the
resolver was the actual cause.

The Asciidoctor test `should not match numeric character references while
searching for fragment in xref target` is promoted from `non_normative!` to a
`verifies!` test. The neighboring `should_not_match_numeric_character_references_in_path_of_interdocument_xref`
test (`xref:{cpp}[{cpp}]` → `C&#43;&#43;`) exercises the same guard and still passes.

Closes #771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)