### PR TITLE
fix: Drop a line emptied by an unresolved reference under attribute-missing=drop (close #730)

### DIFF
--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -727,6 +727,19 @@ impl Replacer for AttributeReplacer<'_> {
     }
 }
 
+/// Whether a line that dropped a missing reference under
+/// [`AttributeMissing::Drop`] should be treated as emptied (and therefore
+/// removed, per Asciidoctor's `reject_if_empty`).
+///
+/// A trailing `\r` left from a CRLF terminator is part of the line ending, not
+/// content: a line the drop reduced to just `\r` still counts as empty. The
+/// block pipeline strips `\r` before content is assembled, but free-standing
+/// text (a docinfo file) is split on `\n` with the `\r` intact, so this guard
+/// is what makes a CRLF reference-only line drop there.
+fn drop_emptied_line(replaced: &str) -> bool {
+    replaced.strip_suffix('\r').unwrap_or(replaced).is_empty()
+}
+
 fn apply_attributes(content: &mut Content<'_>, parser: &Parser) {
     if !content.rendered.contains('{') {
         return;
@@ -778,7 +791,7 @@ fn apply_attributes(content: &mut Content<'_>, parser: &Parser) {
 
         if replacer.missing_on_line
             && (mode == AttributeMissing::DropLine
-                || (mode == AttributeMissing::Drop && replaced.is_empty()))
+                || (mode == AttributeMissing::Drop && drop_emptied_line(&replaced)))
         {
             // Drop the entire line, including its line break: unconditionally
             // in `drop-line` mode, or in `drop` mode when the dropped
@@ -890,7 +903,7 @@ pub(crate) fn substitute_attributes_in_text(text: &str, parser: &Parser) -> Stri
 
         if replacer.missing_on_line
             && (mode == AttributeMissing::DropLine
-                || (mode == AttributeMissing::Drop && replaced.is_empty()))
+                || (mode == AttributeMissing::Drop && drop_emptied_line(&replaced)))
         {
             // Drop the entire line, including its line break: unconditionally
             // in `drop-line` mode, or in `drop` mode when the dropped
@@ -1822,6 +1835,27 @@ mod tests {
                     assert_eq!(
                         substitute_attributes_in_text("Line 1\n{missing} tail\nLine 2", &p),
                         "Line 1\nLine 2"
+                    );
+                }
+
+                #[test]
+                fn drop_removes_a_crlf_reference_only_line() {
+                    // The `\r` left by a CRLF terminator does not keep the line
+                    // from counting as emptied by the dropped reference, so the
+                    // whole `\r\n` line is removed.
+                    let p = parser_with_mode("drop");
+                    assert_eq!(
+                        substitute_attributes_in_text("Line 1\r\n{missing}\r\nLine 2", &p),
+                        "Line 1\r\nLine 2"
+                    );
+                }
+
+                #[test]
+                fn drop_keeps_a_crlf_line_the_reference_did_not_empty() {
+                    let p = parser_with_mode("drop");
+                    assert_eq!(
+                        substitute_attributes_in_text("Line 1\r\ntext {missing}\r\nLine 2", &p),
+                        "Line 1\r\ntext \r\nLine 2"
                     );
                 }
             }

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -1781,6 +1781,51 @@ mod tests {
                 assert_eq!(render("{missing}", &p), "");
             }
 
+            /// Exercises the free-standing text path (used for docinfo file
+            /// content), which applies the same `attribute-missing` handling as
+            /// [`render`] but through [`substitute_attributes_in_text`] rather
+            /// than the block substitution pipeline.
+            mod free_standing_text {
+                use super::parser_with_mode;
+                use crate::content::substitute_attributes_in_text;
+
+                #[test]
+                fn drop_removes_line_that_only_contained_the_reference() {
+                    let p = parser_with_mode("drop");
+                    assert_eq!(
+                        substitute_attributes_in_text("Line 1\n{missing}\nLine 2", &p),
+                        "Line 1\nLine 2"
+                    );
+                }
+
+                #[test]
+                fn drop_keeps_a_line_the_reference_did_not_empty() {
+                    let p = parser_with_mode("drop");
+                    assert_eq!(
+                        substitute_attributes_in_text("Line 1\ntext {missing}\nLine 2", &p),
+                        "Line 1\ntext \nLine 2"
+                    );
+                }
+
+                #[test]
+                fn drop_keeps_a_line_emptied_by_a_resolvable_reference() {
+                    let p = parser_with_mode("drop");
+                    assert_eq!(
+                        substitute_attributes_in_text("Line 1\n{empty}\nLine 2", &p),
+                        "Line 1\n\nLine 2"
+                    );
+                }
+
+                #[test]
+                fn drop_line_removes_the_whole_line() {
+                    let p = parser_with_mode("drop-line");
+                    assert_eq!(
+                        substitute_attributes_in_text("Line 1\n{missing} tail\nLine 2", &p),
+                        "Line 1\nLine 2"
+                    );
+                }
+            }
+
             #[test]
             fn warn_leaves_the_reference_and_records_a_warning() {
                 let p = parser_with_mode("warn");

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -584,8 +584,10 @@ struct AttributeReplacer<'p> {
     match_index: usize,
 
     /// Set to `true` when a (non-escaped) reference to a missing attribute is
-    /// encountered, so the caller can drop the whole line in
-    /// [`AttributeMissing::DropLine`] mode.
+    /// dropped, under either [`AttributeMissing::Drop`] or
+    /// [`AttributeMissing::DropLine`], so the caller can drop the line: the
+    /// whole line in `drop-line` mode, or a line the dropped reference left
+    /// empty in `drop` mode (Asciidoctor's `reject_if_empty`).
     missing_on_line: bool,
 }
 
@@ -696,6 +698,10 @@ impl Replacer for AttributeReplacer<'_> {
                 AttributeMissing::Skip => dest.push_str(&caps[0]),
                 AttributeMissing::Drop => {
                     // Drop the reference, leaving the rest of the line intact.
+                    // Flag that a missing reference was dropped here so the
+                    // caller can remove the line if the drop emptied it
+                    // (Asciidoctor's `reject_if_empty`).
+                    self.missing_on_line = true;
                 }
                 AttributeMissing::DropLine => {
                     // Mark the line for removal; whatever is written to `dest`
@@ -770,8 +776,14 @@ fn apply_attributes(content: &mut Content<'_>, parser: &Parser) {
 
         let replaced = ATTRIBUTE_REFERENCE.replace_all(line, replacer.by_ref());
 
-        if replacer.missing_on_line && mode == AttributeMissing::DropLine {
-            // Drop the entire line, including its line break.
+        if replacer.missing_on_line
+            && (mode == AttributeMissing::DropLine
+                || (mode == AttributeMissing::Drop && replaced.is_empty()))
+        {
+            // Drop the entire line, including its line break: unconditionally
+            // in `drop-line` mode, or in `drop` mode when the dropped
+            // reference was all the line contained (Asciidoctor's
+            // `reject_if_empty`).
             changed = true;
             continue;
         }
@@ -876,8 +888,14 @@ pub(crate) fn substitute_attributes_in_text(text: &str, parser: &Parser) -> Stri
 
         let replaced = ATTRIBUTE_REFERENCE.replace_all(line, replacer.by_ref());
 
-        if replacer.missing_on_line && mode == AttributeMissing::DropLine {
-            // Drop the entire line, including its line break.
+        if replacer.missing_on_line
+            && (mode == AttributeMissing::DropLine
+                || (mode == AttributeMissing::Drop && replaced.is_empty()))
+        {
+            // Drop the entire line, including its line break: unconditionally
+            // in `drop-line` mode, or in `drop` mode when the dropped
+            // reference was all the line contained (Asciidoctor's
+            // `reject_if_empty`).
             continue;
         }
 
@@ -1698,6 +1716,48 @@ mod tests {
             fn drop_keeps_resolvable_references() {
                 let p = parser_with_mode("drop");
                 assert_eq!(render("a {sp}b {missing} c", &p), "a  b  c");
+            }
+
+            #[test]
+            fn drop_removes_line_that_only_contained_the_reference() {
+                // A line consisting solely of an unresolved reference is
+                // dropped entirely, not left as a blank line (issue #730).
+                let p = parser_with_mode("drop");
+                assert_eq!(render("Line 1\n{missing}\nLine 2", &p), "Line 1\nLine 2");
+            }
+
+            #[test]
+            fn drop_keeps_a_line_the_reference_did_not_empty() {
+                // The line still has other content after the reference is
+                // dropped, so it survives (only the reference is removed).
+                let p = parser_with_mode("drop");
+                assert_eq!(
+                    render("Line 1\ntext {missing}\nLine 2", &p),
+                    "Line 1\ntext \nLine 2"
+                );
+            }
+
+            #[test]
+            fn drop_removes_a_leading_or_trailing_reference_only_line() {
+                let p = parser_with_mode("drop");
+                assert_eq!(render("{missing}\nLine 2", &p), "Line 2");
+                assert_eq!(render("Line 1\n{missing}", &p), "Line 1");
+            }
+
+            #[test]
+            fn drop_can_empty_the_content() {
+                // A single line that is only an unresolved reference drops to
+                // empty content, mirroring `drop-line`.
+                let p = parser_with_mode("drop");
+                assert_eq!(render("{missing}", &p), "");
+            }
+
+            #[test]
+            fn drop_keeps_a_line_emptied_by_a_resolvable_reference() {
+                // The line becomes empty, but not because a *missing* reference
+                // was dropped, so it is retained.
+                let p = parser_with_mode("drop");
+                assert_eq!(render("Line 1\n{empty}\nLine 2", &p), "Line 1\n\nLine 2");
             }
 
             #[test]

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -1921,7 +1921,10 @@ mod interpolation {
         let doc = Parser::default()
             .with_intrinsic_attribute("attribute-missing", "drop", ModificationContext::ApiOnly)
             .parse("Line 1\n{unresolved}\nLine 2");
-        assert_eq!(rendered_paragraphs(&doc), vec!["Line 1\nLine 2".to_string()]);
+        assert_eq!(
+            rendered_paragraphs(&doc),
+            vec!["Line 1\nLine 2".to_string()]
+        );
     }
 
     #[test]

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -1897,10 +1897,9 @@ mod interpolation {
         assert_xpath(&doc, "//p[text()=\"Line 1\n{set:a}\nLine 2\"]", 1);
     }
 
-    // Tracked in #730.
     #[test]
     fn should_drop_line_that_only_contains_unresolved_attribute_when_attribute_missing_is_drop() {
-        non_normative!(
+        verifies!(
             r#"
     test 'should drop line that only contains unresolved attribute when attribute-missing is drop' do
       input = <<~'EOS'
@@ -1916,16 +1915,13 @@ mod interpolation {
 "#
         );
 
-        // Divergence: with `attribute-missing=drop` this crate removes the
-        // missing reference but keeps the now-empty line, yielding
-        // `Line 1\n\nLine 2` rather than dropping the whole line.
+        // With `attribute-missing=drop`, a line that contains only an
+        // unresolved reference is dropped entirely (the reference removal
+        // empties the line), matching Asciidoctor's `reject_if_empty` (#730).
         let doc = Parser::default()
             .with_intrinsic_attribute("attribute-missing", "drop", ModificationContext::ApiOnly)
             .parse("Line 1\n{unresolved}\nLine 2");
-        assert_eq!(
-            rendered_paragraphs(&doc),
-            vec!["Line 1\n\nLine 2".to_string()]
-        );
+        assert_eq!(rendered_paragraphs(&doc), vec!["Line 1\nLine 2".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #730.

With `attribute-missing=drop`, Asciidoctor removes an unresolved reference and, when that removal leaves the line empty, drops the whole line (its `reject_if_empty` behavior). This crate removed the reference but kept the now-empty line, so:

```
Line 1
{unresolved}
Line 2
```

rendered as `Line 1\n\nLine 2` instead of the expected `Line 1\nLine 2`.

## Changes

- In `AttributeReplacer`, set the `missing_on_line` flag when a missing reference is dropped in `drop` mode (previously only set in `drop-line` mode).
- In the line-by-line drivers (`apply_attributes` and `substitute_attributes_in_text`), drop the line when it is emptied by a dropped missing reference in `drop` mode, mirroring the existing `drop-line` handling.

The change is deliberately narrow:

- A line the reference did **not** empty (e.g. `text {missing}`) is kept, with only the reference removed.
- A line emptied by a **resolvable** reference (e.g. `{empty}`) is kept, since no missing reference was dropped.
- Block macro targets (`image::{unresolved}[]`) are untouched — they still only drop under `drop-line`.

## Tests

- Converted the tracked divergence test `should_drop_line_that_only_contains_unresolved_attribute_when_attribute_missing_is_drop` from `non_normative!` to `verifies!` and updated its expectation to match Asciidoctor.
- Added unit tests covering: an interior/leading/trailing reference-only line being dropped, a line that still has other content being kept, single-line content dropping to empty, and a line emptied by a resolvable reference being retained.

Full suite (`cargo test -p asciidoc-parser`) and `cargo clippy --all-targets` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmX5vBAiSTaUmvU9XFH8x4

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmX5vBAiSTaUmvU9XFH8x4)_