### PR TITLE
chore: Run CI automatically for same-repository pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,18 @@ on:
   push:
     branches: main
 
+# Every job below is gated on the same condition: run automatically for
+# pushes, for pull requests whose head branch lives in this repository
+# (pushing a branch here already requires write access, so those are
+# trusted – this covers Claude Code and other agent-authored PRs), and for
+# maintainer- or dependabot-authored PRs. Pull requests from forks await a
+# human adding the "safe to test" label.
 jobs:
   tests:
     name: Unit tests
     if: |
       github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
       github.event.pull_request.author_association == 'OWNER' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
       github.event.pull_request.author_association == 'MEMBER' ||
@@ -57,6 +64,7 @@ jobs:
       - name: Upload code coverage results
         if: |
           github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository ||
           github.event.pull_request.author_association == 'OWNER' ||
           github.event.pull_request.author_association == 'COLLABORATOR' ||
           github.event.pull_request.author_association == 'MEMBER' ||
@@ -72,6 +80,7 @@ jobs:
     name: Unit tests with minimum versions of direct dependencies
     if: |
       github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
       github.event.pull_request.author_association == 'OWNER' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
       github.event.pull_request.author_association == 'MEMBER' ||
@@ -102,6 +111,7 @@ jobs:
     name: Preflight crate publish
     if: |
       github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
       github.event.pull_request.author_association == 'OWNER' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
       github.event.pull_request.author_association == 'MEMBER' ||
@@ -136,6 +146,7 @@ jobs:
     name: Clippy
     if: |
       github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
       github.event.pull_request.author_association == 'OWNER' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
       github.event.pull_request.author_association == 'MEMBER' ||
@@ -163,6 +174,7 @@ jobs:
     name: Enforce Rust code format
     if: |
       github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
       github.event.pull_request.author_association == 'OWNER' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
       github.event.pull_request.author_association == 'MEMBER' ||
@@ -187,6 +199,7 @@ jobs:
     name: Enforce TOML format
     if: |
       github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
       github.event.pull_request.author_association == 'OWNER' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
       github.event.pull_request.author_association == 'MEMBER' ||
@@ -211,6 +224,7 @@ jobs:
     name: Preflight docs.rs build
     if: |
       github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
       github.event.pull_request.author_association == 'OWNER' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
       github.event.pull_request.author_association == 'MEMBER' ||
@@ -243,6 +257,7 @@ jobs:
     name: Verify internal crate documentation
     if: |
       github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
       github.event.pull_request.author_association == 'OWNER' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
       github.event.pull_request.author_association == 'MEMBER' ||
@@ -267,6 +282,7 @@ jobs:
     name: License / vulnerability audit
     if: |
       github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
       github.event.pull_request.author_association == 'OWNER' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
       github.event.pull_request.author_association == 'MEMBER' ||
@@ -298,6 +314,7 @@ jobs:
     name: Check for unused dependencies
     if: |
       github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
       github.event.pull_request.author_association == 'OWNER' ||
       github.event.pull_request.author_association == 'COLLABORATOR' ||
       github.event.pull_request.author_association == 'MEMBER' ||
@@ -323,6 +340,14 @@ jobs:
 
   benchmarks:
     name: Test performance on benchmarks
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR' ||
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      contains(github.event.pull_request.labels.*.name, 'safe to test')
 
     permissions:
       contents: read
@@ -351,6 +376,15 @@ jobs:
 
   spec-coverage:
     name: Generate spec coverage
+    if: |
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR' ||
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      contains(github.event.pull_request.labels.*.name, 'safe to test')
+
     runs-on: ubuntu-latest
 
     steps:
@@ -370,7 +404,16 @@ jobs:
       - name: Generate spec coverage
         run: cd sdd && cargo run > spec-coverage.json
 
+      # Tokens aren't available for PRs originating from forks,
+      # so we don't attempt to upload spec coverage in that case.
       - name: Upload code coverage results
+        if: |
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name == github.repository ||
+          github.event.pull_request.author_association == 'OWNER' ||
+          github.event.pull_request.author_association == 'COLLABORATOR' ||
+          github.event.pull_request.author_association == 'MEMBER' ||
+          github.event.pull_request.user.login == 'dependabot[bot]'
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Problem

Every CI job was gated on `author_association`:

```yaml
github.event.pull_request.author_association == 'OWNER' ||
github.event.pull_request.author_association == 'COLLABORATOR' ||
github.event.pull_request.author_association == 'MEMBER' ||
github.event.pull_request.user.login == 'dependabot[bot]' ||
contains(github.event.pull_request.labels.*.name, 'safe to test')
```

That condition asks *who wrote the pull request*, but the security question is really *where does the code come from*. Agent-authored PRs (Claude Code and similar) push their branches into this repository, yet report an association of `CONTRIBUTOR` — so they fell through to the `safe to test` escape hatch and needed a manual label before the suite would run.

## Fix

Add a same-repository clause to each gate:

```yaml
github.event.pull_request.head.repo.full_name == github.repository ||
```

Pushing a branch to `asciidoc-rs/asciidoc-parser` already requires write access, so a same-repo PR cannot carry code from an untrusted party. Fork-based PRs are structurally unable to satisfy this clause.

## Behavior

| Pull request source | Before | After |
| --- | --- | --- |
| Maintainer, branch in repo | Runs | Runs |
| Agent (Claude Code), branch in repo | **Needed `safe to test`** | **Runs** |
| Dependabot | Runs | Runs |
| Third-party fork | Needs `safe to test` | Needs `safe to test` (unchanged) |

Third-party contributions still await human review before CI executes their code, whether or not they were authored with an agent.

## Also in this change

- `benchmarks` and `spec-coverage` had **no gate at all** and ran on every fork PR. They now carry the same condition, so the `safe to test` label applies uniformly across the suite.
- The Codecov upload step in `tests` had its own narrower gate that omitted the same-repo case; it would have skipped coverage upload on agent-authored PRs. Extended to match.
- The `spec-coverage` upload step had no fork guard. Since `CODECOV_TOKEN` is unavailable to fork PRs and `fail_ci_if_error: true` is set, labeling a fork PR `safe to test` would have produced a guaranteed red job. Now guarded like the other upload.

## Verification

YAML parses, and all 12 jobs are gated:

```
tests, test-direct-minimal-versions, publish-preflight, clippy_check,
cargo_fmt, taplo_fmt, docs_rs, internal_docs, cargo-deny, unused_deps,
benchmarks, spec-coverage  -> all GATED
```

Note that CI on this PR is itself a live test of the change: this branch lives in the repository, so the full suite should start without a label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)