### PR TITLE
fix: Resolve soft-unset `toc-placement!` with `toc` set to macro (close #750)

### DIFF
--- a/parser/src/document/toc.rs
+++ b/parser/src/document/toc.rs
@@ -71,17 +71,32 @@ impl TocMode {
             Some("left") => Self::Left,
             Some("right") => Self::Right,
             Some("preamble") => Self::Preamble,
-            _ => match parser
-                .attribute_value("toc-placement")
-                .as_maybe_str()
-                .map(str::trim)
-            {
-                Some("macro") => Self::Macro,
-                Some("left") => Self::Left,
-                Some("right") => Self::Right,
-                Some("preamble") => Self::Preamble,
-                _ => Self::Auto,
-            },
+            _ => {
+                let placement = parser.attribute_value("toc-placement");
+                match placement.as_maybe_str().map(str::trim) {
+                    Some("macro") => Self::Macro,
+                    Some("left") => Self::Left,
+                    Some("right") => Self::Right,
+                    Some("preamble") => Self::Preamble,
+                    // `toc-placement` carries no recognized placement keyword.
+                    // When it has been *explicitly unset* (via `:toc-placement!:`
+                    // or an API unset) while `toc` is enabled, Asciidoctor's
+                    // placement lookup falls through its `auto` default to a
+                    // `macro` fetch fallback, so the TOC defers to a `toc::[]`
+                    // block macro. (Asciidoctor deletes the attribute's default;
+                    // this crate records the unset as an `Unset` tombstone, which
+                    // `has_attribute` still reports as present — distinguishing it
+                    // from a `toc-placement` that was never set.) A `toc-placement`
+                    // that was never set, or set to any other (bogus) value, falls
+                    // back to an automatic placement.
+                    _ if placement == InterpretedValue::Unset
+                        && parser.has_attribute("toc-placement") =>
+                    {
+                        Self::Macro
+                    }
+                    _ => Self::Auto,
+                }
+            }
         }
     }
 
@@ -255,6 +270,28 @@ mod tests {
         assert_eq!(
             doc_with(":toc:\n:toc-placement: bogus").toc_mode(),
             TocMode::Auto
+        );
+    }
+
+    #[test]
+    fn soft_unset_toc_placement_resolves_to_macro() {
+        // With `toc` enabled, explicitly unsetting `toc-placement` defers the
+        // TOC to a `toc::[]` block macro (Asciidoctor's `macro` fetch fallback),
+        // whereas a `toc-placement` that was never set stays automatic.
+        assert_eq!(doc_with(":toc:").toc_mode(), TocMode::Auto);
+        assert_eq!(
+            doc_with(":toc:\n:toc-placement!:").toc_mode(),
+            TocMode::Macro
+        );
+        assert_eq!(
+            doc_with(":toc:\n:!toc-placement:").toc_mode(),
+            TocMode::Macro
+        );
+        // A placement keyword in the `toc` value still wins over an unset
+        // `toc-placement`.
+        assert_eq!(
+            doc_with(":toc: preamble\n:toc-placement!:").toc_mode(),
+            TocMode::Preamble
         );
     }
 

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -1538,14 +1538,14 @@ mod assignment {
         // matrix row is exercised here through `toc_mode()` / `toc_class()`,
         // asserting this crate's actual behavior.
         //
-        // Three rows still diverge from Asciidoctor's matrix (and are asserted
+        // Two rows still diverge from Asciidoctor's matrix (and are asserted
         // as this crate's actual behavior): the `toc2` alias is not recognized
-        // (it resolves to `Disabled`, not a left-placed TOC — #748); `toc-class`
-        // is never switched to `toc2` (#749); and a soft-unset `toc-placement!`
-        // (with `toc` set) resolves to `Auto` here rather than Asciidoctor's
-        // `macro` (#750). The `toc toc-placement=macro` row, by contrast, now
-        // matches Asciidoctor (`macro`) since this crate honors an explicit
-        // `toc-placement`.
+        // (it resolves to `Disabled`, not a left-placed TOC — #748) and
+        // `toc-class` is never switched to `toc2` (#749). The
+        // `toc toc-placement=macro` and `toc toc-placement!` rows now match
+        // Asciidoctor (`macro`): this crate honors an explicit `toc-placement`,
+        // and a soft-unset `toc-placement!` with `toc` set defers the TOC to a
+        // `toc::[]` block macro.
         use crate::document::TocMode;
         // Each row is the raw attribute spec (as it appears in the vendored
         // matrix, parsed the same way Ruby does — space-separated entries,
@@ -1562,8 +1562,9 @@ mod assignment {
             ("toc=preamble", TocMode::Preamble),
             ("toc=macro", TocMode::Macro),
             ("toc toc-placement=macro toc-position=left", TocMode::Macro),
-            // Soft-unset `toc-placement!` (#750); Asciidoctor: `macro`.
-            ("toc toc-placement!", TocMode::Auto),
+            // Soft-unset `toc-placement!` with `toc` set defers to a `toc::[]`
+            // macro, matching Asciidoctor (#750).
+            ("toc toc-placement!", TocMode::Macro),
         ];
         for (spec, expected_mode) in rows {
             let mut parser = Parser::default();


### PR DESCRIPTION
## Summary

Fixes #750.

Loading a document with `toc` set (empty) and `toc-placement` soft-unset — `{'toc' => '', 'toc-placement!' => ''}` — should resolve the placement to `macro`, matching Asciidoctor. Previously `TocMode::from_parser` resolved it to `Auto`.

## Why Asciidoctor resolves this to `macro`

Asciidoctor seeds `toc-placement => 'auto'` in its `DEFAULT_ATTRIBUTES`. In `save_attributes`, the placement comes from `attrs.fetch('toc-placement', 'macro')`:

- With `toc` enabled and `toc-placement` left at its default, `fetch` returns `'auto'`, and the block that would rewrite the placement is skipped → **auto**.
- Explicitly unsetting `toc-placement` (`toc-placement!`) **deletes** that default, so `fetch` falls back to its `'macro'` default → the `case`/`when 'macro'` branch sets `toc-placement = 'macro'` → **macro**, deferring the TOC to a `toc::[]` block macro.

So the distinguishing signal is whether `toc-placement` was *explicitly unset* versus *never set*.

## The fix

`TocMode::from_parser` (`parser/src/document/toc.rs`) previously collapsed both cases to `Auto`, because both resolve `toc-placement` to `InterpretedValue::Unset`. It now distinguishes them:

- An **explicitly unset** `toc-placement` is recorded as an `Unset` tombstone, which `has_attribute` still reports as present. With `toc` enabled, this resolves to `Macro`.
- A `toc-placement` that was **never set** (absent, so `has_attribute` is `false`) — or one set to any other/bogus value — continues to resolve to `Auto`.

This covers both the API unset and the document-header forms (`:toc-placement!:` / `:!toc-placement:`), which both store the tombstone.

## Tests

- New unit test `soft_unset_toc_placement_resolves_to_macro` in `toc.rs` covers `:toc:` (auto), `:toc:\n:toc-placement!:` (macro), `:toc:\n:!toc-placement:` (macro), and `:toc: preamble\n:toc-placement!:` (a `toc` placement keyword still wins → preamble).
- The `verify_toc_attribute_matrix` row `toc toc-placement!` now asserts `TocMode::Macro` (matching Asciidoctor); its explanatory comments are updated.

`cargo test`, `cargo fmt --check`, and `cargo clippy --all-targets` are clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MzetNxsVxtewKcqfRAVAZ1)_