### PR TITLE
fix: Skip `////` block comments in the header before the author or revision line

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -57,6 +57,22 @@ impl<'src> Header<'src> {
             } else if line.starts_with("//") && !line.starts_with("///") {
                 comments.push(line);
                 source = line_mi.after;
+            } else if title.is_some()
+                && let Some(after) = skip_block_comment(line, line_mi.after)
+            {
+                // Once a title has been seen, a `////` block comment delimiter
+                // opens a comment block within the header. Skip every line
+                // through the matching closing delimiter (or to the end of the
+                // input if the block is never closed), retaining the whole block
+                // as a single comment so it is not mistaken for the author or
+                // revision line. Blank lines inside the block do not terminate
+                // the header.
+                //
+                // Before a title is seen there is no header author/revision
+                // context to protect, so a leading `////` is left for the block
+                // parser, which retains it as a body-level comment block.
+                comments.push(source.trim_remainder(after).trim_trailing_line_end());
+                source = after;
             } else if line.starts_with(':')
                 && let Some(attr) = Attribute::parse(source, parser)
             {
@@ -261,6 +277,36 @@ impl<'src> HasSpan<'src> for Header<'src> {
     fn span(&self) -> Span<'src> {
         self.source
     }
+}
+
+/// If `line` opens a `////` block comment, consume the comment block and
+/// return the source position immediately after its closing delimiter;
+/// otherwise return `None`.
+///
+/// A block comment delimiter is a line of four or more forward slashes and
+/// nothing else, matching Asciidoctor's comment-block delimiter (a line of
+/// exactly three slashes instead terminates the header and is handled by the
+/// caller). The closing delimiter must repeat the opening line exactly; when
+/// it is absent the block runs to the end of the input, mirroring
+/// Asciidoctor's `read_lines_until`.
+///
+/// `after` is the source immediately following `line` (the opening delimiter).
+fn skip_block_comment<'src>(line: Span<'src>, after: Span<'src>) -> Option<Span<'src>> {
+    let delimiter = line.data();
+    if delimiter.len() < 4 || !delimiter.bytes().all(|b| b == b'/') {
+        return None;
+    }
+
+    let mut next = after;
+    while !next.is_empty() {
+        let line_mi = next.take_normalized_line();
+        next = line_mi.after;
+        if line_mi.item.data() == delimiter {
+            break;
+        }
+    }
+
+    Some(next)
 }
 
 /// Returns the ATX marker character that introduces `line` as a document
@@ -1104,6 +1150,80 @@ mod tests {
 
         assert_eq!(header.main_title(), Some("Main Title"));
         assert_eq!(header.subtitle(), Some("Subtitle 1"));
+    }
+
+    #[test]
+    fn skips_block_comment_before_author() {
+        // A `////` block comment ahead of the author line is skipped and
+        // retained as a single header comment; the author line that follows it
+        // is parsed normally.
+        let doc = Parser::default()
+            .parse("= Title\n////\nAsciidoctor\nrelease artist\n////\nRyan Waldron");
+        let header = doc.header();
+
+        let author = header.authors().first().unwrap();
+        assert_eq!(author.name(), "Ryan Waldron");
+
+        assert_eq!(header.comments().count(), 1);
+        assert_eq!(
+            header.comments().next().unwrap().data(),
+            "////\nAsciidoctor\nrelease artist\n////"
+        );
+    }
+
+    #[test]
+    fn skips_block_comment_with_blank_lines() {
+        // Blank lines inside a header block comment do not terminate the header;
+        // the whole block is skipped and the author line is still recognized.
+        let doc = Parser::default().parse("= Title\n////\n\nAsciidoctor\n\n////\nRyan Waldron");
+        let header = doc.header();
+
+        assert_eq!(header.authors().first().unwrap().name(), "Ryan Waldron");
+        assert_eq!(header.comments().count(), 1);
+    }
+
+    #[test]
+    fn unterminated_block_comment_consumes_rest_of_header() {
+        // An unterminated `////` block comment runs to the end of the input,
+        // mirroring Asciidoctor; nothing after it is parsed as an author line.
+        let doc = Parser::default().parse("= Title\n////\nAsciidoctor\nRyan Waldron");
+        let header = doc.header();
+
+        assert!(header.authors().is_empty());
+        assert_eq!(header.comments().count(), 1);
+    }
+
+    #[test]
+    fn longer_block_comment_delimiter_requires_matching_close() {
+        // The closing delimiter must repeat the opening line exactly: a `////`
+        // line does not close a `/////` block, so the block runs on until the
+        // matching `/////` and the author line after it is recognized.
+        let doc = Parser::default()
+            .parse("= Title\n/////\nAsciidoctor\n////\nstill comment\n/////\nRyan Waldron");
+        let header = doc.header();
+
+        assert_eq!(header.authors().first().unwrap().name(), "Ryan Waldron");
+        assert_eq!(header.comments().count(), 1);
+    }
+
+    #[test]
+    fn three_slashes_is_not_a_block_comment() {
+        // A line of exactly three slashes is not a block comment delimiter
+        // (which requires four or more slashes), so it is not skipped: were it
+        // mistaken for an unterminated block comment it would swallow the rest
+        // of the header, but instead the author and revision lines before it
+        // are captured as before.
+        let mut parser = Parser::default();
+        parser.parse("= Title\nJoe Cool\nv1.0\n///\nstuff");
+
+        assert_eq!(
+            parser.attribute_value("author"),
+            InterpretedValue::Value("Joe Cool")
+        );
+        assert_eq!(
+            parser.attribute_value("revnumber"),
+            InterpretedValue::Value("1.0")
+        );
     }
 
     mod markdown_style_document_title {

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -2117,13 +2117,14 @@ mod interpolation {
 "#
         );
 
-        // Divergence: Asciidoctor treats the unterminated `////` as a comment
-        // block that swallows the rest of the header, so `:hey: there` is never
-        // applied. This crate instead applies `:hey: there`, so the attribute is
-        // set. (The unterminated-comment warning is also not modeled here.)
+        // As in Asciidoctor, the unterminated `////` opens a comment block that
+        // swallows the rest of the header, so `:hey: there` is never applied
+        // (see https://github.com/asciidoc-rs/asciidoc-parser/issues/760).
+        // Remaining divergence: the `unterminated comment block` warning is not
+        // yet modeled (tracked in #731).
         let doc =
             Parser::default().parse("= Document Title\n:foo: bar\n////\n:hey: there\n\ncontent");
-        assert_eq!(doc.attribute_value("hey"), InterpretedValue::Value("there"));
+        assert_eq!(doc.attribute_value("hey"), InterpretedValue::Unset);
     }
 
     #[test]

--- a/parser/src/tests/asciidoctor_rb/parser_test.rs
+++ b/parser/src/tests/asciidoctor_rb/parser_test.rs
@@ -1580,11 +1580,10 @@ fn skip_line_comments_before_author() {
     );
 }
 
-// Incompatibility (https://github.com/asciidoc-rs/asciidoc-parser/issues/760):
-// this crate does not skip a `////` block comment in the header ahead of the
-// author line; the `////` delimiter is instead taken as the author.
-non_normative!(
-    r#"
+#[test]
+fn skip_block_comment_before_author() {
+    verifies!(
+        r#"
   test "skip block comment before author" do
     input = <<~'EOS'
     ////
@@ -1603,13 +1602,34 @@ non_normative!(
   end
 
 "#
-);
+    );
 
-// Incompatibility (https://github.com/asciidoc-rs/asciidoc-parser/issues/760):
-// this crate does not skip a `////` block comment in the header ahead of the
-// revision line; the `////` delimiter is instead taken as the revision date.
-non_normative!(
-    r#"
+    // A `////` block comment preceding the author line is skipped in its
+    // entirety (synthetic title added so the author line is recognized).
+    let mut parser = Parser::default();
+    parser.parse("= Document Title\n////\nAsciidoctor\nrelease artist\n////\nRyan Waldron");
+    assert_eq!(
+        parser.attribute_value("author"),
+        InterpretedValue::Value("Ryan Waldron")
+    );
+    assert_eq!(
+        parser.attribute_value("firstname"),
+        InterpretedValue::Value("Ryan")
+    );
+    assert_eq!(
+        parser.attribute_value("lastname"),
+        InterpretedValue::Value("Waldron")
+    );
+    assert_eq!(
+        parser.attribute_value("authorinitials"),
+        InterpretedValue::Value("RW")
+    );
+}
+
+#[test]
+fn skip_block_comment_before_rev() {
+    verifies!(
+        r#"
   test "skip block comment before rev" do
     input = <<~'EOS'
     Ryan Waldron
@@ -1628,7 +1648,27 @@ non_normative!(
   end
 
 "#
-);
+    );
+
+    // A `////` block comment between the author line and the revision line is
+    // skipped, so the revision line that follows it is parsed (synthetic title
+    // added so the author line is recognized).
+    let mut parser = Parser::default();
+    let doc = parser.parse(
+        "= Document Title\nRyan Waldron\n////\nAsciidoctor\nrelease info\n////\nv0.0.7, 2013-12-18",
+    );
+    assert_eq!(
+        parser.attribute_value("author"),
+        InterpretedValue::Value("Ryan Waldron")
+    );
+
+    let rev = doc
+        .header()
+        .revision_line()
+        .expect("expected a revision line");
+    assert_eq!(rev.revnumber(), Some("0.0.7"));
+    assert_eq!(rev.revdate(), "2013-12-18");
+}
 
 #[test]
 fn break_header_at_line_with_three_forward_slashes() {


### PR DESCRIPTION
## Summary

Fixes #760.

`document/header.rs` skipped single-line (`//`) comments in the header but not `////`-delimited block comments. As a result, a block comment placed before the author or revision line was not skipped — the `////` delimiter itself was taken as the author (or revision date).

## Changes

- **`parser/src/document/header.rs`**
  - Added a `skip_block_comment` helper that recognizes a `////` block-comment delimiter (a line of four or more forward slashes) and consumes the comment block through its matching closing delimiter, or to the end of the input if it is never closed (mirroring Asciidoctor's `read_lines_until`).
  - In the header parse loop, once a title has been seen, a `////` delimiter now opens a header comment block that is skipped and retained as a single header comment, so it is no longer mistaken for the author or revision line. Blank lines inside the block do not terminate the header.
  - Before a title is seen, a leading `////` is intentionally left for the block parser, which retains it as a body-level comment block (this crate deliberately keeps comment blocks in the parsed model). This preserves existing body-level comment-block behavior.
  - A line of exactly three slashes (`///`) is unaffected and still terminates the header as before.

## Behavior notes

- An **unterminated** header block comment consumes the rest of the header, matching Asciidoctor. This resolves the previously-documented divergence in `should_warn_if_unterminated_block_comment_is_detected_in_document_header` (the `:hey: there` attribute is now correctly left unset). The `unterminated comment block` **warning** itself is still not modeled (tracked in #731).

## Tests

- Promoted the two `parser_test.rb` cases — `skip block comment before author` and `skip block comment before rev` — from `non_normative!` to verified tests.
- Added unit tests in `header.rs` covering: skipping before the author line (with the retained comment span), blank lines inside the block, an unterminated block consuming the rest of the header, a longer (`/////`) delimiter requiring an exact-match close, and confirmation that a three-slash line is not treated as a block comment.
- Updated `should_warn_if_unterminated_block_comment_is_detected_in_document_header` to assert the new (Asciidoctor-matching) attribute behavior.

Full `asciidoc-parser` test suite passes and `cargo clippy` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSbFByGS5VBeoy3pqpx24Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSbFByGS5VBeoy3pqpx24Z)_