### PR TITLE
feat: Define a section ID via an anchor embedded in the section title (#751)

### DIFF
--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -63,6 +63,27 @@ impl<'src> SectionBlock<'src> {
 
         let level = level_and_title.item.0;
 
+        // An explicit ID supplied *above* the heading (a `[#id]`/`[id=…]` block
+        // attribute or a `[[id]]` block anchor) always wins. It also suppresses
+        // embedded-anchor processing below, so a `[[id]]` embedded in the title
+        // is then left in place and rendered as an ordinary inline anchor.
+        let attr_or_anchor_id = metadata
+            .attrlist
+            .as_ref()
+            .and_then(|a| a.id())
+            .or_else(|| metadata.anchor.as_ref().map(|anchor| anchor.data()));
+
+        // AsciiDoc lets a section define its ID via an anchor embedded at the end
+        // of the title (`== Title [[id]] ==`, optionally `[[id,reftext]]`). When
+        // present (and not already overridden by an explicit ID above), the anchor
+        // is consumed to set the section ID and removed from the rendered title,
+        // rather than being rendered as an inline anchor.
+        let (title_span, embedded_id, embedded_reftext) = if attr_or_anchor_id.is_none() {
+            match_embedded_section_anchor(level_and_title.item.1)
+        } else {
+            (level_and_title.item.1, None, None)
+        };
+
         // Assign the section type. At level 1, we look for an `appendix` section style;
         // at all other levels, we inherit the section type from parent.
         let section_type = if discrete {
@@ -99,14 +120,16 @@ impl<'src> SectionBlock<'src> {
         // A cross-reference builds `full`/`short` xrefstyle text from a section's
         // signifier and number, but only when the section has a number *and* no
         // explicit reftext (an explicit reftext is used verbatim instead). An
-        // explicit reftext can come from a `reftext` attribute or the second
-        // field of a `[[id,reftext]]` block anchor.
+        // explicit reftext can come from a `reftext` attribute, the second field
+        // of a `[[id,reftext]]` block anchor, or the second field of an anchor
+        // embedded in the section title.
         let has_explicit_reftext = metadata
             .attrlist
             .as_ref()
             .and_then(|a| a.named_attribute("reftext"))
             .is_some()
-            || metadata.anchor_reftext.is_some();
+            || metadata.anchor_reftext.is_some()
+            || embedded_reftext.is_some();
 
         let (section_number, caption, xref_signifier) = if is_appendix_root {
             // The appendix letter is resolved through the `appendix-number`
@@ -171,7 +194,7 @@ impl<'src> SectionBlock<'src> {
         // sentinels lets those be excised below from a single render — no second
         // substitution pass, so counters and attribute-expanded footnotes are
         // processed exactly once.
-        let mut section_title = Content::from(level_and_title.item.1);
+        let mut section_title = Content::from(title_span);
         parser.mark_footnote_spans.set(true);
         SubstitutionGroup::Title.apply(&mut section_title, parser, metadata.attrlist.as_ref());
         parser.mark_footnote_spans.set(false);
@@ -228,20 +251,19 @@ impl<'src> SectionBlock<'src> {
 
         let proposed_base_id = generate_section_id(&title_reftext, parser);
 
-        let manual_id = metadata
-            .attrlist
-            .as_ref()
-            .and_then(|a| a.id())
-            .or_else(|| metadata.anchor.as_ref().map(|anchor| anchor.data()));
+        // An explicit ID above the heading wins; otherwise an anchor embedded in
+        // the title supplies the ID.
+        let manual_id = attr_or_anchor_id.or(embedded_id);
 
         // Reftext precedence mirrors `Block::block_reftext`: an explicit
-        // `reftext` attribute, then a `[[id,reftext]]` anchor reftext, then the
-        // section title.
+        // `reftext` attribute, then a `[[id,reftext]]` block-anchor reftext, then
+        // an embedded-anchor reftext, then the section title.
         let reftext = metadata
             .attrlist
             .as_ref()
             .and_then(|a| a.named_attribute("reftext").map(|a| a.value()))
             .or_else(|| metadata.anchor_reftext.as_ref().map(|span| span.data()))
+            .or(embedded_reftext)
             .unwrap_or(&title_reftext);
 
         let section_id = if sectids && manual_id.is_none() {
@@ -272,7 +294,11 @@ impl<'src> SectionBlock<'src> {
                 }
             }
 
-            None
+            // An ID drawn from an anchor embedded in the title has no `anchor`
+            // span or attrlist entry for `id()` to read it back from, so record
+            // it here (unlike an ID supplied above the heading, which `id()`
+            // sources directly from the anchor/attrlist).
+            embedded_id.map(str::to_string)
         };
 
         // Restore "normal" top-level section type if exiting a level 1 appendix.
@@ -492,6 +518,66 @@ pub(crate) fn strip_symmetric_title_close(title: Span<'_>, marker: char, count: 
         }
         _ => title,
     }
+}
+
+/// Matches an anchor embedded at the end of a section title (after the
+/// symmetric ATX close has already been stripped): the title text, optional
+/// escape, the anchor ID, and an optional reftext.
+///
+/// Mirrors Asciidoctor's `InlineSectionAnchorRx`. The anchor must be separated
+/// from the title by at least one blank; the ID follows the usual name rules
+/// (leading letter/`_`/`:`, then letters/digits/`_`/`-`/`:`/`.`); an optional
+/// reftext after the first comma may itself contain commas.
+#[allow(clippy::unwrap_used)]
+static EMBEDDED_SECTION_ANCHOR: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?x)
+        ^(.*?)                                                # (1) title text before the anchor
+        [\ \t]+                                               # blank(s) separating title from anchor
+        (\\)?                                                 # (2) optional escape backslash
+        \[\[
+          ( [\p{Alphabetic}_:] [\p{Alphabetic}\p{Nd}_\-:.]* )  # (3) anchor id
+          (?: , [\ \t]* (\S.*) )?                             # (4) optional reftext (may contain commas)
+        \]\]
+        $",
+    )
+    .unwrap()
+});
+
+/// Detects and consumes an anchor embedded at the end of a section `title`
+/// (`Title [[id]]` or `Title [[id,reftext]]`), returning the title span with
+/// the anchor removed, the anchor ID, and the reftext (each `None` when
+/// absent).
+///
+/// The `title` span must already have had any symmetric ATX close stripped. An
+/// *escaped* anchor (`Title \[[id]]`) is intentionally left intact — the ID is
+/// not adopted and the title is returned unchanged so the inline-anchor
+/// substitution can unescape it — mirroring Ruby Asciidoctor.
+fn match_embedded_section_anchor<'src>(
+    title: Span<'src>,
+) -> (Span<'src>, Option<&'src str>, Option<&'src str>) {
+    // A quick reject avoids running the regex on the common no-anchor title.
+    if !title.data().ends_with("]]") {
+        return (title, None, None);
+    }
+
+    let Some(caps) = EMBEDDED_SECTION_ANCHOR.captures(title.data()) else {
+        return (title, None, None);
+    };
+
+    // An escaped anchor is not adopted as the section ID.
+    if caps.get(2).is_some() {
+        return (title, None, None);
+    }
+
+    let title_text = caps.get(1).map_or("", |m| m.as_str());
+    let id = caps.get(3).map(|m| m.as_str());
+
+    // Trailing whitespace is trimmed from the reftext, matching the inline-anchor
+    // substitution's handling of a shorthand `[[id,reftext]]`.
+    let reftext = caps.get(4).map(|m| m.as_str().trim_end());
+
+    (title.slice_to(..title_text.len()), id, reftext)
 }
 
 /// Parses a section title line, returning the section's *effective* level

--- a/parser/src/tests/asciidoctor_rb/sections_test.rs
+++ b/parser/src/tests/asciidoctor_rb/sections_test.rs
@@ -485,15 +485,10 @@ mod ids {
         assert_eq!(first_section(&doc).id(), Some("one"));
     }
 
-    // NOTE: Defining a section's ID via an anchor embedded in its title
-    // (`== Title [[id]] ==`) is not implemented. The crate instead treats
-    // `[[id]]` as an ordinary inline anchor (rendered `<a id="id"></a>`),
-    // leaving the synthetic section ID in place. The three *positive*
-    // embedded-anchor tests (which expect the anchor to become the section ID)
-    // are therefore out of scope (see #751); the two *negative* tests below —
-    // which only require that the anchor NOT be adopted as the ID — do pass.
-    non_normative!(
-        r##"
+    #[test]
+    fn explicit_id_can_be_defined_using_an_embedded_anchor() {
+        verifies!(
+            r##"
     test 'explicit id can be defined using an embedded anchor' do
       sec = block_from_string("== Section One [[one]] ==")
       assert_equal 'one', sec.id
@@ -501,7 +496,15 @@ mod ids {
     end
 
 "##
-    );
+        );
+
+        // The embedded anchor is consumed to set the section ID and removed from
+        // the rendered title.
+        let doc = Parser::default().parse("== Section One [[one]] ==");
+        let sec = first_section(&doc);
+        assert_eq!(sec.id(), Some("one"));
+        assert_eq!(sec.section_title(), "Section One");
+    }
 
     // NOTE: Setext (two-line, underlined) section titles are not implemented
     // (`parse_title_line` recognizes only ATX `=`/`#` markers), so this test —
@@ -522,10 +525,10 @@ mod ids {
 "##
     );
 
-    // Same embedded-anchor gap as above (see #751): the reftext is captured, but
-    // the anchor is not adopted as the section ID.
-    non_normative!(
-        r##"
+    #[test]
+    fn explicit_id_can_be_defined_using_an_embedded_anchor_with_reftext() {
+        verifies!(
+            r##"
     test 'explicit id can be defined using an embedded anchor with reftext' do
       sec = block_from_string("== Section One [[one,Section Uno]] ==")
       assert_equal 'one', sec.id
@@ -534,7 +537,21 @@ mod ids {
     end
 
 "##
-    );
+        );
+
+        // The reftext after the comma is captured and registered as the section
+        // reference's reftext; the anchor is removed from the rendered title.
+        let doc = Parser::default().parse("== Section One [[one,Section Uno]] ==");
+        let sec = first_section(&doc);
+        assert_eq!(sec.id(), Some("one"));
+        assert_eq!(sec.section_title(), "Section One");
+        assert_eq!(
+            doc.catalog()
+                .get_ref("one")
+                .and_then(|r| r.reftext.as_deref()),
+            Some("Section Uno")
+        );
+    }
 
     #[test]
     fn id_and_reftext_in_embedded_anchor_cannot_be_quoted() {
@@ -562,9 +579,10 @@ mod ids {
         assert!(doc.catalog().get_ref("one").is_none());
     }
 
-    // Same embedded-anchor gap (see #751); here the reftext contains a comma.
-    non_normative!(
-        r##"
+    #[test]
+    fn reftext_in_embedded_anchor_may_contain_comma() {
+        verifies!(
+            r##"
     test 'reftext in embedded anchor may contain comma' do
       sec = block_from_string(%(== Section One [[one, Section,Uno]] ==))
       assert_equal 'one', sec.id
@@ -573,7 +591,22 @@ mod ids {
     end
 
 "##
-    );
+        );
+
+        // Only the first comma separates the ID from the reftext; any further
+        // commas belong to the reftext, and the blank after the first comma is
+        // trimmed.
+        let doc = Parser::default().parse("== Section One [[one, Section,Uno]] ==");
+        let sec = first_section(&doc);
+        assert_eq!(sec.id(), Some("one"));
+        assert_eq!(sec.section_title(), "Section One");
+        assert_eq!(
+            doc.catalog()
+                .get_ref("one")
+                .and_then(|r| r.reftext.as_deref()),
+            Some("Section,Uno")
+        );
+    }
 
     #[test]
     fn should_unescape_but_not_process_inline_anchor() {


### PR DESCRIPTION
Fixes #751.

## Summary

AsciiDoc lets a section's ID be defined by an anchor embedded at the end of the title, e.g. `== Section One [[one]] ==` (optionally with a reftext, `[[one,Section Uno]]`). Previously the crate treated the `[[one]]` as an ordinary *inline* anchor rendered inside the title and left the synthetic section ID (`_section_one`) in place.

This PR implements the embedded-anchor form. When **no explicit ID is supplied above the heading**, an anchor at the end of the section title is consumed to set the section ID and removed from the rendered title, rather than being rendered as an inline `<a id="…">`.

### Behavior

| Input | ID | Title | Reftext |
|-------|-----|-------|---------|
| `== Section One [[one]] ==` | `one` | `Section One` | (title) |
| `== Section One [[one,Section Uno]] ==` | `one` | `Section One` | `Section Uno` |
| `== Section One [[one, Section,Uno]] ==` | `one` | `Section One` | `Section,Uno` |

Only the first comma separates the ID from the reftext; the reftext may itself contain commas, and the blank after the first comma is trimmed.

The existing negative cases are preserved (they already passed and still do):
- An **explicit ID above the heading** (`[#sect-one]`) wins and suppresses embedded-anchor processing, so the `[[one]]` renders as an inline anchor.
- A **quoted** anchor (`[["one","Section Uno"]]`) is not a valid inline anchor and is left as literal text.
- An **escaped** anchor (`\[[one]]`) is not adopted; the title is left intact so the inline-anchor substitution unescapes it to `[[one]]`.

## Implementation

- New `match_embedded_section_anchor` helper in `blocks/section.rs`, backed by a regex mirroring Asciidoctor's `InlineSectionAnchorRx`, run against the title span *after* the symmetric ATX close has been stripped.
- The embedded ID feeds the existing `manual_id` path (registration, reftext precedence, `has_explicit_reftext` / xref-signifier handling) and is recorded in `section_id` so `id()` can read it back (there is no `anchor` span or attrlist entry to source it from).
- Extraction is skipped entirely when an explicit ID is supplied above the heading.

## Tests

Promotes three positive embedded-anchor tests in `sections_test.rs` from `non_normative!` to `verifies!`:
- `explicit id can be defined using an embedded anchor`
- `explicit id can be defined using an embedded anchor with reftext`
- `reftext in embedded anchor may contain comma`

The fourth affected Ruby test (setext section titles) remains `non_normative!` — it is additionally blocked on setext-title support, which is out of scope here.

Full test suite passes (`cargo test`), and `cargo clippy --all-targets` and `cargo fmt` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KofuLZ1TMLEwooZjFzyFDv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KofuLZ1TMLEwooZjFzyFDv)_