### PR TITLE
fix: Resolve cross-references embedded in section titles (#770)

### DIFF
--- a/parser/src/blocks/admonition.rs
+++ b/parser/src/blocks/admonition.rs
@@ -41,7 +41,7 @@ pub struct AdmonitionBlock<'src> {
     blocks: Vec<Block<'src>>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    title: Option<String>,
+    pub(crate) title: Option<Content<'src>>,
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
@@ -374,7 +374,7 @@ impl<'src> IsBlock<'src> for AdmonitionBlock<'src> {
     }
 
     fn title(&self) -> Option<&str> {
-        self.title.as_deref()
+        self.title.as_ref().map(Content::rendered_str)
     }
 
     fn anchor(&'src self) -> Option<Span<'src>> {

--- a/parser/src/blocks/admonition.rs
+++ b/parser/src/blocks/admonition.rs
@@ -41,13 +41,24 @@ pub struct AdmonitionBlock<'src> {
     blocks: Vec<Block<'src>>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    pub(crate) title: Option<Content<'src>>,
+    title: Option<Content<'src>>,
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
 }
 
 impl<'src> AdmonitionBlock<'src> {
+    /// Returns the block's title as a mutable [`Content`], if the block has
+    /// one.
+    ///
+    /// This narrow seam exists for the document-order title resolution pass
+    /// (see `document::title_refs`), which installs the re-rendered title
+    /// after resolving any cross-references embedded in it. All other access
+    /// goes through the read-only [`IsBlock::title`] accessor.
+    pub(crate) fn title_content_mut(&mut self) -> Option<&mut Content<'src>> {
+        self.title.as_mut()
+    }
+
     /// Parse an admonition block, if the given metadata and content describe
     /// one.
     ///

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -297,7 +297,12 @@ impl<'src> Block<'src> {
         if let Some(pending_title) = parser.pending_block_title.take()
             && metadata.title.is_none()
         {
-            metadata.title = Some(pending_title);
+            // The carried title arrives already rendered; wrap it as a
+            // cross-reference-free `Content` anchored at the block's start.
+            metadata.title = Some(crate::content::Content::from_filtered(
+                metadata.block_start,
+                pending_title,
+            ));
         }
 
         // Tolerate a blank line between a block's metadata (title, anchor, or
@@ -815,6 +820,52 @@ impl<'src> Block<'src> {
 
         for child in self.nested_blocks_mut() {
             child.resolve_references(resolver, renderer, warnings);
+        }
+    }
+
+    /// Returns this block's *block title* (`.Title`) as a [`Content`], when the
+    /// block has one.
+    ///
+    /// This is the decorative title carried above a block, distinct from a
+    /// section's heading (which is exposed through
+    /// [`content_mut`](Self::content_mut)). Used by the document-order title
+    /// resolution pass to resolve a cross-reference embedded in a block title.
+    /// Blocks that never carry a title return `None`.
+    pub(crate) fn block_title_content(&self) -> Option<&Content<'src>> {
+        match self {
+            Self::Simple(b) => b.title.as_ref(),
+            Self::Media(b) => b.title.as_ref(),
+            Self::List(b) => b.title.as_ref(),
+            Self::RawDelimited(b) => b.title.as_ref(),
+            Self::CompoundDelimited(b) => b.title.as_ref(),
+            Self::Admonition(b) => b.title.as_ref(),
+            Self::Quote(b) => b.title.as_ref(),
+            Self::Table(b) => b.title.as_ref(),
+            Self::Break(b) => b.title.as_ref(),
+            _ => None,
+        }
+    }
+
+    /// Overwrites this block's *block title* rendered text, used by the
+    /// document-order title resolution pass to install a title whose
+    /// cross-references have been resolved. A no-op on a block that has no
+    /// title.
+    pub(crate) fn set_block_title_rendered(&mut self, rendered: String) {
+        let title = match self {
+            Self::Simple(b) => &mut b.title,
+            Self::Media(b) => &mut b.title,
+            Self::List(b) => &mut b.title,
+            Self::RawDelimited(b) => &mut b.title,
+            Self::CompoundDelimited(b) => &mut b.title,
+            Self::Admonition(b) => &mut b.title,
+            Self::Quote(b) => &mut b.title,
+            Self::Table(b) => &mut b.title,
+            Self::Break(b) => &mut b.title,
+            _ => return,
+        };
+
+        if let Some(content) = title {
+            content.set_rendered(rendered);
         }
     }
 }

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -792,16 +792,13 @@ impl<'src> Block<'src> {
         renderer: &dyn InlineSubstitutionRenderer,
         warnings: &mut ReferenceWarnings<'src>,
     ) {
-        // A section's resolvable content is its title, which is resolved
-        // instead by the document-order title pass
-        // (`title_refs::resolve_title_references`): that pass coordinates
-        // cross-references *between* titles (forward and circular), which
-        // per-content resolution cannot see. Resolving it here too would
-        // overwrite that result with an isolated, catalog-reftext-based
-        // rendering, so section content is skipped here.
-        if !matches!(self, Self::Section(_))
-            && let Some(content) = self.content_mut()
-        {
+        // A section is not resolved here: its resolvable content is its
+        // heading, which `content_mut` deliberately does not expose (see
+        // `SectionBlock`). Headings are resolved by the document-order title
+        // pass (`title_refs::resolve_title_references`), which coordinates
+        // cross-references *between* titles (forward and circular) — something
+        // per-content resolution cannot see.
+        if let Some(content) = self.content_mut() {
             content.resolve_references(resolver, renderer, warnings);
         }
 
@@ -846,26 +843,23 @@ impl<'src> Block<'src> {
         }
     }
 
-    /// Overwrites this block's *block title* rendered text, used by the
+    /// The mutable counterpart of [`block_title_content`], used by the
     /// document-order title resolution pass to install a title whose
-    /// cross-references have been resolved. A no-op on a block that has no
-    /// title.
-    pub(crate) fn set_block_title_rendered(&mut self, rendered: String) {
-        let title = match self {
-            Self::Simple(b) => &mut b.title,
-            Self::Media(b) => &mut b.title,
-            Self::List(b) => &mut b.title,
-            Self::RawDelimited(b) => &mut b.title,
-            Self::CompoundDelimited(b) => &mut b.title,
-            Self::Admonition(b) => &mut b.title,
-            Self::Quote(b) => &mut b.title,
-            Self::Table(b) => &mut b.title,
-            Self::Break(b) => &mut b.title,
-            _ => return,
-        };
-
-        if let Some(content) = title {
-            content.set_rendered(rendered);
+    /// cross-references have been resolved.
+    ///
+    /// [`block_title_content`]: Self::block_title_content
+    pub(crate) fn block_title_content_mut(&mut self) -> Option<&mut Content<'src>> {
+        match self {
+            Self::Simple(b) => b.title.as_mut(),
+            Self::Media(b) => b.title.as_mut(),
+            Self::List(b) => b.title.as_mut(),
+            Self::RawDelimited(b) => b.title.as_mut(),
+            Self::CompoundDelimited(b) => b.title.as_mut(),
+            Self::Admonition(b) => b.title.as_mut(),
+            Self::Quote(b) => b.title.as_mut(),
+            Self::Table(b) => b.title.as_mut(),
+            Self::Break(b) => b.title.as_mut(),
+            _ => None,
         }
     }
 }

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -297,9 +297,10 @@ impl<'src> Block<'src> {
         if let Some(pending_title) = parser.pending_block_title.take()
             && metadata.title.is_none()
         {
-            // The carried title arrives already rendered; wrap it as a
-            // cross-reference-free `Content` anchored at the block's start.
-            metadata.title = Some(crate::content::Content::from_filtered(
+            // The carried title arrives as an owned snapshot; rebuild it as a
+            // `Content` anchored at the block's start, restoring any deferred
+            // cross-references so the title pass can still resolve them.
+            metadata.title = Some(crate::content::Content::from_owned_title(
                 metadata.block_start,
                 pending_title,
             ));

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -820,45 +820,25 @@ impl<'src> Block<'src> {
         }
     }
 
-    /// Returns this block's *block title* (`.Title`) as a [`Content`], when the
-    /// block has one.
+    /// Returns this block's *block title* (`.Title`) as a mutable [`Content`],
+    /// when the block has one.
     ///
     /// This is the decorative title carried above a block, distinct from a
-    /// section's heading (which is exposed through
-    /// [`content_mut`](Self::content_mut)). Used by the document-order title
-    /// resolution pass to resolve a cross-reference embedded in a block title.
-    /// Blocks that never carry a title return `None`.
-    pub(crate) fn block_title_content(&self) -> Option<&Content<'src>> {
-        match self {
-            Self::Simple(b) => b.title.as_ref(),
-            Self::Media(b) => b.title.as_ref(),
-            Self::List(b) => b.title.as_ref(),
-            Self::RawDelimited(b) => b.title.as_ref(),
-            Self::CompoundDelimited(b) => b.title.as_ref(),
-            Self::Admonition(b) => b.title.as_ref(),
-            Self::Quote(b) => b.title.as_ref(),
-            Self::Table(b) => b.title.as_ref(),
-            Self::Break(b) => b.title.as_ref(),
-            _ => None,
-        }
-    }
-
-    /// The mutable counterpart of [`block_title_content`], used by the
-    /// document-order title resolution pass to install a title whose
-    /// cross-references have been resolved.
-    ///
-    /// [`block_title_content`]: Self::block_title_content
+    /// section's heading. Used only by the document-order title resolution
+    /// pass, which reads a title's deferred cross-references and installs the
+    /// re-rendered title once they are resolved. Blocks that never carry a
+    /// title return `None`.
     pub(crate) fn block_title_content_mut(&mut self) -> Option<&mut Content<'src>> {
         match self {
-            Self::Simple(b) => b.title.as_mut(),
-            Self::Media(b) => b.title.as_mut(),
-            Self::List(b) => b.title.as_mut(),
-            Self::RawDelimited(b) => b.title.as_mut(),
-            Self::CompoundDelimited(b) => b.title.as_mut(),
-            Self::Admonition(b) => b.title.as_mut(),
-            Self::Quote(b) => b.title.as_mut(),
-            Self::Table(b) => b.title.as_mut(),
-            Self::Break(b) => b.title.as_mut(),
+            Self::Simple(b) => b.title_content_mut(),
+            Self::Media(b) => b.title_content_mut(),
+            Self::List(b) => b.title_content_mut(),
+            Self::RawDelimited(b) => b.title_content_mut(),
+            Self::CompoundDelimited(b) => b.title_content_mut(),
+            Self::Admonition(b) => b.title_content_mut(),
+            Self::Quote(b) => b.title_content_mut(),
+            Self::Table(b) => b.title_content_mut(),
+            Self::Break(b) => b.title_content_mut(),
             _ => None,
         }
     }

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -787,7 +787,16 @@ impl<'src> Block<'src> {
         renderer: &dyn InlineSubstitutionRenderer,
         warnings: &mut ReferenceWarnings<'src>,
     ) {
-        if let Some(content) = self.content_mut() {
+        // A section's resolvable content is its title, which is resolved
+        // instead by the document-order title pass
+        // (`title_refs::resolve_title_references`): that pass coordinates
+        // cross-references *between* titles (forward and circular), which
+        // per-content resolution cannot see. Resolving it here too would
+        // overwrite that result with an isolated, catalog-reftext-based
+        // rendering, so section content is skipped here.
+        if !matches!(self, Self::Section(_))
+            && let Some(content) = self.content_mut()
+        {
             content.resolve_references(resolver, renderer, warnings);
         }
 

--- a/parser/src/blocks/break.rs
+++ b/parser/src/blocks/break.rs
@@ -13,7 +13,7 @@ pub struct Break<'src> {
     type_: BreakType,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    pub(crate) title: Option<Content<'src>>,
+    title: Option<Content<'src>>,
     anchor: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
 }
@@ -38,6 +38,17 @@ impl std::fmt::Debug for BreakType {
 }
 
 impl<'src> Break<'src> {
+    /// Returns the block's title as a mutable [`Content`], if the block has
+    /// one.
+    ///
+    /// This narrow seam exists for the document-order title resolution pass
+    /// (see `document::title_refs`), which installs the re-rendered title
+    /// after resolving any cross-references embedded in it. All other access
+    /// goes through the read-only [`IsBlock::title`] accessor.
+    pub(crate) fn title_content_mut(&mut self) -> Option<&mut Content<'src>> {
+        self.title.as_mut()
+    }
+
     pub(crate) fn parse(
         metadata: &BlockMetadata<'src>,
         _parser: &mut Parser,

--- a/parser/src/blocks/break.rs
+++ b/parser/src/blocks/break.rs
@@ -2,6 +2,7 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::Attrlist,
     blocks::{ContentModel, IsBlock, metadata::BlockMetadata},
+    content::Content,
     span::MatchedItem,
     strings::CowStr,
 };
@@ -12,7 +13,7 @@ pub struct Break<'src> {
     type_: BreakType,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    title: Option<String>,
+    pub(crate) title: Option<Content<'src>>,
     anchor: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
 }
@@ -98,7 +99,7 @@ impl<'src> IsBlock<'src> for Break<'src> {
     }
 
     fn title(&self) -> Option<&str> {
-        self.title.as_deref()
+        self.title.as_ref().map(Content::rendered_str)
     }
 
     fn anchor(&'src self) -> Option<Span<'src>> {

--- a/parser/src/blocks/compound_delimited.rs
+++ b/parser/src/blocks/compound_delimited.rs
@@ -34,7 +34,7 @@ pub struct CompoundDelimitedBlock<'src> {
     context: CowStr<'src>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    pub(crate) title: Option<Content<'src>>,
+    title: Option<Content<'src>>,
     caption: Option<String>,
     number: Option<usize>,
     anchor: Option<Span<'src>>,
@@ -43,6 +43,17 @@ pub struct CompoundDelimitedBlock<'src> {
 }
 
 impl<'src> CompoundDelimitedBlock<'src> {
+    /// Returns the block's title as a mutable [`Content`], if the block has
+    /// one.
+    ///
+    /// This narrow seam exists for the document-order title resolution pass
+    /// (see `document::title_refs`), which installs the re-rendered title
+    /// after resolving any cross-references embedded in it. All other access
+    /// goes through the read-only [`IsBlock::title`] accessor.
+    pub(crate) fn title_content_mut(&mut self) -> Option<&mut Content<'src>> {
+        self.title.as_mut()
+    }
+
     pub(crate) fn is_valid_delimiter(line: &Span<'src>) -> bool {
         let data = line.data();
 

--- a/parser/src/blocks/compound_delimited.rs
+++ b/parser/src/blocks/compound_delimited.rs
@@ -7,6 +7,7 @@ use crate::{
         Block, ContentModel, IsBlock, caption::assign_block_caption, metadata::BlockMetadata,
         parse_utils::parse_blocks_until,
     },
+    content::Content,
     internal::debug::DebugSliceReference,
     span::MatchedItem,
     strings::CowStr,
@@ -33,7 +34,7 @@ pub struct CompoundDelimitedBlock<'src> {
     context: CowStr<'src>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    title: Option<String>,
+    pub(crate) title: Option<Content<'src>>,
     caption: Option<String>,
     number: Option<usize>,
     anchor: Option<Span<'src>>,
@@ -214,7 +215,7 @@ impl<'src> IsBlock<'src> for CompoundDelimitedBlock<'src> {
     }
 
     fn title(&self) -> Option<&str> {
-        self.title.as_deref()
+        self.title.as_ref().map(Content::rendered_str)
     }
 
     fn caption(&self) -> Option<&str> {

--- a/parser/src/blocks/is_block.rs
+++ b/parser/src/blocks/is_block.rs
@@ -145,10 +145,12 @@ pub trait IsBlock<'src>: Debug + Eq + PartialEq {
     }
 
     /// Returns a mutable reference to this block's own resolvable content — its
-    /// body, section title, or description-list term — if any.
+    /// body or description-list term — if any.
     ///
     /// The default returns `None`; content-bearing blocks override it. This is
-    /// used by in-place passes such as cross-reference resolution.
+    /// used by in-place passes such as cross-reference resolution. A section
+    /// keeps the default: its heading is resolved by the document-order title
+    /// pass, not the per-content pass.
     fn content_mut(&mut self) -> Option<&mut Content<'src>> {
         None
     }

--- a/parser/src/blocks/list.rs
+++ b/parser/src/blocks/list.rs
@@ -4,6 +4,7 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::Attrlist,
     blocks::{Block, ContentModel, IsBlock, ListItem, ListItemMarker, metadata::BlockMetadata},
+    content::Content,
     internal::debug::DebugSliceReference,
     span::MatchedItem,
     strings::CowStr,
@@ -21,7 +22,7 @@ pub struct ListBlock<'src> {
     items: Vec<Block<'src>>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    title: Option<String>,
+    pub(crate) title: Option<Content<'src>>,
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
@@ -392,7 +393,7 @@ impl<'src> IsBlock<'src> for ListBlock<'src> {
     }
 
     fn title(&self) -> Option<&str> {
-        self.title.as_deref()
+        self.title.as_ref().map(Content::rendered_str)
     }
 
     fn anchor(&'src self) -> Option<Span<'src>> {

--- a/parser/src/blocks/list.rs
+++ b/parser/src/blocks/list.rs
@@ -22,7 +22,7 @@ pub struct ListBlock<'src> {
     items: Vec<Block<'src>>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    pub(crate) title: Option<Content<'src>>,
+    title: Option<Content<'src>>,
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
@@ -31,6 +31,17 @@ pub struct ListBlock<'src> {
 }
 
 impl<'src> ListBlock<'src> {
+    /// Returns the block's title as a mutable [`Content`], if the block has
+    /// one.
+    ///
+    /// This narrow seam exists for the document-order title resolution pass
+    /// (see `document::title_refs`), which installs the re-rendered title
+    /// after resolving any cross-references embedded in it. All other access
+    /// goes through the read-only [`IsBlock::title`] accessor.
+    pub(crate) fn title_content_mut(&mut self) -> Option<&mut Content<'src>> {
+        self.title.as_mut()
+    }
+
     pub(crate) fn parse(
         metadata: &BlockMetadata<'src>,
         parser: &mut Parser,

--- a/parser/src/blocks/media.rs
+++ b/parser/src/blocks/media.rs
@@ -2,7 +2,7 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     blocks::{ContentModel, IsBlock, caption, metadata::BlockMetadata},
-    content::substitute_attributes_in_macro_target,
+    content::{Content, substitute_attributes_in_macro_target},
     span::MatchedItem,
     strings::CowStr,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -17,7 +17,7 @@ pub struct MediaBlock<'src> {
     macro_attrlist: Attrlist<'src>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    title: Option<String>,
+    pub(crate) title: Option<Content<'src>>,
     caption: Option<String>,
     number: Option<usize>,
     anchor: Option<Span<'src>>,
@@ -290,7 +290,7 @@ impl<'src> IsBlock<'src> for MediaBlock<'src> {
     }
 
     fn title(&self) -> Option<&str> {
-        self.title.as_deref()
+        self.title.as_ref().map(Content::rendered_str)
     }
 
     fn caption(&self) -> Option<&str> {

--- a/parser/src/blocks/media.rs
+++ b/parser/src/blocks/media.rs
@@ -17,7 +17,7 @@ pub struct MediaBlock<'src> {
     macro_attrlist: Attrlist<'src>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    pub(crate) title: Option<Content<'src>>,
+    title: Option<Content<'src>>,
     caption: Option<String>,
     number: Option<usize>,
     anchor: Option<Span<'src>>,
@@ -61,6 +61,17 @@ impl std::fmt::Debug for MediaType {
 }
 
 impl<'src> MediaBlock<'src> {
+    /// Returns the block's title as a mutable [`Content`], if the block has
+    /// one.
+    ///
+    /// This narrow seam exists for the document-order title resolution pass
+    /// (see `document::title_refs`), which installs the re-rendered title
+    /// after resolving any cross-references embedded in it. All other access
+    /// goes through the read-only [`IsBlock::title`] accessor.
+    pub(crate) fn title_content_mut(&mut self) -> Option<&mut Content<'src>> {
+        self.title.as_mut()
+    }
+
     pub(crate) fn parse(
         metadata: &BlockMetadata<'src>,
         parser: &mut Parser,

--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -16,8 +16,11 @@ pub(crate) struct BlockMetadata<'src> {
     /// The block's raw title, if any.
     pub(crate) title_source: Option<Span<'src>>,
 
-    /// The block's rendered title, if any.
-    pub(crate) title: Option<String>,
+    /// The block's title, if any, retained as a [`Content`] so a cross-reference
+    /// embedded in the title can be resolved once the catalog is complete (by
+    /// the document-order title pass). Its rendered text is the block's title
+    /// string.
+    pub(crate) title: Option<Content<'src>>,
 
     /// The block's anchor, if any. The span does not include the opening or
     /// closing square brace pair, nor reftext if it exists.
@@ -161,11 +164,11 @@ impl<'src> BlockMetadata<'src> {
         // Determine the block title. A `.Title` line takes precedence; failing
         // that, a `title=` attribute in the block's attribute list supplies the
         // title (Asciidoctor treats the two as equivalent).
-        let title = match title_source.as_ref() {
+        let title: Option<Content<'src>> = match title_source.as_ref() {
             Some(span) => {
                 let mut content = Content::from(*span);
                 SubstitutionGroup::Normal.apply(&mut content, parser, None);
-                Some(content.rendered.into_string())
+                Some(content)
             }
             None => attrlist.as_ref().and_then(Attrlist::title_attribute).map(
                 |(value, value_is_substituted)| {
@@ -177,13 +180,21 @@ impl<'src> BlockMetadata<'src> {
                     // substitutions now, matching a `.Title` line. (Attribute
                     // references in the value were resolved when the attribute
                     // list was parsed, so they are not re-evaluated here.)
-                    if value_is_substituted {
+                    //
+                    // A `title=` value's rendered text is anchored at the block's
+                    // source (rather than at the attribute value, which is
+                    // borrowed from `attrlist` and would outlive this borrow):
+                    // any cross-reference in it is rendered to its fallback here
+                    // and not re-resolved later, matching the pre-existing
+                    // treatment of a substituted value.
+                    let rendered = if value_is_substituted {
                         value.to_string()
                     } else {
                         let mut content = Content::from(Span::new(value));
                         SubstitutionGroup::Normal.apply(&mut content, parser, None);
                         content.rendered.into_string()
-                    }
+                    };
+                    Content::from_filtered(source, rendered)
                 },
             ),
         };
@@ -200,6 +211,12 @@ impl<'src> BlockMetadata<'src> {
             },
             warnings,
         }
+    }
+
+    /// Returns the block's rendered title text, if any.
+    #[cfg(test)]
+    pub(crate) fn title_str(&self) -> Option<&str> {
+        self.title.as_ref().map(Content::rendered_str)
     }
 
     /// Return `true` if title, anchor, and attrlist are all empty.
@@ -323,7 +340,7 @@ mod tests {
         let input = ".My Title\n[[my-anchor]]\n[role=\"example\"]\nContent\n";
         let metadata = super::BlockMetadata::new(input);
 
-        assert_eq!(metadata.title.as_deref(), Some("My Title"));
+        assert_eq!(metadata.title_str(), Some("My Title"));
         assert_eq!(
             metadata.anchor.unwrap(),
             Span {
@@ -341,7 +358,7 @@ mod tests {
         let input = "[[another-anchor]]\n.Another Title\n[role=\"sidebar\"]\nContent\n";
         let metadata = super::BlockMetadata::new(input);
 
-        assert_eq!(metadata.title.as_deref(), Some("Another Title"));
+        assert_eq!(metadata.title_str(), Some("Another Title"));
         assert_eq!(
             metadata.anchor.unwrap(),
             Span {
@@ -359,7 +376,7 @@ mod tests {
         let input = "[role=\"note\"]\n.Third Title\n[[third-anchor]]\nContent\n";
         let metadata = super::BlockMetadata::new(input);
 
-        assert_eq!(metadata.title.as_deref(), Some("Third Title"));
+        assert_eq!(metadata.title_str(), Some("Third Title"));
         assert_eq!(
             metadata.anchor.unwrap(),
             Span {
@@ -377,7 +394,7 @@ mod tests {
         let input = "[[fourth-anchor]]\n[role=\"warning\"]\n.Fourth Title\nContent\n";
         let metadata = super::BlockMetadata::new(input);
 
-        assert_eq!(metadata.title.as_deref(), Some("Fourth Title"));
+        assert_eq!(metadata.title_str(), Some("Fourth Title"));
         assert_eq!(
             metadata.anchor.unwrap(),
             Span {
@@ -395,7 +412,7 @@ mod tests {
         let input = ".Just Title\n[role=\"tip\"]\nContent\n";
         let metadata = super::BlockMetadata::new(input);
 
-        assert_eq!(metadata.title.as_deref(), Some("Just Title"));
+        assert_eq!(metadata.title_str(), Some("Just Title"));
         assert!(metadata.anchor.is_none());
         assert!(metadata.attrlist.is_some());
     }
@@ -584,7 +601,7 @@ mod tests {
                 "[foo=bar]\n.My Title\n[baz=qux]\ncontent\n",
             );
 
-            assert_eq!(metadata.title.as_deref(), Some("My Title"));
+            assert_eq!(metadata.title_str(), Some("My Title"));
 
             let attrlist = metadata.attrlist.as_ref().unwrap();
             assert_eq!(attrlist.named_attribute("foo").unwrap().value(), "bar");
@@ -694,7 +711,7 @@ mod tests {
                 "[#id1]\n.Title\n[.r1.r2]\n[foo=bar]\ncontent\n",
             );
 
-            assert_eq!(metadata.title.as_deref(), Some("Title"));
+            assert_eq!(metadata.title_str(), Some("Title"));
 
             let attrlist = metadata.attrlist.as_ref().unwrap();
             assert_eq!(attrlist.id().unwrap(), "id1");
@@ -713,7 +730,7 @@ mod tests {
             let metadata =
                 crate::blocks::metadata::BlockMetadata::new("[title=\"My Title\"]\ncontent\n");
 
-            assert_eq!(metadata.title.as_deref(), Some("My Title"));
+            assert_eq!(metadata.title_str(), Some("My Title"));
 
             // A title supplied through an attribute has no `.Title` source line.
             assert!(metadata.title_source.is_none());
@@ -727,7 +744,7 @@ mod tests {
                 ".Line Title\n[title=\"Attr Title\"]\ncontent\n",
             );
 
-            assert_eq!(metadata.title.as_deref(), Some("Line Title"));
+            assert_eq!(metadata.title_str(), Some("Line Title"));
             assert!(metadata.title_source.is_some());
         }
 
@@ -739,7 +756,7 @@ mod tests {
             let metadata =
                 crate::blocks::metadata::BlockMetadata::new("[title=\"a > b\"]\ncontent\n");
 
-            assert_eq!(metadata.title.as_deref(), Some("a &gt; b"));
+            assert_eq!(metadata.title_str(), Some("a &gt; b"));
         }
 
         #[test]
@@ -751,7 +768,7 @@ mod tests {
             let metadata =
                 crate::blocks::metadata::BlockMetadata::new("[title='a > b']\ncontent\n");
 
-            assert_eq!(metadata.title.as_deref(), Some("a &gt; b"));
+            assert_eq!(metadata.title_str(), Some("a &gt; b"));
         }
 
         #[test]
@@ -762,7 +779,7 @@ mod tests {
             let metadata =
                 crate::blocks::metadata::BlockMetadata::new("[title='*bold*']\ncontent\n");
 
-            assert_eq!(metadata.title.as_deref(), Some("<strong>bold</strong>"));
+            assert_eq!(metadata.title_str(), Some("<strong>bold</strong>"));
         }
 
         #[test]
@@ -771,7 +788,7 @@ mod tests {
             // mirroring `.{empty}`.
             let metadata = crate::blocks::metadata::BlockMetadata::new("[title=]\ncontent\n");
 
-            assert_eq!(metadata.title.as_deref(), Some(""));
+            assert_eq!(metadata.title_str(), Some(""));
         }
 
         #[test]
@@ -795,7 +812,7 @@ mod tests {
                 "[title=\"Merged Title\"]\n[sidebar]\ncontent\n",
             );
 
-            assert_eq!(metadata.title.as_deref(), Some("Merged Title"));
+            assert_eq!(metadata.title_str(), Some("Merged Title"));
 
             let attrlist = metadata.attrlist.as_ref().unwrap();
             assert_eq!(attrlist.block_style().unwrap(), "sidebar");

--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -16,10 +16,10 @@ pub(crate) struct BlockMetadata<'src> {
     /// The block's raw title, if any.
     pub(crate) title_source: Option<Span<'src>>,
 
-    /// The block's title, if any, retained as a [`Content`] so a cross-reference
-    /// embedded in the title can be resolved once the catalog is complete (by
-    /// the document-order title pass). Its rendered text is the block's title
-    /// string.
+    /// The block's title, if any, retained as a [`Content`] so a
+    /// cross-reference embedded in the title can be resolved once the
+    /// catalog is complete (by the document-order title pass). Its rendered
+    /// text is the block's title string.
     pub(crate) title: Option<Content<'src>>,
 
     /// The block's anchor, if any. The span does not include the opening or

--- a/parser/src/blocks/quote.rs
+++ b/parser/src/blocks/quote.rs
@@ -101,13 +101,24 @@ pub struct QuoteBlock<'src> {
     citetitle: Option<String>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    pub(crate) title: Option<Content<'src>>,
+    title: Option<Content<'src>>,
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
 }
 
 impl<'src> QuoteBlock<'src> {
+    /// Returns the block's title as a mutable [`Content`], if the block has
+    /// one.
+    ///
+    /// This narrow seam exists for the document-order title resolution pass
+    /// (see `document::title_refs`), which installs the re-rendered title
+    /// after resolving any cross-references embedded in it. All other access
+    /// goes through the read-only [`IsBlock::title`] accessor.
+    pub(crate) fn title_content_mut(&mut self) -> Option<&mut Content<'src>> {
+        self.title.as_mut()
+    }
+
     /// Parse a blockquote, if the given metadata and content describe one.
     ///
     /// Returns `None` (without consuming the block) when the content is not a

--- a/parser/src/blocks/quote.rs
+++ b/parser/src/blocks/quote.rs
@@ -101,7 +101,7 @@ pub struct QuoteBlock<'src> {
     citetitle: Option<String>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    title: Option<String>,
+    pub(crate) title: Option<Content<'src>>,
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
@@ -765,7 +765,7 @@ impl<'src> IsBlock<'src> for QuoteBlock<'src> {
     }
 
     fn title(&self) -> Option<&str> {
-        self.title.as_deref()
+        self.title.as_ref().map(Content::rendered_str)
     }
 
     fn anchor(&'src self) -> Option<Span<'src>> {

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -44,7 +44,7 @@ pub struct RawDelimitedBlock<'src> {
     context: CowStr<'src>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    pub(crate) title: Option<Content<'src>>,
+    title: Option<Content<'src>>,
     caption: Option<String>,
     number: Option<usize>,
     anchor: Option<Span<'src>>,
@@ -54,6 +54,17 @@ pub struct RawDelimitedBlock<'src> {
 }
 
 impl<'src> RawDelimitedBlock<'src> {
+    /// Returns the block's title as a mutable [`Content`], if the block has
+    /// one.
+    ///
+    /// This narrow seam exists for the document-order title resolution pass
+    /// (see `document::title_refs`), which installs the re-rendered title
+    /// after resolving any cross-references embedded in it. All other access
+    /// goes through the read-only [`IsBlock::title`] accessor.
+    pub(crate) fn title_content_mut(&mut self) -> Option<&mut Content<'src>> {
+        self.title.as_mut()
+    }
+
     pub(crate) fn is_valid_delimiter(line: &Span<'src>) -> bool {
         let data = line.data();
 

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -44,7 +44,7 @@ pub struct RawDelimitedBlock<'src> {
     context: CowStr<'src>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    title: Option<String>,
+    pub(crate) title: Option<Content<'src>>,
     caption: Option<String>,
     number: Option<usize>,
     anchor: Option<Span<'src>>,
@@ -387,7 +387,7 @@ impl<'src> IsBlock<'src> for RawDelimitedBlock<'src> {
     }
 
     fn title(&self) -> Option<&str> {
-        self.title.as_deref()
+        self.title.as_ref().map(Content::rendered_str)
     }
 
     fn caption(&self) -> Option<&str> {

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -8,7 +8,7 @@ use crate::{
     blocks::{
         Block, ContentModel, IsBlock, metadata::BlockMetadata, parse_utils::parse_blocks_until,
     },
-    content::{Content, SubstitutionGroup, strip_footnote_marker_spans},
+    content::{Content, SubstitutionGroup, XrefSegment, strip_footnote_marker_spans},
     document::{InterpretedValue, RefType},
     internal::debug::DebugSliceReference,
     parser::XrefSignifier,
@@ -353,6 +353,56 @@ impl<'src> SectionBlock<'src> {
     /// Return the section number assigned to this section, if any.
     pub fn section_number(&'src self) -> Option<&'src SectionNumber> {
         self.section_number.as_ref()
+    }
+
+    /// Returns the section title's deferred cross-reference template and
+    /// segments, if the title contains any cross-references.
+    ///
+    /// Used by the document-order title resolution pass (see
+    /// [`Document::resolve_references`]).
+    ///
+    /// [`Document::resolve_references`]: crate::Document::resolve_references
+    pub(crate) fn section_title_deferred_parts(&self) -> Option<(&str, &[XrefSegment])> {
+        self.section_title.deferred_parts()
+    }
+
+    /// Overwrites the rendered section title, used by the document-order title
+    /// resolution pass to install a title whose cross-references were resolved
+    /// with cross-title coordination.
+    pub(crate) fn set_section_title_rendered(&mut self, rendered: String) {
+        self.section_title.set_rendered(rendered);
+    }
+
+    /// Returns the ID under which this section is registered in the catalog, if
+    /// any, as an owned string.
+    ///
+    /// Mirrors the effective-ID precedence of [`IsBlock::id`] (explicit anchor,
+    /// then attribute-list ID, then the auto-generated section ID) but without
+    /// the `&'src self` borrow, so the document-order title resolution pass can
+    /// key titles by ID while walking `&mut` blocks.
+    pub(crate) fn reference_id(&self) -> Option<String> {
+        self.anchor
+            .map(|a| a.data().to_string())
+            .or_else(|| {
+                self.attrlist
+                    .as_ref()
+                    .and_then(|attrlist| attrlist.id())
+                    .map(str::to_string)
+            })
+            .or_else(|| self.section_id.clone())
+    }
+
+    /// Returns `true` when the section's reference text comes from an explicit
+    /// `reftext` attribute or a `[[id,reftext]]` anchor reftext, rather than
+    /// from its title. Such a section's reference text does not change when its
+    /// title's cross-references resolve, so the title resolution pass does not
+    /// treat it as a recomputable target.
+    pub(crate) fn has_explicit_reftext(&self) -> bool {
+        self.attrlist
+            .as_ref()
+            .and_then(|attrlist| attrlist.named_attribute("reftext"))
+            .is_some()
+            || self.anchor_reftext.is_some()
     }
 }
 

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -441,10 +441,11 @@ impl<'src> IsBlock<'src> for SectionBlock<'src> {
         ContentModel::Compound
     }
 
-    fn content_mut(&mut self) -> Option<&mut Content<'src>> {
-        // The section title is the section's own resolvable content.
-        Some(&mut self.section_title)
-    }
+    // `content_mut` keeps the default `None`: the section's own resolvable
+    // content is its heading, which is resolved by the document-order title
+    // pass (see `document::title_refs`) rather than the per-content pass —
+    // that pass coordinates cross-references *between* titles (forward and
+    // circular), which per-content resolution cannot see.
 
     fn raw_context(&self) -> CowStr<'src> {
         "section".into()

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -28,7 +28,7 @@ pub struct SectionBlock<'src> {
     blocks: Vec<Block<'src>>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    title: Option<String>,
+    pub(crate) title: Option<Content<'src>>,
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
@@ -208,8 +208,11 @@ impl<'src> SectionBlock<'src> {
         // for its own first block. A discrete heading is an ordinary block, not
         // a section, so it keeps its title. See `Block::parse_internal` for the
         // claiming side.
-        if !discrete && metadata.title.is_some() {
-            parser.pending_block_title = metadata.title.clone();
+        if !discrete && let Some(title) = metadata.title.as_ref() {
+            // The carried title is stashed as its already-rendered string; a
+            // cross-reference in a title carried across a section heading is not
+            // re-resolved for the claiming block (a rare corner).
+            parser.pending_block_title = Some(title.rendered_str().to_string());
         }
 
         let mut maw_blocks = parse_blocks_until(
@@ -460,7 +463,7 @@ impl<'src> IsBlock<'src> for SectionBlock<'src> {
     }
 
     fn title(&self) -> Option<&str> {
-        self.title.as_deref()
+        self.title.as_ref().map(Content::rendered_str)
     }
 
     fn anchor(&'src self) -> Option<Span<'src>> {

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -28,7 +28,7 @@ pub struct SectionBlock<'src> {
     blocks: Vec<Block<'src>>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    pub(crate) title: Option<Content<'src>>,
+    title: Option<Content<'src>>,
     anchor: Option<Span<'src>>,
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -209,10 +209,10 @@ impl<'src> SectionBlock<'src> {
         // a section, so it keeps its title. See `Block::parse_internal` for the
         // claiming side.
         if !discrete && let Some(title) = metadata.title.as_ref() {
-            // The carried title is stashed as its already-rendered string; a
-            // cross-reference in a title carried across a section heading is not
-            // re-resolved for the claiming block (a rare corner).
-            parser.pending_block_title = Some(title.rendered_str().to_string());
+            // The carried title travels as an owned snapshot, keeping any
+            // deferred cross-references so an embedded `<<id>>` still resolves
+            // for the claiming block once the catalog is complete.
+            parser.pending_block_title = Some(title.to_owned_title());
         }
 
         let mut maw_blocks = parse_blocks_until(

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -53,7 +53,7 @@ pub struct SimpleBlock<'src> {
     source: Span<'src>,
     style: SimpleBlockStyle,
     title_source: Option<Span<'src>>,
-    pub(crate) title: Option<Content<'src>>,
+    title: Option<Content<'src>>,
     caption: Option<String>,
     number: Option<usize>,
     anchor: Option<Span<'src>>,
@@ -62,6 +62,17 @@ pub struct SimpleBlock<'src> {
 }
 
 impl<'src> SimpleBlock<'src> {
+    /// Returns the block's title as a mutable [`Content`], if the block has
+    /// one.
+    ///
+    /// This narrow seam exists for the document-order title resolution pass
+    /// (see `document::title_refs`), which installs the re-rendered title
+    /// after resolving any cross-references embedded in it. All other access
+    /// goes through the read-only [`IsBlock::title`] accessor.
+    pub(crate) fn title_content_mut(&mut self) -> Option<&mut Content<'src>> {
+        self.title.as_mut()
+    }
+
     pub(crate) fn parse(
         metadata: &BlockMetadata<'src>,
         parser: &mut Parser,

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -53,7 +53,7 @@ pub struct SimpleBlock<'src> {
     source: Span<'src>,
     style: SimpleBlockStyle,
     title_source: Option<Span<'src>>,
-    title: Option<String>,
+    pub(crate) title: Option<Content<'src>>,
     caption: Option<String>,
     number: Option<usize>,
     anchor: Option<Span<'src>>,
@@ -536,7 +536,7 @@ impl<'src> IsBlock<'src> for SimpleBlock<'src> {
     }
 
     fn title(&self) -> Option<&str> {
-        self.title.as_deref()
+        self.title.as_ref().map(Content::rendered_str)
     }
 
     fn caption(&self) -> Option<&str> {

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -131,7 +131,7 @@ pub struct TableBlock<'src> {
     footer_row: Option<TableRow<'src>>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    pub(crate) title: Option<Content<'src>>,
+    title: Option<Content<'src>>,
     caption: Option<String>,
     number: Option<usize>,
     frame: Frame,
@@ -143,6 +143,17 @@ pub struct TableBlock<'src> {
 }
 
 impl<'src> TableBlock<'src> {
+    /// Returns the block's title as a mutable [`Content`], if the block has
+    /// one.
+    ///
+    /// This narrow seam exists for the document-order title resolution pass
+    /// (see `document::title_refs`), which installs the re-rendered title
+    /// after resolving any cross-references embedded in it. All other access
+    /// goes through the read-only [`IsBlock::title`] accessor.
+    pub(crate) fn title_content_mut(&mut self) -> Option<&mut Content<'src>> {
+        self.title.as_mut()
+    }
+
     /// Returns `true` if `line` is a table delimiter.
     ///
     /// A table delimiter is one of the lead characters `|`, `!`, `,`, or `:`

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -131,7 +131,7 @@ pub struct TableBlock<'src> {
     footer_row: Option<TableRow<'src>>,
     source: Span<'src>,
     title_source: Option<Span<'src>>,
-    title: Option<String>,
+    pub(crate) title: Option<Content<'src>>,
     caption: Option<String>,
     number: Option<usize>,
     frame: Frame,
@@ -540,7 +540,7 @@ impl<'src> IsBlock<'src> for TableBlock<'src> {
     }
 
     fn title(&self) -> Option<&str> {
-        self.title.as_deref()
+        self.title.as_ref().map(Content::rendered_str)
     }
 
     // These forward to the inherent `caption()`/`number()` (the documented

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -165,6 +165,27 @@ pub(crate) fn strip_footnote_marker_spans(s: &str) -> String {
     out
 }
 
+/// A fully-owned snapshot of a rendered title, including any deferred
+/// cross-references it carries.
+///
+/// A block title stashed across a section heading (see
+/// `Parser::pending_block_title`) cannot keep its borrowed [`Content`] — the
+/// parser it rides on has no `'src` lifetime — so the title travels in this
+/// owned form and is rebuilt into a [`Content`] (via
+/// [`Content::from_owned_title`]) when the next block claims it. Carrying the
+/// deferred template and cross-references along means an embedded `<<id>>`
+/// still resolves once the catalog is complete.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct OwnedTitle {
+    /// The rendered title text (the unresolved-fallback rendering when
+    /// cross-references are present).
+    rendered: String,
+
+    /// The placeholder template and cross-references, when the title carries
+    /// any; `None` for the (overwhelmingly common) cross-reference-free title.
+    deferred: Option<(String, Vec<XrefSegment>)>,
+}
+
 impl<'src> Content<'src> {
     /// Constructs a `Content` from a source `Span` and a potentially-filtered
     /// view of that source text.
@@ -174,6 +195,33 @@ impl<'src> Content<'src> {
             rendered: filtered.as_ref().to_string().into(),
             source_lines: None,
             deferred: None,
+        }
+    }
+
+    /// Returns a fully-owned snapshot of this content's rendered text and
+    /// deferred cross-references, for a title that must outlive its source
+    /// borrow (see [`OwnedTitle`]).
+    pub(crate) fn to_owned_title(&self) -> OwnedTitle {
+        OwnedTitle {
+            rendered: self.rendered.as_ref().to_string(),
+            deferred: self
+                .deferred
+                .as_ref()
+                .map(|d| (d.template.clone(), d.xrefs.clone())),
+        }
+    }
+
+    /// Reconstitutes a [`Content`] from an [`OwnedTitle`] snapshot, anchored at
+    /// `span`. The deferred cross-references (when present) are restored, so
+    /// the document-order title pass can still resolve them.
+    pub(crate) fn from_owned_title(span: Span<'src>, title: OwnedTitle) -> Self {
+        Self {
+            original: span,
+            rendered: title.rendered.into(),
+            source_lines: None,
+            deferred: title
+                .deferred
+                .map(|(template, xrefs)| Box::new(DeferredContent { template, xrefs })),
         }
     }
 

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -267,6 +267,31 @@ impl<'src> Content<'src> {
         }
     }
 
+    /// Returns the deferred cross-reference template and segments, if this
+    /// content carries any.
+    ///
+    /// The template is the placeholder-bearing text captured by
+    /// [`finalize_deferred`](Self::finalize_deferred); the segments are the
+    /// cross-references in placeholder order. Used by the document-order title
+    /// resolution pass, which re-renders a title's cross-references with
+    /// cross-title (including circular) coordination that the per-content
+    /// [`resolve_references`](Self::resolve_references) cannot provide.
+    pub(crate) fn deferred_parts(&self) -> Option<(&str, &[XrefSegment])> {
+        self.deferred
+            .as_ref()
+            .map(|d| (d.template.as_str(), d.xrefs.as_slice()))
+    }
+
+    /// Overwrites the rendered text directly.
+    ///
+    /// Used by the document-order title resolution pass, which computes a
+    /// title's final rendering (coordinating cross-title references) and
+    /// installs it here, in place of the per-content resolution that cannot see
+    /// other titles.
+    pub(crate) fn set_rendered(&mut self, rendered: String) {
+        self.rendered = rendered.into();
+    }
+
     /// Returns `true` if this content contains one or more cross-references
     /// that have not yet been resolved to a destination.
     pub fn has_unresolved_refs(&self) -> bool {
@@ -463,6 +488,21 @@ pub(crate) fn rehome_xref_placeholders(
 
     out.push_str(rest);
     (out, local)
+}
+
+/// Splices resolved (or fallback) cross-reference renderings into a placeholder
+/// template, producing the final rendered text.
+///
+/// This is the seam used by the document-order title resolution pass: it hands
+/// in a title's captured template together with a set of [`XrefSegment`]s whose
+/// [`resolved`](XrefSegment::resolved) fields it has filled in with cross-title
+/// (including circular) coordination, and receives the final rendered title.
+pub(crate) fn render_xref_template(
+    template: &str,
+    xrefs: &[XrefSegment],
+    renderer: &dyn InlineSubstitutionRenderer,
+) -> String {
+    render_template(template, xrefs, renderer)
 }
 
 /// Splices resolved (or fallback) cross-reference renderings into a placeholder

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -226,6 +226,17 @@ impl<'src> Content<'src> {
         self.rendered.as_ref()
     }
 
+    /// Returns the final rendered text, borrowed for the duration of `&self`
+    /// rather than for `'src`.
+    ///
+    /// [`rendered`](Self::rendered) ties its result to `'src`, which a block's
+    /// `title(&self)` accessor cannot provide. This shorter-lived borrow lets a
+    /// block expose its title `Content`'s rendered text through the `&self`
+    /// accessor.
+    pub(crate) fn rendered_str(&self) -> &str {
+        self.rendered.as_ref()
+    }
+
     /// Returns an owned copy of the final text after all substitutions have
     /// been applied.
     ///

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -7,7 +7,7 @@ mod content;
 pub use content::Content;
 pub(crate) use content::{
     FOOTNOTE_MARKER_END, FOOTNOTE_MARKER_START, FootnoteDeferred, XrefSegment,
-    rehome_xref_placeholders, strip_footnote_marker_spans,
+    rehome_xref_placeholders, render_xref_template, strip_footnote_marker_spans,
 };
 
 mod macros;

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -6,7 +6,7 @@
 mod content;
 pub use content::Content;
 pub(crate) use content::{
-    FOOTNOTE_MARKER_END, FOOTNOTE_MARKER_START, FootnoteDeferred, XrefSegment,
+    FOOTNOTE_MARKER_END, FOOTNOTE_MARKER_START, FootnoteDeferred, OwnedTitle, XrefSegment,
     rehome_xref_placeholders, render_xref_template, strip_footnote_marker_spans,
 };
 

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -474,6 +474,17 @@ impl<'src> Document<'src> {
                 block.resolve_references(resolver, renderer, &mut warnings);
             }
 
+            // Section titles are resolved separately, in document order, so
+            // cross-references between titles (forward and circular) coordinate
+            // the way Asciidoctor's converts-once-and-caches model does.
+            crate::document::title_refs::resolve_title_references(
+                &mut dependent.blocks,
+                &dependent.catalog,
+                resolver,
+                renderer,
+                &mut warnings,
+            );
+
             // Footnote text is extracted out of block content, so its
             // cross-references are resolved here rather than by the block pass
             // above. The host resolver does not alias the catalog, so the
@@ -510,6 +521,17 @@ impl<'src> Document<'src> {
             for block in dependent.blocks.iter_mut() {
                 block.resolve_references(&resolver, renderer, &mut warnings);
             }
+
+            // Section titles are resolved separately, in document order, so
+            // cross-references between titles (forward and circular) coordinate
+            // the way Asciidoctor's converts-once-and-caches model does.
+            crate::document::title_refs::resolve_title_references(
+                &mut dependent.blocks,
+                &dependent.catalog,
+                &resolver,
+                renderer,
+                &mut warnings,
+            );
 
             // Footnote text is extracted out of block content, so its
             // cross-references are resolved here rather than by the block pass

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -371,15 +371,16 @@ struct DocumentMetadata {
 }
 
 /// Parse a block attribute line (e.g. `[reftext="…"]`, `[#id]`, `[role=…]`,
-/// `[separator=::]`) appearing above the document title into [`DocumentMetadata`].
+/// `[separator=::]`) appearing above the document title into
+/// [`DocumentMetadata`].
 ///
-/// The `line` is expected to begin with `[` and end with `]`. Returns the folded
-/// metadata together with any warnings raised while parsing the attribute list
-/// when the line is a well-formed block attribute list, and `None` otherwise (so
-/// the caller can fall through to its normal handling of the line, which then
-/// terminates the header). The warnings are only surfaced when the line is
-/// actually consumed as document metadata; otherwise the line is left for the
-/// block parser, which reports them on its own path.
+/// The `line` is expected to begin with `[` and end with `]`. Returns the
+/// folded metadata together with any warnings raised while parsing the
+/// attribute list when the line is a well-formed block attribute list, and
+/// `None` otherwise (so the caller can fall through to its normal handling of
+/// the line, which then terminates the header). The warnings are only surfaced
+/// when the line is actually consumed as document metadata; otherwise the line
+/// is left for the block parser, which reports them on its own path.
 fn parse_document_metadata_attrlist<'src>(
     line: Span<'src>,
     parser: &Parser,

--- a/parser/src/document/mod.rs
+++ b/parser/src/document/mod.rs
@@ -29,6 +29,8 @@ pub use header::Header;
 mod revision_line;
 pub use revision_line::RevisionLine;
 
+mod title_refs;
+
 mod toc;
 pub(crate) use toc::TocConfig;
 pub use toc::TocMode;

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -27,10 +27,7 @@ use crate::{
     blocks::{Block, IsBlock},
     content::{XrefSegment, render_xref_template},
     document::Catalog,
-    parser::{
-        InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext,
-        ResolvedReference,
-    },
+    parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext},
 };
 
 /// One title carrying cross-references, captured for the resolution pass.
@@ -219,35 +216,48 @@ fn compute<'src>(
         // cycle). Empty explicit text (`<<id,>>`) is treated as absent.
         let has_explicit_text = xref.provided_text.as_deref().is_some_and(|t| !t.is_empty());
 
+        // The resolver is authoritative: only a reference it resolved is
+        // eligible for local title text, and a display text the resolver chose
+        // itself (e.g. an Antora-style resolver mapping the target to another
+        // document) is kept. The locally computed title only replaces text
+        // that is absent or that merely echoes the catalog's frozen
+        // (parse-time) reference text — the stale value this pass exists to
+        // correct.
         if !has_explicit_text
+            && let Some(reference) = resolved.as_mut()
             && let Some(target_id) = lookup_id(catalog, &xref.target)
             && let Some(&(target_index, target_node)) = id_to_node.get(target_id.as_str())
         {
-            // The target's reference text is its own (resolved) title. Recurse,
-            // unless the target is mid-computation — a cycle — in which case its
-            // link text is the bracketed fallback.
-            let target_in_progress = in_progress.get(target_index).copied().unwrap_or(false);
-            let text = if target_in_progress {
-                None
-            } else {
-                Some(compute(
-                    target_index,
-                    target_node,
-                    id_to_node,
-                    catalog,
-                    resolver,
-                    renderer,
-                    memo,
-                    in_progress,
-                    warnings,
-                ))
-            };
+            let catalog_reftext = catalog
+                .get_ref(&target_id)
+                .and_then(|entry| entry.reftext.as_deref());
 
-            let mut reference = resolved
-                .take()
-                .unwrap_or_else(|| ResolvedReference::new(format!("#{target_id}"), None));
-            reference.text = text;
-            resolved = Some(reference);
+            let resolver_chose_text = reference
+                .text
+                .as_deref()
+                .is_some_and(|text| Some(text) != catalog_reftext);
+
+            if !resolver_chose_text {
+                // The target's reference text is its own (resolved) title.
+                // Recurse, unless the target is mid-computation — a cycle — in
+                // which case its link text is the bracketed fallback.
+                let target_in_progress = in_progress.get(target_index).copied().unwrap_or(false);
+                reference.text = if target_in_progress {
+                    None
+                } else {
+                    Some(compute(
+                        target_index,
+                        target_node,
+                        id_to_node,
+                        catalog,
+                        resolver,
+                        renderer,
+                        memo,
+                        in_progress,
+                        warnings,
+                    ))
+                };
+            }
         }
 
         // A target that resolved to nothing — and did not carry its own derived

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -4,16 +4,17 @@
 //! reference text as its link text. When targets reference each other — a
 //! forward reference, or a circular one — the reference text of one title
 //! depends on another, so the per-content resolution pass (which resolves each
-//! [`Content`](crate::content::Content) in isolation) cannot get this right on
-//! its own: it would resolve every title's cross-references independently,
-//! against each target's *parse-time* reference text.
+//! [`Content`] in isolation) cannot get this right on its own: it would
+//! resolve every title's cross-references independently, against each target's
+//! *parse-time* reference text.
 //!
 //! This pass mirrors Asciidoctor, which converts each title exactly once, in
 //! document order, and caches the result. While a title is being converted, a
 //! cross-reference back to a title that is *already being converted* (a cycle)
 //! falls back to the bracketed `[id]` form rather than recursing forever. When
 //! a resolved reference text is spliced into another reference as its link
-//! text, any nested anchor is dropped (handled in the renderer's `render_xref`).
+//! text, any nested anchor is dropped (handled in the renderer's
+//! `render_xref`).
 //!
 //! The result is that a title's rendered form and the reference text every
 //! other reference sees for it are computed together, with cycles broken the

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -22,9 +22,9 @@
 use std::collections::HashMap;
 
 use crate::{
-    Span,
+    HasSpan, Span,
     blocks::{Block, IsBlock},
-    content::{XrefSegment, render_xref_template},
+    content::{Content, XrefSegment, render_xref_template},
     document::Catalog,
     parser::{
         InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext,
@@ -51,14 +51,14 @@ struct TitleNode<'src> {
     source: Span<'src>,
 }
 
-/// Resolves the cross-references embedded in every section title in `blocks`,
-/// in document order, coordinating references between titles (including
-/// circular ones) the way Asciidoctor does.
+/// Resolves the cross-references embedded in every section heading and block
+/// title in `blocks`, in document order, coordinating references between titles
+/// (including circular ones) the way Asciidoctor does.
 ///
-/// The per-content pass skips section titles (see
-/// [`Block::resolve_references`]); this pass owns them. It installs each
-/// title's final rendering directly and reports any unresolved target in
-/// `warnings`.
+/// The per-content pass skips section headings (see
+/// [`Block::resolve_references`]) and never resolved block titles at all; this
+/// pass owns both. It installs each title's final rendering directly and
+/// reports any unresolved target in `warnings`.
 pub(crate) fn resolve_title_references<'src>(
     blocks: &mut [Block<'src>],
     catalog: &Catalog,
@@ -103,24 +103,41 @@ pub(crate) fn resolve_title_references<'src>(
     write_back(blocks, &memo, &mut index);
 }
 
-/// Walks `blocks` in document order, collecting each section title that carries
-/// cross-references.
+/// Walks `blocks` in document order, collecting each section heading and block
+/// title that carries cross-references.
 fn collect<'src>(blocks: &mut [Block<'src>], nodes: &mut Vec<TitleNode<'src>>) {
     for block in blocks.iter_mut() {
-        if let Block::Section(section) = block
-            && let Some((template, xrefs)) = section.section_title_deferred_parts()
-        {
-            let map_id = if section.has_explicit_reftext() {
-                None
-            } else {
-                section.reference_id()
-            };
+        if let Block::Section(section) = block {
+            // A section's resolvable title is its heading.
+            if let Some((template, xrefs)) = section.section_title_deferred_parts() {
+                let map_id = if section.has_explicit_reftext() {
+                    None
+                } else {
+                    section.reference_id()
+                };
 
+                nodes.push(TitleNode {
+                    template: template.to_string(),
+                    xrefs: xrefs.to_vec(),
+                    map_id,
+                    source: section.section_title_source(),
+                });
+            }
+        } else if let Some((template, xrefs)) = block
+            .block_title_content()
+            .and_then(Content::deferred_parts)
+        {
+            // A non-section block's `.Title` decoration. A block title is not
+            // treated as a recomputable reference target (`map_id` is `None`):
+            // its own cross-references are resolved, but a reference *to* the
+            // block still uses the block's parse-time reference text.
+            let (template, xrefs) = (template.to_string(), xrefs.to_vec());
+            let source = block.span();
             nodes.push(TitleNode {
-                template: template.to_string(),
-                xrefs: xrefs.to_vec(),
-                map_id,
-                source: section.section_title_source(),
+                template,
+                xrefs,
+                map_id: None,
+                source,
             });
         }
 
@@ -132,11 +149,20 @@ fn collect<'src>(blocks: &mut [Block<'src>], nodes: &mut Vec<TitleNode<'src>>) {
 /// in the same document order as [`collect`] so `index` stays aligned.
 fn write_back<'src>(blocks: &mut [Block<'src>], memo: &[Option<String>], index: &mut usize) {
     for block in blocks.iter_mut() {
-        if let Block::Section(section) = block
-            && section.section_title_deferred_parts().is_some()
+        if let Block::Section(section) = block {
+            if section.section_title_deferred_parts().is_some() {
+                if let Some(rendered) = memo.get(*index).and_then(Option::as_ref) {
+                    section.set_section_title_rendered(rendered.clone());
+                }
+                *index += 1;
+            }
+        } else if block
+            .block_title_content()
+            .and_then(Content::deferred_parts)
+            .is_some()
         {
             if let Some(rendered) = memo.get(*index).and_then(Option::as_ref) {
-                section.set_section_title_rendered(rendered.clone());
+                block.set_block_title_rendered(rendered.clone());
             }
             *index += 1;
         }

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -217,16 +217,22 @@ fn compute<'src>(
         let has_explicit_text = xref.provided_text.as_deref().is_some_and(|t| !t.is_empty());
 
         // The resolver is authoritative: only a reference it resolved is
-        // eligible for local title text, and a display text the resolver chose
-        // itself (e.g. an Antora-style resolver mapping the target to another
-        // document) is kept. The locally computed title only replaces text
-        // that is absent or that merely echoes the catalog's frozen
+        // eligible for local title text, and then only when its destination is
+        // the local target itself (the `#id` fragment). A resolver that mapped
+        // the target anywhere else — e.g. an Antora-style resolver pointing at
+        // another document — keeps its result untouched, even when its display
+        // text happens to coincide with this document's reference text.
+        //
+        // For a locally-resolved reference, a display text the resolver chose
+        // itself is likewise kept; the locally computed title only replaces
+        // text that is absent or that merely echoes the catalog's frozen
         // (parse-time) reference text — the stale value this pass exists to
         // correct.
         if !has_explicit_text
             && let Some(reference) = resolved.as_mut()
             && let Some(target_id) = lookup_id(catalog, &xref.target)
             && let Some(&(target_index, target_node)) = id_to_node.get(target_id.as_str())
+            && reference.href.strip_prefix('#') == Some(target_id.as_str())
         {
             let catalog_reftext = catalog
                 .get_ref(&target_id)

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -74,22 +74,24 @@ pub(crate) fn resolve_title_references<'src>(
     }
 
     // Referenceable titles, keyed by ID (first registration wins, mirroring the
-    // catalog's own duplicate handling).
-    let mut id_to_index: HashMap<&str, usize> = HashMap::new();
+    // catalog's own duplicate handling). Each entry carries the node itself
+    // alongside its index, so the recursion in `compute` never has to look a
+    // node up by index.
+    let mut id_to_node: HashMap<&str, (usize, &TitleNode<'src>)> = HashMap::new();
     for (index, node) in nodes.iter().enumerate() {
         if let Some(id) = &node.map_id {
-            id_to_index.entry(id.as_str()).or_insert(index);
+            id_to_node.entry(id.as_str()).or_insert((index, node));
         }
     }
 
     let mut memo: Vec<Option<String>> = vec![None; nodes.len()];
     let mut in_progress: Vec<bool> = vec![false; nodes.len()];
 
-    for index in 0..nodes.len() {
+    for (index, node) in nodes.iter().enumerate() {
         compute(
             index,
-            &nodes,
-            &id_to_index,
+            node,
+            &id_to_node,
             catalog,
             resolver,
             renderer,
@@ -156,13 +158,11 @@ fn write_back<'src>(blocks: &mut [Block<'src>], memo: &[Option<String>], index: 
                 }
                 *index += 1;
             }
-        } else if block
-            .block_title_content()
-            .and_then(Content::deferred_parts)
-            .is_some()
+        } else if let Some(title) = block.block_title_content_mut()
+            && title.deferred_parts().is_some()
         {
             if let Some(rendered) = memo.get(*index).and_then(Option::as_ref) {
-                block.set_block_title_rendered(rendered.clone());
+                title.set_rendered(rendered.clone());
             }
             *index += 1;
         }
@@ -182,8 +182,8 @@ fn write_back<'src>(blocks: &mut [Block<'src>], memo: &[Option<String>], index: 
 #[allow(clippy::too_many_arguments)]
 fn compute<'src>(
     index: usize,
-    nodes: &[TitleNode<'src>],
-    id_to_index: &HashMap<&str, usize>,
+    node: &TitleNode<'src>,
+    id_to_node: &HashMap<&str, (usize, &TitleNode<'src>)>,
     catalog: &Catalog,
     resolver: &dyn ReferenceResolver,
     renderer: &dyn InlineSubstitutionRenderer,
@@ -194,10 +194,6 @@ fn compute<'src>(
     if let Some(Some(rendered)) = memo.get(index) {
         return rendered.clone();
     }
-
-    let Some(node) = nodes.get(index) else {
-        return String::new();
-    };
 
     if let Some(flag) = in_progress.get_mut(index) {
         *flag = true;
@@ -219,7 +215,7 @@ fn compute<'src>(
 
         if !has_explicit_text
             && let Some(target_id) = lookup_id(catalog, &xref.target)
-            && let Some(&target_index) = id_to_index.get(target_id.as_str())
+            && let Some(&(target_index, target_node)) = id_to_node.get(target_id.as_str())
         {
             // The target's reference text is its own (resolved) title. Recurse,
             // unless the target is mid-computation — a cycle — in which case its
@@ -230,8 +226,8 @@ fn compute<'src>(
             } else {
                 Some(compute(
                     target_index,
-                    nodes,
-                    id_to_index,
+                    target_node,
+                    id_to_node,
                     catalog,
                     resolver,
                     renderer,

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -4,9 +4,9 @@
 //! reference text as its link text. When targets reference each other — a
 //! forward reference, or a circular one — the reference text of one title
 //! depends on another, so the per-content resolution pass (which resolves each
-//! [`Content`] in isolation) cannot get this right on its own: it would
-//! resolve every title's cross-references independently, against each target's
-//! *parse-time* reference text.
+//! [`Content`](crate::content::Content) in isolation) cannot get this right on
+//! its own: it would resolve every title's cross-references independently,
+//! against each target's *parse-time* reference text.
 //!
 //! This pass mirrors Asciidoctor, which converts each title exactly once, in
 //! document order, and caches the result. While a title is being converted, a
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use crate::{
     HasSpan, Span,
     blocks::{Block, IsBlock},
-    content::{Content, XrefSegment, render_xref_template},
+    content::{XrefSegment, render_xref_template},
     document::Catalog,
     parser::{
         InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext,
@@ -126,22 +126,27 @@ fn collect<'src>(blocks: &mut [Block<'src>], nodes: &mut Vec<TitleNode<'src>>) {
                     source: section.section_title_source(),
                 });
             }
-        } else if let Some((template, xrefs)) = block
-            .block_title_content()
-            .and_then(Content::deferred_parts)
-        {
+        } else {
             // A non-section block's `.Title` decoration. A block title is not
             // treated as a recomputable reference target (`map_id` is `None`):
             // its own cross-references are resolved, but a reference *to* the
             // block still uses the block's parse-time reference text.
-            let (template, xrefs) = (template.to_string(), xrefs.to_vec());
+            //
+            // The span is taken before the title borrow: `block` stays
+            // mutably borrowed while the template is in scope.
             let source = block.span();
-            nodes.push(TitleNode {
-                template,
-                xrefs,
-                map_id: None,
-                source,
-            });
+
+            if let Some((template, xrefs)) = block
+                .block_title_content_mut()
+                .and_then(|title| title.deferred_parts())
+            {
+                nodes.push(TitleNode {
+                    template: template.to_string(),
+                    xrefs: xrefs.to_vec(),
+                    map_id: None,
+                    source,
+                });
+            }
         }
 
         collect(block.nested_blocks_mut(), nodes);

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -1,0 +1,255 @@
+//! Document-order resolution of cross-references embedded in titles.
+//!
+//! A cross-reference in a section (or block) title renders the *target's*
+//! reference text as its link text. When targets reference each other — a
+//! forward reference, or a circular one — the reference text of one title
+//! depends on another, so the per-content resolution pass (which resolves each
+//! [`Content`](crate::content::Content) in isolation) cannot get this right on
+//! its own: it would resolve every title's cross-references independently,
+//! against each target's *parse-time* reference text.
+//!
+//! This pass mirrors Asciidoctor, which converts each title exactly once, in
+//! document order, and caches the result. While a title is being converted, a
+//! cross-reference back to a title that is *already being converted* (a cycle)
+//! falls back to the bracketed `[id]` form rather than recursing forever. When
+//! a resolved reference text is spliced into another reference as its link
+//! text, any nested anchor is dropped (handled in the renderer's `render_xref`).
+//!
+//! The result is that a title's rendered form and the reference text every
+//! other reference sees for it are computed together, with cycles broken the
+//! same way Asciidoctor breaks them.
+
+use std::collections::HashMap;
+
+use crate::{
+    Span,
+    blocks::{Block, IsBlock},
+    content::{XrefSegment, render_xref_template},
+    document::Catalog,
+    parser::{
+        InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext,
+        ResolvedReference,
+    },
+};
+
+/// One title carrying cross-references, captured for the resolution pass.
+struct TitleNode<'src> {
+    /// The placeholder-bearing template captured when the title was finalized.
+    template: String,
+
+    /// The title's cross-references, in placeholder order.
+    xrefs: Vec<XrefSegment>,
+
+    /// The ID under which other cross-references reach this title's reference
+    /// text — present only when the title *is* the target's reference text (no
+    /// explicit `reftext`), so a cross-reference to it should render this
+    /// resolved title. `None` for a title that is not referenceable this way
+    /// (no ID, or an explicit reftext that shadows the title).
+    map_id: Option<String>,
+
+    /// The title's source span, for anchoring an unresolved-reference warning.
+    source: Span<'src>,
+}
+
+/// Resolves the cross-references embedded in every section title in `blocks`,
+/// in document order, coordinating references between titles (including
+/// circular ones) the way Asciidoctor does.
+///
+/// The per-content pass skips section titles (see
+/// [`Block::resolve_references`]); this pass owns them. It installs each
+/// title's final rendering directly and reports any unresolved target in
+/// `warnings`.
+pub(crate) fn resolve_title_references<'src>(
+    blocks: &mut [Block<'src>],
+    catalog: &Catalog,
+    resolver: &dyn ReferenceResolver,
+    renderer: &dyn InlineSubstitutionRenderer,
+    warnings: &mut ReferenceWarnings<'src>,
+) {
+    let mut nodes: Vec<TitleNode<'src>> = Vec::new();
+    collect(blocks, &mut nodes);
+
+    if nodes.is_empty() {
+        return;
+    }
+
+    // Referenceable titles, keyed by ID (first registration wins, mirroring the
+    // catalog's own duplicate handling).
+    let mut id_to_index: HashMap<&str, usize> = HashMap::new();
+    for (index, node) in nodes.iter().enumerate() {
+        if let Some(id) = &node.map_id {
+            id_to_index.entry(id.as_str()).or_insert(index);
+        }
+    }
+
+    let mut memo: Vec<Option<String>> = vec![None; nodes.len()];
+    let mut in_progress: Vec<bool> = vec![false; nodes.len()];
+
+    for index in 0..nodes.len() {
+        compute(
+            index,
+            &nodes,
+            &id_to_index,
+            catalog,
+            resolver,
+            renderer,
+            &mut memo,
+            &mut in_progress,
+            warnings,
+        );
+    }
+
+    let mut index = 0;
+    write_back(blocks, &memo, &mut index);
+}
+
+/// Walks `blocks` in document order, collecting each section title that carries
+/// cross-references.
+fn collect<'src>(blocks: &mut [Block<'src>], nodes: &mut Vec<TitleNode<'src>>) {
+    for block in blocks.iter_mut() {
+        if let Block::Section(section) = block
+            && let Some((template, xrefs)) = section.section_title_deferred_parts()
+        {
+            let map_id = if section.has_explicit_reftext() {
+                None
+            } else {
+                section.reference_id()
+            };
+
+            nodes.push(TitleNode {
+                template: template.to_string(),
+                xrefs: xrefs.to_vec(),
+                map_id,
+                source: section.section_title_source(),
+            });
+        }
+
+        collect(block.nested_blocks_mut(), nodes);
+    }
+}
+
+/// Installs the computed rendering for each collected title, walking `blocks`
+/// in the same document order as [`collect`] so `index` stays aligned.
+fn write_back<'src>(blocks: &mut [Block<'src>], memo: &[Option<String>], index: &mut usize) {
+    for block in blocks.iter_mut() {
+        if let Block::Section(section) = block
+            && section.section_title_deferred_parts().is_some()
+        {
+            if let Some(rendered) = memo.get(*index).and_then(Option::as_ref) {
+                section.set_section_title_rendered(rendered.clone());
+            }
+            *index += 1;
+        }
+
+        write_back(block.nested_blocks_mut(), memo, index);
+    }
+}
+
+/// Computes (and memoizes) the resolved rendering of the title at `index`.
+///
+/// A cross-reference in the title whose target is itself a referenceable title
+/// renders that target's resolved title (recursively), unless the target is
+/// currently being computed — a cycle — in which case its link text falls back
+/// to the bracketed `[target]` form, exactly as Asciidoctor breaks the cycle.
+/// The nested anchor that results when a resolved title is used as link text is
+/// dropped by the renderer.
+#[allow(clippy::too_many_arguments)]
+fn compute<'src>(
+    index: usize,
+    nodes: &[TitleNode<'src>],
+    id_to_index: &HashMap<&str, usize>,
+    catalog: &Catalog,
+    resolver: &dyn ReferenceResolver,
+    renderer: &dyn InlineSubstitutionRenderer,
+    memo: &mut [Option<String>],
+    in_progress: &mut [bool],
+    warnings: &mut ReferenceWarnings<'src>,
+) -> String {
+    if let Some(Some(rendered)) = memo.get(index) {
+        return rendered.clone();
+    }
+
+    let Some(node) = nodes.get(index) else {
+        return String::new();
+    };
+
+    if let Some(flag) = in_progress.get_mut(index) {
+        *flag = true;
+    }
+
+    let mut xrefs = node.xrefs.clone();
+
+    for xref in xrefs.iter_mut() {
+        let mut resolved = resolver.resolve(&ResolutionContext {
+            target: &xref.target,
+            provided_text: xref.provided_text.as_deref(),
+            derived: xref.derived.as_ref(),
+        });
+
+        // Explicit link text is used verbatim, so a target that only supplies
+        // its own reference text need not be consulted (and cannot start a
+        // cycle). Empty explicit text (`<<id,>>`) is treated as absent.
+        let has_explicit_text = xref.provided_text.as_deref().is_some_and(|t| !t.is_empty());
+
+        if !has_explicit_text
+            && let Some(target_id) = lookup_id(catalog, &xref.target)
+            && let Some(&target_index) = id_to_index.get(target_id.as_str())
+        {
+            // The target's reference text is its own (resolved) title. Recurse,
+            // unless the target is mid-computation — a cycle — in which case its
+            // link text is the bracketed fallback.
+            let target_in_progress = in_progress.get(target_index).copied().unwrap_or(false);
+            let text = if target_in_progress {
+                None
+            } else {
+                Some(compute(
+                    target_index,
+                    nodes,
+                    id_to_index,
+                    catalog,
+                    resolver,
+                    renderer,
+                    memo,
+                    in_progress,
+                    warnings,
+                ))
+            };
+
+            let mut reference = resolved
+                .take()
+                .unwrap_or_else(|| ResolvedReference::new(format!("#{target_id}"), None));
+            reference.text = text;
+            resolved = Some(reference);
+        }
+
+        // A target that resolved to nothing — and did not carry its own derived
+        // destination — is an unresolved reference, reported against the title.
+        if resolved.is_none() && xref.derived.is_none() {
+            warnings.unresolved(&xref.target, node.source);
+        }
+
+        xref.resolved = resolved;
+    }
+
+    let rendered = render_xref_template(&node.template, &xrefs, renderer);
+
+    if let Some(flag) = in_progress.get_mut(index) {
+        *flag = false;
+    }
+    if let Some(slot) = memo.get_mut(index) {
+        *slot = Some(rendered.clone());
+    }
+    rendered
+}
+
+/// Resolves a cross-reference target to a catalog ID the same way
+/// [`CatalogResolver`](crate::parser::CatalogResolver) does: a direct ID match
+/// first, then a natural (reference-text) match. Only same-document IDs are
+/// returned, which is exactly the set of titles this pass can recompute.
+fn lookup_id(catalog: &Catalog, target: &str) -> Option<String> {
+    if catalog.contains_id(target) {
+        Some(target.to_string())
+    } else {
+        catalog.resolve_id(target)
+    }
+}

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -949,9 +949,19 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
                 let text = match params.provided_text {
                     Some(provided) if !provided.is_empty() => provided.to_string(),
                     _ => {
+                        // The target's reference text becomes this reference's
+                        // link text. When that reftext is itself a title
+                        // containing a cross-reference (or an inline link), it
+                        // carries a nested `<a>…</a>`; an anchor cannot legally
+                        // nest inside another, so the inner anchor tags are
+                        // dropped (keeping their text), mirroring Asciidoctor's
+                        // `DropAnchorRx`. The bracketed fallback (`[id]`) has no
+                        // anchors, so stripping only applies to a resolved
+                        // reftext.
                         let base = resolved
                             .text
-                            .clone()
+                            .as_deref()
+                            .map(drop_anchor_tags)
                             .unwrap_or_else(|| format!("[{target}]", target = params.target));
                         apply_xrefstyle(params.xrefstyle, resolved.signifier.as_ref(), base)
                     }
@@ -1338,6 +1348,28 @@ static URI_SNIFF: LazyLock<Regex> = LazyLock::new(|| {
     .unwrap()
 });
 
+/// Removes the anchor (`<a …>` / `</a>`) tags from `text`, keeping everything
+/// between them.
+///
+/// Used when a cross-reference's link text is drawn from its target's reference
+/// text and that reftext itself contains an anchor — an inline link, or a
+/// cross-reference embedded in the target's title. HTML forbids nesting an
+/// `<a>` inside another, so the inner anchor tags are stripped, leaving their
+/// text in place. Mirrors Asciidoctor's `DropAnchorRx = /<(?:a\b[^>]*|\/a)>/`.
+fn drop_anchor_tags(text: &str) -> String {
+    // The common case — a reftext with no anchor at all — allocates a plain
+    // copy and does no scanning.
+    if !text.contains("<a") {
+        return text.to_string();
+    }
+
+    #[allow(clippy::unwrap_used)]
+    static DROP_ANCHOR_RX: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"<(?:a\b[^>]*|/a)>").unwrap());
+
+    DROP_ANCHOR_RX.replace_all(text, "").into_owned()
+}
+
 /// Builds the display text for a resolved cross-reference under the selected
 /// [`XrefStyle`].
 ///
@@ -1425,7 +1457,7 @@ fn link_constraint_attrs(attrlist: &Attrlist<'_>, window: Option<&'static str>) 
 
 #[cfg(test)]
 mod tests {
-    use super::encode_html_attribute;
+    use super::{drop_anchor_tags, encode_html_attribute};
 
     #[test]
     fn encode_html_attribute_escapes_special_characters() {
@@ -1437,5 +1469,33 @@ mod tests {
             "a&amp;b&quot;c&lt;d&gt;e"
         );
         assert_eq!(encode_html_attribute("plain"), "plain");
+    }
+
+    #[test]
+    fn drop_anchor_tags_strips_anchor_markup_keeping_text() {
+        // Anchor-free text is returned unchanged.
+        assert_eq!(drop_anchor_tags("plain text"), "plain text");
+
+        // A single anchor's tags are removed, keeping the link text.
+        assert_eq!(
+            drop_anchor_tags(r#"Consult <a href="https://google.com">Google</a>"#),
+            "Consult Google"
+        );
+
+        // A bracketed cross-reference fallback embedded in a reftext.
+        assert_eq!(drop_anchor_tags(r##"B <a href="#a">[a]</a>"##), "B [a]");
+
+        // Multiple anchors are all stripped.
+        assert_eq!(
+            drop_anchor_tags(r##"<a href="#x">X</a> and <a href="#y">Y</a>"##),
+            "X and Y"
+        );
+
+        // A `<article>` tag is not an anchor and must be left intact (the `\b`
+        // word boundary in the pattern keeps `<a` from matching `<article>`).
+        assert_eq!(
+            drop_anchor_tags("<article>text</article>"),
+            "<article>text</article>"
+        );
     }
 }

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -146,11 +146,13 @@ pub struct Parser {
     /// stashing section ends. A block with a title of its own wins over the
     /// carried title, which is then discarded.
     ///
-    /// Only the rendered title is carried (this struct is lifetime-free and
-    /// cannot hold the `.Title` line's source span), so a block claiming a
+    /// The title is carried as an owned snapshot (this struct is lifetime-free
+    /// and cannot hold the `.Title` line's source span), so a block claiming a
     /// carried title has no `title_source` — the same shape as a title
-    /// supplied via a `title=` attribute.
-    pub(crate) pending_block_title: Option<String>,
+    /// supplied via a `title=` attribute. The snapshot keeps any deferred
+    /// cross-references, so an embedded `<<id>>` in a carried title still
+    /// resolves once the catalog is complete.
+    pub(crate) pending_block_title: Option<crate::content::OwnedTitle>,
 
     /// Live values of [counter] attributes, keyed by counter name (e.g.
     /// `index`, `example-number`, `table-number`).

--- a/parser/src/tests/asciidoctor_rb/links_test.rs
+++ b/parser/src/tests/asciidoctor_rb/links_test.rs
@@ -3624,15 +3624,10 @@ fn should_not_fail_to_resolve_broken_xref_in_title_of_block_with_id() {
     );
 }
 
-// Surfaced incompatibility (#770): Asciidoctor resolves the forward xref in a
-// block title to the target title (`Conclusion`); this crate leaves it
-// unresolved (`[conclusion]`). Unlike a section title — whose cross-references
-// now resolve — a block title is flattened to a plain `String` at parse time
-// (see `blocks::metadata`), discarding the deferred-cross-reference state, so
-// there is nothing left to resolve once the target is known. Retaining the
-// title's `Content` through resolution is left as follow-up.
-non_normative!(
-    r###"
+#[test]
+fn should_resolve_forward_xref_in_title_of_block_with_id() {
+    verifies!(
+        r###"
   test 'should resolve forward xref in title of block with ID' do
     input = <<~'EOS'
     [#p1]
@@ -3648,7 +3643,19 @@ non_normative!(
   end
 
 "###
-);
+    );
+
+    // A block title is retained as a `Content`, so the forward cross-reference
+    // in `p1`'s title resolves to the target section's reference text
+    // (`Conclusion`) once the catalog is complete.
+    let doc = Parser::default()
+        .parse("[#p1]\n.<<conclusion>>\nparagraph text\n\n[#conclusion]\n== Conclusion");
+    let blocks = top_blocks(&doc);
+    assert_eq!(
+        blocks[0].title(),
+        Some(r##"<a href="#conclusion">Conclusion</a>"##)
+    );
+}
 
 #[test]
 fn should_not_fail_to_resolve_broken_xref_in_section_title() {

--- a/parser/src/tests/asciidoctor_rb/links_test.rs
+++ b/parser/src/tests/asciidoctor_rb/links_test.rs
@@ -3624,9 +3624,13 @@ fn should_not_fail_to_resolve_broken_xref_in_title_of_block_with_id() {
     );
 }
 
-// Surfaced incompatibility: Asciidoctor resolves the forward xref in a block
-// title to the target title (`Conclusion`); this crate leaves it unresolved
-// (`[conclusion]`). Tracked in #770.
+// Surfaced incompatibility (#770): Asciidoctor resolves the forward xref in a
+// block title to the target title (`Conclusion`); this crate leaves it
+// unresolved (`[conclusion]`). Unlike a section title — whose cross-references
+// now resolve — a block title is flattened to a plain `String` at parse time
+// (see `blocks::metadata`), discarding the deferred-cross-reference state, so
+// there is nothing left to resolve once the target is known. Retaining the
+// title's `Content` through resolution is left as follow-up.
 non_normative!(
     r###"
   test 'should resolve forward xref in title of block with ID' do
@@ -3646,11 +3650,10 @@ non_normative!(
 "###
 );
 
-// Surfaced incompatibility: Asciidoctor resolves `<<s1>>` to section s1's own
-// xreflabel; this crate leaves the sibling xref unresolved (`[s1]`). Tracked in
-// #770.
-non_normative!(
-    r###"
+#[test]
+fn should_not_fail_to_resolve_broken_xref_in_section_title() {
+    verifies!(
+        r###"
   test 'should not fail to resolve broken xref in section title' do
     input = <<~'EOS'
     [#s1]
@@ -3665,11 +3668,33 @@ non_normative!(
   end
 
 "###
-);
+    );
 
-// Surfaced incompatibility: Asciidoctor resolves an xref in a section title to
-// the target section's title; this crate leaves it unresolved (`[b]`/`[a]`).
-// Tracked in #770.
+    let doc = Parser::default().parse("[#s1]\n== <<DNE>>\n\n== <<s1>>");
+    let sections = all_sections(&doc);
+
+    // `s1`'s own title holds a broken cross-reference (`DNE` is never defined):
+    // it stays a bracketed fallback, still linked to the raw target.
+    assert_eq!(sections[0].id().unwrap(), "s1");
+    assert_eq!(sections[0].section_title(), r##"<a href="#DNE">[DNE]</a>"##);
+
+    // The following section references `s1`, whose reference text *is* that
+    // broken-xref rendering. An anchor cannot nest inside another, so the inner
+    // anchor tags are dropped, leaving `[DNE]` as the link text.
+    assert_eq!(sections[1].section_title(), r##"<a href="#s1">[DNE]</a>"##);
+}
+
+// Partially resolved (#770): a cross-reference in a section title now resolves
+// to the target section's title (with nested anchors dropped), so the first
+// heading matches Asciidoctor exactly — `<h2 id="a">A <a href="#b">B [a]</a>`.
+// The second heading still diverges: Asciidoctor renders `<a href="#a">[a]</a>`,
+// while this crate renders `<a href="#a">A [b]</a>`. Asciidoctor converts and
+// caches each section title once, in document order, so `b`'s title is frozen
+// mid-cycle (while `a` is still being resolved) and its back-reference to `a`
+// falls back to `[a]`. This crate resolves every title independently, so `b`'s
+// reference to `a` sees `a`'s fully-resolved reference text. Matching the cached
+// value byte-for-byte would require a document-order, memoized title-resolution
+// pass; left as follow-up.
 non_normative!(
     r###"
   test 'should break circular xref reference in section title' do
@@ -3689,11 +3714,10 @@ non_normative!(
 "###
 );
 
-// Surfaced incompatibility: same section-title xref resolution gap —
-// Asciidoctor renders the target section's title (with the nested anchor
-// dropped); this crate leaves `[b]` unresolved. Tracked in #770.
-non_normative!(
-    r###"
+#[test]
+fn should_drop_nested_anchor_in_xreftext() {
+    verifies!(
+        r###"
   test 'should drop nested anchor in xreftext' do
     input = <<~'EOS'
     [#a]
@@ -3708,7 +3732,21 @@ non_normative!(
   end
 
 "###
-);
+    );
+
+    let doc = Parser::default()
+        .parse("[#a]\n== See <<b>>\n\n[#b]\n== Consult https://google.com[Google]");
+    let sections = all_sections(&doc);
+
+    // `a`'s title cross-references `b`, whose reference text is its own title:
+    // `Consult <a href="https://google.com">Google</a>`. Splicing that in as the
+    // link text of `a`'s cross-reference would nest an anchor inside another, so
+    // the inner link's tags are dropped, leaving `Consult Google`.
+    assert_eq!(
+        sections[0].section_title(),
+        r##"See <a href="#b">Consult Google</a>"##
+    );
+}
 
 #[test]
 fn should_not_resolve_forward_xref_evaluated_during_parsing() {

--- a/parser/src/tests/asciidoctor_rb/links_test.rs
+++ b/parser/src/tests/asciidoctor_rb/links_test.rs
@@ -3684,19 +3684,10 @@ fn should_not_fail_to_resolve_broken_xref_in_section_title() {
     assert_eq!(sections[1].section_title(), r##"<a href="#s1">[DNE]</a>"##);
 }
 
-// Partially resolved (#770): a cross-reference in a section title now resolves
-// to the target section's title (with nested anchors dropped), so the first
-// heading matches Asciidoctor exactly — `<h2 id="a">A <a href="#b">B [a]</a>`.
-// The second heading still diverges: Asciidoctor renders `<a href="#a">[a]</a>`,
-// while this crate renders `<a href="#a">A [b]</a>`. Asciidoctor converts and
-// caches each section title once, in document order, so `b`'s title is frozen
-// mid-cycle (while `a` is still being resolved) and its back-reference to `a`
-// falls back to `[a]`. This crate resolves every title independently, so `b`'s
-// reference to `a` sees `a`'s fully-resolved reference text. Matching the cached
-// value byte-for-byte would require a document-order, memoized title-resolution
-// pass; left as follow-up.
-non_normative!(
-    r###"
+#[test]
+fn should_break_circular_xref_reference_in_section_title() {
+    verifies!(
+        r###"
   test 'should break circular xref reference in section title' do
     input = <<~'EOS'
     [#a]
@@ -3712,7 +3703,25 @@ non_normative!(
   end
 
 "###
-);
+    );
+
+    let doc = Parser::default().parse("[#a]\n== A <<b>>\n\n[#b]\n== B <<a>>");
+    let sections = all_sections(&doc);
+
+    // `a`'s title references `b`; `b`'s reference text is its own title
+    // (`B <<a>>`), which references `a` back. Titles are resolved once, in
+    // document order: while `a` is being resolved, `b`'s reference to `a` sees
+    // `a` mid-resolution and breaks the cycle with the bracketed `[a]`
+    // fallback. So `b`'s reference text is `B [a]` (nested anchor dropped) and
+    // `a`'s title becomes `A <a href="#b">B [a]</a>`.
+    assert_eq!(sections[0].id().unwrap(), "a");
+    assert_eq!(sections[0].section_title(), r##"A <a href="#b">B [a]</a>"##);
+
+    // `b`'s title is the value frozen mid-cycle: its own reference to `a`
+    // resolved to the `[a]` fallback.
+    assert_eq!(sections[1].id().unwrap(), "b");
+    assert_eq!(sections[1].section_title(), r##"B <a href="#a">[a]</a>"##);
+}
 
 #[test]
 fn should_drop_nested_anchor_in_xreftext() {

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -1149,4 +1149,109 @@ mod xrefs_in_titles {
         assert_eq!(sections[0].section_title(), r##"See <a href="#a">A B</a>"##);
         assert_eq!(sections[1].section_title(), r##"A <a href="#b">B</a>"##);
     }
+
+    #[test]
+    fn title_carried_across_a_section_heading_still_resolves_its_xref() {
+        // A `.Title` above a section heading does not become the section's
+        // title; it is carried to the section's first child block. The carried
+        // title keeps its deferred cross-reference, so the forward reference
+        // still resolves once `goal` is defined.
+        let doc = Parser::default().parse(".See <<goal>>\n== Section\n\npara\n\n[#goal]\n== Goal");
+
+        let section = crate::tests::prelude::first_section(&doc);
+        let para = section
+            .nested_blocks()
+            .next()
+            .expect("expected the section's first child block");
+
+        assert_eq!(para.title(), Some(r##"See <a href="#goal">Goal</a>"##));
+    }
+
+    #[test]
+    fn resolver_chosen_text_wins_over_the_local_title() {
+        // A caller-supplied resolver (e.g. a multi-document index) may map a
+        // target to its own destination *and* display text, even when this
+        // document also has a title under that ID. The resolver's choice wins;
+        // the locally computed title only replaces text that echoes the
+        // catalog's frozen reference text.
+        struct BespokeResolver;
+
+        impl crate::parser::ReferenceResolver for BespokeResolver {
+            fn resolve(
+                &self,
+                context: &crate::parser::ResolutionContext<'_>,
+            ) -> Option<crate::parser::ResolvedReference> {
+                (context.target == "b").then(|| {
+                    crate::parser::ResolvedReference::new(
+                        "other-doc.html#b".to_string(),
+                        Some("Bespoke Text".to_string()),
+                    )
+                })
+            }
+        }
+
+        let mut doc = Parser::default().parse_deferred("== See <<b>>\n\n[#b]\n== B <<missing>>");
+
+        doc.resolve_references(
+            &BespokeResolver,
+            &crate::parser::HtmlSubstitutionRenderer {},
+        );
+
+        let sections: Vec<_> = doc
+            .nested_blocks()
+            .filter_map(|block| {
+                if let crate::blocks::Block::Section(section) = block {
+                    Some(section)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(
+            sections[0].section_title(),
+            r##"See <a href="other-doc.html#b">Bespoke Text</a>"##
+        );
+    }
+
+    #[test]
+    fn a_target_the_resolver_does_not_know_stays_unresolved_in_a_title() {
+        // When a caller-supplied resolver cannot resolve a target, the title's
+        // reference stays a bracketed fallback and is reported — even though
+        // this document's own catalog knows the ID. The resolver is
+        // authoritative, matching how body content is resolved.
+        struct KnowsNothing;
+
+        impl crate::parser::ReferenceResolver for KnowsNothing {
+            fn resolve(
+                &self,
+                _context: &crate::parser::ResolutionContext<'_>,
+            ) -> Option<crate::parser::ResolvedReference> {
+                None
+            }
+        }
+
+        let mut doc = Parser::default().parse_deferred("== See <<b>>\n\n[#b]\n== B <<c>>");
+
+        let warnings =
+            doc.resolve_references(&KnowsNothing, &crate::parser::HtmlSubstitutionRenderer {});
+
+        let sections: Vec<_> = doc
+            .nested_blocks()
+            .filter_map(|block| {
+                if let crate::blocks::Block::Section(section) = block {
+                    Some(section)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(sections[0].section_title(), r##"See <a href="#b">[b]</a>"##);
+
+        // Both title references (`b` and `c`) are reported unresolved.
+        let mut targets: Vec<_> = warnings.iter().map(|w| w.target.as_str()).collect();
+        targets.sort_unstable();
+        assert_eq!(targets, vec!["b", "c"]);
+    }
 }

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -766,3 +766,152 @@ mod unresolved_reference_warnings {
         assert_eq!(warnings[0].source.line(), 2);
     }
 }
+
+/// Cross-references embedded in section headings and block titles resolve to
+/// the target's reference text via the document-order title resolution pass
+/// (issue #770). These exercise the pass across the block types that carry a
+/// title, plus the corners of how a title maps (or does not map) to a
+/// referenceable target.
+mod xrefs_in_titles {
+    use crate::{Parser, blocks::IsBlock};
+
+    /// Collects `(context, title)` for every titled block in the document, in
+    /// document order.
+    fn titled_blocks(doc: &crate::Document<'_>) -> Vec<(String, String)> {
+        fn walk(block: &crate::blocks::Block<'_>, out: &mut Vec<(String, String)>) {
+            if let Some(title) = block.title() {
+                out.push((block.raw_context().to_string(), title.to_string()));
+            }
+            for child in block.nested_blocks() {
+                walk(child, out);
+            }
+        }
+
+        let mut out = vec![];
+        for block in doc.nested_blocks() {
+            walk(block, &mut out);
+        }
+        out
+    }
+
+    #[test]
+    fn resolves_xref_in_title_of_every_titled_block_type() {
+        // One document exercising an xref title on each block type that can
+        // carry a `.Title`: paragraph, image (media), list, listing (raw
+        // delimited), example (compound delimited), admonition, quote, table,
+        // and thematic break. Every title resolves to the target section's
+        // reference text.
+        // The final paragraph's title has no cross-reference; it must pass
+        // through the resolution pass untouched.
+        let doc = Parser::default().parse(
+            ".<<goal>>\npara\n\n\
+             .<<goal>>\nimage::a.png[]\n\n\
+             .<<goal>>\n* item\n\n\
+             .<<goal>>\n----\ncode\n----\n\n\
+             .<<goal>>\n====\nexample\n====\n\n\
+             .<<goal>>\nNOTE: note\n\n\
+             .<<goal>>\n[quote]\nquoted\n\n\
+             .<<goal>>\n|===\n|cell\n|===\n\n\
+             .<<goal>>\n'''\n\n\
+             .Plain title\nplain para\n\n\
+             [#goal]\n== Goal",
+        );
+
+        let mut titles = titled_blocks(&doc);
+
+        // The xref-free title is untouched by the pass; the remaining titles
+        // all resolve.
+        let plain_position = titles
+            .iter()
+            .position(|(_, title)| title == "Plain title")
+            .expect("expected the xref-free title to be present and untouched");
+        titles.remove(plain_position);
+
+        let resolved = r##"<a href="#goal">Goal</a>"##;
+
+        let expected_contexts = [
+            "paragraph",
+            "image",
+            "list",
+            "listing",
+            "example",
+            "admonition",
+            "quote",
+            "thematic_break",
+        ];
+
+        // The table's context is checked separately below; contexts here are
+        // asserted as a set because the exact list is not the point — each
+        // titled block resolving its title is.
+        assert_eq!(titles.len(), 9, "titles were: {titles:?}");
+
+        for (context, title) in &titles {
+            assert_eq!(
+                title, resolved,
+                "block with context {context} did not resolve its title"
+            );
+        }
+
+        for context in expected_contexts {
+            assert!(
+                titles.iter().any(|(c, _)| c == context),
+                "no titled block with context {context}; titles were: {titles:?}"
+            );
+        }
+
+        assert!(
+            titles.iter().any(|(c, _)| c == "table"),
+            "no titled table; titles were: {titles:?}"
+        );
+    }
+
+    #[test]
+    fn section_with_explicit_reftext_still_resolves_its_own_title_xref() {
+        // Section `a` carries an explicit `reftext`, so a reference *to* it
+        // renders that reftext — not its (xref-bearing) title. The xref inside
+        // `a`'s own title still resolves normally.
+        let doc = Parser::default()
+            .parse("[reftext=Custom Text]\n[#a]\n== A <<b>>\n\n[#b]\n== B\n\npara with <<a>>");
+
+        let sections: Vec<_> = doc
+            .nested_blocks()
+            .filter_map(|block| {
+                if let crate::blocks::Block::Section(section) = block {
+                    Some(section)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(sections[0].section_title(), r##"A <a href="#b">B</a>"##);
+
+        // The paragraph reference to `a` uses the explicit reftext.
+        let para = super::first_paragraph(&doc);
+        assert_eq!(para, r##"para with <a href="#a">Custom Text</a>"##);
+    }
+
+    #[test]
+    fn section_with_double_bracket_anchor_is_a_recomputable_target() {
+        // The section's ID comes from a `[[a]]` block anchor (rather than a
+        // `[#a]` attribute), and a forward reference to it from another title
+        // renders its resolved title.
+        let doc = Parser::default().parse("== See <<a>>\n\n[[a]]\n== A <<b>>\n\n[#b]\n== B");
+
+        let sections: Vec<_> = doc
+            .nested_blocks()
+            .filter_map(|block| {
+                if let crate::blocks::Block::Section(section) = block {
+                    Some(section)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // `a`'s resolved title (`A <a href="#b">B</a>`) is spliced into the
+        // first heading's reference with the nested anchor dropped.
+        assert_eq!(sections[0].section_title(), r##"See <a href="#a">A B</a>"##);
+        assert_eq!(sections[1].section_title(), r##"A <a href="#b">B</a>"##);
+    }
+}

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -1169,11 +1169,10 @@ mod xrefs_in_titles {
 
     #[test]
     fn resolver_chosen_text_wins_over_the_local_title() {
-        // A caller-supplied resolver (e.g. a multi-document index) may map a
-        // target to its own destination *and* display text, even when this
-        // document also has a title under that ID. The resolver's choice wins;
-        // the locally computed title only replaces text that echoes the
-        // catalog's frozen reference text.
+        // A caller-supplied resolver may resolve a target to its local `#id`
+        // destination while choosing its own display text (e.g. a curated
+        // index label). The resolver's choice wins; the locally computed title
+        // only replaces text that echoes the catalog's frozen reference text.
         struct BespokeResolver;
 
         impl crate::parser::ReferenceResolver for BespokeResolver {
@@ -1183,7 +1182,7 @@ mod xrefs_in_titles {
             ) -> Option<crate::parser::ResolvedReference> {
                 (context.target == "b").then(|| {
                     crate::parser::ResolvedReference::new(
-                        "other-doc.html#b".to_string(),
+                        "#b".to_string(),
                         Some("Bespoke Text".to_string()),
                     )
                 })
@@ -1210,7 +1209,7 @@ mod xrefs_in_titles {
 
         assert_eq!(
             sections[0].section_title(),
-            r##"See <a href="other-doc.html#b">Bespoke Text</a>"##
+            r##"See <a href="#b">Bespoke Text</a>"##
         );
     }
 
@@ -1253,5 +1252,64 @@ mod xrefs_in_titles {
         let mut targets: Vec<_> = warnings.iter().map(|w| w.target.as_str()).collect();
         targets.sort_unstable();
         assert_eq!(targets, vec!["b", "c"]);
+    }
+
+    #[test]
+    fn external_href_with_coinciding_text_is_not_given_the_local_title() {
+        // A resolver may map a target to an *external* destination while
+        // choosing display text that happens to equal this document's frozen
+        // reference text for the same ID. Resolver ownership cannot be
+        // inferred from text equality; the local title applies only when the
+        // reference's destination is the local target itself, so the external
+        // reference is kept exactly as the resolver returned it.
+        struct ExternalResolver;
+
+        impl crate::parser::ReferenceResolver for ExternalResolver {
+            fn resolve(
+                &self,
+                context: &crate::parser::ResolutionContext<'_>,
+            ) -> Option<crate::parser::ResolvedReference> {
+                match context.target {
+                    // The external destination, with text that coincides with
+                    // this document's frozen (parse-time) reftext for `b`.
+                    "b" => Some(crate::parser::ResolvedReference::new(
+                        "other.html#b".to_string(),
+                        Some(r##"B <a href="#c">[c]</a>"##.to_string()),
+                    )),
+                    "c" => Some(crate::parser::ResolvedReference::new(
+                        "#c".to_string(),
+                        Some("C".to_string()),
+                    )),
+                    _ => None,
+                }
+            }
+        }
+
+        let mut doc =
+            Parser::default().parse_deferred("== See <<b>>\n\n[#b]\n== B <<c>>\n\n[#c]\n== C");
+
+        doc.resolve_references(
+            &ExternalResolver,
+            &crate::parser::HtmlSubstitutionRenderer {},
+        );
+
+        let sections: Vec<_> = doc
+            .nested_blocks()
+            .filter_map(|block| {
+                if let crate::blocks::Block::Section(section) = block {
+                    Some(section)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // The resolver's text is kept (nested anchors dropped at render time);
+        // had the local title been spliced in, the link text would instead be
+        // the freshly computed `B C`.
+        assert_eq!(
+            sections[0].section_title(),
+            r##"See <a href="other.html#b">B [c]</a>"##
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #770: cross-references (`<<id>>`) embedded in **section titles** and **block titles** now resolve to the target's reference text instead of the unresolved `[id]` fallback, matching Asciidoctor — including the forward and circular cases. All four tests tracked by the issue now pass as `verifies!` (previously `non_normative!`).

## How it works

Three layers, one per commit:

1. **Drop nested anchors in reference text** (`render_xref`). When a target's reference text is itself a title containing an anchor (an embedded cross-reference, or an inline link), splicing it into the referencing link would nest one `<a>` inside another. A new `drop_anchor_tags` helper strips the inner anchor tags (keeping their text), mirroring Asciidoctor's `DropAnchorRx`.

2. **Document-order title resolution pass** (`document::title_refs`). Section headings were previously resolved independently by the per-content pass, against each target's *parse-time* reference text — which got the first heading of a circular pair right but not the second. The new pass resolves each title exactly once, in document order, coordinating references *between* titles: a cross-reference back to a title that is currently being resolved (a cycle) breaks with the bracketed `[id]` fallback, exactly as Asciidoctor's convert-once-and-cache model does. Section headings are now skipped by the per-content pass and owned by this pass.

3. **Block titles retain their `Content`**. A block title (`.Title` / `title=`) was flattened to a `String` at parse time, discarding its deferred cross-references, so a forward `<<id>>` in a block title never resolved. `BlockMetadata::title` and each block's `title` field become `Option<Content>` (the `title()` accessor still returns `&str`, so the public shape is unchanged), and the title pass resolves block titles alongside section headings.

## Tests

Converted from `non_normative!` to passing `verifies!`:
- `should_not_fail_to_resolve_broken_xref_in_section_title`
- `should_drop_nested_anchor_in_xreftext`
- `should_break_circular_xref_reference_in_section_title` — now matches Asciidoctor byte-for-byte on both headings (`A <a href="#b">B [a]</a>` and `B <a href="#a">[a]</a>`)
- `should_resolve_forward_xref_in_title_of_block_with_id`

Plus a direct unit test for `drop_anchor_tags`. The full suite (4051 tests) passes; `clippy` and `fmt` are clean.

## Notes for review

- The catalog `reftext` registered for a title-bearing element stays the **parse-time** value (frozen with cross-references shown as `[id]`), matching Asciidoctor's behavior for a title whose reference text is captured during parsing — see the still-passing `should_not_resolve_forward_xref_evaluated_during_parsing`. The title pass changes the rendered *heading/title*, not the frozen catalog reftext, so a paragraph that references such a title still sees the parse-time reference text (a minor, untested-by-Asciidoctor divergence noted inline).
- A block title carried across a section heading (`pending_block_title`) is stashed as its already-rendered string, so a cross-reference in such a carried title is not re-resolved for the claiming block — a rare corner, noted in the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtaxLqsxFNshaeTnQ4BiRN