### PR TITLE
fix: Sanitize attribute-entry names (close #761)

### DIFF
--- a/parser/src/document/attribute.rs
+++ b/parser/src/document/attribute.rs
@@ -51,14 +51,21 @@ impl<'src> Attribute<'src> {
 
         let name = line.take_user_attr_name()?;
 
-        let line = if name.after.starts_with('!') && !unset {
+        // A trailing `!` on the name (immediately before the closing colon) is
+        // the postfix unset marker, e.g. `:foo!:`. It is stripped from the
+        // stored name. A name may not carry both a leading and a trailing `!`.
+        let (name_item, after_name) = if name.item.data().ends_with('!') {
+            if unset {
+                return None;
+            }
             unset = true;
-            name.after.slice_from(1..)
+            let len = name.item.data().len();
+            (name.item.slice_to(..len - 1), name.after)
         } else {
-            name.after
+            (name.item, name.after)
         };
 
-        let line = line.take_prefix(":")?;
+        let line = after_name.take_prefix(":")?;
 
         let (value, value_source) = if unset {
             // Ensure line is now empty except for comment.
@@ -76,7 +83,7 @@ impl<'src> Attribute<'src> {
         let source = source.trim_remainder(attr_line.after);
         Some(MatchedItem {
             item: Self {
-                name: name.item,
+                name: name_item,
                 value_source,
                 value,
                 source: source.trim_trailing_whitespace(),
@@ -494,13 +501,83 @@ mod tests {
     }
 
     #[test]
-    fn err_invalid_ident2() {
-        assert!(
-            crate::document::Attribute::parse(
-                crate::Span::new(":invalid@:\nblah"),
-                &Parser::default()
-            )
-            .is_none()
+    fn name_captures_trailing_non_word_char() {
+        // A name may contain (and end with) characters that are not valid in a
+        // canonical attribute name; the raw name runs up to the closing colon.
+        // The stray characters are dropped later, when the name is sanitized
+        // into an attribute key (`invalid@` becomes `invalid`).
+        let mi = crate::document::Attribute::parse(
+            crate::Span::new(":invalid@:\nblah"),
+            &Parser::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            mi.item,
+            Attribute {
+                name: Span {
+                    data: "invalid@",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+                value_source: None,
+                value: InterpretedValue::Set,
+                source: Span {
+                    data: ":invalid@:",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                }
+            }
+        );
+
+        assert_eq!(
+            mi.after,
+            Span {
+                data: "blah",
+                line: 2,
+                col: 1,
+                offset: 11
+            }
+        );
+    }
+
+    #[test]
+    fn name_with_spaces() {
+        // A name containing spaces is captured verbatim up to the closing colon.
+        // It is sanitized to `authorinitials` before it is stored as an
+        // attribute (see the parser's `remap_attr_name`); here we only check
+        // that the entry parses and preserves the raw name span.
+        let mi = crate::document::Attribute::parse(
+            crate::Span::new(":Author Initials: SJR"),
+            &Parser::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            mi.item,
+            Attribute {
+                name: Span {
+                    data: "Author Initials",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+                value_source: Some(Span {
+                    data: "SJR",
+                    line: 1,
+                    col: 19,
+                    offset: 18,
+                }),
+                value: InterpretedValue::Value("SJR"),
+                source: Span {
+                    data: ":Author Initials: SJR",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                }
+            }
         );
     }
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1858,7 +1858,17 @@ fn string_succ(current: &str) -> String {
 }
 
 fn remap_attr_name<N: AsRef<str>>(raw_attr_name: N) -> String {
-    let attr_name = raw_attr_name.as_ref().to_lowercase();
+    // Sanitize the name the way Asciidoctor's `sanitize_attribute_name` does:
+    // drop every character that is not a word character (ASCII letter, digit, or
+    // underscore) or a hyphen, then lower-case the result. This is what lets an
+    // attribute entry written as `:Author Initials:` set the `authorinitials`
+    // attribute, and `:Foo 3^ # - Bar[:` set `foo3-bar`.
+    let attr_name: String = raw_attr_name
+        .as_ref()
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+        .collect::<String>()
+        .to_ascii_lowercase();
 
     // Some attribute names have aliases. Remap to the primary name.
     //

--- a/parser/src/span/primitives.rs
+++ b/parser/src/span/primitives.rs
@@ -52,40 +52,37 @@ impl<'src> Span<'src> {
         Some(self.into_parse_result(self.len()))
     }
 
-    /// Split the span, consuming a user-defined attribute name if found.
+    /// Split the span, consuming the raw name of an [attribute entry].
     ///
-    /// [User-defined attribute names] must:
+    /// The name of an attribute entry begins with a word character (`a`-`z`,
+    /// `A`-`Z`, `0`-`9`, or `_`) and runs up to — but not including — the
+    /// closing colon (`:`) that terminates it. Mirroring Asciidoctor's
+    /// `AttributeEntryRx` (whose capture is `!?\w.*?`), the characters after
+    /// the first are otherwise unconstrained: the raw name may contain spaces
+    /// and other characters that are not valid in a canonical attribute name
+    /// (e.g. `Author Initials` or `Foo 3^ # - Bar[`).
     ///
-    /// * be at least one character long,
-    /// * begin with a word character (`a`-`z`, `0`-`9`, or `_`), and
-    /// * only contain word characters and hyphens (`-`).
+    /// Returns `None` when the span is empty or does not begin with a word
+    /// character. When the span contains no colon, the whole span is consumed
+    /// as the name (the caller then fails to find the terminating colon).
     ///
-    /// A user-defined attribute name cannot contain dots (`.`) or spaces.
-    /// Although uppercase characters are permitted in an attribute name, the
-    /// name is converted to lowercase before being stored. For example,
-    /// `URL-REPO` and `URL-Repo` are treated as `url-repo` when a document is
-    /// loaded or converted. A best practice is to only use lowercase letters in
-    /// the name and avoid starting the name with a number.
+    /// IMPORTANT: This function performs no normalization. The captured name is
+    /// sanitized — lower-cased, with every character outside `[a-z0-9_-]`
+    /// stripped — before it is used as an attribute key, so `URL-Repo` becomes
+    /// `url-repo` and `Author Initials` becomes `authorinitials`. See
+    /// `remap_attr_name` in the parser.
     ///
-    /// IMPORTANT: This function does _not_ perform the lower-case normalization
-    /// defined above.
-    ///
-    /// [User-defined attribute names]: https://docs.asciidoctor.org/asciidoc/latest/attributes/names-and-values/#user-defined
+    /// [attribute entry]: https://docs.asciidoctor.org/asciidoc/latest/attributes/names-and-values/#user-defined
     pub(crate) fn take_user_attr_name(self) -> Option<MatchedItem<'src, Self>> {
-        let mut chars = self.data.char_indices();
-
-        let (_, c) = chars.next()?;
-        if !c.is_ascii_alphanumeric() && c != '_' {
+        let first = self.data.chars().next()?;
+        if !first.is_ascii_alphanumeric() && first != '_' {
             return None;
         }
 
-        for (index, c) in chars {
-            if !c.is_ascii_alphanumeric() && c != '_' && c != '-' {
-                return Some(self.into_parse_result(index));
-            }
+        match self.position(|c| c == ':') {
+            Some(index) => Some(self.into_parse_result(index)),
+            None => Some(self.into_parse_result(self.len())),
         }
-
-        Some(self.into_parse_result(self.len()))
     }
 
     /// Returns [`true`] if the span properly forms an [XML Name].
@@ -509,14 +506,14 @@ mod tests {
         }
 
         #[test]
-        fn stops_at_non_ident() {
-            let span = crate::Span::new("x#");
+        fn stops_at_colon() {
+            let span = crate::Span::new("foo: bar");
             let mi = span.take_user_attr_name().unwrap();
 
             assert_eq!(
                 mi.item,
                 Span {
-                    data: "x",
+                    data: "foo",
                     line: 1,
                     col: 1,
                     offset: 0
@@ -526,17 +523,46 @@ mod tests {
             assert_eq!(
                 mi.after,
                 Span {
-                    data: "#",
+                    data: ": bar",
                     line: 1,
-                    col: 2,
-                    offset: 1
+                    col: 4,
+                    offset: 3
+                }
+            );
+        }
+
+        #[test]
+        fn captures_non_word_chars() {
+            // The raw name runs up to the closing colon and may contain spaces
+            // and other characters that are not valid in a canonical attribute
+            // name; sanitization happens later (see `remap_attr_name`).
+            let span = crate::Span::new("Foo 3^ # - Bar[: x");
+            let mi = span.take_user_attr_name().unwrap();
+
+            assert_eq!(
+                mi.item,
+                Span {
+                    data: "Foo 3^ # - Bar[",
+                    line: 1,
+                    col: 1,
+                    offset: 0
+                }
+            );
+
+            assert_eq!(
+                mi.after,
+                Span {
+                    data: ": x",
+                    line: 1,
+                    col: 16,
+                    offset: 15
                 }
             );
         }
 
         #[test]
         fn numeric() {
-            let span = crate::Span::new("94!");
+            let span = crate::Span::new("94: x");
             let mi = span.take_user_attr_name().unwrap();
 
             assert_eq!(
@@ -552,7 +578,7 @@ mod tests {
             assert_eq!(
                 mi.after,
                 Span {
-                    data: "!",
+                    data: ": x",
                     line: 1,
                     col: 3,
                     offset: 2
@@ -562,7 +588,7 @@ mod tests {
 
         #[test]
         fn contains_hyphens() {
-            let span = crate::Span::new("blah-blah-94 = foo");
+            let span = crate::Span::new("blah-blah-94: foo");
             let mi = span.take_user_attr_name().unwrap();
 
             assert_eq!(
@@ -578,7 +604,7 @@ mod tests {
             assert_eq!(
                 mi.after,
                 Span {
-                    data: " = foo",
+                    data: ": foo",
                     line: 1,
                     col: 13,
                     offset: 12

--- a/parser/src/tests/asciidoc_lang/attributes/custom_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/custom_attributes.rs
@@ -130,14 +130,27 @@ A best practice is to only use lowercase letters in the name and avoid starting 
 
     #[test]
     fn only_contain_word_characters_and_hyphens() {
-        assert!(
+        // The prose above describes what a *well-formed* user-defined name looks
+        // like. Like the lower-case normalization (see `may_contain_uppercase`),
+        // enforcement of this rule is deferred: rather than reject a name that
+        // contains other characters, the parser captures the raw name and it is
+        // sanitized before being stored as an attribute key — every character
+        // outside `[a-z0-9_-]` is dropped and the rest is lower-cased. This
+        // mirrors Asciidoctor (where `:abc def:` sets `abcdef`) and is what lets
+        // `:Author Initials:` set `authorinitials`. See
+        // https://github.com/asciidoc-rs/asciidoc-parser/issues/761 and
+        // https://github.com/asciidoc-rs/asciidoc-parser/issues/726.
+        let mi =
             crate::document::Attribute::parse(crate::Span::new(":abc def:"), &Parser::default())
-                .is_none()
-        );
-        assert!(
+                .unwrap();
+        assert_eq!(mi.item.name().data(), "abc def");
+        assert_eq!(mi.item.value(), &InterpretedValue::Set);
+
+        let mi =
             crate::document::Attribute::parse(crate::Span::new(":abc.def:"), &Parser::default())
-                .is_none()
-        );
+                .unwrap();
+        assert_eq!(mi.item.name().data(), "abc.def");
+        assert_eq!(mi.item.value(), &InterpretedValue::Set);
 
         let mi =
             crate::document::Attribute::parse(crate::Span::new(":9ab-cdef:"), &Parser::default())

--- a/parser/src/tests/asciidoc_lang/attributes/names_and_values.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/names_and_values.rs
@@ -128,14 +128,27 @@ A best practice is to only use lowercase letters in the name and avoid starting 
 
     #[test]
     fn only_contain_word_characters_and_hyphens() {
-        assert!(
+        // The prose above describes what a *well-formed* user-defined name looks
+        // like. Like the lower-case normalization (see `may_contain_uppercase`),
+        // enforcement of this rule is deferred: rather than reject a name that
+        // contains other characters, the parser captures the raw name and it is
+        // sanitized before being stored as an attribute key — every character
+        // outside `[a-z0-9_-]` is dropped and the rest is lower-cased. This
+        // mirrors Asciidoctor (where `:abc def:` sets `abcdef`) and is what lets
+        // `:Author Initials:` set `authorinitials`. See
+        // https://github.com/asciidoc-rs/asciidoc-parser/issues/761 and
+        // https://github.com/asciidoc-rs/asciidoc-parser/issues/726.
+        let mi =
             crate::document::Attribute::parse(crate::Span::new(":abc def:"), &Parser::default())
-                .is_none()
-        );
-        assert!(
+                .unwrap();
+        assert_eq!(mi.item.name().data(), "abc def");
+        assert_eq!(mi.item.value(), &InterpretedValue::Set);
+
+        let mi =
             crate::document::Attribute::parse(crate::Span::new(":abc.def:"), &Parser::default())
-                .is_none()
-        );
+                .unwrap();
+        assert_eq!(mi.item.name().data(), "abc.def");
+        assert_eq!(mi.item.value(), &InterpretedValue::Set);
 
         let mi =
             crate::document::Attribute::parse(crate::Span::new(":9ab-cdef:"), &Parser::default())

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -1672,10 +1672,9 @@ mod interpolation {
         assert_xpath(&doc, "//p[text()=\"R is for Ruby!\"]", 1);
     }
 
-    // Tracked in #726.
     #[test]
     fn collapses_spaces_in_attribute_names() {
-        non_normative!(
+        verifies!(
             r#"
     test "collapses spaces in attribute names" do
       input = <<~'EOS'
@@ -1692,12 +1691,13 @@ mod interpolation {
 "#
         );
 
-        // Divergence: this crate does not collapse spaces in attribute names, so
-        // `:My frog:` is not a valid attribute entry and `{myfrog}` is left
-        // unresolved.
+        // The attribute-entry name `My frog` is sanitized to `myfrog` (spaces
+        // dropped, lower-cased), so the `{myfrog}` reference resolves. See
+        // https://github.com/asciidoc-rs/asciidoc-parser/issues/761 (previously
+        // tracked as a divergence in #726).
         let doc = Parser::default()
             .parse("Main Header\n===========\n:My frog: Tanglefoot\n\nYo, {myfrog}!");
-        assert_xpath(&doc, "//p[text()=\"Yo, {myfrog}!\"]", 1);
+        assert_xpath(&doc, "//p[text()=\"Yo, Tanglefoot!\"]", 1);
     }
 
     #[test]

--- a/parser/src/tests/asciidoctor_rb/parser_test.rs
+++ b/parser/src/tests/asciidoctor_rb/parser_test.rs
@@ -36,10 +36,9 @@
 //! This crate does not expose those helpers by name, but most of the *behavior*
 //! they implement is observable through the public API, so those tests are
 //! `verifies!` and driven through the real path. The helpers with no public
-//! analog at all (`is_section_title?`, `sanitize_attribute_name` as a function,
-//! `adjust_indentation!`) stay `non_normative!`: the Ruby lines are reproduced
-//! verbatim to keep the `sdd` coverage tool aligned, but no crate behavior is
-//! asserted against them.
+//! analog at all (`is_section_title?`, `adjust_indentation!`) stay
+//! `non_normative!`: the Ruby lines are reproduced verbatim to keep the `sdd`
+//! coverage tool aligned, but no crate behavior is asserted against them.
 //!
 //! The `verifies!` mappings:
 //!
@@ -50,6 +49,10 @@
 //!   [`ModificationContext`](crate::parser::ModificationContext) — `Anywhere`
 //!   is accessible, `ApiOnly` is inaccessible (a rejected override is reported
 //!   as [`WarningType::AttributeValueIsLocked`]).
+//! * **`sanitize_attribute_name`** — an attribute entry is stored under its
+//!   sanitized name (lower-cased, characters outside `[a-z0-9_-]` dropped), so
+//!   the tests define a `:Raw Name:` entry and read it back through
+//!   [`Parser::attribute_value`] under its sanitized key.
 //! * **`parse_style_attribute`** — the shorthand `style#id.role%opt` parsing is
 //!   exactly what [`Attrlist`](crate::attributes::Attrlist) does, so those
 //!   tests drive [`Attrlist::parse`] in a block context and assert on
@@ -93,8 +96,6 @@
 //!   document attributes are stored pre-substitution (issue #759).
 //! * Block comments (`////`) in the header are not skipped ahead of the author
 //!   or revision line (issue #760).
-//! * A `:Author Initials:` attribute entry is not sanitized to `authorinitials`
-//!   and so does not override the generated initials (issue #761).
 //! * A duplicate id introduced by an *inline* anchor (`[[id]]`) does not emit a
 //!   `DuplicateId` warning (the error is discarded on the inline path), unlike
 //!   a duplicate block anchor (issue #762).
@@ -163,6 +164,16 @@ fn parse_authors(line: &str) -> Vec<ParsedAuthor> {
         .collect()
 }
 
+/// Define a document attribute entry whose raw (as-written) name is `raw_name`
+/// and return the value stored under the canonical name `canonical`. This
+/// drives Asciidoctor's `sanitize_attribute_name` through the public
+/// attribute-entry path: the entry is only observable under its sanitized name.
+fn entry_value_under(raw_name: &str, canonical: &str) -> crate::document::InterpretedValue {
+    let mut parser = Parser::default();
+    let _doc = parser.parse(&format!(":{raw_name}: sentinel"));
+    parser.attribute_value(canonical)
+}
+
 /// Parse a full document header — `= Document Title`, the author line, and the
 /// revision line — and return the parsed revision line's number / date / remark
 /// as owned data. This drives the same header path Asciidoctor's
@@ -210,10 +221,14 @@ non_normative!(
 );
 
 // `sanitize_attribute_name` is an internal static helper not exposed by this
-// crate. The underlying gap (attribute-entry names are not sanitized) is
-// tracked in https://github.com/asciidoc-rs/asciidoc-parser/issues/761.
-non_normative!(
-    r#"
+// crate by name, but its behavior is observable: an attribute entry is stored
+// under its sanitized name, so a `:Raw Name:` entry is only reachable through
+// the sanitized key. See
+// https://github.com/asciidoc-rs/asciidoc-parser/issues/761.
+#[test]
+fn sanitize_attribute_name() {
+    verifies!(
+        r#"
   test 'sanitize attribute name' do
     assert_equal 'foobar', Asciidoctor::Parser.sanitize_attribute_name("Foo Bar")
     assert_equal 'foo', Asciidoctor::Parser.sanitize_attribute_name("foo")
@@ -221,7 +236,26 @@ non_normative!(
   end
 
 "#
-);
+    );
+
+    // `Foo Bar` -> `foobar`
+    assert_eq!(
+        entry_value_under("Foo Bar", "foobar"),
+        InterpretedValue::Value("sentinel")
+    );
+
+    // `foo` -> `foo`
+    assert_eq!(
+        entry_value_under("foo", "foo"),
+        InterpretedValue::Value("sentinel")
+    );
+
+    // `Foo 3^ # - Bar[` -> `foo3-bar`
+    assert_eq!(
+        entry_value_under("Foo 3^ # - Bar[", "foo3-bar"),
+        InterpretedValue::Value("sentinel")
+    );
+}
 
 // The `store_attribute` group tests the internal static helper that stores an
 // attribute (optionally on a document). This crate exposes the same behavior
@@ -1665,12 +1699,15 @@ fn break_header_at_line_with_three_forward_slashes() {
     );
 }
 
-// Incompatibility (https://github.com/asciidoc-rs/asciidoc-parser/issues/761):
-// a `:Author Initials:` attribute entry is not sanitized to the
-// `authorinitials` attribute name, so it does not override the initials
-// generated from the author line (this crate keeps the generated `SR`).
-non_normative!(
-    r#"
+// This crate has no separate `metadata` hash: the author line's generated
+// initials and a later `:Author Initials:` override both write the one
+// `authorinitials` document attribute. So the generated value (`SR`) is
+// asserted on the parsed author, and the override (`SJR`) on the resolved
+// attribute.
+#[test]
+fn attribute_entry_overrides_generated_author_initials() {
+    verifies!(
+        r#"
   test 'attribute entry overrides generated author initials' do
     doc = empty_document
     metadata, _ = parse_header_metadata %(Stuart Rackham <founder@asciidoc.org>\n:Author Initials: SJR), doc
@@ -1679,7 +1716,25 @@ non_normative!(
   end
 
 "#
-);
+    );
+
+    // The author line on its own generates the initials `SR`.
+    let a = parse_authors("Stuart Rackham <founder@asciidoc.org>");
+    assert_eq!(a.len(), 1);
+    assert_eq!(a[0].initials, "SR");
+
+    // A `:Author Initials: SJR` entry below the author line is sanitized to the
+    // `authorinitials` attribute name and overrides the generated value. (A
+    // synthetic title is required because this crate only recognizes an author
+    // line when a document title is present.)
+    let mut parser = Parser::default();
+    let _doc = parser
+        .parse("= Document Title\nStuart Rackham <founder@asciidoc.org>\n:Author Initials: SJR");
+    assert_eq!(
+        parser.attribute_value("authorinitials"),
+        InterpretedValue::Value("SJR")
+    );
+}
 
 // The `adjust_indentation!` group tests an internal static helper (with
 // explicit indent/tab-size arguments) that this crate does not expose. Verbatim


### PR DESCRIPTION
## Summary

Fixes #761. Attribute-entry names are now sanitized the way Asciidoctor's `sanitize_attribute_name` does, so an entry written as `:Author Initials: SJR` sets the `authorinitials` attribute (overriding the initials generated from the author line), and `:Foo 3^ # - Bar[:` sets `foo3-bar`.

Previously the parser captured the name only up to the first character that was not a word character or hyphen, so a name containing a space (or other punctuation) was not recognized as an attribute entry at all — `:Author Initials:` never resolved to `authorinitials`.

## Approach

Asciidoctor's model is: capture the raw name up to the closing colon (`AttributeEntryRx` — `!?\w.*?`), then sanitize it into a canonical key (drop every character outside `[a-z0-9_-]`, then lower-case). This crate already defers normalization out of `Attribute::parse` (the `name` field stays a raw `Span`, and lower-casing happens in `remap_attr_name`), so the change follows that same split:

- **`Span::take_user_attr_name`** now captures the raw entry name — a word character followed by any characters up to the closing colon — instead of stopping at the first non-word/non-hyphen character. The `name` field remains the raw source span (useful for diagnostics); no type change.
- **`Attribute::parse`** handles a trailing `!` (postfix unset marker, e.g. `:foo!:`) on the captured name, and still rejects a name carrying both a leading and a trailing `!`.
- **`remap_attr_name`** strips characters outside `[a-z0-9_-]` before lower-casing, so the stored attribute key is canonical.

## Behavior change

Consistent with Asciidoctor (and with the crate's existing "normalization is deferred" stance, see `may_contain_uppercase`), the parser now *accepts and sanitizes* names it previously rejected rather than treating them as invalid:

- `:Author Initials: SJR` → sets `authorinitials` = `SJR`
- `:Foo Bar: x` → sets `foobar`
- `:abc def:` / `:abc.def:` → set `abcdef`

This is a divergence from the strict spec prose ("a user-defined attribute name cannot contain dots or spaces"), which the AsciiDoc language docs describe as *validity* while Asciidoctor's implementation is lenient. The affected spec-tracking tests are updated to reflect the raw-capture-then-sanitize contract, with inline notes.

## Tests

- Converted the SDD `non_normative!` blocks in `parser_test.rs` (`sanitize attribute name`, `attribute entry overrides generated author initials`) to `verifies!` tests driven through the public attribute-entry path.
- Resolved the previously-tracked divergence in `attributes_test.rs` where spaces in an attribute-entry name were not collapsed (#726) — now `verifies!`.
- Updated the `only_contain_word_characters_and_hyphens` spec tests and `take_user_attr_name` unit tests to the new semantics; added `Attribute::parse` tests for names with spaces and trailing non-word characters.
- Full suite green (`cargo test -p asciidoc-parser`), clippy clean, nightly rustfmt applied.

Opened as a **draft** for review of the spec-vs-Asciidoctor divergence direction before finalizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk11MCuEJ9QiSh8SqBq4m8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nk11MCuEJ9QiSh8SqBq4m8)_