### PR TITLE
fix: Partition a 4+-part name supplied via the :author: attribute entry (#758)

### DIFF
--- a/parser/src/document/author.rs
+++ b/parser/src/document/author.rs
@@ -26,7 +26,17 @@ pub struct Author {
 }
 
 impl Author {
-    pub(crate) fn parse(source: &str, parser: &Parser) -> Option<Self> {
+    /// Parse a single author from `source`.
+    ///
+    /// `names_only` distinguishes the two contexts in which Asciidoctor parses
+    /// an author. The implicit author line (`names_only == false`) recognizes
+    /// at most three space-separated names via the [`AUTHOR`] pattern and,
+    /// failing that, stores the whole line as the author. An author
+    /// supplied through an attribute entry such as `:author:` (`names_only
+    /// == true`) is instead partitioned by splitting on whitespace into at
+    /// most three parts, so a name with four or more parts still assigns
+    /// its trailing parts to `lastname` (see issue #758).
+    pub(crate) fn parse(source: &str, parser: &Parser, names_only: bool) -> Option<Self> {
         let source = source.trim();
         if source.is_empty() {
             return None;
@@ -143,6 +153,13 @@ impl Author {
                     email: None,
                 })
             }
+        } else if names_only {
+            // Input comes from an attribute entry (e.g. `:author:`) and does not
+            // match the author pattern — typically a name with four or more parts
+            // or one containing punctuation such as a comma. Asciidoctor still
+            // partitions it by splitting on whitespace into at most three parts,
+            // assigning any trailing parts to `lastname`.
+            Some(partition_names_only(source))
         } else {
             // Input doesn't contain attributes and doesn't match the author pattern.
             // Asciidoctor stores the whole line as the author, condensing interior
@@ -262,6 +279,71 @@ fn join_name_parts(firstname: &str, middlename: Option<&str>, lastname: Option<&
     name
 }
 
+/// Partition an attribute-entry author value (e.g. the value of `:author:`)
+/// that does not match the [`AUTHOR`] pattern.
+///
+/// Mirroring Asciidoctor's `names_only` path in `process_authors`, the value is
+/// split on whitespace into at most three segments (Ruby's `String#split(nil,
+/// 3)`, which also drops leading whitespace). The trailing segment retains its
+/// interior text — so a four-plus-part name keeps its later parts in
+/// `lastname` — but has repeating spaces condensed to a single space. Each
+/// segment then has underscore joiners replaced with spaces.
+fn partition_names_only(source: &str) -> Author {
+    let mut segments = split_whitespace_max3(source);
+
+    let firstname = replace_underscores_with_spaces(segments.remove(0));
+    let (middlename, lastname) = match segments.len() {
+        0 => (None, None),
+        1 => (
+            None,
+            Some(replace_underscores_with_spaces(segments.remove(0))),
+        ),
+        _ => (
+            Some(replace_underscores_with_spaces(segments.remove(0))),
+            Some(replace_underscores_with_spaces(segments.remove(0))),
+        ),
+    };
+
+    let name = join_name_parts(&firstname, middlename.as_deref(), lastname.as_deref());
+
+    Author {
+        name,
+        firstname,
+        middlename,
+        lastname,
+        email: None,
+    }
+}
+
+/// Split `source` on runs of whitespace into at most three segments, mirroring
+/// Ruby's `String#split(nil, 3)`. Leading whitespace is dropped and the first
+/// two whitespace runs delimit the first two segments; the remainder becomes
+/// the third segment, with its repeating spaces condensed to a single space
+/// (Ruby's `String#squeeze ' '`). The returned vector always has at least one
+/// element because the caller has already rejected empty input.
+fn split_whitespace_max3(source: &str) -> Vec<String> {
+    let mut segments: Vec<String> = Vec::with_capacity(3);
+    let mut rest = source;
+
+    for _ in 0..2 {
+        rest = rest.trim_start();
+        match rest.find(char::is_whitespace) {
+            Some(index) => {
+                segments.push(rest[..index].to_string());
+                rest = &rest[index..];
+            }
+            None => break,
+        }
+    }
+
+    rest = rest.trim_start();
+    if !rest.is_empty() {
+        segments.push(condense_whitespace(rest));
+    }
+
+    segments
+}
+
 /// Condense runs of spaces into a single space, mirroring Ruby's
 /// `String#tr_s(' ', ' ')`, which Asciidoctor applies to an author line that
 /// does not match the author pattern.
@@ -307,6 +389,18 @@ static AUTHOR: LazyLock<Regex> = LazyLock::new(|| {
     )
     .unwrap()
 });
+
+/// Returns whether `source` matches the author pattern — at most three
+/// space-separated names with an optional trailing `<email>`.
+///
+/// The `:author:` attribute-entry path uses this to tell whether a plain-name
+/// value was partitioned by the fallback whitespace split (a name with four or
+/// more parts, or one containing punctuation such as a comma) rather than by
+/// the pattern. Only in the fallback case is the stored `author` value replaced
+/// with the reconstructed, whitespace-condensed name (issue #758).
+pub(crate) fn matches_author_pattern(source: &str) -> bool {
+    AUTHOR.is_match(source.trim())
+}
 
 fn apply_author_subs(source: &str, parser: &Parser) -> String {
     let span = Span::new(source);

--- a/parser/src/document/author.rs
+++ b/parser/src/document/author.rs
@@ -55,14 +55,22 @@ impl Author {
             // name.
             let expanded_source = apply_author_subs(source, parser);
 
-            let name_with_spaces = replace_underscores_with_spaces(expanded_source);
-            Some(Self {
-                name: name_with_spaces.clone(),
-                firstname: name_with_spaces,
-                middlename: None,
-                lastname: None,
-                email: None,
-            })
+            if names_only {
+                // An attribute-entry value is partitioned *after* its references
+                // are expanded, so a reference that resolves to a multi-part name
+                // (or one with a trailing email) yields the same metadata as the
+                // equivalent literal value.
+                Some(partition_names_only(&expanded_source))
+            } else {
+                let name_with_spaces = replace_underscores_with_spaces(expanded_source);
+                Some(Self {
+                    name: name_with_spaces.clone(),
+                    firstname: name_with_spaces,
+                    middlename: None,
+                    lastname: None,
+                    email: None,
+                })
+            }
         } else if let Some(captures) = AUTHOR.captures(source) {
             // Raw input matches author pattern: Extract components then apply
             // substitutions.
@@ -129,6 +137,13 @@ impl Author {
                     lastname,
                     email,
                 })
+            } else if names_only {
+                // An attribute-entry value that still fails the pattern after
+                // expansion is partitioned by the names-only rules, so a
+                // reference resolving to a four-plus-part name behaves like its
+                // literal equivalent. The expanded value is used before any HTML
+                // encoding so a trailing `<email>` can still be split off.
+                Some(partition_names_only(&expanded_source))
             } else {
                 // Even after expansion, doesn't match: Treat as single name with HTML encoding.
                 let mut expanded_name = expanded_source;
@@ -279,17 +294,34 @@ fn join_name_parts(firstname: &str, middlename: Option<&str>, lastname: Option<&
     name
 }
 
-/// Partition an attribute-entry author value (e.g. the value of `:author:`)
-/// that does not match the [`AUTHOR`] pattern.
+/// Partition an author value that does not match the [`AUTHOR`] pattern using
+/// Asciidoctor's `names_only` rules (the path taken for an attribute-entry
+/// value such as `:author:`).
 ///
-/// Mirroring Asciidoctor's `names_only` path in `process_authors`, the value is
-/// split on whitespace into at most three segments (Ruby's `String#split(nil,
-/// 3)`, which also drops leading whitespace). The trailing segment retains its
-/// interior text — so a four-plus-part name keeps its later parts in
-/// `lastname` — but has repeating spaces condensed to a single space. Each
-/// segment then has underscore joiners replaced with spaces.
+/// A trailing `<email>` (or URL) is first split off so it is not absorbed into
+/// the name — mirroring the email group of the author pattern and Asciidoctor's
+/// XML sanitization of a names-only value. The remaining name is then split on
+/// whitespace into at most three segments (Ruby's `String#split(nil, 3)`, which
+/// also drops leading whitespace). The trailing segment retains its interior
+/// text — so a four-plus-part name keeps its later parts in `lastname` — but
+/// has repeating spaces condensed to a single space. Each segment then has
+/// underscore joiners replaced with spaces.
+///
+/// `source` may already have attribute references substituted (the expanded
+/// value of a reference such as `{full-name}`); in that case any email it
+/// carries is likewise already substituted.
 fn partition_names_only(source: &str) -> Author {
-    let mut segments = split_whitespace_max3(source);
+    let source = source.trim();
+
+    let (name_source, email) = match NAMES_ONLY_EMAIL.captures(source) {
+        Some(captures) => (
+            captures.get(1).map_or(source, |m| m.as_str()),
+            Some(captures[2].to_string()),
+        ),
+        None => (source, None),
+    };
+
+    let mut segments = split_whitespace_max3(name_source);
 
     let firstname = replace_underscores_with_spaces(segments.remove(0));
     let (middlename, lastname) = match segments.len() {
@@ -311,7 +343,7 @@ fn partition_names_only(source: &str) -> Author {
         firstname,
         middlename,
         lastname,
-        email: None,
+        email,
     }
 }
 
@@ -319,15 +351,22 @@ fn partition_names_only(source: &str) -> Author {
 /// Ruby's `String#split(nil, 3)`. Leading whitespace is dropped and the first
 /// two whitespace runs delimit the first two segments; the remainder becomes
 /// the third segment, with its repeating spaces condensed to a single space
-/// (Ruby's `String#squeeze ' '`). The returned vector always has at least one
-/// element because the caller has already rejected empty input.
+/// (Ruby's `String#squeeze ' '`).
+///
+/// Only ASCII whitespace is treated as a delimiter, matching Ruby's split
+/// (which does not break on non-breaking or other Unicode spaces), so a name
+/// joined by such a space stays a single segment. The returned vector always
+/// has at least one element because the caller has already rejected empty
+/// input.
 fn split_whitespace_max3(source: &str) -> Vec<String> {
+    let is_ascii_ws = |c: char| c.is_ascii_whitespace();
+
     let mut segments: Vec<String> = Vec::with_capacity(3);
     let mut rest = source;
 
     for _ in 0..2 {
-        rest = rest.trim_start();
-        match rest.find(char::is_whitespace) {
+        rest = rest.trim_start_matches(is_ascii_ws);
+        match rest.find(is_ascii_ws) {
             Some(index) => {
                 segments.push(rest[..index].to_string());
                 rest = &rest[index..];
@@ -336,7 +375,7 @@ fn split_whitespace_max3(source: &str) -> Vec<String> {
         }
     }
 
-    rest = rest.trim_start();
+    rest = rest.trim_start_matches(is_ascii_ws);
     if !rest.is_empty() {
         segments.push(condense_whitespace(rest));
     }
@@ -388,6 +427,16 @@ static AUTHOR: LazyLock<Regex> = LazyLock::new(|| {
         "#,
     )
     .unwrap()
+});
+
+/// Splits a names-only author value into its name portion (group 1) and a
+/// trailing `<email>` (group 2). The name must contain at least one
+/// non-whitespace character and is followed by whitespace before the bracketed
+/// email, matching the email group of [`AUTHOR`] for a value that otherwise
+/// fails the full pattern (e.g. a name with four or more parts).
+static NAMES_ONLY_EMAIL: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(r"^(.*\S)\s+<([^>]+)>$").unwrap()
 });
 
 /// Returns whether `source` matches the author pattern — at most three

--- a/parser/src/document/author_line.rs
+++ b/parser/src/document/author_line.rs
@@ -17,7 +17,7 @@ impl<'src> AuthorLine<'src> {
     pub(crate) fn parse(source: Span<'src>, parser: &mut Parser) -> Self {
         let authors: Vec<Author> = split_authors(source.data())
             .into_iter()
-            .filter_map(|raw_author| Author::parse(raw_author, parser))
+            .filter_map(|raw_author| Author::parse(raw_author, parser, false))
             .collect();
 
         for (index, author) in authors.iter().enumerate() {

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -1036,6 +1036,106 @@ mod tests {
     }
 
     #[test]
+    fn author_attribute_four_or_more_parts_with_inline_email() {
+        // A four-plus-part fallback value that carries a trailing `<email>` must
+        // split the email off before partitioning, so it lands in `email` rather
+        // than being absorbed into `lastname`.
+        let mut parser = Parser::default();
+        let _doc = parser.parse(":author: Leroy  Harold  Scherer,  Jr. <leroy@example.com>");
+
+        assert_eq!(
+            parser.attribute_value("firstname"),
+            InterpretedValue::Value("Leroy")
+        );
+        assert_eq!(
+            parser.attribute_value("middlename"),
+            InterpretedValue::Value("Harold")
+        );
+        assert_eq!(
+            parser.attribute_value("lastname"),
+            InterpretedValue::Value("Scherer, Jr.")
+        );
+        assert_eq!(
+            parser.attribute_value("email"),
+            InterpretedValue::Value("leroy@example.com")
+        );
+        assert_eq!(
+            parser.attribute_value("authorinitials"),
+            InterpretedValue::Value("LHS")
+        );
+    }
+
+    #[test]
+    fn author_attribute_reference_expands_and_partitions() {
+        // A `:author:` value given entirely as an attribute reference is expanded
+        // and then partitioned by the names-only rules, so it yields the same
+        // metadata as the equivalent literal four-plus-part name.
+        let mut parser = Parser::default();
+        let _doc = parser.parse(":full-name: Leroy Harold Scherer, Jr.\n:author: {full-name}");
+
+        assert_eq!(
+            parser.attribute_value("firstname"),
+            InterpretedValue::Value("Leroy")
+        );
+        assert_eq!(
+            parser.attribute_value("middlename"),
+            InterpretedValue::Value("Harold")
+        );
+        assert_eq!(
+            parser.attribute_value("lastname"),
+            InterpretedValue::Value("Scherer, Jr.")
+        );
+        assert_eq!(
+            parser.attribute_value("authorinitials"),
+            InterpretedValue::Value("LHS")
+        );
+    }
+
+    #[test]
+    fn author_attribute_reference_within_larger_value_expands_and_partitions() {
+        // The same partitioning applies when the reference is only part of the
+        // value (so the single-attribute fast path is not taken) and the expanded
+        // result still fails the author pattern.
+        let mut parser = Parser::default();
+        let _doc = parser.parse(":rest: Harold Scherer, Jr.\n:author: Leroy {rest}");
+
+        assert_eq!(
+            parser.attribute_value("firstname"),
+            InterpretedValue::Value("Leroy")
+        );
+        assert_eq!(
+            parser.attribute_value("middlename"),
+            InterpretedValue::Value("Harold")
+        );
+        assert_eq!(
+            parser.attribute_value("lastname"),
+            InterpretedValue::Value("Scherer, Jr.")
+        );
+    }
+
+    #[test]
+    fn author_attribute_non_breaking_space_is_not_a_name_separator() {
+        // Only ASCII whitespace separates name parts. A non-breaking space
+        // (U+00A0) joining two words keeps them as a single first name, matching
+        // Ruby's whitespace split.
+        let mut parser = Parser::default();
+        let _doc = parser.parse(":author: John\u{a0}Doe Scherer, Jr.");
+
+        assert_eq!(
+            parser.attribute_value("firstname"),
+            InterpretedValue::Value("John\u{a0}Doe")
+        );
+        assert_eq!(
+            parser.attribute_value("middlename"),
+            InterpretedValue::Value("Scherer,")
+        );
+        assert_eq!(
+            parser.attribute_value("lastname"),
+            InterpretedValue::Value("Jr.")
+        );
+    }
+
+    #[test]
     fn sets_author_attributes_from_author_attribute_two_names() {
         let mut parser = Parser::default();
         let _doc = parser.parse(":author: Jane Doe");

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -4,7 +4,9 @@ use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
     content::{Content, SubstitutionGroup},
-    document::{Attribute, Author, AuthorLine, InterpretedValue, RevisionLine},
+    document::{
+        Attribute, Author, AuthorLine, InterpretedValue, RevisionLine, matches_author_pattern,
+    },
     internal::debug::DebugSliceReference,
     span::MatchedItem,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -82,9 +84,15 @@ impl<'src> Header<'src> {
             {
                 // Special handling for :author: attribute to populate individual author
                 // attributes.
+                //
+                // When the value is a plain name, the partitioned name replaces
+                // the stored `author` value. This condenses repeated interior
+                // whitespace and joins a name with four or more parts, matching
+                // Asciidoctor (issue #758).
+                let mut author_name_override: Option<String> = None;
                 if attr.item.name().data().eq_ignore_ascii_case("author")
                     && let Some(raw_value) = attr.item.raw_value()
-                    && let Some(author) = Author::parse(raw_value.data(), parser)
+                    && let Some(author) = Author::parse(raw_value.data(), parser, true)
                 {
                     // Set individual author attributes.
                     parser.set_attribute_by_value_from_header("firstname", author.firstname());
@@ -99,6 +107,19 @@ impl<'src> Header<'src> {
                         parser.set_attribute_by_value_from_header("email", email);
                     }
 
+                    // Only override the `author` value when the name was
+                    // partitioned by the fallback whitespace split — a plain name
+                    // that does not match the author pattern (four or more parts,
+                    // or punctuation such as a comma). A value that matches the
+                    // pattern, carries an inline email (`<…>`), or holds an
+                    // attribute reference (`{…}`) keeps the substituted entry
+                    // value set below, so the handling of those forms is
+                    // unchanged.
+                    let raw = raw_value.data();
+                    if !raw.contains('<') && !raw.contains('{') && !matches_author_pattern(raw) {
+                        author_name_override = Some(author.name().to_string());
+                    }
+
                     // Retain the author parsed from the raw (pre-substitution)
                     // value so the resolved author list does not have to
                     // re-parse the HTML-encoded `author` attribute. A later
@@ -107,6 +128,11 @@ impl<'src> Header<'src> {
                 }
 
                 parser.set_attribute_from_header(&attr.item, &mut warnings);
+
+                if let Some(author_name) = author_name_override {
+                    parser.set_attribute_by_value_from_header("author", author_name);
+                }
+
                 attributes.push(attr.item);
                 source = attr.after;
             } else if title.is_none()
@@ -521,7 +547,7 @@ fn resolve_authors(
     let mut index = 1;
 
     while let Some(name) = value(&format!("author_{index}")) {
-        if let Some(author) = Author::parse(&name, parser) {
+        if let Some(author) = Author::parse(&name, parser, true) {
             authors.push(author.with_email(value(&format!("email_{index}"))));
         }
 
@@ -927,6 +953,86 @@ mod tests {
             parser.attribute_value("author"),
             InterpretedValue::Value("John Q. Smith &lt;john@example.com&gt;")
         );
+    }
+
+    #[test]
+    fn author_attribute_with_four_or_more_parts_is_partitioned() {
+        // https://github.com/asciidoc-rs/asciidoc-parser/issues/758: a value
+        // with more than three parts does not match the author pattern, so it is
+        // partitioned by splitting on whitespace into at most three parts. The
+        // trailing parts are assigned to `lastname` and repeated interior
+        // whitespace is condensed.
+        let mut parser = Parser::default();
+        let _doc = parser.parse(":author: Leroy  Harold  Scherer,  Jr.");
+
+        assert_eq!(
+            parser.attribute_value("author"),
+            InterpretedValue::Value("Leroy Harold Scherer, Jr.")
+        );
+        assert_eq!(
+            parser.attribute_value("firstname"),
+            InterpretedValue::Value("Leroy")
+        );
+        assert_eq!(
+            parser.attribute_value("middlename"),
+            InterpretedValue::Value("Harold")
+        );
+        assert_eq!(
+            parser.attribute_value("lastname"),
+            InterpretedValue::Value("Scherer, Jr.")
+        );
+        assert_eq!(
+            parser.attribute_value("authorinitials"),
+            InterpretedValue::Value("LHS")
+        );
+    }
+
+    #[test]
+    fn author_attribute_two_part_fallback_partitions_lastname() {
+        // A two-part value that does not match the author pattern (here because
+        // of the comma attached to the first part) still partitions into a first
+        // and last name via the whitespace split.
+        let mut parser = Parser::default();
+        let _doc = parser.parse(":author: Jane, Doe");
+
+        assert_eq!(
+            parser.attribute_value("author"),
+            InterpretedValue::Value("Jane, Doe")
+        );
+        assert_eq!(
+            parser.attribute_value("firstname"),
+            InterpretedValue::Value("Jane,")
+        );
+        assert_eq!(
+            parser.attribute_value("middlename"),
+            InterpretedValue::Unset
+        );
+        assert_eq!(
+            parser.attribute_value("lastname"),
+            InterpretedValue::Value("Doe")
+        );
+    }
+
+    #[test]
+    fn author_attribute_single_part_fallback_is_firstname_only() {
+        // A single-token value that does not match the author pattern partitions
+        // to `firstname` alone, with no middle or last name.
+        let mut parser = Parser::default();
+        let _doc = parser.parse(":author: Jane,");
+
+        assert_eq!(
+            parser.attribute_value("author"),
+            InterpretedValue::Value("Jane,")
+        );
+        assert_eq!(
+            parser.attribute_value("firstname"),
+            InterpretedValue::Value("Jane,")
+        );
+        assert_eq!(
+            parser.attribute_value("middlename"),
+            InterpretedValue::Unset
+        );
+        assert_eq!(parser.attribute_value("lastname"), InterpretedValue::Unset);
     }
 
     #[test]

--- a/parser/src/document/mod.rs
+++ b/parser/src/document/mod.rs
@@ -5,6 +5,7 @@ pub use attribute::{Attribute, InterpretedValue};
 
 mod author;
 pub use author::Author;
+pub(crate) use author::matches_author_pattern;
 
 mod author_line;
 pub use author_line::AuthorLine;

--- a/parser/src/document/toc.rs
+++ b/parser/src/document/toc.rs
@@ -120,9 +120,10 @@ pub(crate) const DEFAULT_TOC_TITLE: &str = "Table of Contents";
 /// `toc-class` attribute is not set. Matches Asciidoctor's default.
 pub(crate) const DEFAULT_TOC_CLASS: &str = "toc";
 
-/// The CSS class applied to the table of contents container for a `left`/`right`
-/// side-column TOC when the `toc-class` attribute is not set. This is the class
-/// that drives the fixed side-column styling in Asciidoctor's standalone HTML.
+/// The CSS class applied to the table of contents container for a
+/// `left`/`right` side-column TOC when the `toc-class` attribute is not set.
+/// This is the class that drives the fixed side-column styling in Asciidoctor's
+/// standalone HTML.
 pub(crate) const DEFAULT_TOC_CLASS_SIDE: &str = "toc2";
 
 /// The resolved table-of-contents configuration for a document (or a nested

--- a/parser/src/tests/asciidoctor_rb/parser_test.rs
+++ b/parser/src/tests/asciidoctor_rb/parser_test.rs
@@ -1120,12 +1120,10 @@ fn skips_blank_author_entries_in_implicit_author_line() {
     assert_eq!(a[1].email.as_deref(), Some("john.smith@asciidoc.org"));
 }
 
-// Incompatibility (https://github.com/asciidoc-rs/asciidoc-parser/issues/758):
-// the `:author:` attribute-entry path in this crate does not partition a
-// 4+-part name (it stores the whole value as `firstname` without condensing
-// whitespace), whereas Asciidoctor assigns the trailing parts to `lastname`.
-non_normative!(
-    r#"
+#[test]
+fn parse_name_with_more_than_3_parts_in_author_attribute() {
+    verifies!(
+        r#"
   test 'parse name with more than 3 parts in author attribute' do
     doc = empty_document
     parse_header_metadata ':author: Leroy  Harold  Scherer,  Jr.', doc
@@ -1136,7 +1134,34 @@ non_normative!(
   end
 
 "#
-);
+    );
+
+    // Unlike the implicit author line (which recognizes at most three
+    // space-separated names and otherwise stores the whole line as the author),
+    // the `:author:` attribute entry is partitioned by splitting on whitespace
+    // into at most three parts. A name with four or more parts keeps its
+    // trailing parts in `lastname`, and repeated interior whitespace is
+    // condensed (issue #758).
+    let mut parser = Parser::default();
+    parser.parse(":author: Leroy  Harold  Scherer,  Jr.");
+
+    assert_eq!(
+        parser.attribute_value("author"),
+        InterpretedValue::Value("Leroy Harold Scherer, Jr.")
+    );
+    assert_eq!(
+        parser.attribute_value("firstname"),
+        InterpretedValue::Value("Leroy")
+    );
+    assert_eq!(
+        parser.attribute_value("middlename"),
+        InterpretedValue::Value("Harold")
+    );
+    assert_eq!(
+        parser.attribute_value("lastname"),
+        InterpretedValue::Value("Scherer, Jr.")
+    );
+}
 
 #[test]
 fn use_explicit_authorinitials_if_set_after_implicit_author_line() {


### PR DESCRIPTION
## Summary

Fixes #758.

When an author is supplied via the `:author:` attribute entry, Asciidoctor partitions a name of four or more parts by assigning the trailing parts to `lastname` (and condensing interior whitespace). This crate reused the implicit author-line parser, which recognizes at most three space-separated names via a regex and otherwise stores the whole value as `firstname` with double spaces preserved.

### Repro

```
:author: Leroy  Harold  Scherer,  Jr.
```

| attribute | before | after (this PR) |
|-----------|--------|-----------------|
| `author` | `Leroy  Harold  Scherer,  Jr.` | `Leroy Harold Scherer, Jr.` |
| `firstname` | `Leroy  Harold  Scherer,  Jr.` | `Leroy` |
| `middlename` | *(unset)* | `Harold` |
| `lastname` | *(unset)* | `Scherer, Jr.` |

## Approach

Asciidoctor's `process_authors` parses an attribute-entry value (`names_only`) differently from the implicit author line: rather than the author-line regex, it splits on whitespace into at most three segments (Ruby's `String#split(nil, 3)`), squeezing repeated spaces in the trailing segment, so a 4+-part name keeps its later parts in `lastname`.

This PR mirrors that:

- A `names_only` flag is threaded through `Author::parse`. The implicit author line (`author_line.rs`) keeps the existing regex-then-verbatim behavior (`names_only == false`); the `:author:` and `author_N` attribute entries (`header.rs`) pass `names_only == true`.
- When a `names_only` value does not match the author pattern, it falls back to the whitespace split (`partition_names_only` / `split_whitespace_max3`) instead of storing the whole value as `firstname`.
- For such a plain-name value, the stored `author` attribute is replaced with the reconstructed, whitespace-condensed name. This override is scoped tightly: values that match the author pattern, carry an inline email (`<…>`), or hold an attribute reference (`{…}`) keep their existing behavior, so no other author path changes.

## Tests

- The SDD port test `parse name with more than 3 parts in author attribute` is promoted from `non_normative!` to a verified test.
- New `header.rs` unit tests cover the 4-part, 2-part, and 1-part fallback partitions.
- Full suite passes (`cargo test`), clippy is clean (`-Dwarnings`), and formatting matches `cargo +nightly fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV8ictKY2PakgGLAKWZwgg

---
_Generated by [Claude Code](https://claude.ai/code/session_01FV8ictKY2PakgGLAKWZwgg)_