### PR TITLE
fix: Do not catalog a bibliography anchor found in prose (#769)

### DIFF
--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -144,13 +144,18 @@ fn apply_macros_internal(
     }
 
     if (found_square_bracket && text.contains("[[")) || (found_macroish && text.contains("or:")) {
+        // The replacer inspects the byte preceding each match to detect a
+        // `[[id]]` shorthand that is really the inner part of a bibliography
+        // anchor (`[[[id]]]`), so it needs the haystack alongside the captures.
+        let haystack = content.rendered().to_string();
         let replacer = InlineAnchorReplacer {
             parser,
             source: content.original(),
             leading_anchor_registered,
+            haystack: &haystack,
         };
 
-        if let Cow::Owned(new_result) = INLINE_ANCHOR.replace_all(content.rendered(), replacer) {
+        if let Cow::Owned(new_result) = INLINE_ANCHOR.replace_all(&haystack, replacer) {
             content.rendered = new_result.into();
         }
     }
@@ -1433,13 +1438,17 @@ static INLINE_ANCHOR: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 #[derive(Debug)]
-struct InlineAnchorReplacer<'p, 'src> {
+struct InlineAnchorReplacer<'p, 'src, 'h> {
     parser: &'p Parser,
     source: Span<'src>,
     leading_anchor_registered: bool,
+
+    /// The haystack `INLINE_ANCHOR` is scanned against, used to inspect the byte
+    /// preceding a match (see the bibliography-anchor note in `replace_append`).
+    haystack: &'h str,
 }
 
-impl Replacer for InlineAnchorReplacer<'_, '_> {
+impl Replacer for InlineAnchorReplacer<'_, '_, '_> {
     fn replace_append(&mut self, caps: &Captures<'_>, dest: &mut String) {
         if caps.get(1).is_some() {
             dest.push_str(&caps[0][1..]);
@@ -1448,6 +1457,8 @@ impl Replacer for InlineAnchorReplacer<'_, '_> {
 
         // NOTE: reftext is only relevant for DocBook output;
         // in that case it is used as value of xreflabel attribute.
+
+        let shorthand = caps.get(2).is_some();
 
         let (id, reftext) = if let Some(id) = caps.get(2) {
             // Trailing whitespace is stripped from a shorthand reftext, so
@@ -1464,14 +1475,33 @@ impl Replacer for InlineAnchorReplacer<'_, '_> {
             )
         };
 
+        // A `[[id]]` shorthand that is immediately preceded by a `[` is the
+        // inner part of a bibliography anchor (`[[[id]]]`) appearing outside a
+        // bibliography list item — e.g. in ordinary prose. Asciidoctor renders
+        // the inner anchor but does *not* catalog it: its inline-anchor scan
+        // (`InlineAnchorScanRx`) requires the `[[` to be preceded by the start
+        // of the string or a character that is neither `\` nor `[`, whereas its
+        // substitution regex has no such guard. We mirror that split here by
+        // still rendering the anchor but skipping registration. The guard is
+        // limited to the shorthand form; the `anchor:id[]` macro form carries no
+        // equivalent exclusion in Asciidoctor. See #769.
+        let part_of_bibliography_anchor = shorthand
+            && caps.get(0).is_some_and(|m| {
+                m.start()
+                    .checked_sub(1)
+                    .and_then(|i| self.haystack.as_bytes().get(i))
+                    == Some(&b'[')
+            });
+
         // Register the inline anchor so that later cross-references can resolve
         // against it. A duplicate ID here is non-fatal (first registration
         // wins), but should still surface the same warning as block and section
         // duplicate IDs.
-        if self
-            .parser
-            .register_ref(id, reftext.as_deref(), crate::document::RefType::Anchor)
-            .is_err()
+        if !part_of_bibliography_anchor
+            && self
+                .parser
+                .register_ref(id, reftext.as_deref(), crate::document::RefType::Anchor)
+                .is_err()
             && !(self.leading_anchor_registered && caps.get(0).is_some_and(|m| m.start() == 0))
         {
             self.parser.record_substitution_warning(
@@ -3379,11 +3409,10 @@ mod tests {
             );
             assert!(!rendered.contains("<a id=\"mid\"></a>[mid]"));
 
-            // The entry is registered as a normal anchor, not a bibliography one.
-            assert_eq!(
-                doc.catalog().get_ref("mid").map(|e| e.ref_type.clone()),
-                Some(crate::document::RefType::Anchor)
-            );
+            // Although the inner anchor is rendered, it is *not* registered in
+            // the catalog: Asciidoctor's inline-anchor scan ignores a `[[id]]`
+            // that is the inner part of a surrounding `[[[id]]]`. See #769.
+            assert!(!doc.catalog().contains_id("mid"));
         }
 
         #[test]

--- a/parser/src/tests/asciidoctor_rb/links_test.rs
+++ b/parser/src/tests/asciidoctor_rb/links_test.rs
@@ -1863,18 +1863,26 @@ non_normative!(
 "###
 );
 
-// Surfaced incompatibility: Asciidoctor does not register a bibliography anchor
-// (`[[[label]]]`) found in prose; this crate registers `label`. Tracked in
-// #769.
-non_normative!(
-    r###"
+#[test]
+fn does_not_match_bibliography_anchor_in_prose_when_scanning_for_inline_anchor() {
+    verifies!(
+        r###"
   test 'does not match bibliography anchor in prose when scanning for inline anchor' do
     doc = document_from_string 'Use [[[label]]] to assign a label to a bibliography entry, but not in a paragraph.'
     refute doc.catalog[:refs].key? 'label'
   end
 
 "###
-);
+    );
+
+    let doc = Parser::default().parse(
+        "Use [[[label]]] to assign a label to a bibliography entry, but not in a paragraph.",
+    );
+
+    // A bibliography anchor in prose (not the prefix of a bibliography list
+    // item) is rendered as an inline anchor but must not be cataloged. See #769.
+    assert!(!doc.catalog().contains_id("label"));
+}
 
 #[test]
 fn repeating_inline_anchor_macro_with_empty_reftext() {


### PR DESCRIPTION
Fixes #769.

## Problem

A bibliography-style anchor (`[[[id]]]`) that appears in ordinary prose — rather than as the prefix of a bibliography list item — was being registered in `catalog[:refs]`. Asciidoctor renders the same inline anchor but does **not** register the id.

The divergence comes from how Asciidoctor separates the two concerns:

- Its inline-anchor **scan** (`InlineAnchorScanRx`, used to build the catalog) requires the `[[` to be preceded by the start of the string or a character that is neither `\` nor `[`, so a `[[id]]` that is the inner part of a surrounding `[[[id]]]` is skipped.
- Its inline-anchor **substitution** regex has no such guard, so the inner anchor is still rendered.

In this crate, `InlineAnchorReplacer` (in `parser/src/content/macros.rs`) performs both rendering *and* registration in a single pass, so it matched the inner `[[id]]` and called `register_ref`, leaving the id in the catalog.

## Fix

Mirror Asciidoctor's split: still render the inner anchor, but skip `register_ref` when a `[[id]]` **shorthand** match is immediately preceded by a `[`. The replacer now receives the haystack so it can inspect the byte before each match.

The guard is deliberately limited to the shorthand form — the `anchor:id[]` macro form carries no equivalent exclusion in Asciidoctor, so its registration is unchanged.

For `Use [[[label]]] to assign a label...`:
- Rendered output is unchanged (`Use [<a id="label"></a>] to assign …`, i.e. `Use [] …`), matching Asciidoctor.
- `label` is no longer present in the catalog.

## Tests

- Promoted the ported `links_test.rb` case (`does not match bibliography anchor in prose when scanning for inline anchor`) from `non_normative!` to a real `verifies!` test asserting the id is absent from the catalog.
- Updated the internal `bibliography_anchor::recognized_only_when_it_prefixes_the_entry` test, whose catalog assertion previously encoded the incorrect behavior (registering the inner anchor). Its render assertions are unchanged; it now asserts the inner id is *not* cataloged.

Full parser lib suite passes (`4047 passed`); `cargo clippy` and `cargo fmt --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eodi6qrNTbzTGgkcVtEpMr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eodi6qrNTbzTGgkcVtEpMr)_