### PR TITLE
fix: Switch toc-class default to toc2 for left/right TOC placement (close #749)

### DIFF
--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -381,7 +381,10 @@ impl<'src> Document<'src> {
     }
 
     /// Return the CSS class applied to this document's table of contents
-    /// container, resolved from the [`toc-class` attribute] (default `toc`).
+    /// container, resolved from the [`toc-class` attribute]. An explicit,
+    /// non-empty `toc-class` is used verbatim; otherwise the default is `toc2`
+    /// for a `left`/`right` side-column placement (matching Asciidoctor) and
+    /// `toc` for every other placement.
     ///
     /// [`toc-class` attribute]: https://docs.asciidoctor.org/asciidoc/latest/toc/
     pub fn toc_class(&self) -> &str {

--- a/parser/src/document/toc.rs
+++ b/parser/src/document/toc.rs
@@ -120,6 +120,11 @@ pub(crate) const DEFAULT_TOC_TITLE: &str = "Table of Contents";
 /// `toc-class` attribute is not set. Matches Asciidoctor's default.
 pub(crate) const DEFAULT_TOC_CLASS: &str = "toc";
 
+/// The CSS class applied to the table of contents container for a `left`/`right`
+/// side-column TOC when the `toc-class` attribute is not set. This is the class
+/// that drives the fixed side-column styling in Asciidoctor's standalone HTML.
+pub(crate) const DEFAULT_TOC_CLASS_SIDE: &str = "toc2";
+
 /// The resolved table-of-contents configuration for a document (or a nested
 /// AsciiDoc table cell, which resolves its own configuration independently).
 ///
@@ -149,11 +154,12 @@ impl TocConfig {
     /// Resolves the full table-of-contents configuration from a parser's
     /// current attribute state.
     pub(crate) fn from_parser(parser: &Parser) -> Self {
+        let mode = TocMode::from_parser(parser);
         Self {
-            mode: TocMode::from_parser(parser),
+            mode,
             levels: resolve_levels(parser),
             title: resolve_title(parser),
-            class: resolve_class(parser),
+            class: resolve_class(parser, mode),
         }
     }
 
@@ -195,11 +201,25 @@ fn resolve_title(parser: &Parser) -> String {
     }
 }
 
-/// Resolves the `toc-class`, falling back to the default when unset or empty.
-fn resolve_class(parser: &Parser) -> String {
+/// Resolves the `toc-class`. An explicit, non-empty `toc-class` wins outright.
+/// Otherwise the default depends on placement: a `left`/`right` side-column TOC
+/// uses `toc2` (the class that drives the side-column styling), matching
+/// Asciidoctor, which switches the default `toc-class` to `toc2` for those
+/// placements; every other placement uses the plain `toc`.
+fn resolve_class(parser: &Parser, mode: TocMode) -> String {
     match parser.attribute_value("toc-class") {
         InterpretedValue::Value(v) if !v.trim().is_empty() => v,
-        _ => DEFAULT_TOC_CLASS.to_string(),
+        _ => default_toc_class(mode).to_string(),
+    }
+}
+
+/// Returns the default `toc-class` for a resolved placement: `toc2` for a
+/// `left`/`right` side-column TOC, and the plain `toc` for every other
+/// placement.
+fn default_toc_class(mode: TocMode) -> &'static str {
+    match mode {
+        TocMode::Left | TocMode::Right => DEFAULT_TOC_CLASS_SIDE,
+        _ => DEFAULT_TOC_CLASS,
     }
 }
 
@@ -319,5 +339,27 @@ mod tests {
         assert_eq!(doc_with(":toc:\n:toc-class: floaty").toc_class(), "floaty");
         // An empty `:toc-class:` falls back to the default.
         assert_eq!(doc_with(":toc:\n:toc-class:").toc_class(), "toc");
+    }
+
+    #[test]
+    fn class_defaults_to_toc2_for_side_column_placement() {
+        // A `left`/`right` side-column TOC switches the default class to `toc2`,
+        // matching Asciidoctor; every other placement keeps the plain `toc`.
+        assert_eq!(doc_with(":toc: left").toc_class(), "toc2");
+        assert_eq!(doc_with(":toc: right").toc_class(), "toc2");
+        assert_eq!(doc_with(":toc:\n:toc-placement: left").toc_class(), "toc2");
+        assert_eq!(doc_with(":toc:\n:toc-placement: right").toc_class(), "toc2");
+        assert_eq!(doc_with(":toc: preamble").toc_class(), "toc");
+        assert_eq!(doc_with(":toc: macro").toc_class(), "toc");
+
+        // An explicit `toc-class` still wins over the side-column default.
+        assert_eq!(
+            doc_with(":toc: left\n:toc-class: floaty").toc_class(),
+            "floaty"
+        );
+        // An explicit but empty `:toc-class:` resolves to the built-in `toc-class`
+        // default (`toc`) at the attribute layer, so the placement-derived `toc2`
+        // default only applies when `toc-class` is left entirely unset.
+        assert_eq!(doc_with(":toc: left\n:toc-class:").toc_class(), "toc");
     }
 }

--- a/parser/src/tests/asciidoc_lang/toc/position.rs
+++ b/parser/src/tests/asciidoc_lang/toc/position.rs
@@ -61,11 +61,13 @@ The sidebar column containing the TOC is both fixed and scrollable.
 
     // The `left`/`right` side-column styling needs standalone HTML body framing
     // this crate does not model, but the values still resolve to their own
-    // placements and generate a TOC.
+    // placements, generate a TOC, and switch the default `toc-class` to the
+    // side-column `toc2` (see #749).
     for (value, mode) in [("left", TocMode::Left), ("right", TocMode::Right)] {
         let doc = Parser::default().parse(&format!("= Title\n:toc: {value}\n\n== Section\n\nhi"));
         assert_eq!(doc.toc_mode(), mode, "value: {value}");
-        assert_css(&doc, "#toc.toc", 1);
+        assert_eq!(doc.toc_class(), "toc2", "value: {value}");
+        assert_css(&doc, "#toc.toc2", 1);
     }
 }
 

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -1538,35 +1538,42 @@ mod assignment {
         // matrix row is exercised here through `toc_mode()` / `toc_class()`,
         // asserting this crate's actual behavior.
         //
-        // Two rows still diverge from Asciidoctor's matrix (and are asserted
-        // as this crate's actual behavior): the `toc2` alias is not recognized
-        // (it resolves to `Disabled`, not a left-placed TOC — #748) and
-        // `toc-class` is never switched to `toc2` (#749). The
-        // `toc toc-placement=macro` and `toc toc-placement!` rows now match
-        // Asciidoctor (`macro`): this crate honors an explicit `toc-placement`,
-        // and a soft-unset `toc-placement!` with `toc` set defers the TOC to a
-        // `toc::[]` block macro.
+        // One row still diverges from Asciidoctor's matrix (and is asserted as
+        // this crate's actual behavior): the `toc2` alias is not recognized (it
+        // resolves to `Disabled`, not a left-placed TOC — #748), so its
+        // `toc-class` also stays the default `toc` rather than `toc2`. The
+        // `toc=left` and `toc=right` rows now match Asciidoctor's `toc2`
+        // `toc-class` (#749): a left/right side-column placement switches the
+        // default class to `toc2`. The `toc toc-placement=macro` and
+        // `toc toc-placement!` rows match Asciidoctor (`macro`): this crate
+        // honors an explicit `toc-placement`, and a soft-unset `toc-placement!`
+        // with `toc` set defers the TOC to a `toc::[]` block macro.
         use crate::document::TocMode;
         // Each row is the raw attribute spec (as it appears in the vendored
         // matrix, parsed the same way Ruby does — space-separated entries,
         // `name=value`, or `name!` for an unset) paired with the `TocMode` this
-        // crate resolves for it.
-        let rows: &[(&str, TocMode)] = &[
-            ("toc", TocMode::Auto),
-            ("toc=header", TocMode::Auto),
-            ("toc=beeboo", TocMode::Auto),
-            ("toc=left", TocMode::Left),
-            // `toc2` alias unrecognized (#748); Asciidoctor: left-placed TOC.
-            ("toc2", TocMode::Disabled),
-            ("toc=right", TocMode::Right),
-            ("toc=preamble", TocMode::Preamble),
-            ("toc=macro", TocMode::Macro),
-            ("toc toc-placement=macro toc-position=left", TocMode::Macro),
+        // crate resolves for it and the expected `toc_class()`.
+        let rows: &[(&str, TocMode, &str)] = &[
+            ("toc", TocMode::Auto, "toc"),
+            ("toc=header", TocMode::Auto, "toc"),
+            ("toc=beeboo", TocMode::Auto, "toc"),
+            ("toc=left", TocMode::Left, "toc2"),
+            // `toc2` alias unrecognized (#748); Asciidoctor: left-placed TOC
+            // with `toc-class` `toc2`.
+            ("toc2", TocMode::Disabled, "toc"),
+            ("toc=right", TocMode::Right, "toc2"),
+            ("toc=preamble", TocMode::Preamble, "toc"),
+            ("toc=macro", TocMode::Macro, "toc"),
+            (
+                "toc toc-placement=macro toc-position=left",
+                TocMode::Macro,
+                "toc",
+            ),
             // Soft-unset `toc-placement!` with `toc` set defers to a `toc::[]`
             // macro, matching Asciidoctor (#750).
-            ("toc toc-placement!", TocMode::Macro),
+            ("toc toc-placement!", TocMode::Macro, "toc"),
         ];
-        for (spec, expected_mode) in rows {
+        for (spec, expected_mode, expected_class) in rows {
             let mut parser = Parser::default();
             for entry in spec.split(' ') {
                 parser = if let Some(name) = entry.strip_suffix('!') {
@@ -1579,9 +1586,9 @@ mod assignment {
             }
             let doc = parser.parse("");
             assert_eq!(doc.toc_mode(), *expected_mode, "toc_mode for {spec:?}");
-            // `toc-class` is never switched to `toc2`; it stays the default
-            // (#749); Asciidoctor sets `toc2` for left/right placement.
-            assert_eq!(doc.toc_class(), "toc", "toc_class for {spec:?}");
+            // A left/right side-column placement switches `toc-class` to `toc2`
+            // (#749); every other placement keeps the default `toc`.
+            assert_eq!(doc.toc_class(), *expected_class, "toc_class for {spec:?}");
         }
     }
 }

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -2960,13 +2960,15 @@ mod tests {
         fn left_and_right_render_like_auto_at_top() {
             // `left`/`right` request a side column in standalone HTML, but this
             // embeddable virtual DOM (Asciidoctor's documented fallback) renders
-            // them like `auto`: a `div#toc` at the top of the body.
+            // them like `auto`: a `div#toc` at the top of the body. The container
+            // still carries the side-column `toc2` class (see #749).
             for (value, mode) in [("left", TocMode::Left), ("right", TocMode::Right)] {
                 let doc =
                     Parser::default().parse(&format!("= Title\n:toc: {value}\n\n== Section\n\nhi"));
 
                 assert_eq!(doc.toc_mode(), mode, "value: {value}");
-                assert_css(&doc, "#toc.toc", 1);
+                assert_eq!(doc.toc_class(), "toc2", "value: {value}");
+                assert_css(&doc, "#toc.toc2", 1);
 
                 let vdom = doc.to_virtual_dom();
                 assert_eq!(vdom.children[0].id.as_deref(), Some("toc"));


### PR DESCRIPTION
## Summary

Fixes #749.

`Document::toc_class()` (in `parser/src/document/toc.rs`) always returned the default `toc`, regardless of the resolved TOC placement. Asciidoctor switches the default `toc-class` to `toc2` — the class that drives the fixed side-column styling — when the TOC is placed as a `left` or `right` side column, and keeps `toc` for every other placement.

## Changes

- `resolve_class` now takes the resolved `TocMode` and, when `toc-class` is not explicitly set, returns `toc2` for `TocMode::Left`/`TocMode::Right` and `toc` otherwise (new `DEFAULT_TOC_CLASS_SIDE` const + `default_toc_class` helper).
- An explicit, non-empty `toc-class` still wins outright. An explicit but *empty* `:toc-class:` resolves to the built-in `toc-class` default (`toc`) at the attribute layer, so the placement-derived `toc2` default only applies when `toc-class` is left entirely unset — this matches the crate's existing empty-attribute handling.
- Updated the `verify_toc_attribute_matrix` SDD test so the `toc=left` / `toc=right` rows now assert `toc2` (matching Asciidoctor's matrix). The `toc2` *alias* row still resolves to `Disabled` (and thus `toc`) — that is the separate, unrecognized-alias gap tracked in #748.
- Updated the `side_column` and `left_and_right_render_like_auto_at_top` tests, which now expect the `toc2` container class, and added a focused unit test.

## Testing

- `cargo test -p asciidoc-parser` — all 4154 tests pass
- `cargo clippy -p asciidoc-parser --all-targets` — clean
- `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkgWEy98BxR7v8PN9cXGWG)_