### PR TITLE
fix: Accept `_`-prefixed and dotted named tokens in attribute lists (close #727)

### DIFF
--- a/parser/src/span/primitives.rs
+++ b/parser/src/span/primitives.rs
@@ -31,20 +31,25 @@ impl<'src> Span<'src> {
 
     /// Split the span, consuming an attribute name if found.
     ///
-    /// An [attribute name] consists of a word character (letter or numeral)
-    /// followed by any number of word or `-` characters (e.g., `see-also`).
+    /// An [attribute name] begins with a word character (a letter, numeral, or
+    /// underscore) and continues with any number of word, `-`, or `.`
+    /// characters (e.g., `see-also`, `_foo`, or `foo.foo`). This mirrors
+    /// Asciidoctor's `AttributeList::NameRx` (`#{CG_WORD}[#{CC_WORD}\-.]*`),
+    /// except that — as elsewhere in this crate — a "word character" is
+    /// restricted to ASCII (`[A-Za-z0-9_]`); accepting the full Unicode word
+    /// class is tracked separately.
     ///
     /// [attribute name]: https://docs.asciidoctor.org/asciidoc/latest/attributes/positional-and-named-attributes/#attribute-list-parsing
     pub(crate) fn take_attr_name(self) -> Option<MatchedItem<'src, Self>> {
         let mut chars = self.data.char_indices();
 
         let (_, c) = chars.next()?;
-        if !c.is_ascii_alphanumeric() {
+        if !is_attr_name_start(c) {
             return None;
         }
 
         for (index, c) in chars {
-            if !c.is_ascii_alphanumeric() && c != '-' {
+            if !is_attr_name_continuation(c) {
                 return Some(self.into_parse_result(index));
             }
         }
@@ -168,6 +173,18 @@ impl<'src> Span<'src> {
             self.slice(0..trim_len)
         }
     }
+}
+
+/// Returns `true` when `c` may begin an attribute-list name token: an ASCII
+/// word character (letter, digit, or underscore). See [`Span::take_attr_name`].
+fn is_attr_name_start(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
+}
+
+/// Returns `true` when `c` may continue an attribute-list name token: an ASCII
+/// word character, a hyphen, or a dot. See [`Span::take_attr_name`].
+fn is_attr_name_continuation(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.'
 }
 
 #[cfg(test)]
@@ -479,6 +496,62 @@ mod tests {
                     line: 1,
                     col: 4,
                     offset: 3
+                }
+            );
+        }
+
+        #[test]
+        fn starts_with_underscore() {
+            // A leading underscore is a word character, so it may begin an
+            // attribute name (Asciidoctor's `NameRx` accepts `_foo`).
+            let span = crate::Span::new("_foo = bar");
+            let mi = span.take_attr_name().unwrap();
+
+            assert_eq!(
+                mi.item,
+                Span {
+                    data: "_foo",
+                    line: 1,
+                    col: 1,
+                    offset: 0
+                }
+            );
+
+            assert_eq!(
+                mi.after,
+                Span {
+                    data: " = bar",
+                    line: 1,
+                    col: 5,
+                    offset: 4
+                }
+            );
+        }
+
+        #[test]
+        fn contains_dots_and_underscores() {
+            // Dots and (non-leading) underscores are valid continuation
+            // characters, so `foo.foo` and `foo_foo` are single name tokens.
+            let span = crate::Span::new("foo.foo_bar = baz");
+            let mi = span.take_attr_name().unwrap();
+
+            assert_eq!(
+                mi.item,
+                Span {
+                    data: "foo.foo_bar",
+                    line: 1,
+                    col: 1,
+                    offset: 0
+                }
+            );
+
+            assert_eq!(
+                mi.after,
+                Span {
+                    data: " = baz",
+                    line: 1,
+                    col: 12,
+                    offset: 11
                 }
             );
         }

--- a/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs
@@ -1416,7 +1416,11 @@ Any space or tab characters at the boundaries of the value are ignored.
 
         let mut parser = Parser::default();
 
-        let doc = parser.parse("[_foo = bar , zip , target=url]\nSome text here.");
+        // `-foo` is not a valid attribute name (a name cannot begin with `-`),
+        // so `-foo = bar` is not recognized as a named attribute and falls
+        // through to the "otherwise positional" branch, with the surrounding
+        // spaces trimmed from the value.
+        let doc = parser.parse("[-foo = bar , zip , target=url]\nSome text here.");
 
         assert_eq!(
             doc,
@@ -1446,7 +1450,7 @@ Any space or tab characters at the boundaries of the value are ignored.
                         rendered: "Some text here.",
                     },
                     source: Span {
-                        data: "[_foo = bar , zip , target=url]\nSome text here.",
+                        data: "[-foo = bar , zip , target=url]\nSome text here.",
                         line: 1,
                         col: 1,
                         offset: 0,
@@ -1462,8 +1466,8 @@ Any space or tab characters at the boundaries of the value are ignored.
                         attributes: &[
                             ElementAttribute {
                                 name: None,
-                                value: "_foo = bar",
-                                shorthand_items: &["_foo = bar"]
+                                value: "-foo = bar",
+                                shorthand_items: &["-foo = bar"]
                             },
                             ElementAttribute {
                                 name: None,
@@ -1478,7 +1482,7 @@ Any space or tab characters at the boundaries of the value are ignored.
                         ],
                         anchor: None,
                         source: Span {
-                            data: "_foo = bar , zip , target=url",
+                            data: "-foo = bar , zip , target=url",
                             line: 1,
                             col: 2,
                             offset: 1,
@@ -1486,7 +1490,7 @@ Any space or tab characters at the boundaries of the value are ignored.
                     },),
                 },),],
                 source: Span {
-                    data: "[_foo = bar , zip , target=url]\nSome text here.",
+                    data: "[-foo = bar , zip , target=url]\nSome text here.",
                     line: 1,
                     col: 1,
                     offset: 0,

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -65,8 +65,7 @@
 //! * Multi-line attribute values fuse only the modern backslash continuation,
 //!   not the legacy `+`, so a legacy `+`-continued value keeps only its first
 //!   line.
-//! * Non-ASCII attribute names, names with spaces, and named tokens beginning
-//!   with `_` or containing `.` are not accepted.
+//! * Non-ASCII attribute names and names with spaces are not accepted.
 //! * A counter modifies a locked (API-set or built-in) attribute rather than
 //!   leaving it unchanged.
 //! * The derived `backend*` / `basebackend*` / `filetype*` / `outfilesuffix` /
@@ -3212,10 +3211,9 @@ mod block_attributes {
             .map(|a| a.value())
     }
 
-    // Tracked in #727.
     #[test]
     fn parses_attribute_names_as_name_token() {
-        non_normative!(
+        verifies!(
             r#"
     test 'parses attribute names as name token' do
       input = <<~'EOS'
@@ -3237,16 +3235,12 @@ mod block_attributes {
         let doc = Parser::default().parse(
             "[normal,foo=\"bar\",_foo=\"_bar\",foo1=\"bar1\",foo-foo=\"bar-bar\",foo.foo=\"bar.bar\"]\ncontent",
         );
-        // Divergence: this crate does not accept attribute names that begin with
-        // `_` or contain `.` (`_foo`, `foo.foo`) as named tokens, so those
-        // entries are not recognized. `foo`, `foo1`, and `foo-foo` parse as
-        // expected.
         let block = first_block(&doc);
         assert_eq!(named(block, "foo"), Some("bar"));
+        assert_eq!(named(block, "_foo"), Some("_bar"));
         assert_eq!(named(block, "foo1"), Some("bar1"));
         assert_eq!(named(block, "foo-foo"), Some("bar-bar"));
-        assert_eq!(named(block, "_foo"), None);
-        assert_eq!(named(block, "foo.foo"), None);
+        assert_eq!(named(block, "foo.foo"), Some("bar.bar"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #727.

Asciidoctor's `AttributeList::NameRx` (`#{CG_WORD}[#{CC_WORD}\-.]*`) accepts a named attribute whose name begins with an underscore or contains a dot — e.g. `_foo` or `foo.foo`. This crate's `take_attr_name` only accepted an ASCII-alphanumeric start followed by alphanumerics and hyphens, so in an attribute list like `[normal,foo="bar",_foo="_bar",foo.foo="bar.bar"]` the `_foo` and `foo.foo` entries were silently dropped instead of being recognized as named attributes.

## Changes

- **`parser/src/span/primitives.rs`** — widen `take_attr_name` to accept an ASCII word-character start (adding `_`) and word / `-` / `.` continuation characters, extracted into `is_attr_name_start` / `is_attr_name_continuation` helpers. This matches Asciidoctor while keeping the crate's existing ASCII-only restriction; accepting the full Unicode word class remains tracked separately in #726. Added unit tests for a leading underscore and for embedded dots/underscores.
- **`parser/src/tests/asciidoctor_rb/attributes_test.rs`** — the `parses_attribute_names_as_name_token` SDD test now matches Asciidoctor, so it moves from a documented `non_normative!` divergence to a `verifies!` test asserting the full expected output (`_foo` → `_bar`, `foo.foo` → `bar.bar`). Updated the module-level divergence summary accordingly.
- **`parser/src/tests/asciidoc_lang/attributes/positional_and_named_attributes.rs`** — the `otherwise_positional` test used `_foo = bar` as an example of an entry that *looks* like `name=value` but is treated as positional; since `_foo` is now a valid name, it's switched to `-foo` (a name cannot begin with a hyphen), which still exercises the "otherwise positional" branch. Same length, so all span offsets are preserved.

## Testing

- `cargo test -p asciidoc-parser` — all tests pass (4155 + doctests).
- `cargo clippy -p asciidoc-parser --all-targets` — clean.
- `cargo fmt` — applied.

## Notes

The AsciiDoc language spec's prose (`positional-and-named-attributes.adoc`) describes a name as "a word character (letter or numeral) followed by any number of word or `-` characters", which is narrower than Asciidoctor's actual `NameRx`. This change follows the reference implementation's behavior, consistent with how the issue was found (SDD port of `attributes_test.rb`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNdUv2YTJkRB64m86WoA7s

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNdUv2YTJkRB64m86WoA7s)_