### PR TITLE
fix: Anchor footnote cross-reference warnings at the footnote (#804)

### DIFF
--- a/parser/src/blocks/quote.rs
+++ b/parser/src/blocks/quote.rs
@@ -432,7 +432,12 @@ impl<'src> QuoteBlock<'src> {
         // must not be lost.
         let mut nested_warning_types: Vec<WarningType> = vec![];
         let owned = OwnedQuoteBlocks::new(body, |source| {
+            // The blocks parse from `source`, an owned copy that does not map to
+            // the document. Mark that so a footnote defined inside records no
+            // (misleading) document location; see `Parser::owned_subsource_depth`.
+            parser.owned_subsource_depth += 1;
             let mut maw = parse_blocks_until(Span::new(source), |_, _| false, parser);
+            parser.owned_subsource_depth -= 1;
             nested_warning_types.extend(maw.warnings.drain(..).map(|w| w.warning));
             OwnedQuoteBlocksInner {
                 blocks: maw.item.item,

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1960,7 +1960,13 @@ fn parse_asciidoc_cell_body<'src>(
     // duration of the parse, so a table found within defaults its cell separator
     // to `!` rather than `|` (matching Asciidoctor's `Document#nested?`).
     parser.nested_document_depth += 1;
+    // The cell body parses from its own owned source (whether include-expanded or
+    // a borrowed `a|` cell), whose offsets do not map to the document. Mark that
+    // so a footnote defined inside records no (misleading) document location; see
+    // `Parser::owned_subsource_depth`.
+    parser.owned_subsource_depth += 1;
     let mut maw = parse_blocks_until(body, |_, _| false, parser);
+    parser.owned_subsource_depth -= 1;
     parser.nested_document_depth -= 1;
     warnings.append(&mut maw.warnings);
 

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -1818,7 +1818,7 @@ impl LookaheadReplacer for InlineFootnoteMacroReplacer<'_, '_, '_> {
                     &normalize_footnote_text(&content),
                     self.all_xrefs,
                 );
-                let index = parser.define_footnote(Some(&id), template, xrefs);
+                let index = parser.define_footnote(Some(&id), template, xrefs, self.source);
                 parser.renderer.render_footnote(
                     &FootnoteRenderParams {
                         index: Some(index.as_str()),
@@ -1850,7 +1850,7 @@ impl LookaheadReplacer for InlineFootnoteMacroReplacer<'_, '_, '_> {
                 &normalize_footnote_text(&content),
                 self.all_xrefs,
             );
-            let index = parser.define_footnote(None, template, xrefs);
+            let index = parser.define_footnote(None, template, xrefs, self.source);
             parser.renderer.render_footnote(
                 &FootnoteRenderParams {
                     index: Some(index.as_str()),

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -246,20 +246,35 @@ pub struct Footnote {
     /// resolution. `None` for the common case of a footnote with no
     /// cross-references.
     pub(crate) deferred: Option<Box<FootnoteDeferred>>,
+
+    /// The location of this footnote's defining occurrence, as a
+    /// `(byte offset, byte length)` pair into the document source, used to
+    /// anchor a cross-reference warning at the footnote rather than at the
+    /// whole document. The range spans the enclosing content the footnote was
+    /// written in (paragraph granularity, matching how a non-footnote
+    /// reference is anchored at its `Content`).
+    ///
+    /// `None` when the defining occurrence is not locatable in the document
+    /// source: a footnote defined while substituting a privately-owned
+    /// sub-source (a Markdown-style blockquote, an AsciiDoc table cell) indexes
+    /// that owned source, which is not contiguous in the document, so storing
+    /// its offset would misplace the warning. Resolution falls back to the
+    /// whole-document span in that case.
+    pub(crate) location: Option<(usize, usize)>,
 }
 
 impl Footnote {
     /// Resolves any cross-references embedded in this footnote's text using
     /// `resolver`, then rebuilds [`text`](Self::text) from the resolved state.
-    /// Any unresolved target is reported in `warnings`, anchored at `source`.
+    /// Any unresolved target is reported in `warnings`.
     ///
-    /// A footnote's text is extracted out of the block it was defined in and
-    /// the footnote itself keeps no span, so `source` is the enclosing
-    /// document's span rather than the reference's own location. That makes two
-    /// bad references in two different footnotes indistinguishable by location;
-    /// narrowing it to the defining occurrence needs footnotes registered from
-    /// an owned sub-source (a Markdown blockquote, an include-expanded table
-    /// cell) to be re-homed first (#804).
+    /// A footnote's text is extracted out of the block it was defined in, so
+    /// the warning is anchored using the footnote's recorded
+    /// [`location`](Self::location) — the enclosing content it was written in —
+    /// reconstructed as a sub-span of `document_source`. When no location was
+    /// recorded (a footnote defined inside an owned sub-source, whose offset
+    /// does not map to the document), the warning falls back to the whole
+    /// `document_source` span.
     ///
     /// A footnote with no cross-references is left untouched.
     pub(crate) fn resolve_references<'src>(
@@ -267,9 +282,13 @@ impl Footnote {
         resolver: &dyn crate::parser::ReferenceResolver,
         renderer: &dyn crate::parser::InlineSubstitutionRenderer,
         warnings: &mut crate::parser::ReferenceWarnings<'src>,
-        source: crate::Span<'src>,
+        document_source: crate::Span<'src>,
     ) {
         if let Some(deferred) = self.deferred.as_mut() {
+            let source = match self.location {
+                Some((offset, len)) => document_source.slice(offset..offset + len),
+                None => document_source,
+            };
             deferred.resolve(resolver, warnings, source);
             self.text = deferred.render(renderer);
         }

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -197,6 +197,23 @@ pub struct Parser {
     /// each AsciiDoc cell, so it nests correctly.
     pub(crate) nested_document_depth: usize,
 
+    /// Number of privately-owned sub-sources currently being parsed in the call
+    /// stack.
+    ///
+    /// A Markdown-style blockquote and an AsciiDoc table cell parse their blocks
+    /// from an owned source string whose byte offsets do not map to the primary
+    /// document source. A footnote defined while such a sub-source is being
+    /// substituted therefore cannot record a document-relative location for its
+    /// cross-reference warning; `define_footnote` reads this counter to detect
+    /// that case and leave the location unset (see
+    /// [`Footnote::location`](crate::document::Footnote)). It is incremented and
+    /// decremented around each owned sub-source parse, so it nests correctly.
+    ///
+    /// Unlike [`nested_document_depth`](Self::nested_document_depth), this also
+    /// counts Markdown-style blockquotes (which are not nested documents), so
+    /// the two cannot be merged.
+    pub(crate) owned_subsource_depth: usize,
+
     /// Source map of the document currently being parsed, populated by
     /// [`Document::parse`] for the duration of the parse (and `None` outside
     /// it).
@@ -373,6 +390,7 @@ impl Default for Parser {
             counter_values: RefCell::new(HashMap::new()),
             locked_attribute_names: HashSet::new(),
             nested_document_depth: 0,
+            owned_subsource_depth: 0,
             source_map: None,
             owned_cell_source_maps: vec![],
             owned_cell_warnings: RefCell::new(vec![]),
@@ -975,12 +993,22 @@ impl Parser {
     /// registering the footnote in the current document's registry. Returns the
     /// number assigned to the footnote.
     ///
+    /// `source` is the span of the content the defining `footnote:[…]` macro
+    /// was written in; its offset into the document source is recorded so a
+    /// cross-reference warning can be anchored at the footnote rather than at
+    /// the whole document. When the footnote is defined while substituting a
+    /// privately-owned sub-source (a Markdown-style blockquote or an AsciiDoc
+    /// table cell — see [`owned_subsource_depth`](Self::owned_subsource_depth)),
+    /// that offset does not map to the document, so no location is recorded and
+    /// resolution falls back to the whole-document span.
+    ///
     /// Takes `&self` so it can be called from the macros substitution step.
     pub(crate) fn define_footnote(
         &self,
         id: Option<&str>,
         text: String,
         xrefs: Vec<crate::content::XrefSegment>,
+        source: crate::Span<'_>,
     ) -> String {
         // A footnote's text is extracted out of the block during macro
         // substitution, so any cross-reference inside it never reaches the
@@ -1006,6 +1034,17 @@ impl Parser {
         // (matching Asciidoctor); the value is therefore kept as a string.
         let index = self.counter("footnote-number", None);
 
+        // Record the defining occurrence's location only when it is locatable in
+        // the document source. A footnote defined inside an owned sub-source
+        // indexes that private source, whose offset would misplace the warning,
+        // so it is left unrecorded (resolution then falls back to the
+        // whole-document span).
+        let location = if self.owned_subsource_depth == 0 {
+            Some((source.byte_offset(), source.data().len()))
+        } else {
+            None
+        };
+
         self.catalog
             .borrow_mut()
             .register_footnote(crate::document::Footnote {
@@ -1013,6 +1052,7 @@ impl Parser {
                 id: id.map(|s| s.to_owned()),
                 text,
                 deferred,
+                location,
             });
 
         index

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -200,14 +200,16 @@ pub struct Parser {
     /// Number of privately-owned sub-sources currently being parsed in the call
     /// stack.
     ///
-    /// A Markdown-style blockquote and an AsciiDoc table cell parse their blocks
-    /// from an owned source string whose byte offsets do not map to the primary
-    /// document source. A footnote defined while such a sub-source is being
-    /// substituted therefore cannot record a document-relative location for its
-    /// cross-reference warning; `define_footnote` reads this counter to detect
-    /// that case and leave the location unset (see
-    /// [`Footnote::location`](crate::document::Footnote)). It is incremented and
-    /// decremented around each owned sub-source parse, so it nests correctly.
+    /// A Markdown-style blockquote and an AsciiDoc table cell parse their
+    /// blocks from an owned source string whose byte offsets do not map to
+    /// the primary document source. A footnote defined while such a
+    /// sub-source is being substituted therefore cannot record a
+    /// document-relative location for its cross-reference warning;
+    /// `define_footnote` reads this counter to detect that case and leave
+    /// the location unset (see
+    /// [`Footnote::location`](crate::document::Footnote)). It is incremented
+    /// and decremented around each owned sub-source parse, so it nests
+    /// correctly.
     ///
     /// Unlike [`nested_document_depth`](Self::nested_document_depth), this also
     /// counts Markdown-style blockquotes (which are not nested documents), so
@@ -998,8 +1000,9 @@ impl Parser {
     /// cross-reference warning can be anchored at the footnote rather than at
     /// the whole document. When the footnote is defined while substituting a
     /// privately-owned sub-source (a Markdown-style blockquote or an AsciiDoc
-    /// table cell — see [`owned_subsource_depth`](Self::owned_subsource_depth)),
-    /// that offset does not map to the document, so no location is recorded and
+    /// table cell — see
+    /// [`owned_subsource_depth`](Self::owned_subsource_depth)), that offset
+    /// does not map to the document, so no location is recorded and
     /// resolution falls back to the whole-document span.
     ///
     /// Takes `&self` so it can be called from the macros substitution step.

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -712,10 +712,10 @@ mod unresolved_reference_warnings {
 
     #[test]
     fn reported_for_a_reference_inside_a_footnote() {
-        // A footnote's text is lifted out of the block it was written in and the
-        // footnote keeps no span of its own, so the warning is anchored at the
-        // document.
-        let doc = Parser::default().parse("Text.footnote:[See <<nope>>.]\n");
+        // A footnote's text is lifted out of the block it was written in, but the
+        // footnote records the location of its defining occurrence, so the
+        // warning is anchored at that content rather than at the whole document.
+        let doc = Parser::default().parse("Intro.\n\nText.footnote:[See <<nope>>.]\n");
 
         let warnings: Vec<_> = doc.warnings().collect();
         assert_eq!(warnings.len(), 1);
@@ -724,6 +724,59 @@ mod unresolved_reference_warnings {
             warnings[0].warning,
             WarningType::PossibleInvalidReference("nope".to_string())
         );
+
+        assert_eq!(warnings[0].source.line(), 3);
+    }
+
+    #[test]
+    fn distinguishes_two_footnotes_by_location() {
+        // The whole point of #804: two unresolved references in two different
+        // footnotes must be distinguishable by location, so a host can point the
+        // author at the offending footnote.
+        let doc = Parser::default()
+            .parse("First.footnote:[See <<nope-a>>.]\n\nSecond.footnote:[See <<nope-b>>.]\n");
+
+        let mut warnings: Vec<_> = doc.warnings().collect();
+        warnings.sort_by_key(|w| w.source.line());
+        assert_eq!(warnings.len(), 2);
+
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::PossibleInvalidReference("nope-a".to_string())
+        );
+        assert_eq!(warnings[0].source.line(), 1);
+
+        assert_eq!(
+            warnings[1].warning,
+            WarningType::PossibleInvalidReference("nope-b".to_string())
+        );
+        assert_eq!(warnings[1].source.line(), 3);
+    }
+
+    #[test]
+    fn reported_for_a_reference_inside_a_footnote_in_a_markdown_blockquote() {
+        // A footnote defined inside a Markdown-style blockquote indexes the
+        // quote's owned, `>`-stripped body, which is not contiguous in the
+        // document source, so no precise location is recorded and the warning
+        // falls back to the whole-document span rather than a misleading one.
+        //
+        // The footnote sits on a later line of the quote's owned body (offset > 0
+        // there); were that owned offset stored and applied to the document
+        // source it would resolve to some unrelated line, so asserting the
+        // fallback line 1 guards the owned-sub-source guard specifically.
+        let doc =
+            Parser::default().parse("Intro.\n\n> Line one.\n>\n> Text.footnote:[See <<nope>>.]\n");
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::PossibleInvalidReference("nope".to_string())
+        );
+
+        // The fallback anchor is the whole document, which begins at line 1.
+        assert_eq!(warnings[0].source.line(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #804. Split out of #799 (Greptile review).

## Problem

An unresolved cross-reference inside a footnote was reported as a `WarningType::PossibleInvalidReference` document warning anchored at the **whole document** span, because `Footnote` kept no location of its own. Most references are anchored at the `Content` span holding them, but a footnote's text is lifted out of its defining block, so two bad references in two different footnotes produced two warnings whose locations were indistinguishable — a host could not point the author at the offending footnote.

## Change

`Footnote` now records the location of its defining occurrence as a `(byte offset, byte length)` pair into the document source (the `Catalog` carries no `'src` lifetime, so a raw offset is stored rather than a `Span`). During resolution the anchor `Span` is rebuilt from it via `document_source.slice(offset..offset + len)`.

The recorded range is the enclosing content the footnote was written in — paragraph granularity, matching how a non-footnote reference is already anchored at its `Content`. (Reference-*site* precision within a paragraph would need a source offset threaded onto `XrefSegment` through substitution, which #804 notes is a separate, larger change.)

### Guarding the owned-sub-source case

As #804 spells out, the offset on the span held by `InlineFootnoteMacroReplacer` is not always document-relative: a footnote defined inside a Markdown-style blockquote registers into the shared catalog, but its span indexes the quote's owned, `>`-stripped body, which is not contiguous in the document source. Include-expanded (and borrowed) AsciiDoc table cells have the same shape. Storing that offset unguarded would silently produce a *wrong* document location — worse than the current coarse-but-honest one.

A new `Parser::owned_subsource_depth` counter is incremented around each owned sub-source parse (the Markdown blockquote body in `QuoteBlock::parse_markdown`, and the cell body in `parse_asciidoc_cell_body`). `define_footnote` records a location only when the counter is zero; otherwise the footnote records `None` and resolution falls back to the whole-document span, exactly as before. It is kept separate from `nested_document_depth` because that counter does not cover Markdown blockquotes (which are not nested documents) and drives unrelated cell-separator behavior.

## Tests

New/updated cases in `tests::xref::unresolved_reference_warnings`:

- `reported_for_a_reference_inside_a_footnote` — now asserts the warning is anchored at the footnote's own line rather than the document.
- `distinguishes_two_footnotes_by_location` — the crux of the issue: two bad references in two different footnotes now carry distinct locations.
- `reported_for_a_reference_inside_a_footnote_in_a_markdown_blockquote` — a footnote on a later line of a blockquote's owned body falls back to the whole-document span (line 1) rather than a misleading location, verifying the guard.

Full suite passes (4048 lib tests + integration); `cargo fmt --all -- --check`, `cargo clippy --all-targets`, and `cargo doc --no-deps` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lc7Z9omgGV5pE54sCeRXt9)_