### PR TITLE
fix: Condense author-line whitespace and keep angle brackets literal (#756)

### DIFF
--- a/parser/src/document/author.rs
+++ b/parser/src/document/author.rs
@@ -56,8 +56,6 @@ impl Author {
         } else if let Some(captures) = AUTHOR.captures(source) {
             // Raw input matches author pattern: Extract components then apply
             // substitutions.
-            let name_without_email = source.split_once('<').unwrap_or((source, "")).0.trim();
-            let name = replace_underscores_with_spaces(name_without_email.to_string());
 
             // Extract raw components first.
             let firstname =
@@ -77,6 +75,11 @@ impl Author {
                 middlename = None;
             }
 
+            // Reconstruct the full name from its parsed parts so that any interior
+            // whitespace that appeared between the names in the source is condensed
+            // to a single space (matching Asciidoctor).
+            let name = join_name_parts(&firstname, middlename.as_deref(), lastname.as_deref());
+
             Some(Self {
                 name,
                 firstname,
@@ -91,13 +94,6 @@ impl Author {
 
             if let Some(captures) = AUTHOR.captures(&expanded_source) {
                 // After expansion, it matches the pattern: Parse normally.
-                let name_without_email = expanded_source
-                    .split_once('<')
-                    .unwrap_or((&expanded_source, ""))
-                    .0
-                    .trim();
-                let name = replace_underscores_with_spaces(name_without_email.to_string());
-
                 let firstname = replace_underscores_with_spaces(captures[1].to_string());
                 let mut middlename = captures
                     .get(2)
@@ -111,6 +107,10 @@ impl Author {
                     lastname = middlename;
                     middlename = None;
                 }
+
+                // Reconstruct the full name from its parsed parts so interior
+                // whitespace between the names is condensed (matching Asciidoctor).
+                let name = join_name_parts(&firstname, middlename.as_deref(), lastname.as_deref());
 
                 Some(Self {
                     name,
@@ -144,26 +144,13 @@ impl Author {
                 })
             }
         } else {
-            // Input doesn't contain attributes and doesn't match pattern: Treat as single
-            // name.
-            let mut name = source.to_string();
-
-            // Apply HTML encoding for unparseable patterns that contain angle brackets.
-            if name.contains('<') && name.contains('>') {
-                let span = crate::Span::new(&name);
-                let mut content = crate::content::Content::from(span);
-                crate::content::SubstitutionStep::SpecialCharacters.apply(
-                    &mut content,
-                    parser,
-                    None,
-                );
-                name = content.rendered().to_string();
-            }
-
-            let name_with_spaces = replace_underscores_with_spaces(name);
+            // Input doesn't contain attributes and doesn't match the author pattern.
+            // Asciidoctor stores the whole line as the author, condensing interior
+            // whitespace and keeping any angle brackets literal.
+            let name = replace_underscores_with_spaces(condense_whitespace(source));
             Some(Self {
-                name: name_with_spaces.clone(),
-                firstname: name_with_spaces,
+                name: name.clone(),
+                firstname: name,
                 middlename: None,
                 lastname: None,
                 email: None,
@@ -250,6 +237,49 @@ fn opt_first_char_or_empty_string(s: Option<&str>) -> String {
 /// Replace underscores with spaces in a name component.
 fn replace_underscores_with_spaces(name: String) -> String {
     name.replace('_', " ")
+}
+
+/// Join an author's parsed name parts with a single space.
+///
+/// Asciidoctor reconstructs the full name from its partitioned parts, which
+/// condenses any interior whitespace that appeared between the names in the
+/// source down to a single space.
+fn join_name_parts(firstname: &str, middlename: Option<&str>, lastname: Option<&str>) -> String {
+    let mut name = String::from(firstname);
+
+    if let Some(middlename) = middlename {
+        name.push(' ');
+        name.push_str(middlename);
+    }
+
+    if let Some(lastname) = lastname {
+        name.push(' ');
+        name.push_str(lastname);
+    }
+
+    name
+}
+
+/// Condense runs of spaces into a single space, mirroring Ruby's
+/// `String#tr_s(' ', ' ')`, which Asciidoctor applies to an author line that
+/// does not match the author pattern.
+fn condense_whitespace(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut prev_was_space = false;
+
+    for c in s.chars() {
+        if c == ' ' {
+            if !prev_was_space {
+                result.push(' ');
+            }
+            prev_was_space = true;
+        } else {
+            result.push(c);
+            prev_was_space = false;
+        }
+    }
+
+    result
 }
 
 static AUTHOR: LazyLock<Regex> = LazyLock::new(|| {

--- a/parser/src/document/author.rs
+++ b/parser/src/document/author.rs
@@ -146,8 +146,10 @@ impl Author {
         } else {
             // Input doesn't contain attributes and doesn't match the author pattern.
             // Asciidoctor stores the whole line as the author, condensing interior
-            // whitespace and keeping any angle brackets literal.
-            let name = replace_underscores_with_spaces(condense_whitespace(source));
+            // whitespace and keeping any angle brackets literal. Underscores are left
+            // literal here: Asciidoctor only converts underscore-joined names while
+            // partitioning a *matching* line, not in this fallback.
+            let name = condense_whitespace(source);
             Some(Self {
                 name: name.clone(),
                 firstname: name,

--- a/parser/src/document/author_line.rs
+++ b/parser/src/document/author_line.rs
@@ -248,6 +248,37 @@ mod tests {
     }
 
     #[test]
+    fn fallback_condenses_whitespace_and_keeps_underscores_literal() {
+        // A line that does not match the author pattern (here because of the comma)
+        // is stored verbatim as the author with runs of spaces condensed. Unlike the
+        // matching path, underscores are left literal rather than replaced with
+        // spaces (matching Asciidoctor's `tr_s ' ', ' '` fallback).
+        let mut parser = Parser::default();
+
+        let al =
+            crate::document::AuthorLine::parse(crate::Span::new("Jane_    Q, Doe"), &mut parser);
+
+        assert_eq!(
+            al,
+            AuthorLine {
+                authors: &[Author {
+                    name: "Jane_ Q, Doe",
+                    firstname: "Jane_ Q, Doe",
+                    middlename: None,
+                    lastname: None,
+                    email: None,
+                },],
+                source: Span {
+                    data: "Jane_    Q, Doe",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            }
+        );
+    }
+
+    #[test]
     fn one_name() {
         let mut parser = Parser::default();
 

--- a/parser/src/document/author_line.rs
+++ b/parser/src/document/author_line.rs
@@ -231,8 +231,8 @@ mod tests {
             al,
             AuthorLine {
                 authors: &[Author {
-                    name: "Four Names Not Supported &lt;doc@example.com&gt;",
-                    firstname: "Four Names Not Supported &lt;doc@example.com&gt;",
+                    name: "Four Names Not Supported <doc@example.com>",
+                    firstname: "Four Names Not Supported <doc@example.com>",
                     middlename: None,
                     lastname: None,
                     email: None,

--- a/parser/src/tests/asciidoctor_rb/parser_test.rs
+++ b/parser/src/tests/asciidoctor_rb/parser_test.rs
@@ -985,12 +985,10 @@ fn parse_ideographic_author_names() {
     assert_eq!(a[0].initials, "李四");
 }
 
-// Incompatibility (https://github.com/asciidoc-rs/asciidoc-parser/issues/756):
-// Asciidoctor condenses the interior whitespace of the author name
-// (`Stuart Rackham`); this crate preserves it verbatim in the
-// `name`/`firstname` fields. The parsed name parts and initials still match.
-non_normative!(
-    r#"
+#[test]
+fn parse_author_condenses_whitespace() {
+    verifies!(
+        r#"
   test "parse author condenses whitespace" do
     metadata, _ = parse_header_metadata 'Stuart       Rackham     <founder@asciidoc.org>'
     assert_equal 7, metadata.size
@@ -1004,16 +1002,24 @@ non_normative!(
   end
 
 "#
-);
+    );
 
-// Incompatibility (https://github.com/asciidoc-rs/asciidoc-parser/issues/756):
-// when the author line doesn't match the author regex (here because of the
-// embedded comma), Asciidoctor condenses whitespace and keeps the angle
-// brackets literal, storing the whole line as the author. This crate preserves
-// the interior whitespace and HTML-encodes the angle brackets, so
-// `author`/`firstname` differ (the `S` initial still matches).
-non_normative!(
-    r#"
+    // This crate does not derive the `authors` or `authorcount` attributes, so we
+    // assert on the parsed author directly. The interior whitespace between the
+    // names is condensed to a single space (matching `metadata['author']`).
+    let a = parse_authors("Stuart       Rackham     <founder@asciidoc.org>");
+    assert_eq!(a.len(), 1);
+    assert_eq!(a[0].name, "Stuart Rackham");
+    assert_eq!(a[0].firstname, "Stuart");
+    assert_eq!(a[0].lastname.as_deref(), Some("Rackham"));
+    assert_eq!(a[0].email.as_deref(), Some("founder@asciidoc.org"));
+    assert_eq!(a[0].initials, "SR");
+}
+
+#[test]
+fn parse_invalid_author_line_becomes_author() {
+    verifies!(
+        r#"
   test "parse invalid author line becomes author" do
     metadata, _ = parse_header_metadata '   Stuart       Rackham, founder of AsciiDoc   <founder@asciidoc.org>'
     assert_equal 5, metadata.size
@@ -1025,7 +1031,26 @@ non_normative!(
   end
 
 "#
-);
+    );
+
+    // The author line doesn't match the author pattern (because of the embedded
+    // comma), so Asciidoctor condenses the interior whitespace and stores the whole
+    // line verbatim as the author, keeping the angle brackets literal.
+    let a = parse_authors("   Stuart       Rackham, founder of AsciiDoc   <founder@asciidoc.org>");
+    assert_eq!(a.len(), 1);
+    assert_eq!(
+        a[0].name,
+        "Stuart Rackham, founder of AsciiDoc <founder@asciidoc.org>"
+    );
+    assert_eq!(
+        a[0].firstname,
+        "Stuart Rackham, founder of AsciiDoc <founder@asciidoc.org>"
+    );
+    assert_eq!(a[0].middlename, None);
+    assert_eq!(a[0].lastname, None);
+    assert_eq!(a[0].email, None);
+    assert_eq!(a[0].initials, "S");
+}
 
 #[test]
 fn parse_multiple_authors() {


### PR DESCRIPTION
Fixes #756.

## Problem

Asciidoctor condenses the interior whitespace when partitioning an author name, and when an author line does **not** match the author pattern it stores the (whitespace-condensed) line verbatim as the author — keeping any angle brackets literal.

This crate diverged in two ways (both surfaced by the SDD port of Asciidoctor's `parser_test.rb`):

1. `Stuart       Rackham     <founder@asciidoc.org>` → the `name`/`firstname` kept the runs of spaces instead of condensing to `Stuart Rackham`.
2. `   Stuart       Rackham, founder of AsciiDoc   <founder@asciidoc.org>` (does not match the author pattern because of the comma) → interior whitespace was preserved and the angle brackets were HTML-encoded, rather than stored verbatim as `Stuart Rackham, founder of AsciiDoc <founder@asciidoc.org>`.

## Changes

- **`document/author.rs`**
  - In the matching paths, reconstruct the full `name` from its parsed parts (`join_name_parts`) instead of slicing the raw source. Joining with single spaces condenses any interior whitespace, matching how Asciidoctor rebuilds the name.
  - In the non-matching fallback (no attribute references), condense runs of spaces (`condense_whitespace`, mirroring Ruby's `String#tr_s(' ', ' ')`) and keep angle brackets **literal** instead of HTML-encoding them.
- **`document/author_line.rs`** — update the `too_many_names` unit test, which exercises the fallback path, to expect literal angle brackets (`Four Names Not Supported <doc@example.com>`).
- **`tests/asciidoctor_rb/parser_test.rs`** — promote `parse author condenses whitespace` and `parse invalid author line becomes author` from `non_normative!` to `verifies!`.

## Testing

- `cargo test -p asciidoc-parser` — all 4072 tests pass.
- `cargo clippy -p asciidoc-parser --all-targets` — clean.
- `cargo fmt` — applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019RQzuJw1iLJmDP6qhpnqR8)_