### PR TITLE
fix: Resolve revision components given as attribute references (#759)

### DIFF
--- a/parser/src/document/revision_line.rs
+++ b/parser/src/document/revision_line.rs
@@ -321,6 +321,41 @@ mod tests {
     }
 
     #[test]
+    fn comma_form_prefix_stops_at_attribute_reference() {
+        // Mirrors Asciidoctor's `RevisionInfoLineRx`, whose revision-number
+        // prefix class is `[^\d{]*`: the leading run stops at `{`, so an
+        // attribute reference survives prefix removal and is then resolved by
+        // the header substitutions. With the referenced attribute undefined the
+        // reference is preserved verbatim (default `attribute-missing` skips it).
+        let mut parser = Parser::default();
+        let result =
+            crate::document::RevisionLine::parse(Span::new("v{draft}, 2024-01-01"), &mut parser);
+
+        assert_eq!(result.revnumber(), Some("{draft}"));
+        assert_eq!(result.revdate(), "2024-01-01");
+        assert_eq!(result.revremark(), None);
+    }
+
+    #[test]
+    fn comma_form_prefix_absorbs_escape_before_reference() {
+        // Also mirrors Asciidoctor: the `[^\d{]*` prefix absorbs any leading
+        // characters up to the first `{` — including a backslash — so
+        // `v\{draft}1` yields `{draft}1`, an active reference the header
+        // substitutions then resolve when `draft` is defined.
+        let mut parser = Parser::default().with_intrinsic_attribute(
+            "draft",
+            "beta",
+            ModificationContext::Anywhere,
+        );
+        let result =
+            crate::document::RevisionLine::parse(Span::new("v\\{draft}1, 2024-01-01"), &mut parser);
+
+        assert_eq!(result.revnumber(), Some("beta1"));
+        assert_eq!(result.revdate(), "2024-01-01");
+        assert_eq!(result.revremark(), None);
+    }
+
+    #[test]
     fn sets_document_attributes_with_all_components() {
         let mut parser = Parser::default();
         let _result = crate::document::RevisionLine::parse(

--- a/parser/src/document/revision_line.rs
+++ b/parser/src/document/revision_line.rs
@@ -45,20 +45,33 @@ impl<'src> RevisionLine<'src> {
             }
         };
 
-        if let Some(revnumber) = revnumber.as_deref() {
-            parser.set_attribute_by_value_from_header("revnumber", revnumber);
-        }
+        // Resolve attribute references *before* recording the built-in
+        // `revnumber`/`revdate`/`revremark` document attributes, so a revision
+        // component written as an attribute reference (e.g. `{project-version}`)
+        // is reflected in `doc.attr` with its value resolved rather than as the
+        // raw `{...}` text.
+        let revnumber = revnumber.map(|s| {
+            let resolved = apply_header_subs(&s, parser);
+            parser.set_attribute_by_value_from_header("revnumber", &resolved);
+            resolved
+        });
 
-        parser.set_attribute_by_value_from_header("revdate", &revdate);
+        let revdate = {
+            let resolved = apply_header_subs(&revdate, parser);
+            parser.set_attribute_by_value_from_header("revdate", &resolved);
+            resolved
+        };
 
-        if let Some(revremark) = revremark.as_deref() {
-            parser.set_attribute_by_value_from_header("revremark", revremark);
-        }
+        let revremark = revremark.map(|s| {
+            let resolved = apply_header_subs(&s, parser);
+            parser.set_attribute_by_value_from_header("revremark", &resolved);
+            resolved
+        });
 
         Self {
-            revnumber: revnumber.map(|s| apply_header_subs(&s, parser)),
-            revdate: apply_header_subs(&revdate, parser),
-            revremark: revremark.map(|s| apply_header_subs(&s, parser)),
+            revnumber,
+            revdate,
+            revremark,
             source,
         }
     }
@@ -130,8 +143,13 @@ static STANDALONE_REVISION: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 static NON_NUMERIC_PREFIX: LazyLock<Regex> = LazyLock::new(|| {
+    // Strip any leading run of characters that are neither a digit nor the start
+    // of an attribute reference (`{`). Stopping at `{` preserves a revision
+    // number written purely as an attribute reference (e.g. `v{project-version}`
+    // keeps `{project-version}` for later substitution) instead of dropping the
+    // whole value because it contains no literal digit.
     #[allow(clippy::unwrap_used)]
-    Regex::new(r"^[^0-9]*(.*)$").unwrap()
+    Regex::new(r"^[^0-9{]*(.*)$").unwrap()
 });
 
 #[cfg(test)]

--- a/parser/src/tests/asciidoctor_rb/parser_test.rs
+++ b/parser/src/tests/asciidoctor_rb/parser_test.rs
@@ -91,9 +91,6 @@
 //!   trailing bare `;` mangles the final author (issue #757).
 //! * The `:author:` attribute-entry path does not partition a 4+-part name
 //!   (issue #758).
-//! * A revision number written purely as an attribute reference
-//!   (`v{project-version}`) is stripped to the empty string, and the revision
-//!   document attributes are stored pre-substitution (issue #759).
 //! * Block comments (`////`) in the header are not skipped ahead of the author
 //!   or revision line (issue #760).
 //! * A duplicate id introduced by an *inline* anchor (`[[id]]`) does not emit a
@@ -1340,13 +1337,10 @@ fn parse_rev_number_date_remark() {
     );
 }
 
-// Incompatibility (https://github.com/asciidoc-rs/asciidoc-parser/issues/759):
-// a revision number written purely as an attribute reference
-// (`v{project-version}`) is stripped to the empty string by this crate's
-// non-numeric-prefix removal (it runs before substitution and finds no digit),
-// so `revnumber` does not survive as `{project-version}`.
-non_normative!(
-    r#"
+#[test]
+fn parse_rev_number_date_and_remark_as_attribute_references() {
+    verifies!(
+        r#"
   test 'parse rev number, data, and remark as attribute references' do
     input = <<~'EOS'
     Author Name
@@ -1360,15 +1354,24 @@ non_normative!(
   end
 
 "#
-);
+    );
 
-// Incompatibility (https://github.com/asciidoc-rs/asciidoc-parser/issues/759):
-// this crate stores the `revnumber`/`revdate`/`revremark` document attributes
-// from the *raw* (pre-substitution) revision line, and the `revnumber` is
-// additionally stripped to the empty string (see above), so the resolved
-// attribute references are not reflected in `doc.attr`.
-non_normative!(
-    r#"
+    // With none of the referenced attributes defined, the references survive
+    // verbatim: the `v` prefix is stripped from the revision number, but
+    // `{project-version}` is preserved rather than dropped for lack of a literal
+    // digit. (This crate does not surface the full header-metadata hash, so the
+    // `metadata.size` assertion is not modeled.)
+    let (revnumber, revdate, revremark) =
+        header_rev("Author Name\nv{project-version}, {release-date}: {release-summary}");
+    assert_eq!(revnumber.as_deref(), Some("{project-version}"));
+    assert_eq!(revdate, "{release-date}");
+    assert_eq!(revremark.as_deref(), Some("{release-summary}"));
+}
+
+#[test]
+fn should_resolve_attribute_references_in_rev_number_date_and_remark() {
+    verifies!(
+        r#"
   test 'should resolve attribute references in rev number, data, and remark' do
     input = <<~'EOS'
     = Document Title
@@ -1386,7 +1389,37 @@ non_normative!(
   end
 
 "#
-);
+    );
+
+    // The referenced attributes are resolved before the built-in revision
+    // document attributes are recorded, so `doc.attr` holds the substituted
+    // values rather than the raw `{...}` references.
+    let mut parser = Parser::default()
+        .with_intrinsic_attribute("project-version", "1.0.1", ModificationContext::Anywhere)
+        .with_intrinsic_attribute("release-date", "2018-05-15", ModificationContext::Anywhere)
+        .with_intrinsic_attribute(
+            "release-summary",
+            "The one you can count on!",
+            ModificationContext::Anywhere,
+        );
+
+    let _doc = parser.parse(
+        "= Document Title\nAuthor Name\n{project-version}, {release-date}: {release-summary}",
+    );
+
+    assert_eq!(
+        parser.attribute_value("revnumber").as_maybe_str(),
+        Some("1.0.1")
+    );
+    assert_eq!(
+        parser.attribute_value("revdate").as_maybe_str(),
+        Some("2018-05-15")
+    );
+    assert_eq!(
+        parser.attribute_value("revremark").as_maybe_str(),
+        Some("The one you can count on!")
+    );
+}
 
 #[test]
 fn parse_rev_date() {


### PR DESCRIPTION
Fixes #759.

## Problem

In `document/revision_line.rs`, two related defects caused revision components written as attribute references to be lost:

1. **Prefix stripping ran before substitution.** `strip_non_numeric_prefix` operated on the *raw* revision number. When the number was written purely as an attribute reference (e.g. `v{project-version}`), there was no literal digit, so the non-numeric-prefix regex (`^[^0-9]*(.*)$`) consumed the entire value and stripped it to `""`.
2. **Document attributes stored pre-substitution text.** The built-in `revnumber` / `revdate` / `revremark` document attributes were set from the raw revision line, so resolved attribute references never appeared in `doc.attr`.

## Fix

- Change the prefix-stripping regex to stop at the start of an attribute reference (`^[^0-9{]*(.*)$`). This drops a leading `v`/`LPR`/etc. prefix but preserves a `{...}` reference for later substitution.
- Resolve attribute references (via the header substitution group) *before* recording the `revnumber`/`revdate`/`revremark` document attributes, so `doc.attr` reflects the substituted values.

### Behavior after the fix

| Input (`revnumber, revdate: revremark`) | `revnumber` | `revdate` | `revremark` |
| --- | --- | --- | --- |
| `v{project-version}, {release-date}: {release-summary}` (refs undefined) | `{project-version}` | `{release-date}` | `{release-summary}` |
| `{project-version}, {release-date}: {release-summary}` (refs = `1.0.1` / `2018-05-15` / `The one you can count on!`) | `1.0.1` | `2018-05-15` | `The one you can count on!` |

Existing behavior (stripping `v`/other non-numeric prefixes from literal versions like `v1.2.3` → `1.2.3`, and `nodigits` → `""`) is unchanged.

## Tests

- Converted the two previously `non_normative!` cases in `parser_test.rs` (`parse rev number, data, and remark as attribute references` and `should resolve attribute references in rev number, data, and remark`) into executable `verifies!` tests.
- All existing `revision_line` unit tests continue to pass; full `asciidoc-parser` suite is green (`cargo test`), along with `cargo fmt --check` and `cargo clippy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZvTX4bS4rHncxJAr2QgB6)_