### PR TITLE
fix: Fold stacked block attribute lines above the document title (#821)

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -421,16 +421,27 @@ fn collect_document_metadata_lines<'src>(
     after_first: Span<'src>,
     parser: &Parser,
 ) -> Option<(Span<'src>, Vec<DocumentMetadata>, Vec<Warning<'src>>)> {
-    // First scan forward over the run of consecutive `[…]` lines *without*
-    // parsing their attribute lists. Parsing evaluates substitutions (a value
-    // may contain a `{counter:…}` reference, for instance), so it must not
-    // happen until a document title is known to close the run; a run that is
-    // not terminated by a title is block metadata for the body and is left
-    // untouched for the block parser.
-    let mut candidate_lines: Vec<Span<'src>> = vec![first_line];
+    // First scan forward over the run of consecutive `[…]` lines, validating
+    // each with only the cheap structural checks (via
+    // `is_document_metadata_attrlist`) and *without* parsing its attribute list.
+    // Parsing an attribute list evaluates substitutions — a value may contain a
+    // `{counter:…}` reference, which mutates parser state — so it must be
+    // deferred until the entire run is known to be well-formed *and* closed by a
+    // document title. A run that is rejected here (a bad bracket form such as
+    // `[[anchor]]`, or no trailing title) is left completely untouched for the
+    // block parser, so no counter or other substitution fires prematurely.
+    let mut candidate_lines: Vec<Span<'src>> = vec![];
+    let mut line = first_line;
     let mut rest = after_first;
 
     loop {
+        if !is_document_metadata_attrlist(line) {
+            // A bracket form that is not a well-formed block attribute list
+            // (e.g. `[[anchor]]` or a leading-space form) rejects the whole run.
+            return None;
+        }
+        candidate_lines.push(line);
+
         let next_mi = rest.take_normalized_line();
         let next_line = next_mi.item;
 
@@ -440,8 +451,9 @@ fn collect_document_metadata_lines<'src>(
         }
 
         if next_line.starts_with('[') && next_line.ends_with(']') {
-            // Another block attribute line stacks above the title; fold it too.
-            candidate_lines.push(next_line);
+            // Another block attribute line stacks above the title; validate and
+            // fold it on the next iteration.
+            line = next_line;
             rest = next_mi.after;
             continue;
         }
@@ -451,10 +463,10 @@ fn collect_document_metadata_lines<'src>(
         return None;
     }
 
-    // A document title closes the run: now parse each collected line into
-    // metadata. If any line is not a well-formed block attribute list (e.g. a
-    // `[[anchor]]` or a leading-space form), the whole run is rejected and the
-    // caller falls through, terminating the header as before.
+    // The run is well-formed and closed by a document title: only now parse each
+    // collected line into metadata. Every line was pre-validated above, so
+    // parsing does not reject (the `?` is defensive) and no substitution fires
+    // for a run that is ultimately rejected.
     let mut metadata_list: Vec<DocumentMetadata> = vec![];
     let mut warnings: Vec<Warning<'src>> = vec![];
 
@@ -469,38 +481,54 @@ fn collect_document_metadata_lines<'src>(
     Some((rest, metadata_list, warnings))
 }
 
+/// Returns `true` when `line` — which the caller has confirmed begins with `[`
+/// and ends with `]` — is a well-formed block attribute list that may carry
+/// document metadata above the title, and `false` for the forms rejected there.
+///
+/// The rejected forms mirror the checks used when parsing block metadata
+/// elsewhere: an empty list, a leading space or tab, or a `[[anchor]]` block
+/// anchor. The legacy double-bracket anchor above the document title is left
+/// unsupported (it terminates the header, as before); the single-bracket
+/// `[#id]` shorthand is the supported way to set a document ID.
+///
+/// This performs only cheap structural checks and does not parse the attribute
+/// list, so it never triggers substitutions (e.g. a `{counter:…}` reference in
+/// an attribute value). That lets a caller reject a run of lines before parsing
+/// any of them.
+fn is_document_metadata_attrlist(line: Span<'_>) -> bool {
+    // Drop the enclosing square brackets now that the caller has confirmed they
+    // are present.
+    let inner = line.slice(1..line.len() - 1);
+
+    !(inner.is_empty()
+        || inner.starts_with(' ')
+        || inner.starts_with('\t')
+        || (inner.starts_with('[') && inner.ends_with(']')))
+}
+
 /// Parse a block attribute line (e.g. `[reftext="…"]`, `[#id]`, `[role=…]`,
 /// `[separator=::]`) appearing above the document title into
 /// [`DocumentMetadata`].
 ///
 /// The `line` is expected to begin with `[` and end with `]`. Returns the
 /// folded metadata together with any warnings raised while parsing the
-/// attribute list when the line is a well-formed block attribute list, and
-/// `None` otherwise (so the caller can fall through to its normal handling of
-/// the line, which then terminates the header). The warnings are only surfaced
-/// when the line is actually consumed as document metadata; otherwise the line
-/// is left for the block parser, which reports them on its own path.
+/// attribute list when the line is a well-formed block attribute list (see
+/// [`is_document_metadata_attrlist`]), and `None` otherwise (so the caller can
+/// fall through to its normal handling of the line, which then terminates the
+/// header). The warnings are only surfaced when the line is actually consumed
+/// as document metadata; otherwise the line is left for the block parser, which
+/// reports them on its own path.
 fn parse_document_metadata_attrlist<'src>(
     line: Span<'src>,
     parser: &Parser,
 ) -> Option<(DocumentMetadata, Vec<Warning<'src>>)> {
+    if !is_document_metadata_attrlist(line) {
+        return None;
+    }
+
     // Drop the enclosing square brackets now that the caller has confirmed they
     // are present.
     let inner = line.slice(1..line.len() - 1);
-
-    // Reject forms that are not block attribute lists, mirroring the checks used
-    // when parsing block metadata elsewhere: a leading space or tab, an empty
-    // list, or a `[[anchor]]` block anchor. The legacy double-bracket anchor
-    // above the document title is left unsupported (it terminates the header, as
-    // before); the single-bracket `[#id]` shorthand is the supported way to set
-    // a document ID.
-    if inner.is_empty()
-        || inner.starts_with(' ')
-        || inner.starts_with('\t')
-        || (inner.starts_with('[') && inner.ends_with(']'))
-    {
-        return None;
-    }
 
     let MatchAndWarnings {
         item: MatchedItem {
@@ -1360,6 +1388,23 @@ mod tests {
 
         assert_eq!(header.title(), None);
         assert_eq!(header.id(), None);
+    }
+
+    #[test]
+    fn rejected_metadata_run_does_not_fire_counter() {
+        // A run whose attribute list carries a `{counter:…}` reference but is
+        // ultimately rejected (here by an embedded `[[anchor]]`) must not parse
+        // any of its lines during header parsing: the run is validated
+        // structurally and left for the block parser, so the counter is not
+        // advanced twice. The `reftext` line fires the counter exactly once when
+        // the block parser reaches it (yielding 1), so the following
+        // `{counter:item}` reference renders 2 — not 3, which is what a leaked
+        // header-time evaluation would produce.
+        let doc = Parser::default()
+            .parse("[reftext=\"See {counter:item}\"]\n[[anchor]]\n= Title\n\n{counter:item}");
+
+        assert_eq!(doc.header().title(), None);
+        assert_eq!(rendered_paragraphs(&doc), vec!["= Title", "2"]);
     }
 
     #[test]

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -464,14 +464,13 @@ fn collect_document_metadata_lines<'src>(
     }
 
     // The run is well-formed and closed by a document title: only now parse each
-    // collected line into metadata. Every line was pre-validated above, so
-    // parsing does not reject (the `?` is defensive) and no substitution fires
-    // for a run that is ultimately rejected.
+    // collected line into metadata. Every line was pre-validated above, so no
+    // substitution fires for a run that is ultimately rejected.
     let mut metadata_list: Vec<DocumentMetadata> = vec![];
     let mut warnings: Vec<Warning<'src>> = vec![];
 
     for line in candidate_lines {
-        let (metadata, mut line_warnings) = parse_document_metadata_attrlist(line, parser)?;
+        let (metadata, mut line_warnings) = parse_document_metadata_attrlist(line, parser);
         metadata_list.push(metadata);
         warnings.append(&mut line_warnings);
     }
@@ -510,24 +509,17 @@ fn is_document_metadata_attrlist(line: Span<'_>) -> bool {
 /// `[separator=::]`) appearing above the document title into
 /// [`DocumentMetadata`].
 ///
-/// The `line` is expected to begin with `[` and end with `]`. Returns the
-/// folded metadata together with any warnings raised while parsing the
-/// attribute list when the line is a well-formed block attribute list (see
-/// [`is_document_metadata_attrlist`]), and `None` otherwise (so the caller can
-/// fall through to its normal handling of the line, which then terminates the
-/// header). The warnings are only surfaced when the line is actually consumed
-/// as document metadata; otherwise the line is left for the block parser, which
-/// reports them on its own path.
+/// The `line` must be a well-formed block attribute list — the caller confirms
+/// this with [`is_document_metadata_attrlist`] before calling, so parsing (which
+/// evaluates substitutions) only happens for a run that is actually consumed as
+/// document metadata. Returns the folded metadata together with any warnings
+/// raised while parsing the attribute list.
 fn parse_document_metadata_attrlist<'src>(
     line: Span<'src>,
     parser: &Parser,
-) -> Option<(DocumentMetadata, Vec<Warning<'src>>)> {
-    if !is_document_metadata_attrlist(line) {
-        return None;
-    }
-
-    // Drop the enclosing square brackets now that the caller has confirmed they
-    // are present.
+) -> (DocumentMetadata, Vec<Warning<'src>>) {
+    // Drop the enclosing square brackets; the caller has confirmed they are
+    // present (and that the line is a well-formed block attribute list).
     let inner = line.slice(1..line.len() - 1);
 
     let MatchAndWarnings {
@@ -550,7 +542,7 @@ fn parse_document_metadata_attrlist<'src>(
         options: attrlist.options().iter().map(|o| o.to_string()).collect(),
     };
 
-    Some((metadata, warnings))
+    (metadata, warnings)
 }
 
 /// Partition a document title into its main title and optional subtitle.

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -112,46 +112,53 @@ impl<'src> Header<'src> {
             } else if title.is_none()
                 && line.starts_with('[')
                 && line.ends_with(']')
-                && document_title_marker(line_mi.after.take_normalized_line().item).is_some()
-                && let Some((metadata, metadata_warnings)) =
-                    parse_document_metadata_attrlist(line, parser)
+                && let Some((after_metadata, metadata_list, metadata_warnings)) =
+                    collect_document_metadata_lines(line, line_mi.after, parser)
             {
                 warnings.extend(metadata_warnings);
-                // A block attribute line directly above the document title assigns
-                // metadata to the *document* — its `id`, `reftext`, `role`, and
-                // options — mirroring Asciidoctor's `parse_document_header`. Each
-                // recognized value folds into the document's attributes at this
-                // point in the header, so it follows document order alongside any
-                // equivalent header attribute entry (e.g. `:reftext:`).
+                // One or more consecutive block attribute lines directly above the
+                // document title assign metadata to the *document* — its `id`,
+                // `reftext`, `role`, and options — mirroring Asciidoctor's
+                // `parse_block_metadata_lines`, which accumulates every such line
+                // above the doctitle. Each recognized value folds into the
+                // document's attributes at this point in the header, in document
+                // order, alongside any equivalent header attribute entry (e.g.
+                // `:reftext:`).
                 //
                 // A `separator` sets the subtitle separator; it behaves exactly
                 // like assigning the `title-separator` document attribute here, so
                 // both mechanisms share the same partitioning logic.
                 //
-                // The line is only intercepted when a document title immediately
-                // follows; otherwise it is block metadata for the body (e.g. a
-                // table's `separator`) and is left for the block parser.
-                if let Some(doc_id) = metadata.id {
-                    id = Some(doc_id);
+                // The run is only intercepted when a document title eventually
+                // follows it; otherwise the lines are block metadata for the body
+                // (e.g. a table's `separator`) and are left for the block parser.
+                // When several lines set the same value, the later line wins
+                // (document order); options accumulate across the run.
+                for metadata in metadata_list {
+                    if let Some(doc_id) = metadata.id {
+                        id = Some(doc_id);
+                    }
+                    if let Some(separator) = metadata.separator {
+                        parser.set_attribute_by_value_from_header("title-separator", separator);
+                    }
+                    if let Some(reftext) = metadata.reftext {
+                        parser.set_attribute_by_value_from_header("reftext", reftext);
+                    }
+                    if !metadata.roles.is_empty() {
+                        // Fold the role(s) into the `role` document attribute
+                        // (space-joined, as Asciidoctor stores `attributes['role']`)
+                        // and also retain them on the header so `Document::roles()`
+                        // agrees with the document attribute (see #820). A later
+                        // line's roles replace an earlier line's, matching the
+                        // last-wins document order used for the other values.
+                        parser.set_attribute_by_value_from_header("role", metadata.roles.join(" "));
+                        roles = metadata.roles;
+                    }
+                    for option in metadata.options {
+                        parser.set_attribute_by_value_from_header(format!("{option}-option"), "");
+                    }
                 }
-                if let Some(separator) = metadata.separator {
-                    parser.set_attribute_by_value_from_header("title-separator", separator);
-                }
-                if let Some(reftext) = metadata.reftext {
-                    parser.set_attribute_by_value_from_header("reftext", reftext);
-                }
-                if !metadata.roles.is_empty() {
-                    // Fold the role(s) into the `role` document attribute
-                    // (space-joined, as Asciidoctor stores `attributes['role']`)
-                    // and also retain them on the header so `Document::roles()`
-                    // agrees with the document attribute (see #820).
-                    parser.set_attribute_by_value_from_header("role", metadata.roles.join(" "));
-                    roles = metadata.roles;
-                }
-                for option in metadata.options {
-                    parser.set_attribute_by_value_from_header(format!("{option}-option"), "");
-                }
-                source = line_mi.after;
+                source = after_metadata;
             } else if title.is_none()
                 && let Some(marker) = document_title_marker(line)
             {
@@ -388,6 +395,78 @@ struct DocumentMetadata {
     reftext: Option<String>,
     roles: Vec<String>,
     options: Vec<String>,
+}
+
+/// Collect the run of consecutive block attribute lines that sits directly
+/// above the document title, folding each line into [`DocumentMetadata`].
+///
+/// `first_line` is the block attribute line the caller has already matched (it
+/// begins with `[` and ends with `]`); `after_first` is the source immediately
+/// following it. Subsequent lines are consumed as long as each is itself a
+/// well-formed block attribute list, mirroring Asciidoctor's
+/// `parse_block_metadata_lines`, which accumulates every metadata line above
+/// the doctitle.
+///
+/// Returns `Some((after_metadata, metadata_list, warnings))` — where
+/// `after_metadata` is the source positioned at the document title line (the
+/// title itself is left for the caller to parse) and `metadata_list` holds one
+/// entry per line in document order — only when a document title eventually
+/// follows the run. Returns `None` when any line in the run is not a
+/// well-formed block attribute list (e.g. a `[[anchor]]` or a leading-space
+/// form) or when the run is not followed by a document title, so the caller
+/// falls through to its normal handling (which then terminates the header or
+/// leaves the lines for the block parser).
+fn collect_document_metadata_lines<'src>(
+    first_line: Span<'src>,
+    after_first: Span<'src>,
+    parser: &Parser,
+) -> Option<(Span<'src>, Vec<DocumentMetadata>, Vec<Warning<'src>>)> {
+    // First scan forward over the run of consecutive `[…]` lines *without*
+    // parsing their attribute lists. Parsing evaluates substitutions (a value
+    // may contain a `{counter:…}` reference, for instance), so it must not
+    // happen until a document title is known to close the run; a run that is
+    // not terminated by a title is block metadata for the body and is left
+    // untouched for the block parser.
+    let mut candidate_lines: Vec<Span<'src>> = vec![first_line];
+    let mut rest = after_first;
+
+    loop {
+        let next_mi = rest.take_normalized_line();
+        let next_line = next_mi.item;
+
+        if document_title_marker(next_line).is_some() {
+            // A document title closes the run; `rest` points at the title line.
+            break;
+        }
+
+        if next_line.starts_with('[') && next_line.ends_with(']') {
+            // Another block attribute line stacks above the title; fold it too.
+            candidate_lines.push(next_line);
+            rest = next_mi.after;
+            continue;
+        }
+
+        // The run is followed by neither another block attribute line nor a
+        // document title, so it is not document metadata.
+        return None;
+    }
+
+    // A document title closes the run: now parse each collected line into
+    // metadata. If any line is not a well-formed block attribute list (e.g. a
+    // `[[anchor]]` or a leading-space form), the whole run is rejected and the
+    // caller falls through, terminating the header as before.
+    let mut metadata_list: Vec<DocumentMetadata> = vec![];
+    let mut warnings: Vec<Warning<'src>> = vec![];
+
+    for line in candidate_lines {
+        let (metadata, mut line_warnings) = parse_document_metadata_attrlist(line, parser)?;
+        metadata_list.push(metadata);
+        warnings.append(&mut line_warnings);
+    }
+
+    // `rest` is positioned at the document title line; leave it for the caller
+    // to parse on the next iteration of the header loop.
+    Some((rest, metadata_list, warnings))
 }
 
 /// Parse a block attribute line (e.g. `[reftext="…"]`, `[#id]`, `[role=…]`,
@@ -1222,6 +1301,65 @@ mod tests {
         // The longhand `[id=…]` form is equivalent.
         let doc = Parser::default().parse("[id=docid]\n= Document Title");
         assert_eq!(doc.header().id(), Some("docid"));
+    }
+
+    #[test]
+    fn stacked_block_attributes_above_title() {
+        // Several consecutive block attribute lines above the document title are
+        // all folded into document metadata (matching Asciidoctor's
+        // `parse_block_metadata_lines`), and the title that follows the run is
+        // still recognized rather than lost.
+        let doc = Parser::default()
+            .parse("[#docid]\n[reftext=\"Links and Stuff\"]\n= Links & Stuff\n\nBody.");
+        let header = doc.header();
+
+        assert_eq!(header.title(), Some("Links &amp; Stuff"));
+        assert_eq!(header.id(), Some("docid"));
+        assert_eq!(doc.id(), Some("docid"));
+        assert_eq!(
+            doc.attribute_value("reftext"),
+            InterpretedValue::Value("Links and Stuff")
+        );
+        assert_eq!(rendered_paragraphs(&doc), vec!["Body."]);
+    }
+
+    #[test]
+    fn stacked_block_attributes_accumulate_options() {
+        // Options accumulate across every block attribute line in the run above
+        // the title, while a repeated single-valued attribute (here the ID)
+        // takes its last-specified value in document order.
+        let doc = Parser::default().parse("[%noheader]\n[#final]\n[%autowidth]\n= Document Title");
+        let header = doc.header();
+
+        assert_eq!(header.title(), Some("Document Title"));
+        assert_eq!(header.id(), Some("final"));
+        assert!(doc.is_attribute_set("noheader-option"));
+        assert!(doc.is_attribute_set("autowidth-option"));
+    }
+
+    #[test]
+    fn stacked_block_attributes_without_title_terminate_header() {
+        // A run of block attribute lines that is *not* followed by a document
+        // title is not folded as document metadata: the header terminates and no
+        // title is recognized, mirroring the single-line behavior.
+        let doc = Parser::default().parse("[#docid]\n[reftext=\"X\"]\n\nBody.");
+        let header = doc.header();
+
+        assert_eq!(header.title(), None);
+        assert_eq!(header.id(), None);
+        assert_eq!(doc.attribute_value("reftext"), InterpretedValue::Unset);
+    }
+
+    #[test]
+    fn stacked_block_attributes_reject_embedded_anchor() {
+        // A legacy `[[anchor]]` embedded in the run is not a well-formed block
+        // attribute list above the title, so the whole run is rejected and the
+        // header terminates without recovering the title.
+        let doc = Parser::default().parse("[#docid]\n[[anchor]]\n= Document Title");
+        let header = doc.header();
+
+        assert_eq!(header.title(), None);
+        assert_eq!(header.id(), None);
     }
 
     #[test]

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -510,10 +510,10 @@ fn is_document_metadata_attrlist(line: Span<'_>) -> bool {
 /// [`DocumentMetadata`].
 ///
 /// The `line` must be a well-formed block attribute list — the caller confirms
-/// this with [`is_document_metadata_attrlist`] before calling, so parsing (which
-/// evaluates substitutions) only happens for a run that is actually consumed as
-/// document metadata. Returns the folded metadata together with any warnings
-/// raised while parsing the attribute list.
+/// this with [`is_document_metadata_attrlist`] before calling, so parsing
+/// (which evaluates substitutions) only happens for a run that is actually
+/// consumed as document metadata. Returns the folded metadata together with any
+/// warnings raised while parsing the attribute list.
 fn parse_document_metadata_attrlist<'src>(
     line: Span<'src>,
     parser: &Parser,


### PR DESCRIPTION
Fixes #821.

## Problem

`Header::parse` intercepts a block attribute line directly above the document title and folds its metadata (`id`, `reftext`, `role`, options, `separator`) into the document (added in #814). But the intercept fired only when the *immediately* following line was a document title marker, so it handled only **one** such line. Stacked block attribute lines were not folded:

```asciidoc
[#docid]
[reftext="Links and Stuff"]
= Links & Stuff
```

Here `[#docid]` sees `[reftext="Links and Stuff"]` — not a title marker — as its next line, so the intercept did not fire, parsing fell through to the branch that terminates the header, and the title was lost.

## Fix

`Header::parse` now loops over the run of consecutive block attribute lines above the title, folding each line's metadata in document order (matching Asciidoctor's `parse_block_metadata_lines`). When several lines set the same single-valued attribute the later line wins; options accumulate across the run.

The run is only intercepted when a document title eventually follows it, and the existing rejection rules — `[[anchor]]`, leading space — still apply, so a bad bracket form anywhere in the run rejects the whole run and terminates the header exactly as before.

The lookahead scans the `[…]` lines *without* parsing their attribute lists until a title is confirmed to close the run. Parsing an attribute list can evaluate substitutions (e.g. a value containing `{counter:table-number}`), so deferring it keeps a non-title run — such as block metadata above a table — completely untouched for the block parser. This preserves the existing table-caption/counter behavior.

## Tests

Added to `parser/src/document/header.rs`:
- `stacked_block_attributes_above_title` — the issue's example: both `[#docid]` and `[reftext=…]` fold and the title is recovered.
- `stacked_block_attributes_accumulate_options` — options accumulate across the run; a repeated single-valued attribute takes its last value.
- `stacked_block_attributes_without_title_terminate_header` — a run not followed by a title terminates the header (no title, no folded metadata).
- `stacked_block_attributes_reject_embedded_anchor` — a `[[anchor]]` in the run rejects the whole run.

Full suite (4157 tests), clippy, and rustfmt all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01816rgRuR5TY7WiMXSTtuD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01816rgRuR5TY7WiMXSTtuD4)_