### PR TITLE
fix: Suppress preprocessor directives inside comment blocks and define the `asciidoctor` flag (close #810)

### DIFF
--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -346,12 +346,12 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
         set(ApiOnly, ASCIIDOCTOR_VERSION),
     );
 
-    // NOTE: The companion always-set `asciidoctor` flag is deliberately still
-    // *not* defined here. Defining it exposes a preprocessor bug – conditional
-    // directives are processed inside `////` comment blocks – that Asciidoctor's
-    // own `preprocessor directives should not be processed within comment block`
-    // tests catch via `ifdef::asciidoctor[////]`. See issue #810; the flag lands
-    // with that fix.
+    // The always-set boolean flag identifying an Asciidoctor-compatible
+    // processor. A document uses `ifdef::asciidoctor[]` to guard content meant
+    // only for Asciidoctor (and its compatible implementations, such as this
+    // crate). Like its companions above it is locked against document
+    // assignment (`ApiOnly`).
+    attrs.insert("asciidoctor".to_owned(), empty(ApiOnly, Set));
 
     // ### Safe-mode intrinsic attributes
     //

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2407,6 +2407,63 @@ mod tests {
     }
 
     #[test]
+    fn asciidoctor_flag_is_predefined() {
+        // The crate predefines the always-set `asciidoctor` boolean flag, so a
+        // document guarding Asciidoctor-only content with `ifdef::asciidoctor[]`
+        // behaves the same here. A `////` comment block containing a directive
+        // that would corrupt it once the flag is defined must stay untouched
+        // (see issue #810).
+        let mut parser = Parser::default();
+
+        assert_eq!(
+            parser.attribute_value("asciidoctor"),
+            InterpretedValue::Set
+        );
+
+        let doc = parser.parse(concat!(
+            "= Title\n",
+            "\n",
+            "ifdef::asciidoctor[]\n",
+            "shown when asciidoctor is set\n",
+            "endif::[]\n",
+            "\n",
+            "////\n",
+            "ifdef::asciidoctor[////]\n",
+            "////\n",
+            "\n",
+            "line after comment block\n",
+        ));
+
+        assert_eq!(
+            rendered_paragraphs(&doc),
+            vec![
+                "shown when asciidoctor is set".to_owned(),
+                "line after comment block".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn asciidoctor_flag_is_locked() {
+        // Like the version intrinsics, the flag describes the processor itself,
+        // so a document assignment is rejected with a warning and the built-in
+        // value stays in place.
+        let mut parser = Parser::default();
+
+        let doc = parser.parse(":asciidoctor: 99.99.99");
+
+        assert_eq!(
+            doc.warnings().next().unwrap().warning,
+            WarningType::AttributeValueIsLocked("asciidoctor".to_owned())
+        );
+
+        assert_eq!(
+            parser.attribute_value("asciidoctor"),
+            InterpretedValue::Set
+        );
+    }
+
+    #[test]
     fn asciidoc_parser_version_distinguishes_the_two_processors() {
         // Both version intrinsics are defined, so a document tells the
         // processors apart via `asciidoc-parser-version`, which Ruby

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2415,10 +2415,7 @@ mod tests {
         // (see issue #810).
         let mut parser = Parser::default();
 
-        assert_eq!(
-            parser.attribute_value("asciidoctor"),
-            InterpretedValue::Set
-        );
+        assert_eq!(parser.attribute_value("asciidoctor"), InterpretedValue::Set);
 
         let doc = parser.parse(concat!(
             "= Title\n",
@@ -2457,10 +2454,7 @@ mod tests {
             WarningType::AttributeValueIsLocked("asciidoctor".to_owned())
         );
 
-        assert_eq!(
-            parser.attribute_value("asciidoctor"),
-            InterpretedValue::Set
-        );
+        assert_eq!(parser.attribute_value("asciidoctor"), InterpretedValue::Set);
     }
 
     #[test]

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -249,11 +249,12 @@ impl<'p> PreprocessorState<'p> {
         // `comment_block_delimiter` is the closing delimiter of the comment
         // block currently open (a `////` run, or the `--` of a `[comment]` open
         // block); `in_comment_paragraph` is set while inside the raw portion of
-        // a `[comment]` paragraph; `after_comment_style` records that the line
-        // just emitted was a `[comment]` block-attribute line.
+        // a `[comment]` paragraph; `comment_style_pending` is set once a
+        // `[comment]` block style has been seen and holds while the block's
+        // remaining metadata is read, until the block it introduces is reached.
         let mut comment_block_delimiter: Option<String> = None;
         let mut in_comment_paragraph = false;
-        let mut after_comment_style = false;
+        let mut comment_style_pending = false;
 
         while !source_span.is_empty() {
             let original_source = source_span;
@@ -297,10 +298,6 @@ impl<'p> PreprocessorState<'p> {
                 continue;
             }
 
-            // Whether the line just emitted was a `[comment]` block-attribute
-            // line (consumed below when classifying the block it introduces).
-            let was_comment_style = std::mem::take(&mut after_comment_style);
-
             // Conditional preprocessor directives (`ifdef`, `ifndef`, `ifeval`,
             // `endif`) are handled before anything else so they take effect even
             // while a surrounding conditional is skipping (the nesting still has
@@ -312,6 +309,12 @@ impl<'p> PreprocessorState<'p> {
                 // emitted line must re-anchor the source map (its original line
                 // number no longer matches the output line number).
                 has_reported_file = false;
+
+                // A directive as the first content line after `[comment]` ends
+                // the block's metadata run (Asciidoctor processes that first
+                // line via its one-line look-ahead), so the pending comment
+                // style no longer applies.
+                comment_style_pending = false;
 
                 if caps.get(1).is_some() {
                     // Escaped directive (e.g. `\ifdef::foo[]`): not processed.
@@ -362,18 +365,17 @@ impl<'p> PreprocessorState<'p> {
                 continue;
             }
 
-            // A `[comment]` block-attribute line turns the block it introduces
-            // into a comment. When that block is an open block (`--`), its
-            // content is raw up to the closing `--`; otherwise it is a comment
-            // paragraph, whose lines after the first are raw (see above).
-            //
-            // Further block metadata (a title `.text`, an anchor or attribute
-            // list `[…]`) may sit between the `[comment]` line and the block it
-            // styles, so the comment-style marker is carried across those
-            // metadata lines until the block itself is reached.
-            if was_comment_style {
+            // With a `[comment]` block style pending, classify the block it
+            // introduces. An open block (`--`) is a comment block, raw up to the
+            // closing `--`; otherwise the block is a comment paragraph, whose
+            // lines after the first are raw (see above). Further block metadata
+            // (a title `.text`, an anchor or attribute list `[…]`) may sit
+            // between the `[comment]` line and the block it styles; the pending
+            // style holds across it until the block itself is reached.
+            if comment_style_pending {
                 if line.data() == "--" {
                     comment_block_delimiter = Some("--".to_owned());
+                    comment_style_pending = false;
                     self.emit_line(
                         line.data(),
                         file_name,
@@ -383,21 +385,30 @@ impl<'p> PreprocessorState<'p> {
                     continue;
                 }
 
-                if is_block_metadata_line(line.data()) {
-                    // Still within the block's metadata; keep the marker set so
-                    // the block the metadata introduces is classified below.
-                    after_comment_style = true;
-                } else if !line.data().is_empty() {
-                    // The first line of a comment paragraph is processed as
-                    // usual (falling through below); only its subsequent lines
-                    // are raw. NOTE: if that first line is itself an `include::`
-                    // directive, the merged content is preprocessed with fresh
-                    // comment state, so a directive on its own subsequent lines
-                    // is still evaluated. That case (an include on the very
-                    // first line of a comment paragraph) is an accepted
-                    // limitation of preprocessing in a separate pass.
-                    in_comment_paragraph = true;
+                if !is_block_metadata_line(line.data()) {
+                    // The block's content begins here. The first line of a
+                    // comment paragraph is processed as usual (falling through
+                    // below); only its subsequent lines are raw. NOTE: if that
+                    // first line is itself an `include::` directive, the merged
+                    // content is preprocessed with fresh comment state, so a
+                    // directive on its own subsequent lines is still evaluated.
+                    // That case (an include on the very first line of a comment
+                    // paragraph) is an accepted limitation of preprocessing in a
+                    // separate pass.
+                    if !line.data().is_empty() {
+                        in_comment_paragraph = true;
+                    }
+                    comment_style_pending = false;
                 }
+            }
+
+            // A block attribute list sets or replaces the pending block style:
+            // `[comment]` marks the upcoming block a comment, another positional
+            // style (`[source]`, …) overrides it, and a bracketed line without a
+            // positional style (an anchor `[[id]]`, a shorthand- or named-only
+            // list) leaves the pending style unchanged.
+            if let Some(is_comment) = self.attrlist_block_style_is_comment(line.data()) {
+                comment_style_pending = is_comment;
             }
 
             if self.can_have_attribute
@@ -800,12 +811,6 @@ impl<'p> PreprocessorState<'p> {
                     source_line_number,
                     &mut has_reported_file,
                 );
-
-                // Remember a `[comment]` block-attribute line so the next
-                // iteration can classify the block it introduces as a comment.
-                if line_text == "[comment]" {
-                    after_comment_style = true;
-                }
             }
         }
 
@@ -848,6 +853,31 @@ impl<'p> PreprocessorState<'p> {
             self.output.push_str(line.data());
             self.output.push('\n');
         }
+    }
+
+    /// Determine how a block attribute-list line affects the pending block
+    /// style, for tracking a `[comment]` style across a block's metadata.
+    ///
+    /// Returns `Some(true)` when `line` is an attribute list whose positional
+    /// block style is `comment`, `Some(false)` when it sets some other
+    /// positional style (which overrides an earlier `[comment]`), and `None`
+    /// when it is not a style-setting line — a block title, an anchor
+    /// (`[[id]]`), a shorthand- or named-only attribute list, or any
+    /// non-attribute-list line — so the pending style is left unchanged.
+    fn attrlist_block_style_is_comment(&self, line: &str) -> Option<bool> {
+        // Only a bracketed attribute list carries a positional block style.
+        let inner = line.strip_prefix('[')?.strip_suffix(']')?;
+
+        // A block anchor (`[[id]]`) is not a style.
+        if inner.starts_with('[') {
+            return None;
+        }
+
+        let attrlist = Attrlist::parse(Span::new(inner), self.parser, AttrlistContext::Block)
+            .item
+            .item;
+
+        attrlist.block_style().map(|style| style == "comment")
     }
 
     /// Apply attribute substitution to a string, replacing {attribute-name}
@@ -3307,6 +3337,34 @@ mod tests {
                 "[comment]\n.title\n[[id]]\nfirst line\nifdef::foo[dropped]\n\ntail"
             ),
             "[comment]\n.title\n[[id]]\nfirst line\nifdef::foo[dropped]\n\ntail\n"
+        );
+    }
+
+    #[test]
+    fn later_style_overrides_comment_style() {
+        // A positional style on a later attribute list (`[source]`) overrides an
+        // earlier `[comment]`, so the block is a real listing and an `include::`
+        // within it is processed rather than left raw.
+        let source = "[comment]\n[source]\n----\ninclude::sub.adoc[]\n----\n";
+        let handler = InlineFileHandler::from_pairs([("sub.adoc", "Included.")]);
+        let parser = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_primary_file_name("main.adoc")
+            .with_include_file_handler(handler);
+
+        let (output, _source_map, _warnings, _includes) = preprocess(source, &parser);
+        assert_eq!(output, "[comment]\n[source]\n----\nIncluded.\n----\n");
+    }
+
+    #[test]
+    fn non_style_attribute_list_keeps_comment_style() {
+        // A bracketed line without a positional style (here a role-only
+        // shorthand) is not a style override, so an earlier `[comment]` still
+        // governs the block and the directive on the paragraph's later line
+        // stays raw.
+        assert_eq!(
+            conditional_output("[comment]\n[.rolename]\nfirst line\nifdef::foo[dropped]\n\ntail"),
+            "[comment]\n[.rolename]\nfirst line\nifdef::foo[dropped]\n\ntail\n"
         );
     }
 

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -240,6 +240,21 @@ impl<'p> PreprocessorState<'p> {
         let mut has_reported_file = file_name.is_none();
         let mut source_span = Span::new(source);
 
+        // Comment-block tracking. Asciidoctor's `PreprocessorReader` never
+        // processes preprocessor directives inside a comment block: the parser
+        // reads the block's content with line processing disabled. This crate
+        // preprocesses in a separate pass, so it tracks that state here. See
+        // issue #810.
+        //
+        // `comment_block_delimiter` is the closing delimiter of the comment
+        // block currently open (a `////` run, or the `--` of a `[comment]` open
+        // block); `in_comment_paragraph` is set while inside the raw portion of
+        // a `[comment]` paragraph; `after_comment_style` records that the line
+        // just emitted was a `[comment]` block-attribute line.
+        let mut comment_block_delimiter: Option<String> = None;
+        let mut in_comment_paragraph = false;
+        let mut after_comment_style = false;
+
         while !source_span.is_empty() {
             let original_source = source_span;
 
@@ -247,6 +262,44 @@ impl<'p> PreprocessorState<'p> {
             source_span = after;
 
             let source_line_number = line.line();
+
+            // Inside a comment block, every line is raw: emit it verbatim, with
+            // no directive or include processing, until the closing delimiter.
+            if let Some(delimiter) = &comment_block_delimiter {
+                let closes = line.data() == delimiter;
+                self.emit_line(
+                    line.data(),
+                    file_name,
+                    source_line_number,
+                    &mut has_reported_file,
+                );
+                if closes {
+                    comment_block_delimiter = None;
+                }
+                continue;
+            }
+
+            // The lines of a `[comment]` paragraph after its first are likewise
+            // raw, up to the blank line that ends the paragraph. (Its first line
+            // is still processed, matching Asciidoctor's one-line look-ahead: by
+            // the time a paragraph is recognized as a comment, the reader has
+            // already visited that line.)
+            if in_comment_paragraph {
+                if line.data().is_empty() {
+                    in_comment_paragraph = false;
+                }
+                self.emit_line(
+                    line.data(),
+                    file_name,
+                    source_line_number,
+                    &mut has_reported_file,
+                );
+                continue;
+            }
+
+            // Whether the line just emitted was a `[comment]` block-attribute
+            // line (consumed below when classifying the block it introduces).
+            let was_comment_style = std::mem::take(&mut after_comment_style);
 
             // Conditional preprocessor directives (`ifdef`, `ifndef`, `ifeval`,
             // `endif`) are handled before anything else so they take effect even
@@ -292,6 +345,42 @@ impl<'p> PreprocessorState<'p> {
             if self.skipping() {
                 has_reported_file = false;
                 continue;
+            }
+
+            // A `////` line (four or more slashes, nothing else) opens a comment
+            // block. Its content is raw, so it is emitted verbatim and no
+            // directive within it is processed until the matching closing
+            // delimiter. See issue #810.
+            if is_comment_block_delimiter(line.data()) {
+                comment_block_delimiter = Some(line.data().to_owned());
+                self.emit_line(
+                    line.data(),
+                    file_name,
+                    source_line_number,
+                    &mut has_reported_file,
+                );
+                continue;
+            }
+
+            // A `[comment]` block-attribute line turns the block it introduces
+            // into a comment. When that block is an open block (`--`), its
+            // content is raw up to the closing `--`; otherwise it is a comment
+            // paragraph, whose lines after the first are raw (see above).
+            if was_comment_style {
+                if line.data() == "--" {
+                    comment_block_delimiter = Some("--".to_owned());
+                    self.emit_line(
+                        line.data(),
+                        file_name,
+                        source_line_number,
+                        &mut has_reported_file,
+                    );
+                    continue;
+                }
+
+                if !line.data().is_empty() {
+                    in_comment_paragraph = true;
+                }
             }
 
             if self.can_have_attribute
@@ -694,6 +783,12 @@ impl<'p> PreprocessorState<'p> {
                     source_line_number,
                     &mut has_reported_file,
                 );
+
+                // Remember a `[comment]` block-attribute line so the next
+                // iteration can classify the block it introduces as a comment.
+                if line_text == "[comment]" {
+                    after_comment_style = true;
+                }
             }
         }
 
@@ -1400,6 +1495,14 @@ fn has_conditional_prefix(line: &str) -> bool {
 
 fn to_owned(maybe_file_name: Option<&str>) -> Option<String> {
     maybe_file_name.map(|n| n.to_string())
+}
+
+/// Returns `true` if `line` is a `////` comment-block delimiter: a run of four
+/// or more slashes and nothing else. A shorter run (`//`, `///`) is a line
+/// comment, not a delimiter. This mirrors the comment case of
+/// [`RawDelimitedBlock::is_valid_delimiter`](crate::blocks::RawDelimitedBlock).
+fn is_comment_block_delimiter(line: &str) -> bool {
+    line.len() >= 4 && line.bytes().all(|b| b == b'/')
 }
 
 /// Parse the attribute list of an `include::` directive from the directive's
@@ -3096,6 +3199,64 @@ mod tests {
         assert_eq!(
             conditional_output("head\n\nifdef::foo[dropped]\n\ntail"),
             "head\n\n\ntail\n"
+        );
+    }
+
+    #[test]
+    fn comment_block_suppresses_conditional_directive() {
+        // A conditional directive inside a `////` comment block is not
+        // processed: the block's content is emitted verbatim so it parses as a
+        // comment (see issue #810). `foo` is unset, so were the directive
+        // processed, `hidden` would be dropped and the block corrupted.
+        assert_eq!(
+            conditional_output("////\nifdef::foo[]\nhidden\nendif::[]\n////\n\ntail"),
+            "////\nifdef::foo[]\nhidden\nendif::[]\n////\n\ntail\n"
+        );
+    }
+
+    #[test]
+    fn longer_comment_delimiter_closes_only_on_exact_match() {
+        // A comment block closes on a line matching its opening delimiter
+        // exactly; a shorter run of slashes inside it is ordinary content.
+        assert_eq!(
+            conditional_output("/////\nifdef::foo[x]\n////\nstill in comment\n/////\ntail"),
+            "/////\nifdef::foo[x]\n////\nstill in comment\n/////\ntail\n"
+        );
+    }
+
+    #[test]
+    fn comment_block_suppresses_include_expansion() {
+        // An include directive inside a comment block is likewise left
+        // untouched rather than expanded.
+        let source = "////\ninclude::sub.adoc[]\n////\n\ntail";
+        let handler = InlineFileHandler::from_pairs([("sub.adoc", "Included.")]);
+        let parser = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_primary_file_name("main.adoc")
+            .with_include_file_handler(handler);
+
+        let (output, _source_map, _warnings, _includes) = preprocess(source, &parser);
+        assert_eq!(output, "////\ninclude::sub.adoc[]\n////\n\ntail\n");
+    }
+
+    #[test]
+    fn comment_open_block_suppresses_conditional_directive() {
+        // A `[comment]`-styled open block (`--`) is a comment block: a directive
+        // within it is emitted verbatim.
+        assert_eq!(
+            conditional_output("[comment]\n--\nfirst\nifdef::foo[dropped]\nlast\n--\n\ntail"),
+            "[comment]\n--\nfirst\nifdef::foo[dropped]\nlast\n--\n\ntail\n"
+        );
+    }
+
+    #[test]
+    fn comment_paragraph_suppresses_directive_after_first_line() {
+        // In a `[comment]` paragraph the first line is still processed, but its
+        // subsequent lines are raw (matching Asciidoctor's one-line
+        // look-ahead). The directive on the second line is left untouched.
+        assert_eq!(
+            conditional_output("[comment]\nfirst line\nifdef::foo[dropped]\n\ntail"),
+            "[comment]\nfirst line\nifdef::foo[dropped]\n\ntail\n"
         );
     }
 

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -366,6 +366,11 @@ impl<'p> PreprocessorState<'p> {
             // into a comment. When that block is an open block (`--`), its
             // content is raw up to the closing `--`; otherwise it is a comment
             // paragraph, whose lines after the first are raw (see above).
+            //
+            // Further block metadata (a title `.text`, an anchor or attribute
+            // list `[…]`) may sit between the `[comment]` line and the block it
+            // styles, so the comment-style marker is carried across those
+            // metadata lines until the block itself is reached.
             if was_comment_style {
                 if line.data() == "--" {
                     comment_block_delimiter = Some("--".to_owned());
@@ -378,7 +383,19 @@ impl<'p> PreprocessorState<'p> {
                     continue;
                 }
 
-                if !line.data().is_empty() {
+                if is_block_metadata_line(line.data()) {
+                    // Still within the block's metadata; keep the marker set so
+                    // the block the metadata introduces is classified below.
+                    after_comment_style = true;
+                } else if !line.data().is_empty() {
+                    // The first line of a comment paragraph is processed as
+                    // usual (falling through below); only its subsequent lines
+                    // are raw. NOTE: if that first line is itself an `include::`
+                    // directive, the merged content is preprocessed with fresh
+                    // comment state, so a directive on its own subsequent lines
+                    // is still evaluated. That case (an include on the very
+                    // first line of a comment paragraph) is an accepted
+                    // limitation of preprocessing in a separate pass.
                     in_comment_paragraph = true;
                 }
             }
@@ -1503,6 +1520,24 @@ fn to_owned(maybe_file_name: Option<&str>) -> Option<String> {
 /// [`RawDelimitedBlock::is_valid_delimiter`](crate::blocks::RawDelimitedBlock).
 fn is_comment_block_delimiter(line: &str) -> bool {
     line.len() >= 4 && line.bytes().all(|b| b == b'/')
+}
+
+/// Returns `true` if `line` is block metadata that may appear between a
+/// `[comment]` attribute line and the block it styles: an attribute-list or
+/// anchor line (`[…]`), or a block title (`.text`). Used only to carry
+/// comment-block state across the metadata preceding a comment paragraph or
+/// open block, so that the paragraph's true first line is the one processed.
+fn is_block_metadata_line(line: &str) -> bool {
+    if line.starts_with('[') {
+        return true;
+    }
+
+    // A block title is a leading `.` followed by a non-space, non-`.`
+    // character, so it is neither a `....` delimiter nor a `. ` list marker.
+    matches!(
+        line.strip_prefix('.'),
+        Some(rest) if rest.starts_with(|c: char| !c.is_whitespace() && c != '.')
+    )
 }
 
 /// Parse the attribute list of an `include::` directive from the directive's
@@ -3257,6 +3292,32 @@ mod tests {
         assert_eq!(
             conditional_output("[comment]\nfirst line\nifdef::foo[dropped]\n\ntail"),
             "[comment]\nfirst line\nifdef::foo[dropped]\n\ntail\n"
+        );
+    }
+
+    #[test]
+    fn comment_style_carried_across_block_metadata() {
+        // Block metadata (a title, then an anchor) may sit between the
+        // `[comment]` line and the paragraph it styles. The comment style must
+        // carry across that metadata so the paragraph's true first line is the
+        // one processed and its later lines stay raw. Here the directive on the
+        // paragraph's second line must be left untouched.
+        assert_eq!(
+            conditional_output(
+                "[comment]\n.title\n[[id]]\nfirst line\nifdef::foo[dropped]\n\ntail"
+            ),
+            "[comment]\n.title\n[[id]]\nfirst line\nifdef::foo[dropped]\n\ntail\n"
+        );
+    }
+
+    #[test]
+    fn comment_style_carried_across_metadata_before_open_block() {
+        // The same carry-across applies before a `[comment]` open block: a title
+        // between `[comment]` and `--` must not stop the block from being
+        // recognized as a comment.
+        assert_eq!(
+            conditional_output("[comment]\n.title\n--\nifdef::foo[dropped]\n--\n\ntail"),
+            "[comment]\n.title\n--\nifdef::foo[dropped]\n--\n\ntail\n"
         );
     }
 

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -356,6 +356,10 @@ impl<'p> PreprocessorState<'p> {
             // delimiter. See issue #810.
             if is_comment_block_delimiter(line.data()) {
                 comment_block_delimiter = Some(line.data().to_owned());
+                // A `////` block is self-identifying, so it consumes any pending
+                // `[comment]` style; clearing it keeps the block that follows
+                // this one independent.
+                comment_style_pending = false;
                 self.emit_line(
                     line.data(),
                     file_name,
@@ -3337,6 +3341,17 @@ mod tests {
                 "[comment]\n.title\n[[id]]\nfirst line\nifdef::foo[dropped]\n\ntail"
             ),
             "[comment]\n.title\n[[id]]\nfirst line\nifdef::foo[dropped]\n\ntail\n"
+        );
+    }
+
+    #[test]
+    fn comment_style_cleared_after_comment_block_delimiter() {
+        // A pending `[comment]` style consumed by a `////` block must not leak
+        // into the block that follows it: the directive on the next paragraph's
+        // second line must still be processed (here, expanded to `VISIBLE`).
+        assert_eq!(
+            conditional_output(":foo:\n\n[comment]\n////\nc\n////\n\nnext\nifdef::foo[VISIBLE]"),
+            ":foo:\n\n[comment]\n////\nc\n////\n\nnext\nVISIBLE\n"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #810.

The preprocessor evaluated conditional directives (`ifdef`, `ifndef`, `ifeval`) and expanded `include::` directives on **every** line, including lines inside a comment block — where Ruby Asciidoctor's `PreprocessorReader` skips them. Asciidoctor achieves this by having the parser read comment content with line processing disabled (`read_lines_until … skip_processing: true`); because this crate preprocesses in a separate pass, it must track that state itself.

This PR:

1. **Tracks comment-block state in the preprocessor's main loop** (`process_adoc_include`) and emits comment content verbatim, with no directive or include processing. Three shapes are handled, matching `PreprocessorReader`:
   - `////` delimited comment blocks (a run of four or more slashes), closed on an exact-match delimiter line;
   - `[comment]`-styled open blocks (`--`);
   - `[comment]` paragraphs, whose lines *after the first* are raw (matching Asciidoctor's documented one-line look-ahead — by the time a paragraph is recognized as a comment, the reader has already visited its first line).

2. **Defines the always-set `asciidoctor` boolean flag** as a predefined intrinsic in `built_in_attrs.rs`, alongside `asciidoctor-version`, locked against document assignment (`ApiOnly`). This replaces the `NOTE:` left there by #809.

## Why this was hidden

The four ported regression tests gate on `ifdef::asciidoctor[////]`. They passed only because the crate never defined `asciidoctor`, so the directive expanded to nothing and the block corruption stayed invisible. Defining the flag without the preprocessor fix makes all four fail; with the fix they pass for the right reason.

## Tests

- The four acceptance-criteria tests in `blocks_test.rs` now pass with `asciidoctor` defined:
  - `preprocessor_directives_should_not_be_processed_within_comment_block`
  - `preprocessor_directives_should_not_be_processed_within_comment_block_within_block_metadata`
  - `preprocessor_directives_should_not_be_processed_within_comment_open_block`
  - `preprocessor_directives_should_not_be_processed_on_subsequent_lines_of_a_comment_paragraph`
- New preprocessor unit tests cover directive suppression, include-expansion suppression, exact-match delimiter closing, comment open blocks, and comment paragraphs.
- New `asciidoctor_flag_is_predefined` / `asciidoctor_flag_is_locked` tests in `parser.rs`.
- Full workspace suite green (4160 passed, 0 failed); `clippy --workspace --all-targets` and `cargo doc` (warnings-as-errors) both clean.

## Scope: comment blocks only, by design

The suppression is deliberately limited to comment blocks, because comment blocks are the *only* block type where Asciidoctor disables preprocessing. In `Parser#build_block`, `skip_processing` is set from the content model:

```ruby
case content_model
when :skip                                    # comment blocks
  skip_processing, parse_as_content_model = true, :simple
when :raw                                      # passthrough ++++
  skip_processing, parse_as_content_model = false, :simple
else                                           # verbatim ----, ....
  skip_processing, parse_as_content_model = false, content_model
end
```

Only `:skip` (comment) passes `skip_processing: true`. Listing (`----`), literal (`....`), and passthrough (`++++`) all read with `skip_processing: false`, so preprocessor directives **are** processed inside them — which is correct and intended: `include::` inside a `[source]`/`----` block is the primary include use case. This crate already matches that behavior (see the verified test `verbatim/source_blocks.rs`, where `include::app.rb[]` inside a `----` block resolves to an "Unresolved directive" and raises a warning). Extending suppression to those blocks would be a regression, so it is intentionally not done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)