### PR TITLE
feat: Resolve an inter-document xref to an included file as an internal anchor (#808)

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1750,15 +1750,32 @@ fn process_content<'src>(
             // resulting source map: while this cell's owned source is parsed it
             // lets a directive buried deeper (e.g. in a nested table cell) map
             // its position back to the file and line it originally came from.
-            // An AsciiDoc table cell is a nested document with its own catalog,
-            // so any files it includes are not registered on the enclosing
-            // document's include registry (the fourth element is dropped).
-            let (expanded, cell_source_map, preprocessor_warnings, _cell_includes) =
+            let (expanded, cell_source_map, preprocessor_warnings, cell_includes) =
                 preprocess_with_initial_file_name(
                     trimmed.data(),
                     parser,
                     cell_origin_file.as_deref(),
                 );
+
+            // An AsciiDoc table cell shares the enclosing document's catalog
+            // (only its footnote list is cell-local), so a file included by the
+            // cell registers on the document's include registry — as it does in
+            // Asciidoctor, where the cell's nested document shares the parent's
+            // `catalog[:includes]`. Registration is skipped when the cell was
+            // itself brought in from an included file: the cell's include
+            // targets are then relative to that file, not the outermost
+            // document, and a mis-keyed entry could falsely collapse a
+            // root-relative xref naming a different file (the same rule the
+            // preprocessor applies to nested includes). Note that xrefs are
+            // interpreted in document order as blocks parse, so only xrefs in
+            // this cell and beyond observe these entries; Asciidoctor, which
+            // resolves xrefs after the whole document is read, has no such
+            // ordering.
+            if cell_origin_file.as_deref() == parser.primary_file_name.as_deref() {
+                for (key, full) in &cell_includes {
+                    parser.register_include(key, *full);
+                }
+            }
             let cell_source_map = Rc::new(cell_source_map);
 
             // The cell's first line as it appears in the source it was sliced

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1750,7 +1750,10 @@ fn process_content<'src>(
             // resulting source map: while this cell's owned source is parsed it
             // lets a directive buried deeper (e.g. in a nested table cell) map
             // its position back to the file and line it originally came from.
-            let (expanded, cell_source_map, preprocessor_warnings) =
+            // An AsciiDoc table cell is a nested document with its own catalog,
+            // so any files it includes are not registered on the enclosing
+            // document's include registry (the fourth element is dropped).
+            let (expanded, cell_source_map, preprocessor_warnings, _cell_includes) =
                 preprocess_with_initial_file_name(
                     trimmed.data(),
                     parser,

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -1639,14 +1639,22 @@ impl Replacer for InlineXrefReplacer<'_, '_> {
 
             XrefTarget::SameDocument(id) => (id, None),
 
-            // A target that names *this* document is a reference within it
-            // after all: the element it names (if any) is in the catalog being
-            // built right now.
+            // A target that names *this* document, or a file that was included
+            // into it in full, is a reference within it after all: the element
+            // it names (if any) is in the catalog being built right now. The
+            // path is compared against `docname` and against the include
+            // registry the preprocessor populated, matching Asciidoctor's
+            // `docname == path || catalog[:includes][path]` test. A merely
+            // *partial* include does not qualify — the referenced anchor may not
+            // have been carried across.
             XrefTarget::OtherDocument {
                 path,
                 source,
                 fragment,
-            } if source && self.parser.docname().as_deref() == Some(path.as_str()) => {
+            } if source
+                && (self.parser.docname().as_deref() == Some(path.as_str())
+                    || self.parser.catalog_include_is_full(&path)) =>
+            {
                 match fragment {
                     Some(fragment) => (fragment, None),
                     None => (String::new(), Some(this_document_reference(self.parser))),

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -24,6 +24,25 @@ pub struct Catalog {
     /// A nested document (an AsciiDoc table cell) keeps its own footnote list:
     /// footnotes defined inside a cell are *not* shared with the main document.
     pub(crate) footnotes: Vec<Footnote>,
+
+    /// AsciiDoc files that were included into this document, keyed by the
+    /// include target relative to the outermost document with its AsciiDoc
+    /// extension removed (e.g. `other-chapters` for
+    /// `include::other-chapters.adoc[]`). The value records whether the file
+    /// was ever included *in full*: `true` when at least one include merged the
+    /// whole file, `false` when every include of it selected only a
+    /// `lines`/`tag(s)` portion.
+    ///
+    /// The preprocessor records each include while it expands `include::`
+    /// directives (before parsing); `Parser::parse_deferred` folds those into
+    /// this map via [`register_include`](Self::register_include), and it
+    /// survives into the document's catalog. It lets an
+    /// inter-document cross reference whose target names an included file
+    /// collapse to a same-document reference — the target's anchors are now
+    /// part of *this* document — but only when the file was included in
+    /// full, since a partial include may not have carried the referenced
+    /// anchor across. See [`interpret_xref_target`](crate::content).
+    pub(crate) includes: HashMap<String, bool>,
 }
 
 impl Default for Catalog {
@@ -38,6 +57,7 @@ impl Catalog {
             refs: HashMap::new(),
             reftext_to_id: HashMap::new(),
             footnotes: Vec::new(),
+            includes: HashMap::new(),
         }
     }
 
@@ -200,6 +220,43 @@ impl Catalog {
         self.footnotes.iter().find(|f| f.id.as_deref() == Some(id))
     }
 
+    /// Records that the AsciiDoc file named by `key` was included into this
+    /// document.
+    ///
+    /// `key` is the include target relative to the outermost document, with its
+    /// AsciiDoc extension removed (e.g. `other-chapters`). `full` is `true`
+    /// when the entire file was included and `false` when only a
+    /// `lines`/`tag(s)` selection of it was.
+    ///
+    /// A file included in full at least once is recorded as full even if it was
+    /// also included partially (a full include always carries every anchor
+    /// across), matching Asciidoctor.
+    pub(crate) fn register_include(&mut self, key: &str, full: bool) {
+        self.includes
+            .entry(key.to_string())
+            .and_modify(|existing| *existing |= full)
+            .or_insert(full);
+    }
+
+    /// Returns `true` if the file named by `key` (an include target relative to
+    /// the outermost document, without its AsciiDoc extension) was included
+    /// into this document *in full* — i.e. at least one `include::`
+    /// directive merged the whole file, rather than only a `lines`/`tag(s)`
+    /// portion of it.
+    ///
+    /// Returns `false` if the file was only ever partially included, or was not
+    /// included at all.
+    pub fn include_is_full(&self, key: &str) -> bool {
+        self.includes.get(key).copied().unwrap_or(false)
+    }
+
+    /// Returns `true` if the file named by `key` (an include target relative to
+    /// the outermost document, without its AsciiDoc extension) was included
+    /// into this document, whether in full or only partially.
+    pub fn was_included(&self, key: &str) -> bool {
+        self.includes.contains_key(key)
+    }
+
     /// Removes and returns the current footnote list, leaving an empty list
     /// behind. Used to give a nested document (an AsciiDoc table cell) its own
     /// footnote registry so its footnotes are not shared with the enclosing
@@ -300,6 +357,7 @@ impl std::fmt::Debug for Catalog {
             .field("refs", &DebugHashMapFrom(&self.refs))
             .field("reftext_to_id", &DebugHashMapFrom(&self.reftext_to_id))
             .field("footnotes", &self.footnotes)
+            .field("includes", &DebugHashMapFrom(&self.includes))
             .finish()
     }
 }
@@ -514,6 +572,45 @@ mod tests {
             .unwrap();
 
         assert_eq!(catalog.resolve_id("Same Text"), Some("first".to_string()));
+    }
+
+    #[test]
+    fn register_include_records_full_and_partial() {
+        let mut catalog = Catalog::new();
+
+        // An unregistered file is neither included nor full.
+        assert!(!catalog.was_included("tigers"));
+        assert!(!catalog.include_is_full("tigers"));
+
+        catalog.register_include("tigers", false);
+        assert!(catalog.was_included("tigers"));
+        assert!(!catalog.include_is_full("tigers"));
+
+        catalog.register_include("lions", true);
+        assert!(catalog.was_included("lions"));
+        assert!(catalog.include_is_full("lions"));
+    }
+
+    #[test]
+    fn a_full_include_wins_over_a_partial_one_in_either_order() {
+        // partial then full → full
+        let mut catalog = Catalog::new();
+        catalog.register_include("tigers", false);
+        catalog.register_include("tigers", true);
+        assert!(catalog.include_is_full("tigers"));
+
+        // full then partial → still full
+        let mut catalog = Catalog::new();
+        catalog.register_include("tigers", true);
+        catalog.register_include("tigers", false);
+        assert!(catalog.include_is_full("tigers"));
+
+        // partial then partial → partial
+        let mut catalog = Catalog::new();
+        catalog.register_include("tigers", false);
+        catalog.register_include("tigers", false);
+        assert!(catalog.was_included("tigers"));
+        assert!(!catalog.include_is_full("tigers"));
     }
 
     #[test]

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -1605,6 +1605,7 @@ mod tests {
         refs: HashMap::from([]),
         reftext_to_id: HashMap::from([]),
         footnotes: [],
+        includes: HashMap::from([]),
     },
 }"#
         );

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -371,15 +371,16 @@ struct DocumentMetadata {
 }
 
 /// Parse a block attribute line (e.g. `[reftext="…"]`, `[#id]`, `[role=…]`,
-/// `[separator=::]`) appearing above the document title into [`DocumentMetadata`].
+/// `[separator=::]`) appearing above the document title into
+/// [`DocumentMetadata`].
 ///
-/// The `line` is expected to begin with `[` and end with `]`. Returns the folded
-/// metadata together with any warnings raised while parsing the attribute list
-/// when the line is a well-formed block attribute list, and `None` otherwise (so
-/// the caller can fall through to its normal handling of the line, which then
-/// terminates the header). The warnings are only surfaced when the line is
-/// actually consumed as document metadata; otherwise the line is left for the
-/// block parser, which reports them on its own path.
+/// The `line` is expected to begin with `[` and end with `]`. Returns the
+/// folded metadata together with any warnings raised while parsing the
+/// attribute list when the line is a well-formed block attribute list, and
+/// `None` otherwise (so the caller can fall through to its normal handling of
+/// the line, which then terminates the header). The warnings are only surfaced
+/// when the line is actually consumed as document metadata; otherwise the line
+/// is left for the block parser, which reports them on its own path.
 fn parse_document_metadata_attrlist<'src>(
     line: Span<'src>,
     parser: &Parser,

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -14,7 +14,7 @@ use crate::{
         IncludeFileHandler, InlineSubstitutionRenderer, ModificationContext, PathResolver,
         ResolvedAttributes, SafeMode, SourceLine, SourceMap, SvgFileHandler,
         built_in_attrs::{built_in_attr, built_in_default_values, synthesized_attr},
-        preprocessor::preprocess,
+        preprocessor::preprocess_with_initial_file_name,
     },
     warnings::{Warning, WarningType},
 };
@@ -442,11 +442,24 @@ impl Parser {
     /// [`parse()`]: Self::parse
     /// [`catalog()`]: Document::catalog
     pub fn parse_deferred(&mut self, source: &str) -> Document<'static> {
-        let (preprocessed_source, source_map, preprocessor_warnings) = preprocess(source, self);
+        let (preprocessed_source, source_map, preprocessor_warnings, includes) =
+            preprocess_with_initial_file_name(source, self, self.primary_file_name.as_deref());
 
         // NOTE: `Document::parse` will transfer the catalog to itself at the end of the
         // parsing operation. Start each parse with a fresh catalog.
         *self.catalog.borrow_mut() = Catalog::new();
+
+        // Seed the fresh catalog with the files the preprocessor just expanded,
+        // so an inter-document cross reference to an included file can resolve
+        // to an internal anchor while the document is parsed. Replaying each
+        // event lets the catalog resolve a file that was included both fully and
+        // partially to a full include.
+        {
+            let mut catalog = self.catalog.borrow_mut();
+            for (key, full) in includes {
+                catalog.register_include(&key, full);
+            }
+        }
 
         // Start each parse with an empty callout catalog.
         *self.callouts.borrow_mut() = CalloutCatalog::default();
@@ -1474,6 +1487,20 @@ impl Parser {
         } else {
             Some(stem.to_string())
         }
+    }
+
+    /// Returns `true` if the AsciiDoc file named by `key` (an inter-document
+    /// xref path — relative to this document, AsciiDoc extension removed) was
+    /// included into this document *in full* by the preprocessor.
+    ///
+    /// A cross reference to such a file collapses to a same-document reference,
+    /// since the file's anchors are now part of this document. Takes `&self` so
+    /// it can be called from an inline-substitution
+    /// [`Replacer`](regex::Replacer) that holds only a shared reference to
+    /// the parser. See
+    /// [`Catalog::include_is_full`](crate::document::Catalog::include_is_full).
+    pub(crate) fn catalog_include_is_full(&self, key: &str) -> bool {
+        self.catalog.borrow().include_is_full(key)
     }
 
     /// Called from [`Header::parse()`] to accept or reject an attribute value.

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -14,7 +14,7 @@ use crate::{
         IncludeFileHandler, InlineSubstitutionRenderer, ModificationContext, PathResolver,
         ResolvedAttributes, SafeMode, SourceLine, SourceMap, SvgFileHandler,
         built_in_attrs::{built_in_attr, built_in_default_values, synthesized_attr},
-        preprocessor::preprocess_with_initial_file_name,
+        preprocessor::preprocess,
     },
     warnings::{Warning, WarningType},
 };
@@ -443,7 +443,7 @@ impl Parser {
     /// [`catalog()`]: Document::catalog
     pub fn parse_deferred(&mut self, source: &str) -> Document<'static> {
         let (preprocessed_source, source_map, preprocessor_warnings, includes) =
-            preprocess_with_initial_file_name(source, self, self.primary_file_name.as_deref());
+            preprocess(source, self);
 
         // NOTE: `Document::parse` will transfer the catalog to itself at the end of the
         // parsing operation. Start each parse with a fresh catalog.

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1503,6 +1503,19 @@ impl Parser {
         self.catalog.borrow().include_is_full(key)
     }
 
+    /// Records an included AsciiDoc file in the document catalog's include
+    /// registry, mid-parse.
+    ///
+    /// `Parser::parse_deferred` seeds the registry with the outermost
+    /// document's own includes before parsing begins; this entry point is for
+    /// an include performed while a nested scope with a shared catalog — an
+    /// AsciiDoc table cell — is parsed. Takes `&self` for the same reason as
+    /// [`catalog_include_is_full`](Self::catalog_include_is_full). See
+    /// [`Catalog::register_include`](crate::document::Catalog::register_include).
+    pub(crate) fn register_include(&self, key: &str, full: bool) {
+        self.catalog.borrow_mut().register_include(key, full);
+    }
+
     /// Called from [`Header::parse()`] to accept or reject an attribute value.
     ///
     /// [`Header::parse()`]: crate::document::Header::parse

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -103,16 +103,22 @@ struct PreprocessorState<'p> {
     source_map: SourceMap,
     warnings: Vec<DeferredWarning>,
 
-    /// AsciiDoc files included while expanding this document, in the order the
-    /// `include::` directives were processed. Each entry pairs the include
-    /// target (relative to the outermost document, AsciiDoc extension removed)
-    /// with whether that directive merged the file *in full* (`true`) or only a
-    /// `lines`/`tag(s)` portion of it (`false`); the same file may appear more
-    /// than once. `Parser::parse_deferred` replays these through
+    /// AsciiDoc files included by directives written in the outermost document,
+    /// in the order the `include::` directives were processed. Each entry pairs
+    /// the include target (relative to the outermost document, AsciiDoc
+    /// extension removed) with whether that directive merged the file *in full*
+    /// (`true`) or only a `lines`/`tag(s)` portion of it (`false`); the same
+    /// file may appear more than once. `Parser::parse_deferred` replays these
+    /// through
     /// [`Catalog::register_include`](crate::document::Catalog::register_include),
     /// which resolves the full/partial value (a full include wins), so an
     /// inter-document cross reference to an included file can collapse to a
     /// same-document one.
+    ///
+    /// A directive in a *nested* include (depth 2 and below) is not recorded:
+    /// its target is relative to the file containing it, not the outermost
+    /// document, so registering it as written could falsely collapse a
+    /// root-relative xref that names a different file.
     includes: Vec<(String, bool)>,
 
     /// The include-depth limit currently in effect, or `None` when
@@ -554,10 +560,22 @@ impl<'p> PreprocessorState<'p> {
                         // [`Catalog::register_include`] when these entries are
                         // replayed into the catalog.
                         //
+                        // Only a directive written in the *outermost* document
+                        // (depth 1) is recorded: its target is already in the
+                        // coordinate system an inter-document xref target uses.
+                        // A nested include's target is relative to the file
+                        // containing it, so registering it as written could
+                        // collide with — and falsely collapse — a root-relative
+                        // xref that names a different file. A nested include is
+                        // therefore not recorded at all: an xref to it keeps
+                        // its ordinary inter-document destination.
+                        //
                         // [`Catalog::register_include`]: crate::document::Catalog::register_include
-                        let full = is_full_include(&attrlist);
-                        self.includes
-                            .push((include_catalog_key(&target).to_string(), full));
+                        if self.include_depth == 1 {
+                            let full = is_full_include(&attrlist);
+                            self.includes
+                                .push((include_catalog_key(&target).to_string(), full));
+                        }
 
                         // The directive's `depth` attribute lowers the maximum
                         // include depth while the included file (and anything
@@ -1431,12 +1449,10 @@ fn is_asciidoc_file(target: &str) -> bool {
 /// [`interpret_xref_target`](crate::content)). `target` must name an AsciiDoc
 /// file (see [`is_asciidoc_file`]).
 ///
-/// The key is the target as written in the `include::` directive, so for an
-/// include in the outermost document it is relative to that document — the
-/// coordinate system an inter-document xref target uses. (A nested include's
-/// target is relative to the file that includes it rather than the outermost
-/// document; the common single-level case, which every collapse test exercises,
-/// is exact.)
+/// The key is the target as written in the `include::` directive. Only
+/// directives written in the outermost document are registered (see the
+/// `includes` field of [`PreprocessorState`]), so the key is always relative to
+/// that document — the coordinate system an inter-document xref target uses.
 fn include_catalog_key(target: &str) -> &str {
     // `target` names an AsciiDoc file, so its final `.`-delimited segment is the
     // extension to strip; only the trailing extension is removed, so a path that

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -3895,6 +3895,13 @@ mod tests {
                 include_catalog_key("using-.net-web-services.adoc"),
                 "using-.net-web-services"
             );
+
+            // Defensive fallback: production only reaches this function for a
+            // target `is_asciidoc_file` accepted (a dotted name with a
+            // non-empty stem), but a target without one is returned whole
+            // rather than truncated.
+            assert_eq!(include_catalog_key("no-extension"), "no-extension");
+            assert_eq!(include_catalog_key(".adoc"), ".adoc");
         }
 
         fn is_full(attrlist_text: &str) -> bool {

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -24,35 +24,27 @@ use crate::{
 /// by byte offset within the returned (preprocessed) source. `Document::parse`
 /// reconstitutes them into spanned [`Warning`]s once it owns that source.
 ///
+/// The fourth returned value lists the AsciiDoc files this pass included, each
+/// paired with whether it was included in full; see the `includes` field of
+/// [`PreprocessorState`]. `Parser::parse_deferred` folds these into the
+/// document's [`Catalog`](crate::document::Catalog).
+///
 /// [include file]: https://docs.asciidoctor.org/asciidoc/latest/directives/include/
 /// [conditional]: https://docs.asciidoctor.org/asciidoc/latest/directives/conditionals/
-///
-/// Thin wrapper retaining the three-value shape used throughout the
-/// preprocessor's own tests, which do not exercise the include registry (the
-/// fourth value). Production parsing calls
-/// [`preprocess_with_initial_file_name`] directly.
-#[cfg(test)]
 pub(crate) fn preprocess(
     source: &str,
     parser: &Parser,
-) -> (String, SourceMap, Vec<DeferredWarning>) {
-    let (output, source_map, warnings, _includes) =
-        preprocess_with_initial_file_name(source, parser, parser.primary_file_name.as_deref());
-    (output, source_map, warnings)
+) -> (String, SourceMap, Vec<DeferredWarning>, Vec<(String, bool)>) {
+    preprocess_with_initial_file_name(source, parser, parser.primary_file_name.as_deref())
 }
 
-/// Like `preprocess`, but treats `initial_file_name` (rather than the parser's
-/// `primary_file_name`) as the file the top-level `source` came from.
+/// Like [`preprocess`], but treats `initial_file_name` (rather than the
+/// parser's `primary_file_name`) as the file the top-level `source` came from.
 ///
 /// This is used to preprocess the content of an AsciiDoc table cell, which the
 /// cell reached from some enclosing file: naming that file lets an unresolved
 /// `include::` directive inside the cell report the correct originating file in
 /// its "Unresolved directive in …" replacement, matching Asciidoctor.
-///
-/// The fourth returned value lists the AsciiDoc files this pass included, each
-/// paired with whether it was included in full; see the `includes` field of
-/// [`PreprocessorState`]. `Parser::parse_deferred` folds these into the
-/// document's [`Catalog`](crate::document::Catalog).
 pub(crate) fn preprocess_with_initial_file_name(
     source: &str,
     parser: &Parser,
@@ -2012,7 +2004,7 @@ mod tests {
             "= Document Title\n\nThis is a simple document with no includes or conditionals.";
         let parser = Parser::default().with_primary_file_name("test.adoc");
 
-        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -2039,7 +2031,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -2088,7 +2080,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -2136,7 +2128,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings, _includes) = preprocess(source, &parser);
 
         // The include is converted to a link; the handler is never consulted.
         assert_eq!(
@@ -2174,7 +2166,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings, _includes) = preprocess(source, &parser);
 
         // The include is converted to a link; the handler is never consulted.
         assert_eq!(
@@ -2216,7 +2208,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -2277,7 +2269,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -2328,7 +2320,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -2352,7 +2344,7 @@ mod tests {
             .with_safe_mode(SafeMode::Server)
             .with_primary_file_name("main.adoc");
 
-        let (processed_source, source_map, warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -2422,7 +2414,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, _source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, _source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(processed_source, "Top.\nNested.\n");
     }
@@ -2443,7 +2435,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(processed_source, "a,b\ninclude::inner.adoc[]\n");
         assert!(warnings.is_empty());
@@ -2473,7 +2465,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, _source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, _source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(processed_source, "Body.\n\nrow one\n\nrow two\n");
     }
@@ -2492,7 +2484,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, warnings, _includes) = preprocess(source, &parser);
 
         // The directive line is gone; no "Unresolved directive" text is inserted.
         assert_eq!(processed_source, "Before.\n\n\nAfter.\n");
@@ -2528,7 +2520,7 @@ mod tests {
         // file.
         let source = "Before.\n\ninclude::{foodir}/partial.adoc[]\n\nAfter.";
 
-        let (processed_source, _source_map, warnings) =
+        let (processed_source, _source_map, warnings, _includes) =
             preprocess(source, &parser_with_attribute_missing("skip"));
 
         assert_eq!(
@@ -2552,7 +2544,7 @@ mod tests {
         // that follow. See issue #776.
         let source = "Before.\n\ninclude::{foodir}/partial.adoc[]\n\nAfter.";
 
-        let (processed_source, source_map, warnings) =
+        let (processed_source, source_map, warnings, _includes) =
             preprocess(source, &parser_with_attribute_missing("drop-line"));
 
         assert_eq!(processed_source, "Before.\n\n\nAfter.\n");
@@ -2584,7 +2576,7 @@ mod tests {
                 ModificationContext::Anywhere,
             );
 
-        let (processed_source, _source_map, warnings) = preprocess(source, &parser);
+        let (processed_source, _source_map, warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(processed_source, "Before.\n\n\nAfter.\n");
         assert!(warnings.is_empty());
@@ -2598,7 +2590,7 @@ mod tests {
         // include target, so the target is emptied and never resolved).
         let source = "Before.\n\ninclude::{foodir}/partial.adoc[]\n\nAfter.";
 
-        let (processed_source, _source_map, warnings) =
+        let (processed_source, _source_map, warnings, _includes) =
             preprocess(source, &parser_with_attribute_missing("warn"));
 
         assert_eq!(
@@ -2622,7 +2614,7 @@ mod tests {
         // warning that `warn` would otherwise produce for a dropped directive.
         let source = "Before.\n\ninclude::{foodir}/partial.adoc[opts=optional]\n\nAfter.";
 
-        let (processed_source, _source_map, warnings) =
+        let (processed_source, _source_map, warnings, _includes) =
             preprocess(source, &parser_with_attribute_missing("warn"));
 
         assert_eq!(processed_source, "Before.\n\n\nAfter.\n");
@@ -2635,7 +2627,7 @@ mod tests {
         // is otherwise complete still resolves and the include is expanded.
         let source = "Before.\n\ninclude::{foodir}partial.adoc[]\n\nAfter.";
 
-        let (processed_source, _source_map, warnings) =
+        let (processed_source, _source_map, warnings, _includes) =
             preprocess(source, &parser_with_attribute_missing("drop"));
 
         assert_eq!(processed_source, "Before.\n\nIncluded content.\n\nAfter.\n");
@@ -2656,7 +2648,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -2675,7 +2667,7 @@ mod tests {
         // thus no include handler) so the escape behaves identically.
         let source = "\\include::partial.adoc[]";
         let parser = Parser::default();
-        let (processed_source, _source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, _source_map, _warnings, _includes) = preprocess(source, &parser);
         assert_eq!(processed_source, "include::partial.adoc[]\n");
     }
 
@@ -2685,7 +2677,7 @@ mod tests {
         // (here, no attribute brackets) is left untouched.
         let source = "\\include::partial.adoc";
         let parser = Parser::default().with_primary_file_name("main.adoc");
-        let (processed_source, _source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, _source_map, _warnings, _includes) = preprocess(source, &parser);
         assert_eq!(processed_source, "\\include::partial.adoc\n");
     }
 
@@ -2695,7 +2687,7 @@ mod tests {
         // backslash is left as-is.
         let source = "\\\\include::partial.adoc[]";
         let parser = Parser::default().with_primary_file_name("main.adoc");
-        let (processed_source, _source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, _source_map, _warnings, _includes) = preprocess(source, &parser);
         assert_eq!(processed_source, "\\\\include::partial.adoc[]\n");
     }
 
@@ -2713,7 +2705,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -2740,7 +2732,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -2810,7 +2802,7 @@ mod tests {
             )
             .with_include_file_handler(handler);
 
-        let (processed_source, _source_map, warnings) = preprocess(source, &parser);
+        let (processed_source, _source_map, warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(processed_source, "Brace in the file name.\n");
         assert!(warnings.is_empty());
@@ -2830,7 +2822,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -2868,7 +2860,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -2908,7 +2900,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, _source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, _source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(processed_source, "Included via escaped literal target.\n");
     }
@@ -2933,7 +2925,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -2971,7 +2963,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -3003,7 +2995,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (processed_source, source_map, _warnings) = preprocess(source, &parser);
+        let (processed_source, source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             processed_source,
@@ -3039,7 +3031,7 @@ mod tests {
     /// resulting text, for the conditional-directive tests below.
     fn conditional_output(source: &str) -> String {
         let parser = Parser::default();
-        let (output, _source_map, _warnings) = preprocess(source, &parser);
+        let (output, _source_map, _warnings, _includes) = preprocess(source, &parser);
         output
     }
 
@@ -3117,7 +3109,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (output, _source_map, warnings) = preprocess(source, &parser);
+        let (output, _source_map, warnings, _includes) = preprocess(source, &parser);
 
         assert!(output.contains("Included."), "output was: {output:?}");
         assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
@@ -3245,7 +3237,7 @@ mod tests {
         // the lines that follow back to their original line numbers.
         let source = "l1\n\nifdef::foo[]\ndropped\ndropped\nendif::[]\n\nl8";
         let parser = Parser::default();
-        let (output, source_map, _warnings) = preprocess(source, &parser);
+        let (output, source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(output, "l1\n\n\nl8\n");
 
@@ -3491,7 +3483,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (output, _source_map, warnings) = preprocess(source, &parser);
+        let (output, _source_map, warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             output,
@@ -3513,7 +3505,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (output, _source_map, warnings) = preprocess(source, &parser);
+        let (output, _source_map, warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(output, "Remote content.\n");
         assert!(warnings.is_empty());
@@ -3533,7 +3525,7 @@ mod tests {
             .with_safe_mode(SafeMode::Server)
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
-        let (_output, _source_map, warnings) = preprocess(source, &parser);
+        let (_output, _source_map, warnings, _includes) = preprocess(source, &parser);
         assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
     }
 
@@ -3548,7 +3540,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (output, _source_map, warnings) = preprocess(source, &parser);
+        let (output, _source_map, warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(output, "Résumé.\n");
         assert_eq!(warnings.len(), 1);
@@ -3592,7 +3584,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(TranscodingFileHandler);
 
-        let (output, _source_map, warnings) = preprocess(source, &parser);
+        let (output, _source_map, warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(output, "Résumé.\n");
         assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
@@ -3609,7 +3601,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (output, _source_map, _warnings) = preprocess(source, &parser);
+        let (output, _source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             output,
@@ -3630,7 +3622,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (output, _source_map, _warnings) = preprocess(source, &parser);
+        let (output, _source_map, _warnings, _includes) = preprocess(source, &parser);
 
         assert_eq!(
             output,
@@ -3713,7 +3705,7 @@ mod tests {
             .with_primary_file_name("main.adoc")
             .with_include_file_handler(handler);
 
-        let (output, _source_map, _warnings) = preprocess(source, &parser);
+        let (output, _source_map, _warnings, _includes) = preprocess(source, &parser);
 
         // Tabs expand to the tab stop; the common indent is zero (the middle line
         // is flush left), so no further indentation change is made.
@@ -3732,7 +3724,8 @@ mod tests {
             .with_safe_mode(SafeMode::Server)
             .with_include_file_handler(handler);
 
-        let (output, _source_map, warnings) = preprocess("include::loop.adoc[]", &parser);
+        let (output, _source_map, warnings, _includes) =
+            preprocess("include::loop.adoc[]", &parser);
 
         // Each nesting level's only line is the directive itself, which
         // expands to the next level (contributing no output of its own) until
@@ -3759,7 +3752,8 @@ mod tests {
             .with_intrinsic_attribute_bool("max-include-depth", true, ModificationContext::ApiOnly)
             .with_include_file_handler(handler);
 
-        let (output, _source_map, warnings) = preprocess("include::shared.adoc[]", &parser);
+        let (output, _source_map, warnings, _includes) =
+            preprocess("include::shared.adoc[]", &parser);
 
         assert_eq!(output, "include::shared.adoc[]\n");
         assert!(warnings.is_empty());
@@ -3777,7 +3771,8 @@ mod tests {
             .with_intrinsic_attribute_bool("max-include-depth", false, ModificationContext::ApiOnly)
             .with_include_file_handler(handler);
 
-        let (output, _source_map, warnings) = preprocess("include::shared.adoc[]", &parser);
+        let (output, _source_map, warnings, _includes) =
+            preprocess("include::shared.adoc[]", &parser);
 
         assert_eq!(output, "shared content\n");
         assert!(warnings.is_empty());
@@ -3800,7 +3795,8 @@ mod tests {
             .with_intrinsic_attribute("max-include-depth", "2", ModificationContext::ApiOnly)
             .with_include_file_handler(handler);
 
-        let (output, _source_map, warnings) = preprocess("include::a.adoc[depth=10]", &parser);
+        let (output, _source_map, warnings, _includes) =
+            preprocess("include::a.adoc[depth=10]", &parser);
 
         assert_eq!(output, "include::c.adoc[]\n");
         assert_eq!(warnings.len(), 1);
@@ -3822,7 +3818,8 @@ mod tests {
                 .with_intrinsic_attribute("max-include-depth", value, ModificationContext::ApiOnly)
                 .with_include_file_handler(handler);
 
-            let (output, _source_map, warnings) = preprocess("include::shared.adoc[]", &parser);
+            let (output, _source_map, warnings, _includes) =
+                preprocess("include::shared.adoc[]", &parser);
 
             assert_eq!(output, "shared content\n");
             assert!(warnings.is_empty());
@@ -3847,7 +3844,7 @@ mod tests {
                 .with_intrinsic_attribute("max-include-depth", "1", ModificationContext::ApiOnly)
                 .with_include_file_handler(handler);
 
-            let (output, _source_map, warnings) =
+            let (output, _source_map, warnings, _includes) =
                 preprocess(&format!("include::a.adoc[depth={value}]"), &parser);
 
             assert_eq!(output, "include::b.adoc[]\n");

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -26,25 +26,38 @@ use crate::{
 ///
 /// [include file]: https://docs.asciidoctor.org/asciidoc/latest/directives/include/
 /// [conditional]: https://docs.asciidoctor.org/asciidoc/latest/directives/conditionals/
+///
+/// Thin wrapper retaining the three-value shape used throughout the
+/// preprocessor's own tests, which do not exercise the include registry (the
+/// fourth value). Production parsing calls
+/// [`preprocess_with_initial_file_name`] directly.
+#[cfg(test)]
 pub(crate) fn preprocess(
     source: &str,
     parser: &Parser,
 ) -> (String, SourceMap, Vec<DeferredWarning>) {
-    preprocess_with_initial_file_name(source, parser, parser.primary_file_name.as_deref())
+    let (output, source_map, warnings, _includes) =
+        preprocess_with_initial_file_name(source, parser, parser.primary_file_name.as_deref());
+    (output, source_map, warnings)
 }
 
-/// Like [`preprocess`], but treats `initial_file_name` (rather than the
-/// parser's `primary_file_name`) as the file the top-level `source` came from.
+/// Like `preprocess`, but treats `initial_file_name` (rather than the parser's
+/// `primary_file_name`) as the file the top-level `source` came from.
 ///
 /// This is used to preprocess the content of an AsciiDoc table cell, which the
 /// cell reached from some enclosing file: naming that file lets an unresolved
 /// `include::` directive inside the cell report the correct originating file in
 /// its "Unresolved directive in …" replacement, matching Asciidoctor.
+///
+/// The fourth returned value lists the AsciiDoc files this pass included, each
+/// paired with whether it was included in full; see the `includes` field of
+/// [`PreprocessorState`]. `Parser::parse_deferred` folds these into the
+/// document's [`Catalog`](crate::document::Catalog).
 pub(crate) fn preprocess_with_initial_file_name(
     source: &str,
     parser: &Parser,
     initial_file_name: Option<&str>,
-) -> (String, SourceMap, Vec<DeferredWarning>) {
+) -> (String, SourceMap, Vec<DeferredWarning>, Vec<(String, bool)>) {
     // Short-circuit if the original source document has no pre-processor
     // directives. `if` covers `ifdef`/`ifndef`/`ifeval`; `endif` is checked
     // separately because it does not share that prefix, and a stray `endif`
@@ -65,7 +78,7 @@ pub(crate) fn preprocess_with_initial_file_name(
         && !source.contains("\n\\include::")
         && initial_file_name.is_none()
     {
-        return (source.to_owned(), SourceMap::default(), vec![]);
+        return (source.to_owned(), SourceMap::default(), vec![], vec![]);
     }
 
     // We use a temporary clone of the parser to track document attribute values
@@ -79,7 +92,12 @@ pub(crate) fn preprocess_with_initial_file_name(
     // processed was never closed by a matching `endif`.
     state.emit_unterminated_conditional_warnings();
 
-    (state.output, state.source_map, state.warnings)
+    (
+        state.output,
+        state.source_map,
+        state.warnings,
+        state.includes,
+    )
 }
 
 #[derive(Debug)]
@@ -92,6 +110,18 @@ struct PreprocessorState<'p> {
     output: String,
     source_map: SourceMap,
     warnings: Vec<DeferredWarning>,
+
+    /// AsciiDoc files included while expanding this document, in the order the
+    /// `include::` directives were processed. Each entry pairs the include
+    /// target (relative to the outermost document, AsciiDoc extension removed)
+    /// with whether that directive merged the file *in full* (`true`) or only a
+    /// `lines`/`tag(s)` portion of it (`false`); the same file may appear more
+    /// than once. `Parser::parse_deferred` replays these through
+    /// [`Catalog::register_include`](crate::document::Catalog::register_include),
+    /// which resolves the full/partial value (a full include wins), so an
+    /// inter-document cross reference to an included file can collapse to a
+    /// same-document one.
+    includes: Vec<(String, bool)>,
 
     /// The include-depth limit currently in effect, or `None` when
     /// `max-include-depth` is 0 — which disables the include directive
@@ -194,6 +224,7 @@ impl<'p> PreprocessorState<'p> {
             output: String::new(),
             source_map: SourceMap::default(),
             warnings: vec![],
+            includes: vec![],
             max_include_depth,
             conditional_stack: vec![],
         }
@@ -520,6 +551,22 @@ impl<'p> PreprocessorState<'p> {
                     let content_start = self.output.len();
 
                     if is_asciidoc_file(&target) {
+                        // Register the included AsciiDoc file so an
+                        // inter-document cross reference whose target names it
+                        // can later collapse to a same-document reference (its
+                        // anchors are now part of this document). A `lines` or
+                        // partial `tag(s)` selection records a *partial* include,
+                        // which does not collapse the reference. A file
+                        // included both fully and partially resolves to full;
+                        // that merge is applied by
+                        // [`Catalog::register_include`] when these entries are
+                        // replayed into the catalog.
+                        //
+                        // [`Catalog::register_include`]: crate::document::Catalog::register_include
+                        let full = is_full_include(&attrlist);
+                        self.includes
+                            .push((include_catalog_key(&target).to_string(), full));
+
                         // The directive's `depth` attribute lowers the maximum
                         // include depth while the included file (and anything
                         // it includes) is processed; the previous limit is
@@ -1383,6 +1430,56 @@ fn is_asciidoc_file(target: &str) -> bool {
         // A leading dot (e.g. `.adoc`) denotes a hidden file with no extension.
         Some((stem, ext)) if !stem.is_empty() => ASCIIDOC_EXTENSIONS.contains(&ext),
         _ => false,
+    }
+}
+
+/// The [`Catalog`](crate::document::Catalog) include-registry key for an
+/// AsciiDoc include `target`: the target with its AsciiDoc file extension
+/// removed, matching the path an inter-document xref target interprets to (see
+/// [`interpret_xref_target`](crate::content)). `target` must name an AsciiDoc
+/// file (see [`is_asciidoc_file`]).
+///
+/// The key is the target as written in the `include::` directive, so for an
+/// include in the outermost document it is relative to that document — the
+/// coordinate system an inter-document xref target uses. (A nested include's
+/// target is relative to the file that includes it rather than the outermost
+/// document; the common single-level case, which every collapse test exercises,
+/// is exact.)
+fn include_catalog_key(target: &str) -> &str {
+    // `target` names an AsciiDoc file, so its final `.`-delimited segment is the
+    // extension to strip; only the trailing extension is removed, so a path that
+    // contains a period elsewhere (`using-.net-web-services.adoc`) keeps it.
+    match target.rsplit_once('.') {
+        Some((stem, _ext)) if !stem.is_empty() => stem,
+        _ => target,
+    }
+}
+
+/// Reports whether an `include::` directive with the given attributes merges
+/// the file *in full*, as opposed to selecting only a portion of it.
+///
+/// A `lines` selection is always partial. A `tag(s)` selection is partial too,
+/// except for the `**` wildcard, which selects every line of the file (both
+/// tagged and untagged regions) and so is a full include — matching
+/// Asciidoctor's `catalog[:includes]` bookkeeping.
+fn is_full_include(attrlist: &Attrlist<'_>) -> bool {
+    if attrlist
+        .named_attribute("lines")
+        .map(|a| a.value())
+        .is_some_and(|v| !v.is_empty())
+    {
+        return false;
+    }
+
+    match attrlist
+        .named_attribute("tags")
+        .or_else(|| attrlist.named_attribute("tag"))
+        .map(|a| a.value())
+        .filter(|v| !v.is_empty())
+    {
+        // `tags=**` selects the whole file; any other selection is partial.
+        Some(tags) => tags.trim() == "**",
+        None => true,
     }
 }
 
@@ -3775,5 +3872,70 @@ mod tests {
         assert_eq!(ruby_to_i("abc"), 0);
         assert_eq!(ruby_to_i("-"), 0);
         assert_eq!(ruby_to_i(""), 0);
+    }
+
+    mod include_registry {
+        use super::super::{include_catalog_key, is_full_include};
+        use crate::{
+            Span,
+            attributes::{Attrlist, AttrlistContext},
+            tests::prelude::*,
+        };
+
+        #[test]
+        fn catalog_key_strips_the_asciidoc_extension() {
+            assert_eq!(include_catalog_key("other-chapters.adoc"), "other-chapters");
+            assert_eq!(include_catalog_key("part1/tigers.adoc"), "part1/tigers");
+            assert_eq!(include_catalog_key("../section-a.adoc"), "../section-a");
+            assert_eq!(include_catalog_key("notes.txt"), "notes");
+
+            // Only the trailing extension is removed, so a period elsewhere in
+            // the name is kept.
+            assert_eq!(
+                include_catalog_key("using-.net-web-services.adoc"),
+                "using-.net-web-services"
+            );
+        }
+
+        fn is_full(attrlist_text: &str) -> bool {
+            let parser = Parser::default();
+            let span = Span::new(attrlist_text);
+            let attrlist = Attrlist::parse(span, &parser, AttrlistContext::Inline)
+                .item
+                .item;
+            is_full_include(&attrlist)
+        }
+
+        #[test]
+        fn an_unfiltered_include_is_full() {
+            assert!(is_full(""));
+        }
+
+        #[test]
+        fn a_lines_selection_is_partial() {
+            assert!(!is_full("lines=1..5"));
+
+            // An empty `lines` value selects nothing in particular, so it does
+            // not make the include partial on its own.
+            assert!(is_full("lines="));
+        }
+
+        #[test]
+        fn a_tag_selection_is_partial_unless_it_selects_everything() {
+            assert!(!is_full("tags=ch2"));
+            assert!(!is_full("tag=ch2"));
+            assert!(!is_full("tags=ch2;ch3"));
+
+            // The `**` wildcard selects every line, so it is a full include.
+            assert!(is_full("tags=**"));
+            assert!(is_full("tag=**"));
+        }
+
+        #[test]
+        fn lines_takes_precedence_over_a_whole_file_tag_selection() {
+            // A `lines` selection is partial even when `tags=**` is also present
+            // (`lines` wins, matching the selection the preprocessor applies).
+            assert!(!is_full("lines=1..2,tags=**"));
+        }
     }
 }

--- a/parser/src/tests/asciidoc_lang/macros/inter_document_xref.rs
+++ b/parser/src/tests/asciidoc_lang/macros/inter_document_xref.rs
@@ -72,14 +72,10 @@ If not, it will generate a link to [.path]_document-b.html_, intelligently subst
     );
 }
 
-// Include processing (`catalog[:includes]`) is out of scope for this crate, so
-// a cross reference to a document that was included into this one is not
-// collapsed to a same-document reference. A reference to the document being
-// parsed itself (by `docname`) *is* collapsed; see
-// `should_use_doctitle_as_fallback_link_text_if_inter_document_xref_points_to_current_doc_and_no_link_text_is_provided`
-// in the `links_test.rs` port.
-non_normative!(
-    r##"
+#[test]
+fn collapses_to_an_internal_anchor_when_the_target_was_included() {
+    verifies!(
+        r##"
 If [.path]_document-b.adoc_ is included in the same document as [.path]_document-a.doc_, then the document will be dropped in the link target and look like the output of a normal cross reference:
 
 [source,html]
@@ -90,7 +86,30 @@ If [.path]_document-b.adoc_ is included in the same document as [.path]_document
 Now you can create inter-document cross references without the headache.
 
 "##
-);
+    );
+
+    // `document-b.adoc` is included into this document in full, so its
+    // `section-b` anchor is now part of this document and the inter-document
+    // reference to it collapses to a same-document one (issue #808). The Ruby
+    // suite reads the included file from disk; here an include handler serves it
+    // inline.
+    let doc = Parser::default()
+        .with_safe_mode(SafeMode::Server)
+        .with_include_file_handler(inline_file_handler::InlineFileHandler::from_pairs([(
+            "document-b.adoc",
+            "[#section-b]\n== Section B\n",
+        )]))
+        .parse(
+            "Refer to xref:document-b.adoc#section-b[Section B].\n\ninclude::document-b.adoc[]\n",
+        );
+
+    assert!(doc.catalog().include_is_full("document-b"));
+
+    assert_eq!(
+        rendered_paragraphs(&doc)[0],
+        r##"Refer to <a href="#section-b">Section B</a>."##
+    );
+}
 
 non_normative!(
     r##"

--- a/parser/src/tests/asciidoctor_rb/links_test.rs
+++ b/parser/src/tests/asciidoctor_rb/links_test.rs
@@ -42,9 +42,13 @@
 //!
 //! * **DocBook backend** output — out of scope for this parser crate.
 //! * **Compat mode** — disregarded per the porting conventions.
-//! * **Include processing** (`include::[]`, `catalog[:includes]`) and
-//!   Ruby-internal APIs (`doc.register`, `using_memory_logger`) — not modeled
-//!   the same way here.
+//! * **Ruby-internal APIs** (`doc.register`, `using_memory_logger`) — not
+//!   modeled the same way here.
+//!
+//! The inter-document-xref-to-included-file tests (`catalog[:includes]`) *are*
+//! ported (issue #808): the Ruby suite reads the included files from
+//! `fixturedir`, while these ports serve the same content through an
+//! [`InlineFileHandler`](crate::tests::fixtures::inline_file_handler::InlineFileHandler).
 //! * A number of **other surfaced incompatibilities**, each carrying a `//
 //!   NOTE:` describing how the crate diverges from Asciidoctor.
 
@@ -60,6 +64,27 @@ fn doc_with(src: &str, attrs: &[(&str, &str)]) -> crate::Document<'static> {
     }
     parser.parse(src)
 }
+
+/// Parses `src` with an include handler serving `files`, so an `include::`
+/// directive resolves to inline content. This is the crate's stand-in for
+/// Asciidoctor's `base_dir: fixturedir`, where the Ruby suite reads the same
+/// content from files on disk. `SafeMode::Server` keeps the include directive
+/// enabled (it is disabled at `Secure` and above).
+fn doc_with_includes<const N: usize>(
+    src: &str,
+    files: [(&'static str, &'static str); N],
+) -> crate::Document<'static> {
+    Parser::default()
+        .with_safe_mode(SafeMode::Server)
+        .with_include_file_handler(inline_file_handler::InlineFileHandler::from_pairs(files))
+        .parse(src)
+}
+
+/// The `other-chapters.adoc` include used by the inter-document-xref collapse
+/// tests. It defines the `ch2` section (so a full include registers that
+/// anchor) and carries `ch2` and `ch2-noid` tagged regions so a partial include
+/// can select a portion of it.
+const OTHER_CHAPTERS: &str = "[#ch2]\n== Chapter 2\n\n// tag::ch2[]\nThe second chapter.\n// end::ch2[]\n\n// tag::ch2-noid[]\nAn extra note.\n// end::ch2-noid[]\n";
 
 non_normative!(
     r###"
@@ -2658,9 +2683,10 @@ fn xref_using_angled_bracket_syntax_with_path_and_custom_relfilesuffix() {
     );
 }
 
-// Include processing / `catalog[:includes]` is out of scope for this crate.
-non_normative!(
-    r###"
+#[test]
+fn xref_with_path_which_has_been_included_in_this_document() {
+    verifies!(
+        r###"
   test 'xref using angled bracket syntax with path which has been included in this document' do
     using_memory_logger do |logger|
       in_verbose_mode do
@@ -2674,11 +2700,38 @@ non_normative!(
   end
 
 "###
-);
+    );
 
-// Include processing / `catalog[:includes]` is out of scope for this crate.
-non_normative!(
-    r###"
+    // The Ruby test seeds `catalog[:includes]['tigers']` directly through the
+    // API. This crate populates that registry only from real `include::`
+    // directives, so the equivalent state is reached by actually including
+    // `tigers.adoc` in full — the file does not define the `about` anchor, so
+    // the collapsed reference is still an unresolved (`possible invalid
+    // reference`) one, exactly as in the Ruby test.
+    let doc = doc_with_includes(
+        "<<tigers#about,About Tigers>>\n\ninclude::tigers.adoc[]\n",
+        [("tigers.adoc", "Tigers are big cats.\n")],
+    );
+
+    assert!(doc.catalog().include_is_full("tigers"));
+
+    assert_eq!(
+        rendered_paragraphs(&doc)[0],
+        r##"<a href="#about">About Tigers</a>"##
+    );
+
+    let warnings: Vec<_> = doc.warnings().collect();
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(
+        warnings[0].warning,
+        WarningType::PossibleInvalidReference("about".to_string())
+    );
+}
+
+#[test]
+fn xref_with_nested_path_which_has_been_included_in_this_document() {
+    verifies!(
+        r###"
   test 'xref using angled bracket syntax with nested path which has been included in this document' do
     using_memory_logger do |logger|
       in_verbose_mode do
@@ -2692,7 +2745,30 @@ non_normative!(
   end
 
 "###
-);
+    );
+
+    // As above, the seeded registry entry is reached by a real include; the
+    // nested path is registered under the target as written (`part1/tigers`),
+    // which the inter-document target interprets to the same key.
+    let doc = doc_with_includes(
+        "<<part1/tigers#about,About Tigers>>\n\ninclude::part1/tigers.adoc[]\n",
+        [("part1/tigers.adoc", "Tigers are big cats.\n")],
+    );
+
+    assert!(doc.catalog().include_is_full("part1/tigers"));
+
+    assert_eq!(
+        rendered_paragraphs(&doc)[0],
+        r##"<a href="#about">About Tigers</a>"##
+    );
+
+    let warnings: Vec<_> = doc.warnings().collect();
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(
+        warnings[0].warning,
+        WarningType::PossibleInvalidReference("about".to_string())
+    );
+}
 
 #[test]
 fn xref_using_angled_bracket_syntax_inline_with_text() {
@@ -3179,9 +3255,10 @@ fn should_warn_and_create_link_if_verbose_flag_is_set_and_reference_using_hash_n
     assert_eq!(warnings[0].source.line(), 6);
 }
 
-// Include processing / `catalog[:includes]` is out of scope for this crate.
-non_normative!(
-    r###"
+#[test]
+fn internal_anchor_from_inter_document_xref_to_included_file() {
+    verifies!(
+        r###"
   test 'should produce an internal anchor from an inter-document xref to file included into current file' do
     input = <<~'EOS'
     = Book Title
@@ -3205,11 +3282,30 @@ non_normative!(
   end
 
 "###
-);
+    );
 
-// Include processing / `catalog[:includes]` is out of scope for this crate.
-non_normative!(
-    r###"
+    // The Ruby suite reads `other-chapters.adoc` from `fixturedir`; here the
+    // include handler serves the same content inline.
+    let doc = doc_with_includes(
+        "= Book Title\n:doctype: book\n\n[#ch1]\n== Chapter 1\n\nSo it begins.\n\nRead <<other-chapters.adoc#ch2>> to find out what happens next!\n\ninclude::other-chapters.adoc[]\n",
+        [("other-chapters.adoc", OTHER_CHAPTERS)],
+    );
+
+    // The file was included in full, so it registers as a full include.
+    assert!(doc.catalog().was_included("other-chapters"));
+    assert!(doc.catalog().include_is_full("other-chapters"));
+
+    // The inter-document reference collapses to an internal anchor.
+    assert_eq!(
+        rendered_paragraphs(&doc)[1],
+        r##"Read <a href="#ch2">Chapter 2</a> to find out what happens next!"##
+    );
+}
+
+#[test]
+fn internal_anchor_from_inter_document_xref_to_file_included_entirely_using_tags() {
+    verifies!(
+        r###"
   test 'should produce an internal anchor from an inter-document xref to file included entirely into current file using tags' do
     input = <<~'EOS'
     = Book Title
@@ -3230,11 +3326,26 @@ non_normative!(
   end
 
 "###
-);
+    );
 
-// Include processing / `catalog[:includes]` is out of scope for this crate.
-non_normative!(
-    r###"
+    // `tags=**` selects every line of the file, so it is a full include.
+    let doc = doc_with_includes(
+        "= Book Title\n:doctype: book\n\n[#ch1]\n== Chapter 1\n\nSo it begins.\n\nRead <<other-chapters.adoc#ch2>> to find out what happens next!\n\ninclude::other-chapters.adoc[tags=**]\n",
+        [("other-chapters.adoc", OTHER_CHAPTERS)],
+    );
+
+    assert!(doc.catalog().include_is_full("other-chapters"));
+
+    assert_eq!(
+        rendered_paragraphs(&doc)[1],
+        r##"Read <a href="#ch2">Chapter 2</a> to find out what happens next!"##
+    );
+}
+
+#[test]
+fn no_internal_anchor_for_inter_document_xref_to_partially_included_file() {
+    verifies!(
+        r###"
   test 'should not produce an internal anchor for inter-document xref to file partially included into current file' do
     input = <<~'EOS'
     = Book Title
@@ -3258,11 +3369,29 @@ non_normative!(
   end
 
 "###
-);
+    );
 
-// Include processing / `catalog[:includes]` is out of scope for this crate.
-non_normative!(
-    r###"
+    // Only the `ch2` region is selected, so the file registers as a *partial*
+    // include and the reference is not collapsed: its derived output path
+    // stands.
+    let doc = doc_with_includes(
+        "= Book Title\n:doctype: book\n\n[#ch1]\n== Chapter 1\n\nSo it begins.\n\nRead <<other-chapters.adoc#ch2,the next chapter>> to find out what happens next!\n\ninclude::other-chapters.adoc[tags=ch2]\n",
+        [("other-chapters.adoc", OTHER_CHAPTERS)],
+    );
+
+    assert!(doc.catalog().was_included("other-chapters"));
+    assert!(!doc.catalog().include_is_full("other-chapters"));
+
+    assert_eq!(
+        rendered_paragraphs(&doc)[1],
+        r##"Read <a href="other-chapters.html#ch2">the next chapter</a> to find out what happens next!"##
+    );
+}
+
+#[test]
+fn internal_anchor_for_inter_document_xref_to_file_included_fully_and_partially() {
+    verifies!(
+        r###"
   test 'should produce an internal anchor for inter-document xref to file included fully and partially' do
     input = <<~'EOS'
     = Book Title
@@ -3288,7 +3417,22 @@ non_normative!(
   end
 
 "###
-);
+    );
+
+    // The file is included once in full and once partially (`tag=ch2-noid`);
+    // the full include wins, so the reference collapses to an internal anchor.
+    let doc = doc_with_includes(
+        "= Book Title\n:doctype: book\n\n[#ch1]\n== Chapter 1\n\nSo it begins.\n\nRead <<other-chapters.adoc#ch2,the next chapter>> to find out what happens next!\n\ninclude::other-chapters.adoc[]\n\ninclude::other-chapters.adoc[tag=ch2-noid]\n",
+        [("other-chapters.adoc", OTHER_CHAPTERS)],
+    );
+
+    assert!(doc.catalog().include_is_full("other-chapters"));
+
+    assert_eq!(
+        rendered_paragraphs(&doc)[1],
+        r##"Read <a href="#ch2">the next chapter</a> to find out what happens next!"##
+    );
+}
 
 // NOTE: Asciidoctor emits the `possible invalid reference` message only in
 // verbose (pedantic) mode. This crate has no such mode: an unresolved reference
@@ -3555,9 +3699,10 @@ non_normative!(
 "###
 );
 
-// Include processing / `catalog[:includes]` is out of scope for this crate.
-non_normative!(
-    r###"
+#[test]
+fn internal_anchor_for_inter_document_xref_to_file_outside_base_directory() {
+    verifies!(
+        r###"
   test 'should produce an internal anchor for inter-document xref to file outside of base directory' do
     input = <<~'EOS'
     = Document Title
@@ -3574,7 +3719,24 @@ non_normative!(
   end
 
 "###
-);
+    );
+
+    // A file included from outside the base directory registers under the target
+    // as written (`../section-a`), and the reference to it collapses just the
+    // same.
+    let doc = doc_with_includes(
+        "= Document Title\n\nSee <<../section-a.adoc#section-a>>.\n\ninclude::../section-a.adoc[]\n",
+        [("../section-a.adoc", "[#section-a]\n== Section A\n")],
+    );
+
+    assert!(doc.catalog().was_included("../section-a"));
+    assert!(doc.catalog().include_is_full("../section-a"));
+
+    assert_eq!(
+        rendered_paragraphs(&doc)[0],
+        r##"See <a href="#section-a">Section A</a>."##
+    );
+}
 
 #[test]
 fn xref_uses_title_of_target_as_label_for_forward_and_backward_references_in_html_output() {

--- a/parser/src/tests/asciidoctor_rb/reader_test.rs
+++ b/parser/src/tests/asciidoctor_rb/reader_test.rs
@@ -168,7 +168,8 @@ impl IncludeFileHandler for RecordingIncludeFileHandler {
 /// no trailing newline, so the single trailing newline the preprocessor emits
 /// is stripped.)
 fn reader_read(parser: &Parser, input: &str) -> String {
-    let (output, _source_map, _warnings) = crate::parser::preprocessor::preprocess(input, parser);
+    let (output, _source_map, _warnings, _includes) =
+        crate::parser::preprocessor::preprocess(input, parser);
     output
         .strip_suffix('\n')
         .map(str::to_owned)
@@ -1556,7 +1557,7 @@ fn should_use_encoding_specified_by_encoding_attribute_when_reading_include_file
         .with_safe_mode(SafeMode::Server)
         .with_include_file_handler(handler);
 
-    let (output, _source_map, warnings) = crate::parser::preprocessor::preprocess(
+    let (output, _source_map, warnings, _includes) = crate::parser::preprocessor::preprocess(
         "include::fixtures/iso-8859-1.txt[encoding=iso-8859-1]",
         &parser,
     );
@@ -1614,7 +1615,7 @@ fn unresolved_target_referenced_by_include_directive_is_skipped_when_optional_op
         .with_safe_mode(SafeMode::Server)
         .with_include_file_handler(handler);
 
-    let (output, _source_map, warnings) = crate::parser::preprocessor::preprocess(
+    let (output, _source_map, warnings, _includes) = crate::parser::preprocessor::preprocess(
         "include::fixtures/{no-such-file}[opts=optional]\n\ntrailing content",
         &parser,
     );
@@ -1665,7 +1666,7 @@ fn should_skip_include_directive_that_references_missing_file_if_optional_option
     let parser = Parser::default()
         .with_safe_mode(SafeMode::Server)
         .with_include_file_handler(handler);
-    let (output, _source_map, warnings) = crate::parser::preprocessor::preprocess(
+    let (output, _source_map, warnings, _includes) = crate::parser::preprocessor::preprocess(
         "include::fixtures/no-such-file.adoc[opts=optional]\n\ntrailing content",
         &parser,
     );
@@ -1713,7 +1714,7 @@ fn should_replace_include_directive_that_references_missing_file_with_message() 
     let parser = Parser::default()
         .with_safe_mode(SafeMode::Server)
         .with_include_file_handler(handler);
-    let (output, _source_map, warnings) = crate::parser::preprocessor::preprocess(
+    let (output, _source_map, warnings, _includes) = crate::parser::preprocessor::preprocess(
         "include::fixtures/no-such-file.adoc[]\n\ntrailing content",
         &parser,
     );
@@ -1773,7 +1774,7 @@ fn should_replace_include_directive_that_references_unreadable_file_with_message
     let parser = Parser::default()
         .with_safe_mode(SafeMode::Server)
         .with_include_file_handler(handler);
-    let (output, _source_map, warnings) = crate::parser::preprocessor::preprocess(
+    let (output, _source_map, warnings, _includes) = crate::parser::preprocessor::preprocess(
         "include::fixtures/chapter-a.adoc[]\n\ntrailing content",
         &parser,
     );
@@ -4051,7 +4052,7 @@ fn line_is_skipped_by_default_if_target_of_include_directive_resolves_to_empty()
         .with_safe_mode(SafeMode::Server)
         .with_include_file_handler(handler);
 
-    let (output, _source_map, warnings) =
+    let (output, _source_map, warnings, _includes) =
         crate::parser::preprocessor::preprocess("include::{blank}[]", &parser);
 
     assert_eq!(
@@ -4106,7 +4107,7 @@ fn include_is_dropped_if_target_contains_missing_attribute_and_attribute_missing
         )
         .with_include_file_handler(handler);
 
-    let (output, _source_map, warnings) =
+    let (output, _source_map, warnings, _includes) =
         crate::parser::preprocessor::preprocess("include::{foodir}/include-file.adoc[]", &parser);
 
     assert_eq!(output, "");
@@ -4153,7 +4154,7 @@ fn line_following_dropped_include_is_not_dropped() {
         .with_intrinsic_attribute("attribute-missing", "warn", ModificationContext::Anywhere)
         .with_include_file_handler(handler);
 
-    let (output, _source_map, warnings) = crate::parser::preprocessor::preprocess(
+    let (output, _source_map, warnings, _includes) = crate::parser::preprocessor::preprocess(
         "include::{foodir}/include-file.adoc[]\nyo",
         &parser,
     );
@@ -4256,7 +4257,7 @@ fn include_directive_is_disabled_when_max_include_depth_attribute_is_0() {
         .with_intrinsic_attribute("max-include-depth", "0", ModificationContext::ApiOnly)
         .with_include_file_handler(handler);
 
-    let (output, _source_map, warnings) =
+    let (output, _source_map, warnings, _includes) =
         crate::parser::preprocessor::preprocess("include::include-file.adoc[]", &parser);
 
     assert_eq!(output, "include::include-file.adoc[]\n");
@@ -4292,7 +4293,7 @@ fn max_include_depth_cannot_be_set_by_document() {
         .with_intrinsic_attribute("max-include-depth", "0", ModificationContext::ApiOnly)
         .with_include_file_handler(handler);
 
-    let (output, _source_map, warnings) = crate::parser::preprocessor::preprocess(
+    let (output, _source_map, warnings, _includes) = crate::parser::preprocessor::preprocess(
         ":max-include-depth: 1\n\ninclude::include-file.adoc[]",
         &parser,
     );
@@ -4357,7 +4358,7 @@ fn include_directive_should_be_disabled_if_max_include_depth_has_been_exceeded()
             ("grandchild-include.adoc", GRANDCHILD_INCLUDE_ADOC),
         ]));
 
-    let (output, source_map, warnings) = crate::parser::preprocessor::preprocess(
+    let (output, source_map, warnings, _includes) = crate::parser::preprocessor::preprocess(
         "include::fixtures/parent-include.adoc[depth=1]",
         &parser,
     );
@@ -4427,7 +4428,7 @@ fn include_directive_should_be_disabled_if_max_include_depth_set_in_nested_conte
             ("grandchild-include.adoc", GRANDCHILD_INCLUDE_ADOC),
         ]));
 
-    let (output, _source_map, warnings) = crate::parser::preprocessor::preprocess(
+    let (output, _source_map, warnings, _includes) = crate::parser::preprocessor::preprocess(
         "include::fixtures/parent-include-restricted.adoc[depth=3]",
         &parser,
     );

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -888,4 +888,63 @@ mod included_file_collapses_to_internal_anchor {
             r#"Read <a href="other-chapters.html#ch2">the next chapter</a> next!"#
         );
     }
+
+    #[test]
+    fn a_nested_include_does_not_register_and_cannot_falsely_collapse() {
+        // The root document includes `part1/chapters.adoc`, which itself
+        // includes `intro.adoc` — a target relative to *that* file, i.e.
+        // `part1/intro.adoc` on disk. Registering it under the key `intro`
+        // would collide with the root-relative path of a *different* file, so
+        // a root-level `<<intro.adoc#…>>` would falsely collapse to an
+        // internal anchor. A nested include is therefore not registered at
+        // all, and the reference keeps its inter-document output path.
+        let handler = InlineFileHandler::from_pairs([
+            (
+                "part1/chapters.adoc",
+                "== Chapters\n\ninclude::intro.adoc[]\n",
+            ),
+            ("intro.adoc", "[#nested-intro]\n== Nested Intro\n"),
+        ]);
+
+        let doc = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_include_file_handler(handler)
+            .parse("See <<intro.adoc#other,text>>.\n\ninclude::part1/chapters.adoc[]\n");
+
+        // The outermost include registers; the nested one does not.
+        assert!(doc.catalog().was_included("part1/chapters"));
+        assert!(!doc.catalog().was_included("intro"));
+
+        assert_eq!(
+            first_paragraph(&doc),
+            r#"See <a href="intro.html#other">text</a>."#
+        );
+    }
+
+    #[test]
+    fn an_include_inside_a_table_cell_registers_and_collapses() {
+        // An AsciiDoc table cell shares the enclosing document's catalog, so a
+        // file the cell includes in full registers on the document's include
+        // registry (as in Asciidoctor, where the cell's nested document shares
+        // the parent's `catalog[:includes]`) and an inter-document reference in
+        // that cell collapses to an internal anchor.
+        let handler =
+            InlineFileHandler::from_pairs([("chapter.adoc", "[#target]\n== Chapter\n\nBody.\n")]);
+
+        let doc = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_include_file_handler(handler)
+            .parse("|===\na|See xref:chapter.adoc#target[].\n\ninclude::chapter.adoc[]\n|===\n");
+
+        assert!(doc.catalog().include_is_full("chapter"));
+
+        // The cell's blocks live in the cell's own owned sub-document, so the
+        // rendered link is asserted through the converted output.
+        crate::tests::assert_dom::assert_xpath(&doc, r##"//a[@href="#target"]"##, 1);
+        crate::tests::assert_dom::assert_xpath(
+            &doc,
+            r##"//a[@href="#target"][text()="Chapter"]"##,
+            1,
+        );
+    }
 }

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -766,3 +766,126 @@ mod unresolved_reference_warnings {
         assert_eq!(warnings[0].source.line(), 2);
     }
 }
+
+/// Issue #808: an inter-document cross reference whose target names a file that
+/// was included into this document collapses to a same-document reference — but
+/// only when the file was included in full.
+mod included_file_collapses_to_internal_anchor {
+    use super::first_paragraph;
+    use crate::{Parser, parser::SafeMode, tests::prelude::inline_file_handler::InlineFileHandler};
+
+    /// `other-chapters.adoc`, defining the `ch2` section. It carries a `ch2`
+    /// tagged region (so a partial include can select a portion of it) and a
+    /// separate `ch2-noid` region (for the fully-and-partially-included case).
+    const OTHER_CHAPTERS: &str = "[#ch2]\n== Chapter 2\n\n// tag::ch2[]\nThe second chapter.\n// end::ch2[]\n\n// tag::ch2-noid[]\nAn extra note.\n// end::ch2-noid[]\n";
+
+    fn parse_book(body: &str) -> crate::Document<'static> {
+        let handler = InlineFileHandler::from_pairs([("other-chapters.adoc", OTHER_CHAPTERS)]);
+        let source = format!("= Book Title\n:doctype: book\n\n{body}");
+        Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_include_file_handler(handler)
+            .parse(&source)
+    }
+
+    #[test]
+    fn full_include_collapses_reference_with_fragment() {
+        // The whole file is included, so `ch2` is now an anchor in this
+        // document: `<<other-chapters.adoc#ch2>>` resolves to `#ch2`.
+        let doc = parse_book(
+            "Read <<other-chapters.adoc#ch2>> next!\n\ninclude::other-chapters.adoc[]\n",
+        );
+
+        assert!(doc.catalog().was_included("other-chapters"));
+        assert!(doc.catalog().include_is_full("other-chapters"));
+
+        assert_eq!(
+            first_paragraph(&doc),
+            r##"Read <a href="#ch2">Chapter 2</a> next!"##
+        );
+    }
+
+    #[test]
+    fn full_include_via_double_star_tag_collapses_reference() {
+        // `tags=**` selects the entire file, so the include is full.
+        let doc = parse_book(
+            "Read <<other-chapters.adoc#ch2>> next!\n\ninclude::other-chapters.adoc[tags=**]\n",
+        );
+
+        assert!(doc.catalog().include_is_full("other-chapters"));
+
+        assert_eq!(
+            first_paragraph(&doc),
+            r##"Read <a href="#ch2">Chapter 2</a> next!"##
+        );
+    }
+
+    #[test]
+    fn partial_include_does_not_collapse_reference() {
+        // Only the `ch2` region is included, so the reference may point at an
+        // anchor that never made it across: it stays an inter-document
+        // reference and keeps its derived output path.
+        let doc = parse_book(
+            "Read <<other-chapters.adoc#ch2,the next chapter>> next!\n\ninclude::other-chapters.adoc[tags=ch2]\n",
+        );
+
+        assert!(doc.catalog().was_included("other-chapters"));
+        assert!(!doc.catalog().include_is_full("other-chapters"));
+
+        assert_eq!(
+            first_paragraph(&doc),
+            r#"Read <a href="other-chapters.html#ch2">the next chapter</a> next!"#
+        );
+    }
+
+    #[test]
+    fn full_and_partial_includes_collapse_reference() {
+        // The file is included once in full and once partially; the full
+        // include wins, so the reference collapses.
+        let doc = parse_book(
+            "Read <<other-chapters.adoc#ch2,the next chapter>> next!\n\ninclude::other-chapters.adoc[]\n\ninclude::other-chapters.adoc[tags=ch2-noid]\n",
+        );
+
+        assert!(doc.catalog().include_is_full("other-chapters"));
+
+        assert_eq!(
+            first_paragraph(&doc),
+            r##"Read <a href="#ch2">the next chapter</a> next!"##
+        );
+    }
+
+    #[test]
+    fn include_outside_base_directory_still_registers_and_collapses() {
+        // A file included from outside the base directory registers under the
+        // target as written (`../section-a`), and an inter-document reference to
+        // it collapses just the same.
+        let handler =
+            InlineFileHandler::from_pairs([("../section-a.adoc", "[#section-a]\n== Section A\n")]);
+        let doc = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_include_file_handler(handler)
+            .parse("= Document Title\n\nSee <<../section-a.adoc#section-a>>.\n\ninclude::../section-a.adoc[]\n");
+
+        assert!(doc.catalog().was_included("../section-a"));
+        assert!(doc.catalog().include_is_full("../section-a"));
+
+        assert_eq!(
+            first_paragraph(&doc),
+            r##"See <a href="#section-a">Section A</a>."##
+        );
+    }
+
+    #[test]
+    fn a_reference_to_a_file_that_was_not_included_is_unaffected() {
+        // With no include of `other-chapters.adoc`, the reference keeps its
+        // inter-document output path.
+        let doc = parse_book("Read <<other-chapters.adoc#ch2,the next chapter>> next!\n");
+
+        assert!(!doc.catalog().was_included("other-chapters"));
+
+        assert_eq!(
+            first_paragraph(&doc),
+            r#"Read <a href="other-chapters.html#ch2">the next chapter</a> next!"#
+        );
+    }
+}


### PR DESCRIPTION
Fixes #808. Follow-on from #803, which resolved inter-document xref targets to output paths and handled the `docname` self-reference case, but deliberately left out the include branch — the crate kept no record of what the preprocessor included.

Asciidoctor collapses an inter-document cross reference to a same-document one when its target names a file whose contents were included into the document being converted, so the link points at the anchor now in *this* output rather than at a separate page that may not exist.

| Input (with `include::other-chapters.adoc[]`) | Before | After |
|---|---|---|
| `<<other-chapters.adoc#ch2>>` | `<a href="other-chapters.html#ch2">other-chapters.html</a>` | `<a href="#ch2">Chapter 2</a>` |

## An include registry on `Catalog`

New `includes` map on `Catalog`, keyed by include target **relative to the outermost document with the AsciiDoc extension removed** (`other-chapters` for `include::other-chapters.adoc[]`), with a boolean value:

* `true` when the file was ever included **in full**, `false` when every include of it selected only a `lines`/`tag(s)` portion.
* A full include **wins** over any partial include of the same file, in either order. Only a full include collapses the reference — a partial one may not have carried the referenced anchor across.
* `tags=**` selects the whole file, so it counts as full.

The preprocessor records each `include::` directive it expands (a `Vec` of `(key, full)` events, order-independent), and `Parser::parse_deferred` replays them through the new `Catalog::register_include`, which owns the full-wins merge rule. The registry is seeded into the fresh catalog before parsing, so it is available while cross references are interpreted, and rides along into the document's catalog — exposed publicly via `Catalog::was_included` and `Catalog::include_is_full` (the crate's stand-in for `doc.catalog[:includes]`, and plausibly useful beyond xrefs).

**Only directives written in the outermost document register.** A nested include's target is relative to the file containing it, not the outermost document, so registering it as written could collide with — and falsely collapse — a root-relative xref naming a different file. A nested include therefore produces no registry entry: an xref to it keeps its ordinary inter-document destination (a benign missed collapse rather than a wrong URL).

**Includes inside an AsciiDoc table cell register too.** A cell shares the enclosing document's catalog (only its footnote list is cell-local), matching Asciidoctor, where the cell's nested document shares the parent's `catalog[:includes]`. The cell's include events replay into the shared registry, gated on the cell living in the outermost document so keys stay root-relative. (Because this crate interprets xrefs in document order as blocks parse, only xrefs in that cell and beyond observe these entries; Asciidoctor, which resolves xrefs after the whole document is read, has no such ordering.)

## Where it plugs in

The xref side is the sibling of #803's `docname` self-reference branch in `content/macros.rs`: a target that names a fully-included file is treated as a reference within this document (a fragment becomes `#fragment`, resolved against the catalog; a bare target becomes `#`), matching Asciidoctor's `docname == path || catalog[:includes][path]` test in `substitutors.rb`.

## Threading

`preprocess` (and `preprocess_with_initial_file_name`) gained a fourth return value carrying the include events; `preprocess` remains the production entry point, called by `Parser::parse_deferred` as before. Test call sites destructure the extra value as `_includes`.

## Tests

* The `catalog[:includes]` blocks in the `links_test.rs` port become real `verifies!` tests (full include, `tags=**` full, partial, full-and-partial, outside-base-directory, and the two that seed the registry — adapted to a real full include, since the crate populates the registry only from actual `include::` directives rather than the Ruby seeding API). The Ruby suite reads the included files from `fixturedir`; these ports serve the same content through an `InlineFileHandler`.
* The "included in the same document" paragraph of the `inter-document-xref.adoc` spec page is now `verifies!`.
* Integration tests in `tests/xref.rs` covering each collapse case end-to-end — including the nested-include collision (must **not** collapse) and the table-cell include (must collapse) — plus unit tests for the `Catalog` merge rule and the preprocessor's full/partial and key derivation.

## Note

One commit reformats two doc comments in `parser/src/document/header.rs` that the CI format job's current nightly rustfmt rewraps — pre-existing drift on `main` (it fails the format job on a clean checkout too), folded in here so the job goes green. Comment reflow only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BykBRZFaRqpVuEWkEcHus