### PR TITLE
fix: Do not register a bibliography anchor found in prose (#769)

### DIFF
--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -144,13 +144,20 @@ fn apply_macros_internal(
     }
 
     if (found_square_bracket && text.contains("[[")) || (found_macroish && text.contains("or:")) {
+        // The haystack is captured so the replacer can inspect the character
+        // immediately preceding each match (see `InlineAnchorReplacer`); prior
+        // passes above may have mutated the rendered text, so the initial `text`
+        // snapshot cannot be reused here.
+        let haystack = content.rendered().to_string();
+
         let replacer = InlineAnchorReplacer {
             parser,
             source: content.original(),
             leading_anchor_registered,
+            haystack: &haystack,
         };
 
-        if let Cow::Owned(new_result) = INLINE_ANCHOR.replace_all(content.rendered(), replacer) {
+        if let Cow::Owned(new_result) = INLINE_ANCHOR.replace_all(&haystack, replacer) {
             content.rendered = new_result.into();
         }
     }
@@ -1433,13 +1440,17 @@ static INLINE_ANCHOR: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 #[derive(Debug)]
-struct InlineAnchorReplacer<'p, 'src> {
+struct InlineAnchorReplacer<'p, 'src, 'h> {
     parser: &'p Parser,
     source: Span<'src>,
     leading_anchor_registered: bool,
+
+    /// The text being scanned, retained so the shorthand form can be tested for
+    /// a preceding `[` (see the bibliography-anchor note in `replace_append`).
+    haystack: &'h str,
 }
 
-impl Replacer for InlineAnchorReplacer<'_, '_> {
+impl Replacer for InlineAnchorReplacer<'_, '_, '_> {
     fn replace_append(&mut self, caps: &Captures<'_>, dest: &mut String) {
         if caps.get(1).is_some() {
             dest.push_str(&caps[0][1..]);
@@ -1464,14 +1475,32 @@ impl Replacer for InlineAnchorReplacer<'_, '_> {
             )
         };
 
+        // A shorthand anchor (`[[id]]`) immediately preceded by a `[` is the
+        // inner anchor of a bibliography-style `[[[id]]]` sequence appearing
+        // outside a bibliography list item (a genuine bibliography anchor is
+        // consumed by the earlier `INLINE_BIBLIO_ANCHOR` pass). Asciidoctor's
+        // inline-anchor *scan* (`InlineAnchorScanRx`) excludes a `[[id]]`
+        // preceded by a `[`, so it renders the anchor but never catalogs the id.
+        // We match that: render below, but skip registration here. This applies
+        // only to the shorthand form (capture group 2), not the `anchor:id[]`
+        // macro form. See #769.
+        let is_bibliography_inner = caps.get(2).is_some()
+            && caps.get(0).is_some_and(|m| {
+                m.start()
+                    .checked_sub(1)
+                    .and_then(|i| self.haystack.as_bytes().get(i))
+                    == Some(&b'[')
+            });
+
         // Register the inline anchor so that later cross-references can resolve
         // against it. A duplicate ID here is non-fatal (first registration
         // wins), but should still surface the same warning as block and section
         // duplicate IDs.
-        if self
-            .parser
-            .register_ref(id, reftext.as_deref(), crate::document::RefType::Anchor)
-            .is_err()
+        if !is_bibliography_inner
+            && self
+                .parser
+                .register_ref(id, reftext.as_deref(), crate::document::RefType::Anchor)
+                .is_err()
             && !(self.leading_anchor_registered && caps.get(0).is_some_and(|m| m.start() == 0))
         {
             self.parser.record_substitution_warning(
@@ -3379,11 +3408,11 @@ mod tests {
             );
             assert!(!rendered.contains("<a id=\"mid\"></a>[mid]"));
 
-            // The entry is registered as a normal anchor, not a bibliography one.
-            assert_eq!(
-                doc.catalog().get_ref("mid").map(|e| e.ref_type.clone()),
-                Some(crate::document::RefType::Anchor)
-            );
+            // The inner `[[mid]]` is preceded by a `[`, so — like Asciidoctor's
+            // inline-anchor scan (`InlineAnchorScanRx`) — the id is rendered but
+            // not registered in the catalog, neither as a bibliography anchor nor
+            // as a normal one. See #769.
+            assert!(doc.catalog().get_ref("mid").is_none());
         }
 
         #[test]

--- a/parser/src/tests/asciidoctor_rb/links_test.rs
+++ b/parser/src/tests/asciidoctor_rb/links_test.rs
@@ -1863,18 +1863,31 @@ non_normative!(
 "###
 );
 
-// Surfaced incompatibility: Asciidoctor does not register a bibliography anchor
-// (`[[[label]]]`) found in prose; this crate registers `label`. Tracked in
-// #769.
-non_normative!(
-    r###"
+#[test]
+fn does_not_match_bibliography_anchor_in_prose_when_scanning_for_inline_anchor() {
+    verifies!(
+        r###"
   test 'does not match bibliography anchor in prose when scanning for inline anchor' do
     doc = document_from_string 'Use [[[label]]] to assign a label to a bibliography entry, but not in a paragraph.'
     refute doc.catalog[:refs].key? 'label'
   end
 
 "###
-);
+    );
+
+    // A bibliography-style anchor (`[[[label]]]`) in ordinary prose (not as the
+    // prefix of a bibliography list item) is rendered like Asciidoctor — the
+    // inner `[[label]]` becomes an empty anchor, leaving a literal `[]` — but the
+    // id is *not* registered in the catalog. See #769.
+    let doc = Parser::default().parse(
+        "Use [[[label]]] to assign a label to a bibliography entry, but not in a paragraph.",
+    );
+    assert!(doc.catalog().get_ref("label").is_none());
+    assert_eq!(
+        rendered_paragraphs(&doc)[0],
+        r##"Use [<a id="label"></a>] to assign a label to a bibliography entry, but not in a paragraph."##
+    );
+}
 
 #[test]
 fn repeating_inline_anchor_macro_with_empty_reftext() {


### PR DESCRIPTION
## Summary

Fixes #769.

A bibliography-style anchor (`[[[label]]]`) that appears in ordinary prose — not as the prefix of a bibliography list item — was being registered in `catalog[:refs]`. The inline-anchor substitution pass (`InlineAnchorReplacer` in `parser/src/content/macros.rs`) matched the inner `[[label]]` and called `register_ref`, so the id leaked into the catalog.

Asciidoctor renders the same inline anchor but does **not** catalog the id: its inline-anchor *scan* (`InlineAnchorScanRx`) excludes a `[[id]]` that is immediately preceded by a `[`, while the *substitution* still renders it.

## Changes

- In `InlineAnchorReplacer`, detect when a shorthand `[[id]]` match is immediately preceded by a `[` (making it the inner anchor of a `[[[…]]]` sequence) and skip `register_ref` for it, while still rendering the anchor. The replacer now carries the scanned text (`haystack`) so it can inspect the preceding byte. The `anchor:id[]` macro form is unaffected, matching Asciidoctor's scan regex.
- Promoted the ported `links_test.rb` case (`does not match bibliography anchor in prose when scanning for inline anchor`) from `non_normative!` to a real verifying test.
- Updated the internal `recognized_only_when_it_prefixes_the_entry` unit test: a mid-entry `[[[mid]]]` is likewise no longer registered (its inner `[[mid]]` is preceded by a `[`), matching Asciidoctor.

## Behavior

For `Use [[[label]]] to assign a label to a bibliography entry, but not in a paragraph.`:

- Rendered output is unchanged: `Use [<a id="label"></a>] to assign …`
- `label` is no longer present in the catalog.

## Testing

- `cargo test -p asciidoc-parser --lib` — all pass (4047 passed, 0 failed).
- `cargo clippy -p asciidoc-parser --all-targets` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRBBSexxxrrbNMk2Syh7Xu

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRBBSexxxrrbNMk2Syh7Xu)_