### PR TITLE
fix: Report an unresolved cross-reference as a document warning (#772)

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     content::{Content, SubstitutionGroup},
     document::{Attribute, InterpretedValue, RefType},
-    parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning, XrefSignifier},
+    parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, XrefSignifier},
     span::MatchedItem,
     strings::CowStr,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -785,7 +785,7 @@ impl<'src> Block<'src> {
         &mut self,
         resolver: &dyn ReferenceResolver,
         renderer: &dyn InlineSubstitutionRenderer,
-        warnings: &mut Vec<ReferenceWarning>,
+        warnings: &mut ReferenceWarnings<'src>,
     ) {
         if let Some(content) = self.content_mut() {
             content.resolve_references(resolver, renderer, warnings);

--- a/parser/src/blocks/quote.rs
+++ b/parser/src/blocks/quote.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     content::{Content, SubstitutionGroup},
     internal::debug::DebugSliceReference,
-    parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning},
+    parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings},
     span::MatchedItem,
     strings::CowStr,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -523,8 +523,10 @@ impl<'src> QuoteBlock<'src> {
         &mut self,
         resolver: &dyn ReferenceResolver,
         renderer: &dyn InlineSubstitutionRenderer,
-        warnings: &mut Vec<ReferenceWarning>,
+        warnings: &mut ReferenceWarnings<'src>,
     ) {
+        let source = self.source;
+
         // The owned store is shared behind an `Arc`, but references are resolved
         // immediately after parsing while the block is still its sole owner, so
         // `get_mut` succeeds.
@@ -532,9 +534,16 @@ impl<'src> QuoteBlock<'src> {
             && let Some(owned) = Arc::get_mut(owned)
         {
             owned.with_dependent_mut(|_, dependent| {
+                // These blocks borrow the quote's own owned source, so their
+                // warnings are collected separately and then re-anchored to the
+                // quote block's span in the document.
+                let mut owned_warnings = ReferenceWarnings::default();
+
                 for block in &mut dependent.blocks {
-                    block.resolve_references(resolver, renderer, warnings);
+                    block.resolve_references(resolver, renderer, &mut owned_warnings);
                 }
+
+                owned_warnings.rehome_into(warnings, source);
             });
         }
     }

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -13,7 +13,7 @@ use crate::{
     document::{InterpretedValue, TocConfig, TocMode},
     parser::{
         AttributeValue, InlineSubstitutionRenderer, ModificationContext, ReferenceResolver,
-        ReferenceWarning, ResolvedAttributes, SourceLine, built_in_attr, built_in_attrs_iter,
+        ReferenceWarnings, ResolvedAttributes, SourceLine, built_in_attr, built_in_attrs_iter,
         preprocessor::preprocess_with_initial_file_name,
     },
     span::MatchedItem,
@@ -510,7 +510,7 @@ impl<'src> TableBlock<'src> {
         &mut self,
         resolver: &dyn ReferenceResolver,
         renderer: &dyn InlineSubstitutionRenderer,
-        warnings: &mut Vec<ReferenceWarning>,
+        warnings: &mut ReferenceWarnings<'src>,
     ) {
         let rows = self
             .header_row
@@ -2229,14 +2229,16 @@ impl<'src> TableCell<'src> {
         &mut self,
         resolver: &dyn ReferenceResolver,
         renderer: &dyn InlineSubstitutionRenderer,
-        warnings: &mut Vec<ReferenceWarning>,
+        warnings: &mut ReferenceWarnings<'src>,
     ) {
+        let source = self.source;
+
         match &mut self.content {
             TableCellContent::Simple(content) => {
                 content.resolve_references(resolver, renderer, warnings);
             }
             TableCellContent::AsciiDoc(cell) => {
-                cell.resolve_references(resolver, renderer, warnings);
+                cell.resolve_references(resolver, renderer, warnings, source);
             }
         }
     }
@@ -2411,12 +2413,15 @@ impl<'src> AsciiDocCell<'src> {
         }
     }
 
-    /// Resolves any deferred cross-references in the cell's blocks.
+    /// Resolves any deferred cross-references in the cell's blocks. `source` is
+    /// the enclosing cell's span, used to anchor warnings raised from an
+    /// [owned](Self::Owned) cell's private source.
     fn resolve_references(
         &mut self,
         resolver: &dyn ReferenceResolver,
         renderer: &dyn InlineSubstitutionRenderer,
-        warnings: &mut Vec<ReferenceWarning>,
+        warnings: &mut ReferenceWarnings<'src>,
+        source: Span<'src>,
     ) {
         match self {
             Self::Borrowed(cell) => {
@@ -2431,9 +2436,16 @@ impl<'src> AsciiDocCell<'src> {
             Self::Owned(cell) => {
                 if let Some(cell) = Arc::get_mut(cell) {
                     cell.with_dependent_mut(|_, dependent| {
+                        // These blocks borrow the cell's own owned source, so
+                        // their warnings are collected separately and then
+                        // re-anchored to the cell's span in the document.
+                        let mut owned_warnings = ReferenceWarnings::default();
+
                         for block in &mut dependent.blocks {
-                            block.resolve_references(resolver, renderer, warnings);
+                            block.resolve_references(resolver, renderer, &mut owned_warnings);
                         }
+
+                        owned_warnings.rehome_into(warnings, source);
                     });
                 }
             }
@@ -3122,9 +3134,12 @@ mod tests {
         AsciiDocCell, OwnedCell, OwnedCellInner, ResolvedAttributes, TocConfig,
         absolute_cell_directive_origin,
     };
-    use crate::parser::{
-        HtmlSubstitutionRenderer, ReferenceResolver, ResolutionContext, ResolvedReference,
-        SourceLine,
+    use crate::{
+        Span,
+        parser::{
+            HtmlSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext,
+            ResolvedReference, SourceLine,
+        },
     };
 
     #[test]
@@ -3205,12 +3220,19 @@ mod tests {
         // Hold a second reference to the same store so `Arc::get_mut` fails.
         let shared = cell.clone();
 
-        let mut warnings = vec![];
-        cell.resolve_references(&NoopResolver, &HtmlSubstitutionRenderer {}, &mut warnings);
+        let mut warnings = ReferenceWarnings::default();
+
+        cell.resolve_references(
+            &NoopResolver,
+            &HtmlSubstitutionRenderer {},
+            &mut warnings,
+            Span::new(""),
+        );
 
         // Resolution was skipped silently: no warnings, and the two references
         // still describe the same (unmodified) cell.
-        assert!(warnings.is_empty());
+        assert!(warnings.host.is_empty());
+        assert!(warnings.doc.is_empty());
         assert_eq!(cell, shared);
     }
 

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -6,8 +6,8 @@
 use crate::{
     Span,
     parser::{
-        InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarning, ReferenceWarningKind,
-        ResolutionContext, XrefRenderParams,
+        InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext,
+        XrefRenderParams,
     },
     strings::CowStr,
 };
@@ -351,8 +351,10 @@ impl<'src> Content<'src> {
         &mut self,
         resolver: &dyn ReferenceResolver,
         renderer: &dyn InlineSubstitutionRenderer,
-        warnings: &mut Vec<ReferenceWarning>,
+        warnings: &mut ReferenceWarnings<'src>,
     ) {
+        let source = self.original;
+
         if let Some(deferred) = self.deferred.as_mut() {
             let DeferredContent { template, xrefs } = deferred.as_mut();
 
@@ -374,10 +376,7 @@ impl<'src> Content<'src> {
                 // re-homed into a footnote (see `rehome_xref_placeholders`); the
                 // footnote resolves and reports it, so it is not reported here.
                 if xref.resolved.is_none() && template.contains(&Content::xref_placeholder(index)) {
-                    warnings.push(ReferenceWarning {
-                        target: xref.target.clone(),
-                        kind: ReferenceWarningKind::Unresolved,
-                    });
+                    warnings.unresolved(&xref.target, source);
                 }
             }
         }
@@ -548,12 +547,13 @@ impl FootnoteDeferred {
     }
 
     /// Resolves the footnote's cross-references using `resolver`, reporting any
-    /// unresolved target in `warnings`. Rendering the resolved text is left to
-    /// the caller (via [`render`](Self::render)).
-    pub(crate) fn resolve(
+    /// unresolved target in `warnings` against `source`. Rendering the resolved
+    /// text is left to the caller (via [`render`](Self::render)).
+    pub(crate) fn resolve<'src>(
         &mut self,
         resolver: &dyn ReferenceResolver,
-        warnings: &mut Vec<ReferenceWarning>,
+        warnings: &mut ReferenceWarnings<'src>,
+        source: Span<'src>,
     ) {
         for xref in self.xrefs.iter_mut() {
             xref.resolved = resolver.resolve(&ResolutionContext {
@@ -562,10 +562,7 @@ impl FootnoteDeferred {
             });
 
             if xref.resolved.is_none() {
-                warnings.push(ReferenceWarning {
-                    target: xref.target.clone(),
-                    kind: ReferenceWarningKind::Unresolved,
-                });
+                warnings.unresolved(&xref.target, source);
             }
         }
     }

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -251,17 +251,22 @@ pub struct Footnote {
 impl Footnote {
     /// Resolves any cross-references embedded in this footnote's text using
     /// `resolver`, then rebuilds [`text`](Self::text) from the resolved state.
-    /// Any unresolved target is reported in `warnings`.
+    /// Any unresolved target is reported in `warnings`, anchored at `source`.
+    ///
+    /// A footnote's text is extracted out of the block it was defined in and
+    /// the footnote itself keeps no span, so `source` is the enclosing
+    /// document's span rather than the reference's own location.
     ///
     /// A footnote with no cross-references is left untouched.
-    pub(crate) fn resolve_references(
+    pub(crate) fn resolve_references<'src>(
         &mut self,
         resolver: &dyn crate::parser::ReferenceResolver,
         renderer: &dyn crate::parser::InlineSubstitutionRenderer,
-        warnings: &mut Vec<crate::parser::ReferenceWarning>,
+        warnings: &mut crate::parser::ReferenceWarnings<'src>,
+        source: crate::Span<'src>,
     ) {
         if let Some(deferred) = self.deferred.as_mut() {
-            deferred.resolve(resolver, warnings);
+            deferred.resolve(resolver, warnings, source);
             self.text = deferred.render(renderer);
         }
     }

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -255,7 +255,11 @@ impl Footnote {
     ///
     /// A footnote's text is extracted out of the block it was defined in and
     /// the footnote itself keeps no span, so `source` is the enclosing
-    /// document's span rather than the reference's own location.
+    /// document's span rather than the reference's own location. That makes two
+    /// bad references in two different footnotes indistinguishable by location;
+    /// narrowing it to the defining occurrence needs footnotes registered from
+    /// an owned sub-source (a Markdown blockquote, an include-expanded table
+    /// cell) to be re-homed first (#804).
     ///
     /// A footnote with no cross-references is left untouched.
     pub(crate) fn resolve_references<'src>(

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -14,7 +14,7 @@ use crate::{
     internal::debug::DebugSliceReference,
     parser::{
         CatalogResolver, DeferredWarning, InlineSubstitutionRenderer, ReferenceResolver,
-        ReferenceWarning, ResolvedAttributes, SourceMap,
+        ReferenceWarning, ReferenceWarnings, ResolvedAttributes, SourceMap,
     },
     strings::CowStr,
     warnings::{Warning, WarningType},
@@ -455,14 +455,21 @@ impl<'src> Document<'src> {
     /// own catalog) will re-report those now-unknown targets as unresolved.
     /// Multi-document pipelines should therefore start from
     /// [`Parser::parse_deferred`], which does not auto-resolve.
+    ///
+    /// Each unresolved target is also recorded on the document as a
+    /// `WarningType::PossibleInvalidReference` warning, so a host that reads
+    /// [`warnings()`](Self::warnings) sees it alongside every other parse-time
+    /// diagnostic. Because each sweep is independent, those warnings replace
+    /// (rather than accumulate on top of) any left by an earlier sweep.
     pub fn resolve_references(
         &mut self,
         resolver: &dyn ReferenceResolver,
         renderer: &dyn InlineSubstitutionRenderer,
     ) -> Vec<ReferenceWarning> {
-        let mut warnings = Vec::new();
-
         self.internal.with_dependent_mut(|_owner, dependent| {
+            let source = dependent.source;
+            let mut warnings = ReferenceWarnings::default();
+
             for block in dependent.blocks.iter_mut() {
                 block.resolve_references(resolver, renderer, &mut warnings);
             }
@@ -472,11 +479,13 @@ impl<'src> Document<'src> {
             // above. The host resolver does not alias the catalog, so the
             // footnotes can be borrowed mutably in place.
             for footnote in dependent.catalog.footnotes.iter_mut() {
-                footnote.resolve_references(resolver, renderer, &mut warnings);
+                footnote.resolve_references(resolver, renderer, &mut warnings, source);
             }
-        });
 
-        warnings
+            replace_reference_warnings(&mut dependent.warnings, &mut warnings.doc);
+
+            warnings.host
+        })
     }
 
     /// Resolve the document's deferred cross-references against its own
@@ -487,9 +496,10 @@ impl<'src> Document<'src> {
         &mut self,
         renderer: &dyn InlineSubstitutionRenderer,
     ) -> Vec<ReferenceWarning> {
-        let mut warnings = Vec::new();
-
         self.internal.with_dependent_mut(|_owner, dependent| {
+            let source = dependent.source;
+            let mut warnings = ReferenceWarnings::default();
+
             // The footnotes are moved out of the catalog so they can be resolved
             // mutably while the `CatalogResolver` borrows the (footnote-free)
             // catalog. Footnotes are never cross-reference *targets*, so their
@@ -505,14 +515,32 @@ impl<'src> Document<'src> {
             // cross-references are resolved here rather than by the block pass
             // above.
             for footnote in footnotes.iter_mut() {
-                footnote.resolve_references(&resolver, renderer, &mut warnings);
+                footnote.resolve_references(&resolver, renderer, &mut warnings, source);
             }
 
             dependent.catalog.restore_footnotes(footnotes);
-        });
 
-        warnings
+            replace_reference_warnings(&mut dependent.warnings, &mut warnings.doc);
+
+            warnings.host
+        })
     }
+}
+
+/// Folds the document warnings raised by a resolution sweep into the document's
+/// own warning list.
+///
+/// Each sweep is a full, independent pass, so any unresolved-reference warning
+/// left by an earlier sweep is discarded first; otherwise resolving a document
+/// twice would report every still-unresolved reference twice.
+fn replace_reference_warnings<'src>(
+    document_warnings: &mut Vec<Warning<'src>>,
+    sweep_warnings: &mut Vec<Warning<'src>>,
+) {
+    document_warnings
+        .retain(|warning| !matches!(warning.warning, WarningType::PossibleInvalidReference(_)));
+
+    document_warnings.append(sweep_warnings);
 }
 
 impl<'src> IsBlock<'src> for Document<'src> {

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -457,7 +457,7 @@ impl<'src> Document<'src> {
     /// [`Parser::parse_deferred`], which does not auto-resolve.
     ///
     /// Each unresolved target is also recorded on the document as a
-    /// `WarningType::PossibleInvalidReference` warning, so a host that reads
+    /// [`WarningType::PossibleInvalidReference`] warning, so a host that reads
     /// [`warnings()`](Self::warnings) sees it alongside every other parse-time
     /// diagnostic. Because each sweep is independent, those warnings replace
     /// (rather than accumulate on top of) any left by an earlier sweep.

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -27,7 +27,7 @@ pub mod strings;
 #[cfg(test)]
 mod tests;
 
-mod warnings;
+pub mod warnings;
 
 // Use `pretty_assertion_sorted`'s version of `assert_eq` across the board.
 #[cfg(test)]

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -41,6 +41,7 @@ mod resolved_attributes;
 pub(crate) use resolved_attributes::ResolvedAttributes;
 
 mod reference_resolver;
+pub(crate) use reference_resolver::ReferenceWarnings;
 pub use reference_resolver::{
     CatalogResolver, ReferenceResolver, ReferenceWarning, ReferenceWarningKind, ResolutionContext,
     ResolvedReference, XrefSignifier, XrefStyle,

--- a/parser/src/parser/reference_resolver.rs
+++ b/parser/src/parser/reference_resolver.rs
@@ -11,7 +11,11 @@
 //! its own implementation (binding the "from" document when it constructs the
 //! resolver), and this crate makes no attempt to merge catalogs.
 
-use crate::document::Catalog;
+use crate::{
+    Span,
+    document::Catalog,
+    warnings::{Warning, WarningType},
+};
 
 /// The cross-reference text style selected by the `xrefstyle` attribute.
 ///
@@ -159,6 +163,61 @@ pub struct ReferenceWarning {
 pub enum ReferenceWarningKind {
     /// The target could not be resolved to any destination.
     Unresolved,
+}
+
+/// Accumulates what a cross-reference resolution sweep found, in the two forms
+/// the crate needs to report it.
+///
+/// Both lists describe the same conditions: [`host`](Self::host) is handed back
+/// to whoever drove the sweep (and is the crate's public resolution API), while
+/// [`doc`](Self::doc) is folded into the document's own
+/// [warnings](crate::Document::warnings) so an unresolved reference shows up
+/// alongside every other parse-time diagnostic.
+#[derive(Default)]
+pub(crate) struct ReferenceWarnings<'src> {
+    /// The warnings returned from the resolution pass.
+    pub(crate) host: Vec<ReferenceWarning>,
+
+    /// The same warnings, anchored to the source they were found in.
+    pub(crate) doc: Vec<Warning<'src>>,
+}
+
+impl<'src> ReferenceWarnings<'src> {
+    /// Records a target that `resolver` could not resolve, found within
+    /// `source`.
+    pub(crate) fn unresolved(&mut self, target: &str, source: Span<'src>) {
+        self.host.push(ReferenceWarning {
+            target: target.to_string(),
+            kind: ReferenceWarningKind::Unresolved,
+        });
+
+        self.doc.push(Warning {
+            source,
+            warning: WarningType::PossibleInvalidReference(target.to_string()),
+            origin: None,
+        });
+    }
+
+    /// Folds warnings gathered from a privately-owned sub-parse – the blocks of
+    /// a Markdown-style blockquote, or of an include-expanded AsciiDoc table
+    /// cell – into `dest`.
+    ///
+    /// Those blocks borrow their own owned source, so their spans cannot be
+    /// named in the enclosing document. Each document warning is re-anchored to
+    /// `anchor`, the enclosing element's span in the document.
+    pub(crate) fn rehome_into<'outer>(
+        self,
+        dest: &mut ReferenceWarnings<'outer>,
+        anchor: Span<'outer>,
+    ) {
+        dest.host.extend(self.host);
+
+        dest.doc.extend(self.doc.into_iter().map(|warning| Warning {
+            source: anchor,
+            warning: warning.warning,
+            origin: warning.origin,
+        }));
+    }
 }
 
 /// Describes a single cross-reference that needs to be resolved.

--- a/parser/src/tests/asciidoc_lang/macros/xref_validate.rs
+++ b/parser/src/tests/asciidoc_lang/macros/xref_validate.rs
@@ -53,6 +53,22 @@ See <<foobar>>.
 
     assert_eq!(warnings.len(), 1);
     assert_eq!(warnings[0].target, "foobar");
+
+    // The same condition is folded into the document's own warnings, so a host
+    // that does not drive resolution itself still sees it.
+    let doc_warnings: Vec<_> = doc.warnings().collect();
+    assert_eq!(doc_warnings.len(), 1);
+
+    assert_eq!(
+        doc_warnings[0].warning,
+        WarningType::PossibleInvalidReference("foobar".to_string())
+    );
+
+    // Resolution is repeatable: a second sweep replaces the first sweep's
+    // warnings rather than accumulating a duplicate.
+    let warnings = doc.resolve_references(&resolver, &HtmlSubstitutionRenderer {});
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(doc.warnings().count(), 1);
 }
 
 non_normative!(

--- a/parser/src/tests/asciidoctor_rb/links_test.rs
+++ b/parser/src/tests/asciidoctor_rb/links_test.rs
@@ -2854,11 +2854,14 @@ non_normative!(
 "###
 );
 
-// Surfaced incompatibility: this crate creates the fallback link but does not
-// emit the `possible invalid reference` log message that this test also
-// asserts. Tracked in #772.
-non_normative!(
-    r###"
+// NOTE: Asciidoctor emits the `possible invalid reference` message only in
+// verbose (pedantic) mode. This crate has no such mode: an unresolved reference
+// is always reported as a `WarningType::PossibleInvalidReference` warning on
+// the document, which a host is free to ignore.
+#[test]
+fn should_warn_and_create_link_if_verbose_flag_is_set_and_reference_is_not_found() {
+    verifies!(
+        r###"
   test 'should warn and create link if verbose flag is set and reference is not found' do
     input = <<~'EOS'
     [#foobar]
@@ -2878,7 +2881,25 @@ non_normative!(
   end
 
 "###
-);
+    );
+
+    let doc = Parser::default().parse("[#foobar]\n== Foobar\n\n== Section B\n\nSee <<foobaz>>.\n");
+
+    assert_eq!(
+        rendered_paragraphs(&doc)[0],
+        r##"See <a href="#foobaz">[foobaz]</a>."##
+    );
+
+    let warnings: Vec<_> = doc.warnings().collect();
+    assert_eq!(warnings.len(), 1);
+
+    assert_eq!(
+        warnings[0].warning,
+        WarningType::PossibleInvalidReference("foobaz".to_string())
+    );
+
+    assert_eq!(warnings[0].source.line(), 6);
+}
 
 // Compat mode is out of scope for this crate.
 non_normative!(
@@ -2904,12 +2925,13 @@ non_normative!(
 "###
 );
 
-// Surfaced incompatibility: this crate creates the fallback link `<a
-// href="#foobaz">[foobaz]</a>` but does not emit the `possible invalid
-// reference` log message that this test also asserts (verbose logging). Tracked
-// in #772.
-non_normative!(
-    r###"
+// NOTE: As above, this crate always reports the unresolved reference rather
+// than gating it behind a verbose mode.
+#[test]
+fn should_warn_and_create_link_if_verbose_flag_is_set_and_reference_using_hash_notation_is_not_found()
+ {
+    verifies!(
+        r###"
   test 'should warn and create link if verbose flag is set and reference using # notation is not found' do
     input = <<~'EOS'
     [#foobar]
@@ -2929,7 +2951,25 @@ non_normative!(
   end
 
 "###
-);
+    );
+
+    let doc = Parser::default().parse("[#foobar]\n== Foobar\n\n== Section B\n\nSee <<#foobaz>>.\n");
+
+    assert_eq!(
+        rendered_paragraphs(&doc)[0],
+        r##"See <a href="#foobaz">[foobaz]</a>."##
+    );
+
+    let warnings: Vec<_> = doc.warnings().collect();
+    assert_eq!(warnings.len(), 1);
+
+    assert_eq!(
+        warnings[0].warning,
+        WarningType::PossibleInvalidReference("foobaz".to_string())
+    );
+
+    assert_eq!(warnings[0].source.line(), 6);
+}
 
 // Include processing / `catalog[:includes]` is out of scope for this crate.
 non_normative!(

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -599,3 +599,85 @@ fn xref_escapes_author_supplied_window_and_role() {
         "expected escaped quotes in: {rendered}"
     );
 }
+
+/// Issue #772: an unresolved cross-reference is reported on the document
+/// alongside every other parse-time warning, not only through the resolution
+/// pass's own return value.
+mod unresolved_reference_warnings {
+    use crate::{
+        Parser,
+        parser::SafeMode,
+        tests::prelude::{inline_file_handler::InlineFileHandler, *},
+    };
+
+    #[test]
+    fn reported_against_the_referencing_block() {
+        let doc = Parser::default().parse("== Section\n\nSee <<nope>>.\n");
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::PossibleInvalidReference("nope".to_string())
+        );
+
+        assert_eq!(warnings[0].source.line(), 3);
+    }
+
+    #[test]
+    fn reported_for_a_reference_inside_a_footnote() {
+        // A footnote's text is lifted out of the block it was written in and the
+        // footnote keeps no span of its own, so the warning is anchored at the
+        // document.
+        let doc = Parser::default().parse("Text.footnote:[See <<nope>>.]\n");
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::PossibleInvalidReference("nope".to_string())
+        );
+    }
+
+    #[test]
+    fn reported_for_a_reference_inside_a_markdown_blockquote() {
+        // A Markdown-style blockquote's blocks borrow the block's own owned
+        // source, so the warning is re-anchored to the blockquote in the
+        // document.
+        let doc = Parser::default().parse("Intro.\n\n> See <<nope>>.\n");
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::PossibleInvalidReference("nope".to_string())
+        );
+
+        assert_eq!(warnings[0].source.line(), 3);
+    }
+
+    #[test]
+    fn reported_for_a_reference_inside_an_include_expanded_table_cell() {
+        // An include-expanded AsciiDoc table cell is parsed from its own owned
+        // source, so the warning is re-anchored to the cell in the document.
+        let handler = InlineFileHandler::from_pairs([("frag.adoc", "See <<nope>>.")]);
+
+        let doc = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_include_file_handler(handler)
+            .parse("|===\na|include::frag.adoc[]\n|===");
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::PossibleInvalidReference("nope".to_string())
+        );
+
+        assert_eq!(warnings[0].source.line(), 2);
+    }
+}

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -229,6 +229,17 @@ pub enum WarningType {
         "abstract block cannot be used in a document without a doctitle when doctype is book. Excluding block content."
     )]
     AbstractBlockInBookWithoutDoctitle,
+
+    /// A cross-reference (`<<id>>` or `xref:id[…]`) named a target that the
+    /// resolution pass could not resolve. The reference still renders as the
+    /// unresolved fallback link (`<a href="#id">[id]</a>`). The field is the
+    /// target exactly as written in the source.
+    ///
+    /// Asciidoctor reports this only in verbose (pedantic) mode, since a
+    /// reference to an anchor that is not stored in the parse tree can be a
+    /// false positive.
+    #[error("possible invalid reference: {0}")]
+    PossibleInvalidReference(String),
 }
 
 impl std::fmt::Debug for WarningType {
@@ -435,6 +446,11 @@ impl std::fmt::Debug for WarningType {
             WarningType::AbstractBlockInBookWithoutDoctitle => {
                 write!(f, "WarningType::AbstractBlockInBookWithoutDoctitle")
             }
+
+            WarningType::PossibleInvalidReference(target) => f
+                .debug_tuple("WarningType::PossibleInvalidReference")
+                .field(target)
+                .finish(),
         }
     }
 }
@@ -943,6 +959,16 @@ mod tests {
                 assert_eq!(
                     debug_output,
                     "WarningType::AbstractBlockInBookWithoutDoctitle"
+                );
+            }
+
+            #[test]
+            fn possible_invalid_reference() {
+                let warning = WarningType::PossibleInvalidReference("foobaz".to_string());
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(
+                    debug_output,
+                    "WarningType::PossibleInvalidReference(\"foobaz\")"
                 );
             }
         }

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -1,3 +1,10 @@
+//! Describes conditions where a parse result might be unexpected.
+//!
+//! Every UTF-8 string is a valid AsciiDoc document, so parsing never fails.
+//! Anything ambiguous or likely unintended is reported as a [`Warning`]
+//! instead, and a caller is advised to review the warnings a parse produced
+//! (see [`Document::warnings`](crate::Document::warnings)).
+
 use thiserror::Error;
 
 use crate::{Span, parser::SourceLine};
@@ -37,105 +44,169 @@ pub struct Warning<'src> {
 }
 
 /// Type of possible parse error that was detected.
+///
+/// This enum is `non_exhaustive`: new conditions are recognized as the parser
+/// grows, so a host matching on it needs a catch-all arm.
 #[derive(Clone, Eq, Error, PartialEq)]
+#[non_exhaustive]
 pub enum WarningType {
+    /// A quoted attribute value ran to the end of its line (or the end of the
+    /// attribute list) without a matching closing quote.
     #[error("An attribute value is missing its terminating quote")]
     AttributeValueMissingTerminatingQuote,
 
+    /// A document header was not followed by a blank line, so the line that
+    /// follows it can not be parsed as part of the header.
     #[error(
         "Document header wasn't terminated by a blank line (this line can't be parsed as part of a document header)"
     )]
     DocumentHeaderNotTerminated,
 
+    /// The `inline` doctype was requested for a document that holds no single
+    /// paragraph, verbatim, or raw block to convert.
     #[error(
         "no inline candidate; use the inline doctype to convert a single paragraph, verbatim, or raw block"
     )]
     NoInlineDoctypeCandidate,
 
+    /// An element attribute was written with a name and `=` but no value.
     #[error("An empty attribute value was detected")]
     EmptyAttributeValue,
 
+    /// A shorthand element attribute marker (`.` for a role, `#` for an ID, or
+    /// `%` for an option) was found with no name after it.
     #[error(
         "A shorthand element attribute marker ('.', '#', or '%') was found with no subsequent text"
     )]
     EmptyShorthandItem,
 
     // TO DO BEFORE CHECKING IN TO MAIN: Review these error names and descriptions.
+    /// The name in a block or inline macro is not a valid identifier.
     #[error("Macro name is not a valid identifier")]
     InvalidMacroName,
 
+    /// A media macro (`image::`, `video::`, or `audio::`) was written without
+    /// the target that names the media to embed.
     #[error("Media macro missing target")]
     MediaMacroMissingTarget,
 
+    /// A macro was written without the `[…]` attribute list that terminates it.
     #[error("Macro missing attribute list")]
     MacroMissingAttributeList,
 
+    /// A block macro was written without the `::` that separates its name from
+    /// its target.
     #[error("Macro missing :: separator")]
     MacroMissingDoubleColon,
 
+    /// A quoted attribute value in an attribute list was followed by something
+    /// other than the comma that separates it from the next attribute.
     #[error("Missing comma after quoted attribute value")]
     MissingCommaAfterQuotedAttributeValue,
 
+    /// A delimited block was opened but the matching closing delimiter was
+    /// never found, so the block runs to the end of the document.
     #[error("Closing marker for delimited block not found")]
     UnterminatedDelimitedBlock,
 
+    /// A block title (`.Title`) or attribute list (`[…]`) was found at the end
+    /// of the document or immediately before a blank line, with no block for it
+    /// to describe.
     #[error("A block title or attribute list was found without a subsequent block")]
     MissingBlockAfterTitleOrAttributeList,
 
+    /// A block anchor (`[[…]]`) was written with no name between its brackets.
     #[error("Block anchor name is empty")]
     EmptyBlockAnchorName,
 
+    /// A block anchor (`[[…]]`) names an ID containing characters that are not
+    /// permitted in a name.
     #[error("Block anchor name contains invalid name characters")]
     InvalidBlockAnchorName,
 
+    /// The document tried to set an attribute that the API caller locked when
+    /// it configured the parser. The field is the attribute name.
     #[error("Attribute {0:?} can not be modified by document")]
     AttributeValueIsLocked(String),
 
+    /// An ID was assigned to an element when an earlier element had already
+    /// registered it. The field is the duplicated ID.
     #[error("Duplicate ID: {0:?} is already registered")]
     DuplicateId(String),
 
+    /// A level-0 section heading (`= Title`) was found somewhere other than the
+    /// document header, where this crate does not support it.
     #[error("Level 0 section headings not supported")]
     Level0SectionHeadingNotSupported,
 
+    /// A section heading skipped one or more levels below its parent. The
+    /// fields are the expected level and the level actually found.
     #[error("Section heading level skipped (expected {0}, found {1})")]
     SectionHeadingLevelSkipped(usize, usize),
 
+    /// A section heading nests deeper than the deepest supported level. The
+    /// field is the level found.
     #[error("Section heading level exceeds maximum (maximum 5, found {0})")]
     SectionHeadingLevelExceedsMaximum(usize),
 
+    /// A `leveloffset` shifted a section heading outside the supported range,
+    /// so its level was clamped. The fields are the offset level and the level
+    /// it was clamped to.
     #[error("Section heading level {0} is outside the supported range 1-5; clamped to {1}")]
     SectionHeadingLevelOutOfRange(i32, usize),
 
+    /// A `leveloffset` is so large (or so negative) that no authored heading
+    /// level could land inside the supported range. The field is the offset.
     #[error("leveloffset {0} places every section heading outside the supported range 1-5")]
     LeveloffsetExcludesAllHeadingLevels(i32),
 
+    /// An explicitly-numbered list item does not continue the sequence its list
+    /// established. The fields are the expected and actual indexes.
     #[error("List item index: expected {0}, got {1}")]
     ListItemOutOfSequence(String, String),
 
+    /// A callout list item has no matching callout marker in the verbatim block
+    /// it annotates. The field is the callout number.
     #[error("No callout found for <{0}>")]
     NoCalloutFound(usize),
 
+    /// A callout list item does not continue the sequence its list established.
+    /// The fields are the expected and actual indexes.
     #[error("Callout list item index: expected {0}, got {1}")]
     CalloutListItemOutOfSequence(usize, usize),
 
+    /// A table row holds more cells than the table's column count allows; the
+    /// surplus cell is dropped.
     #[error("Dropping table cell because it exceeds the specified number of columns")]
     TableCellExceedsColumnCount,
 
+    /// A quoted field in a CSV-format table was never closed; the cell is set
+    /// to empty.
     #[error("Unclosed quote in CSV data; setting cell to empty")]
     TableCsvDataHasUnclosedQuote,
 
+    /// A table row does not begin with the cell separator its table uses;
+    /// parsing recovers by assuming one.
     #[error("Table is missing a leading separator; recovering automatically")]
     TableMissingLeadingSeparator,
 
+    /// A table ended part-way through a row; the cells of that partial row are
+    /// dropped.
     #[error("Dropping cells from incomplete row; detected end of table")]
     TableDroppingIncompleteRowAtEndOfTable,
 
+    /// An attribute reference (`{name}`) names an attribute that is not set,
+    /// under `attribute-missing=warn`. The field is the attribute name.
     #[error("skipping reference to missing attribute: {0}")]
     SkippingReferenceToMissingAttribute(String),
 
+    /// A `stem:` macro named a substitution type that is not recognized. The
+    /// field is the unrecognized name.
     #[error("invalid substitution type for stem macro: {0}")]
     InvalidSubstitutionTypeForStemMacro(String),
 
+    /// A passthrough macro (`pass:`) named a substitution type that is not
+    /// recognized. The field is the unrecognized name.
     #[error("invalid substitution type for passthrough macro: {0}")]
     InvalidSubstitutionTypeForPassthroughMacro(String),
 
@@ -155,6 +226,8 @@ pub enum WarningType {
     #[error("found deprecated footnoteref macro: {0}; use footnote macro with target instead")]
     DeprecatedFootnorefMacro(String),
 
+    /// An `include::` directive named a file that the configured include file
+    /// handler could not resolve. The field is the target as written.
     #[error("include file not found: {0}")]
     IncludeFileNotFound(String),
 

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -80,7 +80,8 @@ pub enum WarningType {
     )]
     EmptyShorthandItem,
 
-    // TO DO BEFORE CHECKING IN TO MAIN: Review these error names and descriptions.
+    // TODO: Review the names and message strings of the variants that follow
+    // (#801).
     /// The name in a block or inline macro is not a valid identifier.
     #[error("Macro name is not a valid identifier")]
     InvalidMacroName,


### PR DESCRIPTION
Fixes #772.

## Problem

Cross-reference resolution already recorded every target it could not resolve, but only in the `Vec<ReferenceWarning>` returned from the resolution pass. A host using `Parser::parse` – which drives resolution internally and discards that value – never saw the condition, so an unresolved `<<foobaz>>` rendered its fallback link `<a href="#foobaz">[foobaz]</a>` silently.

## Change

Each unresolved target is now also recorded on the document as a new `WarningType::PossibleInvalidReference(String)` warning (`possible invalid reference: foobaz`), so it shows up in `Document::warnings()` alongside every other parse-time diagnostic.

Internally, the `warnings: &mut Vec<ReferenceWarning>` parameter threaded through the resolution walk becomes a `ReferenceWarnings<'src>` collector holding both forms: the `ReferenceWarning`s handed back to whoever drove the sweep, and the spanned `Warning`s folded into the document.

Because a resolution sweep is a full, independent pass, a later sweep replaces the reference warnings left by an earlier one rather than accumulating duplicates.

### Warning locations

Warnings are anchored at the `Content` span holding the reference. Two cases cannot name a span in the document source and are re-anchored to the enclosing element instead:

- Blocks of a Markdown-style blockquote and of an include-expanded AsciiDoc table cell are parsed from their own owned source, so their warnings are re-homed onto the quote block / table cell span (the same problem `Warning::origin` exists for).
- A footnote's text is lifted out of its defining block and the `Footnote` keeps no span, so its references are anchored at the document span.

Getting reference-site precision in those cases would mean carrying a source offset on `XrefSegment` through substitution; that seemed out of scope here, but say the word and I'll open a follow-up issue.

### Divergence from Asciidoctor

Asciidoctor emits this message only in verbose (pedantic) mode. This crate has no such mode, so the warning is always recorded; a host is free to ignore it. Noted in the ported tests.

## Second commit: make the `warnings` module public

`Document::warnings()` has always been public, but `Warning` and `WarningType` lived in a private `mod warnings`, so a host could read a warning's `Display` text yet had no way to name the type or match on the variant — which would have left this fix unusable from outside the crate.

That commit makes the module public, documents every `WarningType` variant (required under `#![deny(missing_docs)]`), and marks the enum `non_exhaustive`, since new conditions are recognized as the parser grows and each one would otherwise be a breaking change.

## Tests

- Two `links_test.rb` cases become normative: `should warn and create link if verbose flag is set and reference is not found` and the `#`-notation variant.
- `xref-validate.adoc`'s `reports_an_invalid_reference` now also asserts the document warning and that a repeated sweep does not duplicate it.
- New `tests::xref::unresolved_reference_warnings` module covering the block, footnote, Markdown-blockquote, and include-expanded-cell anchoring paths.

Full suite passes (3986 tests); `cargo +nightly fmt --all -- --check`, `cargo clippy --all-targets`, and `cargo doc` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
