### PR TITLE
fix: Recognize a URL macro preceded by a no-break space (#768)

### DIFF
--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -700,6 +700,12 @@ fn strip_see_and_seealso(term: &str) -> String {
 // A stray `&gt;` with no matching `&lt;` (e.g. `https://example.org>;`) can then
 // only match the bare-link alternative, exactly as Ruby routes it. See #503.
 //
+// The blank alternative in the prefix (`[\ \t\p{Zs}]`) mirrors Asciidoctor's
+// `CG_BLANK` (`\p{Blank}`), which under Ruby's Unicode-aware engine treats any
+// space separator — including a no-break space (U+00A0) — as a boundary before
+// the scheme. A plain ASCII `[\ \t]` would leave such a URL as literal text
+// (see #768).
+//
 // `InlineLinkReplacer` normalizes the two capture-group sets into a single view
 // (see `NormalizedCaps`), so the numbering below is only referenced there.
 static INLINE_LINK: LazyLock<Regex> = LazyLock::new(|| {
@@ -719,7 +725,7 @@ static INLINE_LINK: LazyLock<Regex> = LazyLock::new(|| {
             )
           |
             #### NON-ANGLE branch: no `&gt;` alternative (unreachable without `&lt;`).
-            ( ^ | link: | [\ \t] | [>\(\)\[\];"'] )           # group 8: prefix
+            ( ^ | link: | [\ \t\p{Zs}] | [>\(\)\[\];"'] )     # group 8: prefix
             ( \\? (?: https? | file | ftp | irc ):// )        # group 9: scheme
             (?:
                 ( [^\s\[\]]+ )                                # group 10: target

--- a/parser/src/tests/asciidoctor_rb/links_test.rs
+++ b/parser/src/tests/asciidoctor_rb/links_test.rs
@@ -963,17 +963,23 @@ fn qualified_url_adjacent_to_text_in_round_brackets() {
     );
 }
 
-// Surfaced incompatibility: Asciidoctor recognizes a URL macro preceded by a
-// no-break space; this crate does not treat U+00A0 as a leading boundary and
-// leaves the macro as literal text. Tracked in #768.
-non_normative!(
-    r###"
+#[test]
+fn qualified_url_following_no_break_space() {
+    verifies!(
+        r###"
   test 'qualified url following no-break space' do
     assert_xpath '//a[@href="http://asciidoc.org"][text()="AsciiDoc"]', convert_string(%(#{[0xa0].pack 'U1'}http://asciidoc.org[AsciiDoc] project page.)), 1
   end
 
 "###
-);
+    );
+
+    let doc = Parser::default().parse("\u{a0}http://asciidoc.org[AsciiDoc] project page.");
+    assert_eq!(
+        rendered_paragraphs(&doc)[0],
+        "\u{a0}<a href=\"http://asciidoc.org\">AsciiDoc</a> project page."
+    );
+}
 
 #[test]
 fn qualified_url_following_smart_apostrophe() {


### PR DESCRIPTION
Fixes #768.

## Problem

A URL/link macro immediately preceded by a no-break space (U+00A0) was left as literal text:

```
 http://asciidoc.org[AsciiDoc] project page.
```

(the leading character is U+00A0)

- Expected: `<a href="http://asciidoc.org">AsciiDoc</a> project page.`
- Actual: literal `http://asciidoc.org[AsciiDoc] project page.` (no link)

`INLINE_LINK`'s non-angle prefix alternation in `parser/src/content/macros.rs` only accepted start-of-string, `link:`, an ASCII space/tab (`[\ \t]`), or one of `>()[];"'` as a boundary before the scheme, so a leading U+00A0 was not treated as a boundary.

## Fix

Asciidoctor's `InlineLinkRx` uses `CG_BLANK`, defined as `\p{Blank}`. Under Ruby's Unicode-aware regex engine that class matches any space separator — including a no-break space (U+00A0) — not just ASCII space/tab. The Rust `regex` crate's ASCII `[\ \t]` does not.

Widen the non-angle prefix's blank alternative from `[\ \t]` to `[\ \t\p{Zs}]` (tab plus the Unicode `Space_Separator` category, which covers the regular space, U+00A0, and other Unicode spaces) so the boundary handling matches Asciidoctor. Only the non-angle branch carries the blank alternative, so that is the only change.

## Tests

Promoted the previously `non_normative!` `qualified url following no-break space` case in `parser/src/tests/asciidoctor_rb/links_test.rs` to a passing `verifies!` test. The full lib test suite (4047 tests) passes; `cargo clippy` and `cargo fmt` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177nufqhZsJstg3WwWGcvyB

---
_Generated by [Claude Code](https://claude.ai/code/session_0177nufqhZsJstg3WwWGcvyB)_