### PR TITLE
fix: Implement the partintro block style (close #794)

### DIFF
--- a/parser/src/blocks/is_block.rs
+++ b/parser/src/blocks/is_block.rs
@@ -70,13 +70,16 @@ pub trait IsBlock<'src>: Debug + Eq + PartialEq {
                 return "listing".into();
             }
 
-            // The `abstract` style is not itself a context; it specializes the
-            // `open` context. Asciidoctor rebuilds an `[abstract]` paragraph as
-            // an open block (keeping the simple content model), so the style
-            // resolves a paragraph's context to `open`. On any other context
-            // (including the `--` delimited form, which is already `open`), the
-            // declared style is preserved without changing the context.
-            if declared_style == "abstract" && self.raw_context().as_ref() == "paragraph" {
+            // Neither the `abstract` style nor the `partintro` style is itself
+            // a context; each specializes the `open` context. Asciidoctor
+            // rebuilds such a paragraph as an open block (keeping the simple
+            // content model), so either style resolves a paragraph's context to
+            // `open`. On any other context (including the `--` delimited form,
+            // which is already `open`), the declared style is preserved without
+            // changing the context.
+            if matches!(declared_style, "abstract" | "partintro")
+                && self.raw_context().as_ref() == "paragraph"
+            {
                 return "open".into();
             }
         }

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -208,25 +208,33 @@ impl<'src> Document<'src> {
             }
 
             // A partintro block is only permitted as a direct child of a book
-            // part (a level-0 section under `doctype: book`), so no block at the
-            // document's top level qualifies. Asciidoctor's converter excludes
-            // such a block's content and logs an error; the parser keeps the
-            // block in the AST (as Asciidoctor does) and records the warning
-            // here, for a renderer to act on.
+            // part. Asciidoctor's converter excludes a misplaced block's content
+            // and logs an error; the parser keeps the block in the AST (as
+            // Asciidoctor does) and records the warning here, for a renderer to
+            // act on.
             //
-            // Book parts are not modeled by this crate yet (a level-0 heading
-            // records its own warning and its content lands in the preamble), so
-            // a partintro nested below the top level is left alone rather than
-            // reported as misplaced.
-            for block in &blocks {
-                if is_partintro(block) {
-                    warnings.push(Warning {
-                        source: block.span(),
-                        warning: WarningType::PartintroBlockOutsideOfBookPart,
-                        origin: None,
-                    });
-                }
-            }
+            // A book part is a level-0 section, which this crate does not model
+            // yet (#800): a `= Part` heading records its own warning and its
+            // content is folded into the document's preamble. Every position a
+            // partintro can occupy is therefore decidable except one – a direct
+            // child of a preamble that absorbed such a heading – and that one is
+            // left unreported. See [`partintro_placement_warnings`].
+            let doctype_is_book = matches!(
+                parser.attribute_value("doctype"),
+                InterpretedValue::Value(ref v) if v == "book"
+            );
+
+            let preamble_may_stand_in_for_part = doctype_is_book
+                && warnings
+                    .iter()
+                    .any(|w| w.warning == WarningType::Level0SectionHeadingNotSupported);
+
+            partintro_placement_warnings(
+                &mut blocks,
+                false,
+                preamble_may_stand_in_for_part,
+                &mut warnings,
+            );
 
             // Under `doctype: inline`, only the first eligible block is converted,
             // as bare inline content, and everything after it is dropped (the
@@ -592,6 +600,59 @@ impl std::fmt::Debug for Document<'_> {
 /// resolve to the `open` context with the `partintro` declared style.
 fn is_partintro(block: &Block<'_>) -> bool {
     block.declared_style() == Some("partintro") && block.resolved_context().as_ref() == "open"
+}
+
+/// Records a warning for every misplaced `[partintro]` block in `blocks` and,
+/// recursively, in their nested blocks.
+///
+/// Asciidoctor rejects a partintro unless its parent is a section, that section
+/// is level 0, and the doctype is `book` – in other words, unless it is a
+/// direct child of a book part. `parent_is_book_part` says whether the blocks
+/// at this level of the walk have such a parent.
+///
+/// Book parts are not modeled yet (#800), so `parent_is_book_part` is never
+/// `true` today. A `= Part` heading is dropped (with its own warning) and the
+/// blocks below it are folded into the document's preamble, which is why a
+/// preamble that absorbed such a heading is treated as *undecidable* rather
+/// than misplaced: `preamble_stands_in_for_part` suppresses the check for its
+/// direct children. Every other position – the document's top level, a level-1+
+/// section, any non-section container, and anything at all under a non-book
+/// doctype – is decided here exactly as Asciidoctor decides it.
+///
+/// The walk is read-only, but it descends through
+/// [`IsBlock::nested_blocks_mut`] (as [`Block::resolve_references`] does),
+/// since that is the accessor that preserves the `'src` lifetime of a child's
+/// span.
+fn partintro_placement_warnings<'src>(
+    blocks: &mut [Block<'src>],
+    parent_is_book_part: bool,
+    preamble_stands_in_for_part: bool,
+    warnings: &mut Vec<Warning<'src>>,
+) {
+    for block in blocks.iter_mut() {
+        if is_partintro(block) && !parent_is_book_part {
+            warnings.push(Warning {
+                source: block.span(),
+                warning: WarningType::PartintroBlockOutsideOfBookPart,
+                origin: None,
+            });
+        }
+
+        // A level-0 section is the only true book part; a preamble standing in
+        // for one that was dropped is the single undecidable case.
+        let child_parent_is_book_part = match block {
+            Block::Section(section) => section.level() == 0,
+            Block::Preamble(_) => preamble_stands_in_for_part,
+            _ => false,
+        };
+
+        partintro_placement_warnings(
+            block.nested_blocks_mut(),
+            child_parent_is_book_part,
+            preamble_stands_in_for_part,
+            warnings,
+        );
+    }
 }
 
 /// Returns the first block eligible to be the sole rendered block of an
@@ -1726,6 +1787,85 @@ mod tests {
                 doc.attribute_value("my-counter"),
                 InterpretedValue::Value("2".to_string())
             );
+        }
+    }
+
+    /// Placement checks for the `[partintro]` block style.
+    ///
+    /// A partintro is only permitted as a direct child of a book part.
+    /// Asciidoctor's own tests cover the document's top level (see
+    /// `blocks_test.rs`); these cover the positions that only this crate's
+    /// recursive walk decides.
+    mod partintro_placement {
+        use crate::tests::prelude::*;
+
+        /// Returns the misplaced-partintro warnings recorded for `doc`.
+        fn warnings<'src>(
+            doc: &'src crate::Document<'src>,
+        ) -> Vec<&'src crate::warnings::Warning<'src>> {
+            doc.warnings()
+                .filter(|w| w.warning == WarningType::PartintroBlockOutsideOfBookPart)
+                .collect()
+        }
+
+        #[test]
+        fn misplaced_in_chapter_of_book() {
+            // A chapter is a level-1 section, so a partintro inside it is not a
+            // child of a part, even though the doctype is book.
+            let doc = Parser::default()
+                .parse("= Book\n:doctype: book\n\n== Chapter 1\n\n[partintro]\n--\nintro\n--\n");
+
+            assert_eq!(warnings(&doc).len(), 1);
+            assert_css(&doc, ".partintro", 0);
+        }
+
+        #[test]
+        fn misplaced_in_section_of_article() {
+            // Without `doctype: book` there are no parts at all, so a partintro
+            // is misplaced wherever it appears.
+            let doc = Parser::default().parse("= Article\n\n== Section\n\n[partintro]\nintro\n");
+
+            assert_eq!(warnings(&doc).len(), 1);
+            assert_css(&doc, ".partintro", 0);
+        }
+
+        #[test]
+        fn misplaced_inside_another_block_below_a_part_heading() {
+            // The partintro's parent is a sidebar rather than the part itself,
+            // which Asciidoctor rejects (its parent's context is not a section).
+            let doc = Parser::default().parse(
+                "= Book\n:doctype: book\n\n= Part 1\n\n****\n[partintro]\nintro\n****\n\n== Chapter 1\n\ncontent\n",
+            );
+
+            assert_eq!(warnings(&doc).len(), 1);
+            assert_css(&doc, ".partintro", 0);
+        }
+
+        #[test]
+        fn not_reported_below_a_dropped_part_heading() {
+            // Book parts are not modeled yet (#800): a `= Part` heading is
+            // dropped and the blocks below it are folded into the preamble, so
+            // this is the one position that cannot be decided. The partintro is
+            // left unreported and renders as `openblock.partintro`.
+            let doc = Parser::default().parse(
+                "= Book\n:doctype: book\n\n= Part 1\n\n[partintro]\n--\nintro\n--\n\n== Chapter 1\n\ncontent\n",
+            );
+
+            assert!(warnings(&doc).is_empty());
+            assert_css(&doc, ".openblock.partintro", 1);
+        }
+
+        #[test]
+        fn reported_in_a_preamble_with_no_part_heading() {
+            // A preamble only stands in for a part when a `= Part` heading was
+            // actually dropped into it; without one, the partintro is decidably
+            // misplaced.
+            let doc = Parser::default().parse(
+                "= Book\n:doctype: book\n\n[partintro]\n--\nintro\n--\n\n== Chapter 1\n\ncontent\n",
+            );
+
+            assert_eq!(warnings(&doc).len(), 1);
+            assert_css(&doc, ".partintro", 0);
         }
     }
 }

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -207,6 +207,27 @@ impl<'src> Document<'src> {
                 }
             }
 
+            // A partintro block is only permitted as a direct child of a book
+            // part (a level-0 section under `doctype: book`), so no block at the
+            // document's top level qualifies. Asciidoctor's converter excludes
+            // such a block's content and logs an error; the parser keeps the
+            // block in the AST (as Asciidoctor does) and records the warning
+            // here, for a renderer to act on.
+            //
+            // Book parts are not modeled by this crate yet (a level-0 heading
+            // records its own warning and its content lands in the preamble), so
+            // a partintro nested below the top level is left alone rather than
+            // reported as misplaced.
+            for block in &blocks {
+                if is_partintro(block) {
+                    warnings.push(Warning {
+                        source: block.span(),
+                        warning: WarningType::PartintroBlockOutsideOfBookPart,
+                        origin: None,
+                    });
+                }
+            }
+
             // Under `doctype: inline`, only the first eligible block is converted,
             // as bare inline content, and everything after it is dropped (the
             // rendering lives on the embed path). A compound or empty candidate
@@ -564,6 +585,13 @@ impl std::fmt::Debug for Document<'_> {
             .field("catalog", &dependent.catalog)
             .finish()
     }
+}
+
+/// Returns `true` if `block` is a partintro block: the `--` structural
+/// container or a paragraph carrying the `partintro` style, both of which
+/// resolve to the `open` context with the `partintro` declared style.
+fn is_partintro(block: &Block<'_>) -> bool {
+    block.declared_style() == Some("partintro") && block.resolved_context().as_ref() == "open"
 }
 
 /// Returns the first block eligible to be the sole rendered block of an

--- a/parser/src/tests/asciidoctor_rb/blocks_test.rs
+++ b/parser/src/tests/asciidoctor_rb/blocks_test.rs
@@ -7406,12 +7406,29 @@ mod abstract_and_part_intro {
     // block (or paragraph) resolves to the `open` context with the `abstract`
     // declared style, renders as `quoteblock.abstract`, and an abstract used as
     // a direct child of a doctitle-less book document is excluded with a
-    // warning. The `partintro` block style is still unmodeled: a `[partintro]`
-    // open block does not gain the `partintro` class, and its validation
-    // errors are not emitted; those tests are kept `#[ignore]`d with the
-    // Ruby-intended assertions. The DocBook variants are reproduced as
-    // `non_normative`.
-    // TODO: implement the partintro block style (#794).
+    // warning. The `partintro` block style (#794) is modeled the same way: a
+    // `[partintro]` open block (or paragraph) resolves to the `open` context
+    // with the `partintro` declared style, renders as `openblock.partintro`,
+    // and a partintro used as a direct child of the document – where it can
+    // never be the child of a book part – is excluded with a warning. Book
+    // parts themselves are not modeled yet, so a partintro below the top level
+    // is rendered without further placement checks. The DocBook variants are
+    // reproduced as `non_normative`.
+
+    /// Returns `true` if `doc` recorded a misplaced-partintro warning.
+    ///
+    /// A book part is a level-0 section, which this crate does not model yet,
+    /// so a document that places a partintro under a `= Part 1` heading
+    /// records the unrelated level-0 heading warning; only the partintro
+    /// warning is of interest here.
+    fn has_misplaced_partintro_warning(doc: &crate::Document<'_>) -> bool {
+        doc.warnings().any(|warning| {
+            matches!(
+                warning.warning,
+                WarningType::PartintroBlockOutsideOfBookPart
+            )
+        })
+    }
 
     #[test]
     fn should_make_abstract_on_open_block_without_title_a_quote_block_for_article() {
@@ -7613,7 +7630,6 @@ mod abstract_and_part_intro {
 "#
     );
 
-    #[ignore]
     #[test]
     fn should_accept_partintro_on_open_block_without_title() {
         verifies!(
@@ -7655,9 +7671,9 @@ mod abstract_and_part_intro {
         );
         assert_css(&doc, ".openblock.partintro", 1);
         assert_css(&doc, ".openblock .content", 1);
+        assert!(!has_misplaced_partintro_warning(&doc));
     }
 
-    #[ignore]
     #[test]
     fn should_accept_partintro_on_open_block_with_title() {
         verifies!(
@@ -7698,9 +7714,9 @@ mod abstract_and_part_intro {
         );
         assert_css(&doc, ".openblock.partintro", 1);
         assert_css(&doc, ".openblock .title", 1);
+        assert!(!has_misplaced_partintro_warning(&doc));
     }
 
-    #[ignore]
     #[test]
     fn should_exclude_partintro_if_not_a_child_of_part() {
         verifies!(
@@ -7725,9 +7741,15 @@ mod abstract_and_part_intro {
         let doc = Parser::default()
             .parse("= Book\n:doctype: book\n\n[partintro]\npart intro paragraph\n");
         assert_css(&doc, ".partintro", 0);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert!(matches!(
+            warnings[0].warning,
+            WarningType::PartintroBlockOutsideOfBookPart
+        ));
     }
 
-    #[ignore]
     #[test]
     fn should_not_allow_partintro_unless_doctype_is_book() {
         verifies!(
@@ -7748,6 +7770,13 @@ mod abstract_and_part_intro {
 
         let doc = Parser::default().parse("[partintro]\npart intro paragraph\n");
         assert_css(&doc, ".partintro", 0);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert!(matches!(
+            warnings[0].warning,
+            WarningType::PartintroBlockOutsideOfBookPart
+        ));
     }
 
     // The DocBook partintro variants are backend-specific and out of scope.

--- a/parser/src/tests/asciidoctor_rb/blocks_test.rs
+++ b/parser/src/tests/asciidoctor_rb/blocks_test.rs
@@ -7409,17 +7409,21 @@ mod abstract_and_part_intro {
     // warning. The `partintro` block style (#794) is modeled the same way: a
     // `[partintro]` open block (or paragraph) resolves to the `open` context
     // with the `partintro` declared style, renders as `openblock.partintro`,
-    // and a partintro used as a direct child of the document – where it can
-    // never be the child of a book part – is excluded with a warning. Book
-    // parts themselves are not modeled yet, so a partintro below the top level
-    // is rendered without further placement checks. The DocBook variants are
-    // reproduced as `non_normative`.
+    // and a partintro outside of a book part is excluded with a warning.
+    //
+    // Out of scope here: book parts are level-0 sections, which this crate does
+    // not model yet (#800), so the one placement that cannot be judged is a
+    // direct child of the preamble a dropped `= Part` heading collapses into –
+    // exactly where the two accepting tests below put their partintro. Every
+    // other placement is decided as Asciidoctor decides it; see
+    // `document::document::tests::partintro_placement`. The DocBook variants
+    // are backend-specific (this crate has no converters) and are reproduced as
+    // `non_normative`.
 
     /// Returns `true` if `doc` recorded a misplaced-partintro warning.
     ///
-    /// A book part is a level-0 section, which this crate does not model yet,
-    /// so a document that places a partintro under a `= Part 1` heading
-    /// records the unrelated level-0 heading warning; only the partintro
+    /// A document that places a partintro under a `= Part 1` heading also
+    /// records the unrelated level-0 heading warning (#800); only the partintro
     /// warning is of interest here.
     fn has_misplaced_partintro_warning(doc: &crate::Document<'_>) -> bool {
         doc.warnings().any(|warning| {

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -632,9 +632,12 @@ impl ToVirtualDom for Document<'_> {
             InterpretedValue::Value(ref v) if v == "book"
         ) && self.doctitle().is_none();
 
-        // Add child blocks, including block titles as separate siblings.
+        // Add child blocks, including block titles as separate siblings. A
+        // partintro is only permitted as a direct child of a book part, so
+        // Asciidoctor's converter excludes every partintro found here (an error
+        // was recorded at parse time).
         for block in self.nested_blocks() {
-            if exclude_abstracts && is_abstract(block) {
+            if (exclude_abstracts && is_abstract(block)) || is_partintro(block) {
                 continue;
             }
             add_block_with_title(&mut node, block);
@@ -1666,6 +1669,12 @@ fn compound_delimited_to_node<'a>(compound: &'a CompoundDelimitedBlock<'a>) -> V
 
     let mut node = VirtualNode::new("div").with_class(class);
 
+    // The `partintro` style specializes the open block rather than replacing
+    // it, so it rides along as a second class on `div.openblock`.
+    if is_partintro(compound) {
+        node = node.with_class("partintro");
+    }
+
     for role in compound.roles() {
         node = node.with_class(role);
     }
@@ -1702,6 +1711,12 @@ fn compound_delimited_to_node<'a>(compound: &'a CompoundDelimitedBlock<'a>) -> V
 fn open_paragraph_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
     let mut node = VirtualNode::new("div").with_class("openblock");
 
+    // The `partintro` style specializes the open block rather than replacing
+    // it, so it rides along as a second class on `div.openblock`.
+    if is_partintro(block) {
+        node = node.with_class("partintro");
+    }
+
     for role in block.roles() {
         node = node.with_class(role);
     }
@@ -1723,6 +1738,13 @@ fn open_paragraph_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
     node.children.push(content);
 
     node
+}
+
+/// Returns `true` if `block` is a partintro block: the `--` structural
+/// container or a paragraph carrying the `partintro` style, both of which
+/// resolve to the `open` context with the `partintro` declared style.
+fn is_partintro<'src, B: IsBlock<'src>>(block: &'src B) -> bool {
+    block.declared_style() == Some("partintro") && block.resolved_context().as_ref() == "open"
 }
 
 /// Returns `true` if `block` is an abstract block: the `--` structural

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -22,6 +22,7 @@ use crate::{
         TableRow, VerticalAlignment,
     },
     document::{InterpretedValue, TocMode, first_inline_candidate},
+    warnings::WarningType,
 };
 
 /// The document-wide `icons` mode, which controls how callouts and callout
@@ -45,6 +46,40 @@ enum IconsMode {
 
 thread_local! {
     static ICONS_MODE: Cell<IconsMode> = const { Cell::new(IconsMode::None) };
+}
+
+thread_local! {
+    /// Whether a `[partintro]` block that is a direct child of the preamble
+    /// should be rendered rather than excluded.
+    ///
+    /// A partintro belongs to a book part, which this crate does not model yet
+    /// (#800); the blocks below a dropped `= Part` heading are folded into the
+    /// document's preamble, so a preamble in such a document is the one place a
+    /// partintro cannot be ruled misplaced. The virtual DOM builder has no
+    /// document context threaded through it, so the document stashes that fact
+    /// here for [`preamble_to_node`] to read.
+    static PARTINTRO_ALLOWED_IN_PREAMBLE: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Restores a `bool` thread-local to its previous value when dropped, so a
+/// nested AsciiDoc cell can mask the enclosing document's value and reinstate
+/// it afterward.
+struct BoolScopeGuard {
+    key: &'static LocalKey<Cell<bool>>,
+    prev: bool,
+}
+
+impl Drop for BoolScopeGuard {
+    fn drop(&mut self) {
+        self.key.with(|c| c.set(self.prev));
+    }
+}
+
+/// Sets the `bool` thread-local `key` to `value` for the current scope,
+/// returning a guard that restores the previous value on drop.
+fn scoped_bool(key: &'static LocalKey<Cell<bool>>, value: bool) -> BoolScopeGuard {
+    let prev = key.with(|c| c.replace(value));
+    BoolScopeGuard { key, prev }
 }
 
 /// A fully resolved table of contents, ready to render: the prebuilt section
@@ -632,10 +667,24 @@ impl ToVirtualDom for Document<'_> {
             InterpretedValue::Value(ref v) if v == "book"
         ) && self.doctitle().is_none();
 
-        // Add child blocks, including block titles as separate siblings. A
-        // partintro is only permitted as a direct child of a book part, so
-        // Asciidoctor's converter excludes every partintro found here (an error
-        // was recorded at parse time).
+        // A partintro is only permitted as a direct child of a book part, and
+        // Asciidoctor's converter excludes a misplaced one's content (an error
+        // was recorded at parse time). Book parts are not modeled yet (#800), so
+        // the sole position this virtual DOM cannot rule out is a direct child
+        // of a preamble that absorbed a dropped `= Part` heading – which is
+        // where a real part intro lands today. That exemption is stashed for
+        // [`preamble_to_node`] to read; every other position is excluded.
+        let _partintro_scope = scoped_bool(
+            &PARTINTRO_ALLOWED_IN_PREAMBLE,
+            matches!(
+                self.attribute_value("doctype"),
+                InterpretedValue::Value(ref v) if v == "book"
+            ) && self
+                .warnings()
+                .any(|w| w.warning == WarningType::Level0SectionHeadingNotSupported),
+        );
+
+        // Add child blocks, including block titles as separate siblings.
         for block in self.nested_blocks() {
             if (exclude_abstracts && is_abstract(block)) || is_partintro(block) {
                 continue;
@@ -653,6 +702,15 @@ impl ToVirtualDom for Document<'_> {
 /// NOTE: Some block types (like lists) handle their titles internally, so we
 /// skip adding a separate title element for those.
 fn add_block_with_title<'a>(parent: &mut VirtualNode, block: &'a Block<'a>) {
+    // No parent that adds its children through this function is a book part: a
+    // part is a level-0 section, which this crate does not model yet (#800), and
+    // the preamble that stands in for one adds its own children (see
+    // [`preamble_to_node`]). A partintro reaching here is therefore misplaced,
+    // and its content and title alike are excluded.
+    if is_partintro(block) {
+        return;
+    }
+
     // A `toc::[]` macro renders the table of contents (when a `toc: macro` scope
     // is active) rather than a paragraph, and never carries a separate title.
     if is_toc_macro(block) {
@@ -2686,6 +2744,13 @@ fn preamble_to_node<'a>(preamble: &'a Preamble<'a>) -> VirtualNode {
     let mut node = VirtualNode::new("div").with_id("preamble");
 
     for child in preamble.nested_blocks() {
+        // A partintro is excluded unless this preamble stands in for a book part
+        // this crate does not model yet (#800), which is where a real part intro
+        // lands today.
+        if is_partintro(child) && !PARTINTRO_ALLOWED_IN_PREAMBLE.with(Cell::get) {
+            continue;
+        }
+
         // A `toc::[]` macro in the preamble renders the table of contents.
         if is_toc_macro(child) {
             if let Some(toc) = toc_macro_node(child) {

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -229,6 +229,14 @@ pub enum WarningType {
         "abstract block cannot be used in a document without a doctitle when doctype is book. Excluding block content."
     )]
     AbstractBlockInBookWithoutDoctitle,
+
+    /// A `[partintro]` block was found somewhere other than as a direct child
+    /// of a book part (a level-0 section under `doctype: book`). Asciidoctor
+    /// excludes such a block's content from the converted output.
+    #[error(
+        "partintro block can only be used when doctype is book and must be a child of a book part. Excluding block content."
+    )]
+    PartintroBlockOutsideOfBookPart,
 }
 
 impl std::fmt::Debug for WarningType {
@@ -434,6 +442,10 @@ impl std::fmt::Debug for WarningType {
 
             WarningType::AbstractBlockInBookWithoutDoctitle => {
                 write!(f, "WarningType::AbstractBlockInBookWithoutDoctitle")
+            }
+
+            WarningType::PartintroBlockOutsideOfBookPart => {
+                write!(f, "WarningType::PartintroBlockOutsideOfBookPart")
             }
         }
     }
@@ -944,6 +956,13 @@ mod tests {
                     debug_output,
                     "WarningType::AbstractBlockInBookWithoutDoctitle"
                 );
+            }
+
+            #[test]
+            fn partintro_block_outside_of_book_part() {
+                let warning = WarningType::PartintroBlockOutsideOfBookPart;
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(debug_output, "WarningType::PartintroBlockOutsideOfBookPart");
             }
         }
     }


### PR DESCRIPTION
Closes #794.

## What changed

* **Context resolution** – a `[partintro]` paragraph now resolves to the `open` context with the `partintro` declared style, matching Asciidoctor's AST (which rebuilds such a paragraph as an open block). The `--` delimited form already resolved to `open`. This extends the rule the `abstract` style got in #790.
* **Rendering** – the `partintro` style specializes the open block rather than replacing it, so it rides along as a second class: `div.openblock.partintro`, for both the delimited and paragraph forms.
* **Placement validation** – a misplaced partintro is excluded from the rendered output and records a new `PartintroBlockOutsideOfBookPart` warning carrying Asciidoctor's message text. The block itself stays in the AST, as it does in Asciidoctor, where exclusion is converter behavior.

Asciidoctor rejects a partintro unless its parent is a section, that section is level 0, and the doctype is `book`. All of that is enforced here except one position — see below — so a partintro is now reported and excluded when it sits at the document's top level, in a level-1+ section, in a non-section container (sidebar, example, open block), or anywhere at all under a non-book doctype.

## Out of scope

* **Book parts (#800, filed with this PR).** A part is a level-0 section, which this crate does not model: a `= Part` heading records `Level0SectionHeadingNotSupported`, is dropped, and the blocks below it are folded into the document's preamble. That makes exactly one placement undecidable — a direct child of a preamble that absorbed such a heading, which is where a real part intro lands today — so it is left unreported and rendered. `document::document::tests::partintro_placement` pins both sides of that line, including the undecidable case, so the behavior is visible when parts do get modeled. #800 also notes the paragraph-to-partintro promotion Asciidoctor performs for a plain paragraph inside a part, which likewise needs parts.
* **DocBook.** This crate has no converters, so the four DocBook partintro variants stay `non_normative!`, as the rest of the suite treats backend-specific tests.

## Tests

Un-ignores the four partintro tests in `blocks_test.rs` and adds five placement tests. Full workspace suite: 3989 passed, 0 failed. `cargo +nightly fmt --all -- --check` and clippy are clean.