### PR TITLE
fix: Promote a level-0 heading after a comment line under an active leveloffset (close #746)

### DIFF
--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -598,8 +598,8 @@ impl<'src> HasSpan<'src> for SimpleBlock<'src> {
 /// [`SectionBlock::parse`](crate::blocks::SectionBlock). A heading of two or
 /// more markers (`== `/`## `, effective level 1+, or clamped up to 1 under a
 /// negative offset) is always a section. A single-marker heading (`= `/`# `) is
-/// a document title rather than a section *unless* a positive offset lifts it to
-/// level 1 or beyond — mirroring the level-0 rule in
+/// a document title rather than a section *unless* a positive offset lifts it
+/// to level 1 or beyond — mirroring the level-0 rule in
 /// [`parse_title_line`](crate::blocks::section).
 fn is_section_header(line: &str, level_offset: i32) -> bool {
     // AsciiDoc `=` style or Markdown `#` style.

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -611,9 +611,11 @@ fn is_section_header(line: &str, level_offset: i32) -> bool {
         return false;
     };
 
-    // A section marker is one to six characters followed by a space.
+    // A section marker is one to six characters followed by a blank (space or
+    // tab), matching the whitespace `parse_title_line` requires after the
+    // marker (`take_required_whitespace`).
     let count = line.len() - rest.len();
-    if count == 0 || count > 6 || !rest.starts_with(' ') {
+    if count == 0 || count > 6 || !rest.starts_with([' ', '\t']) {
         return false;
     }
 
@@ -934,10 +936,20 @@ mod tests {
         }
 
         #[test]
-        fn requires_a_space_after_the_marker() {
+        fn requires_a_blank_after_the_marker() {
             assert!(!is_section_header("==nospace", 0));
             assert!(!is_section_header("=nospace", 1));
             assert!(!is_section_header("##nospace", 0));
+        }
+
+        #[test]
+        fn accepts_a_tab_after_the_marker() {
+            // `parse_title_line` accepts a tab (not just a space) after the
+            // marker, so the lookahead must too, or a valid tab-delimited
+            // heading would be swallowed as paragraph text.
+            assert!(is_section_header("==\tSection", 0));
+            assert!(is_section_header("=\tSection", 1));
+            assert!(!is_section_header("=\tSection", 0));
         }
 
         #[test]

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -395,7 +395,7 @@ fn parse_lines<'src>(
         if !stop_for_list_items
             && skipped_comment_line
             && style == SimpleBlockStyle::Paragraph
-            && is_section_header(line.data())
+            && is_section_header(line.data(), parser.level_offset())
         {
             break;
         }
@@ -589,26 +589,41 @@ impl<'src> HasSpan<'src> for SimpleBlock<'src> {
     }
 }
 
-/// Returns true if the line looks like a section header.
-/// Matches `== `, `=== `, etc. (AsciiDoc) or `## `, `### `, etc. (Markdown).
-fn is_section_header(line: &str) -> bool {
-    // AsciiDoc style: `== `, `=== `, etc. (at least 2 `=` followed by space)
-    if line.starts_with("==") {
-        let rest = line.trim_start_matches('=');
-        if rest.starts_with(' ') {
-            return true;
-        }
+/// Reports whether `line` is a section heading (so a paragraph that has already
+/// swallowed a leading comment line must stop before it, letting the heading be
+/// parsed as its own section).
+///
+/// `level_offset` is the running `leveloffset` document attribute, which folds
+/// into the heading's effective level exactly as in
+/// [`SectionBlock::parse`](crate::blocks::SectionBlock). A heading of two or
+/// more markers (`== `/`## `, effective level 1+, or clamped up to 1 under a
+/// negative offset) is always a section. A single-marker heading (`= `/`# `) is
+/// a document title rather than a section *unless* a positive offset lifts it to
+/// level 1 or beyond — mirroring the level-0 rule in
+/// [`parse_title_line`](crate::blocks::section).
+fn is_section_header(line: &str, level_offset: i32) -> bool {
+    // AsciiDoc `=` style or Markdown `#` style.
+    let rest = if line.starts_with('=') {
+        line.trim_start_matches('=')
+    } else if line.starts_with('#') {
+        line.trim_start_matches('#')
+    } else {
+        return false;
+    };
+
+    // A section marker is one to six characters followed by a space.
+    let count = line.len() - rest.len();
+    if count == 0 || count > 6 || !rest.starts_with(' ') {
+        return false;
     }
 
-    // Markdown style: `## `, `### `, etc. (at least 2 `#` followed by space)
-    if line.starts_with("##") {
-        let rest = line.trim_start_matches('#');
-        if rest.starts_with(' ') {
-            return true;
-        }
-    }
-
-    false
+    // A bare `=`/`#` (syntactic level 0) heads a section only when a positive
+    // `leveloffset` promotes it to level 1 or deeper; otherwise it is a
+    // document title, not a section. Any deeper marker is always a section (a
+    // negative offset that would push it below level 1 is clamped, not
+    // rejected).
+    let syntactic_level = (count - 1) as i32;
+    syntactic_level > 0 || syntactic_level.saturating_add(level_offset) >= 1
 }
 
 #[cfg(test)]
@@ -891,5 +906,45 @@ mod tests {
             mi.item.rendered_content().unwrap(),
             "a<b>c <strong>bold</strong>"
         );
+    }
+
+    mod is_section_header {
+        use super::super::is_section_header;
+
+        #[test]
+        fn multi_marker_is_always_a_section_regardless_of_offset() {
+            // Two or more markers followed by a space are always a section, at
+            // any offset (a negative offset that would push the level below 1 is
+            // clamped in `parse_title_line`, not rejected).
+            assert!(is_section_header("== Section", 0));
+            assert!(is_section_header("=== Section", 0));
+            assert!(is_section_header("## Section", 0));
+            assert!(is_section_header("== Section", -1));
+        }
+
+        #[test]
+        fn single_marker_is_a_section_only_under_positive_offset() {
+            // A bare `=`/`#` is a document title, not a section, unless a
+            // positive `leveloffset` promotes it to level 1 or beyond.
+            assert!(!is_section_header("= Title", 0));
+            assert!(!is_section_header("# Title", 0));
+            assert!(is_section_header("= Title", 1));
+            assert!(is_section_header("# Title", 1));
+            assert!(is_section_header("= Title", 2));
+        }
+
+        #[test]
+        fn requires_a_space_after_the_marker() {
+            assert!(!is_section_header("==nospace", 0));
+            assert!(!is_section_header("=nospace", 1));
+            assert!(!is_section_header("##nospace", 0));
+        }
+
+        #[test]
+        fn non_marker_and_over_long_marker_are_not_sections() {
+            assert!(!is_section_header("paragraph", 1));
+            // Seven markers exceed the level-5 maximum, so this is not a heading.
+            assert!(!is_section_header("======= Too deep", 0));
+        }
     }
 }

--- a/parser/src/tests/asciidoctor_rb/sections_test.rs
+++ b/parser/src/tests/asciidoctor_rb/sections_test.rs
@@ -2889,15 +2889,10 @@ mod level_offset {
 "##
     );
 
-    // NOTE: In this simulated-include scenario a `= ` heading is immediately
-    // followed by an attribute entry (`= Standalone Document` / `:author:`).
-    // The crate does not promote that heading to a section under the active
-    // `:leveloffset: 1` (the "Standalone Document" section is dropped), so the
-    // full section shape asserted here is not reproduced. The core level-offset
-    // behavior is covered by the other three tests in this context. Out of
-    // scope pending this edge case (see #746).
-    non_normative!(
-        r##"
+    #[test]
+    fn should_add_level_offset_to_section_level() {
+        verifies!(
+            r##"
     test 'should add level offset to section level' do
       input = <<~'EOS'
       = Main Document
@@ -2939,7 +2934,56 @@ mod level_offset {
     end
 
 "##
-    );
+        );
+
+        // The `= Standalone Document` heading is immediately followed by an
+        // attribute entry (`:author:`). A comment line (`// begin simulated
+        // include::[]`) precedes the heading, which previously caused the
+        // heading to be swallowed into a comment-led paragraph and the section
+        // to be dropped under the active `:leveloffset: 1` (see #746). It is now
+        // promoted to a level-1 section like its `==` sibling.
+        let doc = Parser::default().parse(
+            "= Main Document\nDoc Writer\n\nMain document written by {author}.\n\n:leveloffset: 1\n\n// begin simulated include::[]\n= Standalone Document\n:author: Junior Writer\n\nStandalone document written by {author}.\n\n== Section in Standalone\n\nStandalone section text.\n// end simulated include::[]\n\n:leveloffset!:\n\n== Section in Main\n\nMain section text.\n",
+        );
+
+        // No diagnostics are raised (`assert logger.empty?`).
+        assert!(doc.warnings().next().is_none());
+
+        // The offset shifts the included headings down one level: the level-0
+        // `= Standalone Document` becomes a level-1 section, its `== Section in
+        // Standalone` becomes level 2, and (after `:leveloffset!:` resets the
+        // offset) `== Section in Main` is level 1.
+        let by_title: Vec<(usize, &str)> = all_sections(&doc)
+            .iter()
+            .map(|s| (s.level(), s.section_title()))
+            .collect();
+        assert_eq!(
+            by_title,
+            vec![
+                (1, "Standalone Document"),
+                (2, "Section in Standalone"),
+                (1, "Section in Main"),
+            ]
+        );
+
+        // The `{author}` reference in each paragraph resolves to the author in
+        // effect where it appears: the document header's "Doc Writer" for the
+        // main paragraph, and the standalone section's `:author: Junior Writer`
+        // for its paragraph.
+        let paragraphs = rendered_paragraphs(&doc);
+        assert!(
+            paragraphs
+                .iter()
+                .any(|p| p == "Main document written by Doc Writer."),
+            "paragraphs: {paragraphs:?}"
+        );
+        assert!(
+            paragraphs
+                .iter()
+                .any(|p| p == "Standalone document written by Junior Writer."),
+            "paragraphs: {paragraphs:?}"
+        );
+    }
 
     #[test]
     fn level_offset_should_be_added_to_discrete_heading() {
@@ -5312,10 +5356,10 @@ mod table_of_contents {
 "##
     );
 
-    // NOTE: `:toc-placement!:` (which suppresses the TOC in Asciidoctor) is not
-    // honored by this crate — the TOC still renders. Out of scope (see #746).
-    non_normative!(
-        r##"
+    #[test]
+    fn should_not_output_table_of_contents_if_toc_placement_attribute_is_unset() {
+        verifies!(
+            r##"
     test 'should not output table of contents if toc-placement attribute is unset' do
       input = <<~'EOS'
       = Article
@@ -5336,7 +5380,19 @@ mod table_of_contents {
     end
 
 "##
-    );
+        );
+
+        // Unsetting `toc-placement` while `toc` is enabled resolves the
+        // placement to `macro` (Asciidoctor's `macro` fetch fallback), so the
+        // TOC renders only where a `toc::[]` block macro appears. With no such
+        // macro in this document, no `#toc` is emitted. See #746 (and #750,
+        // which introduced the soft-unset resolution).
+        let doc = Parser::default().parse(
+            "= Article\n:toc:\n:toc-placement!:\n\n== Section One\n\nIt was a dark and stormy night...\n\n== Section Two\n\nThey couldn't believe their eyes when...\n",
+        );
+        assert_eq!(doc.toc_mode(), crate::document::TocMode::Macro);
+        assert_xpath(&doc, r##"//*[@id="toc"]"##, 0);
+    }
 
     // NOTE: The remaining tests depend on standalone `#header` framing, the
     // `toc::[]` macro placement family, `toc-class`/`toc-title` rendered via the


### PR DESCRIPTION
Fixes #746 — the two section edge cases surfaced by the SDD port of Asciidoctor's `sections_test.rb`.

## Case 2 (the actual bug): a `= ` heading after a comment line is dropped under `:leveloffset:`

In a simulated-include scenario, a `= ` heading directly preceded by a line comment (`// begin simulated include::[]`) and under an active `:leveloffset: 1` was silently dropped — the "Standalone Document" section (and its nested `==` section) disappeared with no diagnostic, while a sibling `==` heading offset correctly.

**Root cause:** When `SimpleBlock::parse` swallows a leading comment line, it stops the paragraph at the next section heading so the heading can be parsed as its own section. That check used `is_section_header`, which only recognized `==`+ (two-or-more-marker) headings and ignored the running `leveloffset`. A bare `= ` heading that a positive offset promotes to level 1 was therefore not recognized, so it was absorbed into the comment-led paragraph and its section was lost.

**Fix:** `is_section_header` now folds `leveloffset` into the heading's effective level, mirroring `parse_title_line` in `section.rs`:
- a multi-marker heading (`== `/`## `) is always a section (a negative offset that would push it below level 1 is clamped, not rejected);
- a single-marker heading (`= `/`# `) is a document title *unless* a positive offset lifts it to level 1 or beyond.

## Case 1: `:toc-placement!:` suppressing the TOC

This was already resolved by the soft-unset handling added in #826/#750: unsetting `toc-placement` while `toc` is enabled resolves the placement to `macro`, so with no `toc::[]` block macro in the document, no `#toc` is emitted — matching Asciidoctor's "no table of contents" output. This PR just promotes the corresponding test to a real assertion.

## Tests
- Both Ruby tests reproduced in `parser/src/tests/asciidoctor_rb/sections_test.rs` are converted from `non_normative!` to `verifies!`:
  - `Level offset` › `should add level offset to section level`
  - `Table of Contents` › `should not output table of contents if toc-placement attribute is unset`
- A focused unit test covers the new offset-aware `is_section_header` logic (multi-marker vs. single-marker, positive/negative offset, space requirement, over-long markers).
- Full suite: `4159 passed`; `cargo clippy --all-targets` clean; `cargo fmt` applied.

Note: the `numbered` → `sectnums` legacy alias mentioned in the issue is tracked separately and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BCvCfzj81ALejPJWyipjz

---
_Generated by [Claude Code](https://claude.ai/code/session_015BCvCfzj81ALejPJWyipjz)_