### PR TITLE
feat: Materialize derived backend/basebackend/filetype/doctype attributes (#738)

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1671,11 +1671,11 @@ fn process_content<'src>(
         // The inherited attribute set is the shared built-in defaults with the
         // parent's per-parser entries (`saved_attributes`) layered on top, so
         // walk both, letting a per-parser entry shadow a like-named built-in.
-        // The synthesized `backend-html5-doctype-*` and `safe-mode-*` flags need
-        // no lock here: they are read-only intrinsics that reject a cell-body
-        // assignment on their own (see `DERIVED_DOCTYPE_ATTR` /
-        // `SAFE_MODE_ACTIVE_FLAG`), which a static lock could not do anyway once
-        // the cell changes its own doctype.
+        // The synthesized backend-family and `safe-mode-*` flags need no lock
+        // here: they are read-only intrinsics that reject a cell-body assignment
+        // on their own (see `DERIVED_FAMILY_FLAG` / `SAFE_MODE_ACTIVE_FLAG`),
+        // which a static lock could not do anyway once the cell changes its own
+        // doctype.
         let saved_locks = parser.locked_attribute_names.clone();
         {
             let locks = &mut parser.locked_attribute_names;

--- a/parser/src/document/toc.rs
+++ b/parser/src/document/toc.rs
@@ -52,6 +52,13 @@ pub enum TocMode {
 impl TocMode {
     /// Resolves the table-of-contents placement from a parser's current `toc`
     /// attribute state.
+    // TODO(#840): Asciidoctor also materializes the derived `toc-position`,
+    // `toc-placement`, and `toc-class` document attributes (queryable via
+    // `attribute_value` / `has_attribute`). This crate resolves the TOC
+    // configuration only through the `Document::toc_*` accessors below. Note the
+    // entanglement: this resolver reads the raw `toc-placement` attribute and
+    // relies on distinguishing a never-set `toc-placement` from an explicit
+    // unset tombstone, so materializing a default of `auto` needs care.
     pub(crate) fn from_parser(parser: &Parser) -> Self {
         let value = parser.attribute_value("toc");
         if value == InterpretedValue::Unset {

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -33,23 +33,26 @@ pub(crate) const DEFAULT_ICONSDIR: &str = "./images/icons";
 static BUILT_IN_ATTRS: LazyLock<HashMap<String, AttributeValue>> =
     LazyLock::new(build_built_in_attrs);
 
-/// The synthesized `backend-html5-doctype-{doctype}` attribute, which is
-/// defined (with an empty value) only for the document's active doctype. It is
-/// resolved on the fly from the current `doctype` rather than materialized, so
-/// it lives here as a single shared value that lookups can hand out by
-/// reference. See [`synthesized_attr`].
+/// The shared value handed out for every synthesized *backend-family flag* —
+/// `backend-{backend}`, `basebackend-{basebackend}`, `filetype-{filetype}`,
+/// `doctype-{doctype}`, `backend-{backend}-doctype-{doctype}`, and
+/// `basebackend-{basebackend}-doctype-{doctype}`. Each is defined (with an empty
+/// value) only while its `{...}` component matches the document's active
+/// backend / basebackend / filetype / doctype, so they are resolved on the fly
+/// rather than materialized, and every active flag can hand out this one shared
+/// value by reference. See [`synthesized_attr`].
 ///
-/// It is a read-only intrinsic: it tracks `doctype` automatically, so a
-/// document header or body assignment to it (e.g.
+/// They are read-only intrinsics: a flag tracks the `backend` / `doctype` state
+/// automatically, so a document header or body assignment to one (e.g.
 /// `:backend-html5-doctype-article: x`) is silently ignored ([`ApiOnly`] +
 /// [`silent_when_locked`]) rather than being allowed to shadow the intrinsic
 /// empty value. This self-protection replaces the previous scheme
 /// (materialize-and-lock inside an AsciiDoc table cell), which could not follow
-/// the cell's dynamically-changing doctype.
+/// a cell's dynamically-changing doctype.
 ///
 /// [`ApiOnly`]: ModificationContext::ApiOnly
 /// [`silent_when_locked`]: AttributeValue::silent_when_locked
-static DERIVED_DOCTYPE_ATTR: LazyLock<AttributeValue> = LazyLock::new(|| AttributeValue {
+static DERIVED_FAMILY_FLAG: LazyLock<AttributeValue> = LazyLock::new(|| AttributeValue {
     allowable_value: AllowableValue::Any,
     modification_context: ModificationContext::ApiOnly,
     silent_when_locked: true,
@@ -86,41 +89,117 @@ pub(crate) fn built_in_attrs_iter()
     BUILT_IN_ATTRS.iter()
 }
 
+/// Strips the trailing version digits from a backend name to yield its
+/// *basebackend* (e.g. `html5` &rarr; `html`, `docbook45` &rarr; `docbook`),
+/// matching Asciidoctor's `TrailingDigitsRx` derivation.
+pub(crate) fn basebackend_of(backend: &str) -> &str {
+    backend.trim_end_matches(|c: char| c.is_ascii_digit())
+}
+
+/// Derives the output *filetype* from a backend name, matching Asciidoctor's
+/// `DEFAULT_EXTENSIONS` table (keyed on the basebackend): a recognized
+/// basebackend maps to its file type (`docbook` &rarr; `xml`, `manpage` &rarr;
+/// `man`, `asciidoc` &rarr; `adoc`), and any other basebackend is its own
+/// filetype (`html` &rarr; `html`, `pdf` &rarr; `pdf`, `epub` &rarr; `epub`).
+pub(crate) fn filetype_of(backend: &str) -> String {
+    match basebackend_of(backend) {
+        "docbook" => "xml".to_owned(),
+        "manpage" => "man".to_owned(),
+        "asciidoc" => "adoc".to_owned(),
+        other => other.to_owned(),
+    }
+}
+
+/// Reports whether `name` is a derived backend-family *value* attribute
+/// (`basebackend` or `filetype`), resolved on the fly from the current
+/// `backend` rather than stored in either attribute table (see
+/// [`derived_backend_value`]).
+pub(crate) fn is_derived_backend_value(name: &str) -> bool {
+    matches!(name, "basebackend" | "filetype")
+}
+
+/// Reads the effective plain value of a *stored* attribute `key` (a per-parser
+/// entry layered over the shared built-in default), or `None` if it is absent,
+/// unset, or value-less.
+fn stored_value(key: &str, overrides: &HashMap<String, AttributeValue>) -> Option<String> {
+    overrides
+        .get(key)
+        .or_else(|| BUILT_IN_ATTRS.get(key))
+        .and_then(|av| match &av.value {
+            InterpretedValue::Value(v) => Some(v.clone()),
+            _ => None,
+        })
+}
+
+/// Resolves a derived backend-family *value* attribute (`basebackend` or
+/// `filetype`) from the current `backend`, mirroring Asciidoctor's
+/// backend-trait derivation. Returns `None` for any other name.
+///
+/// `overrides` is the caller's per-parser attribute map; layered over the
+/// shared built-in defaults it determines the active `backend`.
+pub(crate) fn derived_backend_value(
+    name: &str,
+    overrides: &HashMap<String, AttributeValue>,
+) -> Option<InterpretedValue> {
+    let backend = stored_value("backend", overrides).unwrap_or_default();
+    match name {
+        "basebackend" => Some(InterpretedValue::Value(basebackend_of(&backend).to_owned())),
+        "filetype" => Some(InterpretedValue::Value(filetype_of(&backend))),
+        _ => None,
+    }
+}
+
 /// Resolves a *synthesized* attribute — one computed from other state rather
 /// than stored in either attribute table — for the active document state:
 ///
-/// * `backend-html5-doctype-{doctype}` is defined (empty) only for the active
-///   `doctype`.
+/// * The backend-family flags `backend-{backend}`, `basebackend-{basebackend}`,
+///   `filetype-{filetype}`, `doctype-{doctype}`,
+///   `backend-{backend}-doctype-{doctype}`, and
+///   `basebackend-{basebackend}-doctype-{doctype}` are each defined (empty) only
+///   while their `{...}` component matches the active `backend` / `doctype`.
 /// * `safe-mode-{name}` is defined (empty) only for the active safe mode (as
 ///   reported by `safe-mode-name`).
 ///
 /// `overrides` is the caller's per-parser attribute map; its entries (layered
-/// over the shared built-in defaults) determine the active doctype / safe mode.
-/// Returns `None` for any name that is not a currently-active synthesized
-/// attribute (so the inactive doctype/safe-mode flags stay absent, matching
+/// over the shared built-in defaults) determine the active backend / doctype /
+/// safe mode. Returns `None` for any name that is not a currently-active
+/// synthesized attribute (so the inactive flags stay absent, matching
 /// Asciidoctor).
 pub(crate) fn synthesized_attr(
     name: &str,
     overrides: &HashMap<String, AttributeValue>,
 ) -> Option<&'static AttributeValue> {
-    // Reports whether the *stored* attribute `key` (never itself a synthesized
-    // one) currently resolves to the plain value `expected`, letting a per-parser
-    // entry shadow the built-in default.
-    let has_value = |key: &str, expected: &str| -> bool {
-        overrides
-            .get(key)
-            .or_else(|| BUILT_IN_ATTRS.get(key))
-            .is_some_and(|av| matches!(&av.value, InterpretedValue::Value(v) if v == expected))
-    };
+    // The derived backend-family flags are all empty-valued and defined only for
+    // the *active* backend / basebackend / filetype / doctype. Rather than parse
+    // the queried name, compute the six flag names that are currently active and
+    // compare — unambiguous even where the components overlap.
+    if name.starts_with("backend-")
+        || name.starts_with("basebackend-")
+        || name.starts_with("filetype-")
+        || name.starts_with("doctype-")
+    {
+        let backend = stored_value("backend", overrides).unwrap_or_default();
+        let doctype = stored_value("doctype", overrides).unwrap_or_default();
+        let basebackend = basebackend_of(&backend);
+        let filetype = filetype_of(&backend);
 
-    if let Some(suffix) = name.strip_prefix("backend-html5-doctype-") {
-        return has_value("doctype", suffix).then(|| &*DERIVED_DOCTYPE_ATTR);
+        let is_active = name == format!("backend-{backend}")
+            || name == format!("basebackend-{basebackend}")
+            || name == format!("filetype-{filetype}")
+            || name == format!("doctype-{doctype}")
+            || name == format!("backend-{backend}-doctype-{doctype}")
+            || name == format!("basebackend-{basebackend}-doctype-{doctype}");
+
+        if is_active {
+            return Some(&*DERIVED_FAMILY_FLAG);
+        }
     }
 
     if let Some(suffix) = name.strip_prefix("safe-mode-")
         && matches!(suffix, "unsafe" | "safe" | "server" | "secure")
     {
-        return has_value("safe-mode-name", suffix).then(|| &*SAFE_MODE_ACTIVE_FLAG);
+        let active = stored_value("safe-mode-name", overrides).as_deref() == Some(suffix);
+        return active.then(|| &*SAFE_MODE_ACTIVE_FLAG);
     }
 
     None
@@ -275,10 +354,21 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
 
     // ### General content and formatting attributes
     //
+    // The active backend defaults to `html5` (the only backend this crate
+    // renders). It is a normal, unlocked attribute — settable in the header, the
+    // body, or via the API, matching Asciidoctor, where `{backend}` reflects the
+    // latest assignment — so its default context is `Anywhere`; an API caller
+    // that wants to pin it uses `ApiOnly`. Its derived family —
+    // `backend-{backend}`, `basebackend`, `basebackend-{basebackend}`,
+    // `filetype`, `filetype-{filetype}`, and the `*-doctype-{doctype}` flags —
+    // is synthesized on the fly from this value (see [`synthesized_attr`] and
+    // [`derived_backend_value`]), so it is never materialized or kept in sync
+    // when `backend` changes.
+    attrs.insert("backend".to_owned(), any(Anywhere, Value("html5".into())));
+
     // The document type defaults to `article` and may be set in the header or
-    // via the API. The derived `backend-html5-doctype-{doctype}` attribute
-    // (defined below) is kept in sync by `Parser::refresh_doctype_derived_attr`
-    // whenever `doctype` changes.
+    // via the API. The derived `*-doctype-{doctype}` flags (see
+    // [`synthesized_attr`]) track this value automatically.
     attrs.insert(
         "doctype".to_owned(),
         any(ApiOrHeader, Value("article".into())),
@@ -370,11 +460,13 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
         any(ApiOnly, Value("secure".into())),
     );
 
-    // NOTE: The derived `backend-html5-doctype-{doctype}` attribute (see
-    // `doctype` above) is *not* registered here. It is synthesized on the fly
-    // for the active doctype by `Parser::attribute_value` (via
-    // [`derived_doctype_attr`]), so it never needs to be materialized or kept in
-    // sync when `doctype` changes.
+    // NOTE: The derived backend-family flags (`backend-{backend}`,
+    // `basebackend-{basebackend}`, `filetype-{filetype}`, `doctype-{doctype}`,
+    // and the `*-doctype-*` combinations) are *not* registered here, nor are the
+    // derived `basebackend` / `filetype` values. They are synthesized on the fly
+    // for the active `backend` / `doctype` by `Parser::attribute_value` (via
+    // [`synthesized_attr`] and [`derived_backend_value`]), so they never need to
+    // be materialized or kept in sync when `backend` or `doctype` changes.
 
     attrs
 }

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -36,8 +36,8 @@ static BUILT_IN_ATTRS: LazyLock<HashMap<String, AttributeValue>> =
 /// The shared value handed out for every synthesized *backend-family flag* —
 /// `backend-{backend}`, `basebackend-{basebackend}`, `filetype-{filetype}`,
 /// `doctype-{doctype}`, `backend-{backend}-doctype-{doctype}`, and
-/// `basebackend-{basebackend}-doctype-{doctype}`. Each is defined (with an empty
-/// value) only while its `{...}` component matches the document's active
+/// `basebackend-{basebackend}-doctype-{doctype}`. Each is defined (with an
+/// empty value) only while its `{...}` component matches the document's active
 /// backend / basebackend / filetype / doctype, so they are resolved on the fly
 /// rather than materialized, and every active flag can hand out this one shared
 /// value by reference. See [`synthesized_attr`].
@@ -155,8 +155,9 @@ pub(crate) fn derived_backend_value(
 /// * The backend-family flags `backend-{backend}`, `basebackend-{basebackend}`,
 ///   `filetype-{filetype}`, `doctype-{doctype}`,
 ///   `backend-{backend}-doctype-{doctype}`, and
-///   `basebackend-{basebackend}-doctype-{doctype}` are each defined (empty) only
-///   while their `{...}` component matches the active `backend` / `doctype`.
+///   `basebackend-{basebackend}-doctype-{doctype}` are each defined (empty)
+///   only while their `{...}` component matches the active `backend` /
+///   `doctype`.
 /// * `safe-mode-{name}` is defined (empty) only for the active safe mode (as
 ///   reported by `safe-mode-name`).
 ///

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -179,11 +179,16 @@ fn stored_value(key: &str, overrides: &HashMap<String, AttributeValue>) -> Optio
 ///
 /// `overrides` is the caller's per-parser attribute map; layered over the
 /// shared built-in defaults it determines the active `backend`.
+///
+/// When `backend` has been explicitly unset (or resolves to an empty value)
+/// the whole family is treated as *absent*: this returns `None` so a reader
+/// reports `basebackend` / `filetype` as unset rather than as an empty derived
+/// value.
 pub(crate) fn derived_backend_value(
     name: &str,
     overrides: &HashMap<String, AttributeValue>,
 ) -> Option<InterpretedValue> {
-    let backend = stored_value("backend", overrides).unwrap_or_default();
+    let backend = stored_value("backend", overrides).filter(|b| !b.is_empty())?;
     match name {
         "basebackend" => Some(InterpretedValue::Value(basebackend_of(&backend).to_owned())),
         "filetype" => Some(InterpretedValue::Value(filetype_of(&backend))),
@@ -214,24 +219,42 @@ pub(crate) fn synthesized_attr(
 ) -> Option<&'static AttributeValue> {
     // The derived backend-family flags are all empty-valued and defined only for
     // the *active* backend / basebackend / filetype / doctype. Rather than parse
-    // the queried name, compute the six flag names that are currently active and
-    // compare — unambiguous even where the components overlap.
+    // the queried name, compute the flag names that are currently active and
+    // compare — unambiguous even where the components overlap. An explicitly
+    // unset (or empty) `backend` / `doctype` contributes no flags, so the
+    // backend-dependent and doctype-dependent groups are each gated on a
+    // present, non-empty value.
     if name.starts_with("backend-")
         || name.starts_with("basebackend-")
         || name.starts_with("filetype-")
         || name.starts_with("doctype-")
     {
-        let backend = stored_value("backend", overrides).unwrap_or_default();
-        let doctype = stored_value("doctype", overrides).unwrap_or_default();
-        let basebackend = basebackend_of(&backend);
-        let filetype = filetype_of(&backend);
+        let backend = stored_value("backend", overrides).filter(|b| !b.is_empty());
+        let doctype = stored_value("doctype", overrides).filter(|d| !d.is_empty());
 
-        let is_active = name == format!("backend-{backend}")
-            || name == format!("basebackend-{basebackend}")
-            || name == format!("filetype-{filetype}")
-            || name == format!("doctype-{doctype}")
-            || name == format!("backend-{backend}-doctype-{doctype}")
-            || name == format!("basebackend-{basebackend}-doctype-{doctype}");
+        let mut is_active = false;
+
+        // `doctype-{doctype}` depends on the doctype alone.
+        if let Some(doctype) = &doctype {
+            is_active = name == format!("doctype-{doctype}");
+        }
+
+        // The remaining flags all depend on the backend (and its derived
+        // basebackend / filetype), and the `*-doctype-*` combinations on the
+        // doctype as well.
+        if !is_active && let Some(backend) = &backend {
+            let basebackend = basebackend_of(backend);
+            let filetype = filetype_of(backend);
+
+            is_active = name == format!("backend-{backend}")
+                || name == format!("basebackend-{basebackend}")
+                || name == format!("filetype-{filetype}");
+
+            if !is_active && let Some(doctype) = &doctype {
+                is_active = name == format!("backend-{backend}-doctype-{doctype}")
+                    || name == format!("basebackend-{basebackend}-doctype-{doctype}");
+            }
+        }
 
         if is_active {
             return Some(&*DERIVED_FAMILY_FLAG);

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2994,6 +2994,11 @@ mod tests {
             assert!(doc.has_attribute("basebackend-docbook"));
             assert!(doc.has_attribute("backend-docbook5-doctype-article"));
 
+            // The derived values report as set through the post-parse
+            // `Document` (snapshot) reader, not just the live parser.
+            assert!(doc.is_attribute_set("basebackend"));
+            assert!(doc.is_attribute_set("filetype"));
+
             // The html5 flags are no longer active.
             assert!(!doc.has_attribute("backend-html5"));
             assert!(!doc.has_attribute("basebackend-html"));

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -14,7 +14,10 @@ use crate::{
         HtmlSubstitutionRenderer, IncludeFileHandler, InlineSubstitutionRenderer,
         ModificationContext, PathResolver, ReferenceTime, ResolvedAttributes, SafeMode, SourceLine,
         SourceMap, SvgFileHandler,
-        built_in_attrs::{built_in_attr, built_in_default_values, synthesized_attr},
+        built_in_attrs::{
+            built_in_attr, built_in_default_values, derived_backend_value,
+            is_derived_backend_value, synthesized_attr,
+        },
         is_datetime_attribute,
         preprocessor::preprocess,
     },
@@ -606,6 +609,13 @@ impl Parser {
             return self.attribute_value("outfilesuffix");
         }
 
+        // `basebackend` / `filetype` are derived on the fly from the current
+        // `backend` (see [`derived_backend_value`]) rather than stored; they are
+        // read-only intrinsics, so no per-parser entry ever shadows this.
+        if let Some(value) = derived_backend_value(name, &self.attribute_values) {
+            return value;
+        }
+
         match self.effective_attribute(name) {
             Some(av) => {
                 if let InterpretedValue::Set = av.value
@@ -678,6 +688,9 @@ impl Parser {
         if self.tracks_outfilesuffix(name) {
             return self.has_attribute("outfilesuffix");
         }
+        if is_derived_backend_value(name) {
+            return true;
+        }
         self.effective_attribute(name).is_some() || self.resolve_datetime_attribute(name).is_some()
     }
 
@@ -696,6 +709,12 @@ impl Parser {
 
         if self.tracks_outfilesuffix(name) {
             return self.is_attribute_set("outfilesuffix");
+        }
+
+        // A derived `basebackend` / `filetype` always holds a concrete (set)
+        // value.
+        if is_derived_backend_value(name) {
+            return true;
         }
 
         self.effective_attribute(name)
@@ -1737,10 +1756,10 @@ impl Parser {
     ) {
         let attr_name = remap_attr_name(attr.name().data());
 
-        // The `backend-html5-doctype-*` namespace is a read-only synthesized
+        // The derived backend-family namespace is a read-only synthesized
         // intrinsic; a document must not write any of it (see
-        // [`is_reserved_doctype_derived_attr`]).
-        if is_reserved_doctype_derived_attr(&attr_name) {
+        // [`is_reserved_derived_attr`]).
+        if is_reserved_derived_attr(&attr_name) {
             return;
         }
 
@@ -1887,10 +1906,10 @@ impl Parser {
     ) {
         let attr_name = remap_attr_name(attr.name().data());
 
-        // The `backend-html5-doctype-*` namespace is a read-only synthesized
+        // The derived backend-family namespace is a read-only synthesized
         // intrinsic; a document must not write any of it (see
-        // [`is_reserved_doctype_derived_attr`]).
-        if is_reserved_doctype_derived_attr(&attr_name) {
+        // [`is_reserved_derived_attr`]).
+        if is_reserved_derived_attr(&attr_name) {
             return;
         }
 
@@ -2133,9 +2152,11 @@ fn remap_attr_name<N: AsRef<str>>(raw_attr_name: N) -> String {
     }
 }
 
-/// Returns `true` if `name` belongs to the reserved `backend-html5-doctype-*`
-/// namespace, which is a read-only synthesized intrinsic keyed on the active
-/// `doctype` (see [`synthesized_attr`]).
+/// Returns `true` if `name` belongs to the reserved derived backend-family
+/// namespace — the `basebackend` / `filetype` values and the
+/// `backend-*` / `basebackend-*` / `filetype-*` / `doctype-*` flags — each a
+/// read-only synthesized intrinsic keyed on the active `backend` / `doctype`
+/// (see [`synthesized_attr`] and [`derived_backend_value`]).
 ///
 /// A document header or body assignment to any such name is rejected — not only
 /// the flag that is active when the assignment is parsed. Otherwise a name that
@@ -2144,8 +2165,16 @@ fn remap_attr_name<N: AsRef<str>>(raw_attr_name: N) -> String {
 /// permission check, and be stored as a per-parser override that then shadows
 /// the intrinsic once the doctype switches to that value (e.g. in an AsciiDoc
 /// table cell that resets, then changes, its doctype).
-fn is_reserved_doctype_derived_attr(name: &str) -> bool {
-    name.starts_with("backend-html5-doctype-")
+///
+/// The settable roots `backend` and `doctype` (bare, with no suffix) are
+/// deliberately *not* reserved: they are the inputs the derived family is
+/// computed from.
+fn is_reserved_derived_attr(name: &str) -> bool {
+    is_derived_backend_value(name)
+        || name.starts_with("backend-")
+        || name.starts_with("basebackend-")
+        || name.starts_with("filetype-")
+        || name.starts_with("doctype-")
 }
 
 #[cfg(test)]
@@ -2835,7 +2864,7 @@ mod tests {
         }
     }
 
-    mod derived_doctype_attr {
+    mod derived_backend_family_attrs {
         use crate::{
             document::InterpretedValue,
             parser::{AllowableValue, AttributeValue, ModificationContext, Parser},
@@ -2910,6 +2939,91 @@ mod tests {
             assert_eq!(
                 parser.attribute_value("backend-html5-doctype-book"),
                 InterpretedValue::Unset
+            );
+        }
+
+        #[test]
+        fn default_backend_family_is_materialized() {
+            let parser = Parser::default();
+
+            // The default backend is `html5`; its whole derived family resolves
+            // to queryable document attributes (empty-valued flags plus the
+            // `backend` / `basebackend` / `filetype` values).
+            for (name, value) in [
+                ("backend", "html5"),
+                ("backend-html5", ""),
+                ("basebackend", "html"),
+                ("basebackend-html", ""),
+                ("filetype", "html"),
+                ("filetype-html", ""),
+                ("doctype-article", ""),
+                ("backend-html5-doctype-article", ""),
+                ("basebackend-html-doctype-article", ""),
+            ] {
+                assert!(parser.has_attribute(name), "missing {name:?}");
+                assert!(parser.is_attribute_set(name), "not set: {name:?}");
+                assert_eq!(
+                    parser.attribute_value(name),
+                    InterpretedValue::Value(value.to_string()),
+                    "unexpected value for {name:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn family_tracks_a_non_html_backend() {
+            // Setting a different backend re-derives the whole family from it
+            // (basebackend strips the trailing digits, filetype maps through the
+            // Asciidoctor extension table), and the inactive `html5` flags fall
+            // away.
+            let doc = Parser::default().parse(":backend: docbook5\n\nbody");
+
+            assert_eq!(
+                doc.attribute_value("backend"),
+                InterpretedValue::Value("docbook5".to_string())
+            );
+            assert_eq!(
+                doc.attribute_value("basebackend"),
+                InterpretedValue::Value("docbook".to_string())
+            );
+            assert_eq!(
+                doc.attribute_value("filetype"),
+                InterpretedValue::Value("xml".to_string())
+            );
+            assert!(doc.has_attribute("backend-docbook5"));
+            assert!(doc.has_attribute("basebackend-docbook"));
+            assert!(doc.has_attribute("backend-docbook5-doctype-article"));
+
+            // The html5 flags are no longer active.
+            assert!(!doc.has_attribute("backend-html5"));
+            assert!(!doc.has_attribute("basebackend-html"));
+            assert!(!doc.has_attribute("backend-html5-doctype-article"));
+        }
+
+        #[test]
+        fn derived_value_and_flag_attributes_are_read_only() {
+            // `basebackend` / `filetype` and the derived flag namespace are
+            // read-only intrinsics; a document assignment is silently ignored and
+            // the synthesized value stands.
+            let doc = Parser::default().parse(
+                ":basebackend: custom\n:filetype: custom\n:backend-html5: custom\n:doctype-article: custom\n\nbody",
+            );
+
+            assert_eq!(
+                doc.attribute_value("basebackend"),
+                InterpretedValue::Value("html".to_string())
+            );
+            assert_eq!(
+                doc.attribute_value("filetype"),
+                InterpretedValue::Value("html".to_string())
+            );
+            assert_eq!(
+                doc.attribute_value("backend-html5"),
+                InterpretedValue::Value(String::new())
+            );
+            assert_eq!(
+                doc.attribute_value("doctype-article"),
+                InterpretedValue::Value(String::new())
             );
         }
     }

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -699,7 +699,9 @@ impl Parser {
         if self.tracks_outfilesuffix(name) {
             return self.has_attribute("outfilesuffix");
         }
-        if is_derived_backend_value(name) {
+        // A derived `basebackend` / `filetype` is present only while `backend`
+        // resolves to a non-empty value (see [`derived_backend_value`]).
+        if derived_backend_value(name, &self.attribute_values).is_some() {
             return true;
         }
         self.effective_attribute(name).is_some() || self.resolve_datetime_attribute(name).is_some()
@@ -722,9 +724,10 @@ impl Parser {
             return self.is_attribute_set("outfilesuffix");
         }
 
-        // A derived `basebackend` / `filetype` always holds a concrete (set)
-        // value.
-        if is_derived_backend_value(name) {
+        // A derived `basebackend` / `filetype` holds a concrete (set) value
+        // whenever it is present, i.e. while `backend` is non-empty (see
+        // [`derived_backend_value`]).
+        if derived_backend_value(name, &self.attribute_values).is_some() {
             return true;
         }
 
@@ -2229,29 +2232,30 @@ fn remap_attr_name<N: AsRef<str>>(raw_attr_name: N) -> String {
     }
 }
 
-/// Returns `true` if `name` belongs to the reserved derived backend-family
-/// namespace — the `basebackend` / `filetype` values and the
-/// `backend-*` / `basebackend-*` / `filetype-*` / `doctype-*` flags — each a
-/// read-only synthesized intrinsic keyed on the active `backend` / `doctype`
-/// (see [`synthesized_attr`] and [`derived_backend_value`]).
+/// Returns `true` if `name` is a derived backend-family attribute whose
+/// assignment must be rejected *even while it is inactive*, because the flag it
+/// would name can become active later in the same parse and the stored override
+/// would then shadow the read-only intrinsic:
 ///
-/// A document header or body assignment to any such name is rejected — not only
-/// the flag that is active when the assignment is parsed. Otherwise a name that
-/// is inactive at assignment time (e.g. `backend-html5-doctype-article` while
-/// the doctype is `book`) would resolve to no synthesized attribute, pass the
-/// permission check, and be stored as a per-parser override that then shadows
-/// the intrinsic once the doctype switches to that value (e.g. in an AsciiDoc
-/// table cell that resets, then changes, its doctype).
+/// * The bare derived values `basebackend` / `filetype` — always resolved on
+///   the fly from `backend` (see [`derived_backend_value`]), never stored.
+/// * The doctype-keyed flags `backend-<b>-doctype-<d>` /
+///   `basebackend-<bb>-doctype-<d>` — the `doctype` component shifts mid-parse
+///   (e.g. an AsciiDoc table cell that resets, then changes, its doctype), so
+///   an assignment to an inactive one (`backend-html5-doctype-article` while
+///   the doctype is `book`) must not be stored where it could shadow the
+///   intrinsic once the doctype switches.
 ///
-/// The settable roots `backend` and `doctype` (bare, with no suffix) are
-/// deliberately *not* reserved: they are the inputs the derived family is
-/// computed from.
+/// The remaining flag names (`backend-<b>`, `basebackend-<bb>`, `filetype-<f>`,
+/// and bare `doctype-<d>`) are deliberately **not** reserved: rejecting them
+/// would swallow author-defined attributes such as `:backend-custom:` or
+/// `:doctype-draft:` (used as `ifdef` flags), which Asciidoctor keeps. The
+/// *active* one of these is still write-protected by the normal permission
+/// check, since [`synthesized_attr`] resolves it to a locked intrinsic.
 fn is_reserved_derived_attr(name: &str) -> bool {
     is_derived_backend_value(name)
-        || name.starts_with("backend-")
-        || name.starts_with("basebackend-")
-        || name.starts_with("filetype-")
-        || name.starts_with("doctype-")
+        || ((name.starts_with("backend-") || name.starts_with("basebackend-"))
+            && name.contains("-doctype-"))
 }
 
 #[cfg(test)]
@@ -3107,6 +3111,61 @@ mod tests {
                 doc.attribute_value("doctype-article"),
                 InterpretedValue::Value(String::new())
             );
+        }
+
+        #[test]
+        fn custom_prefixed_flags_stay_assignable() {
+            // Author-defined attributes that share a derived-family prefix but
+            // name no active flag (and are not the doctype-keyed namespace) are
+            // kept, not swallowed by the read-only reservation, so they stay
+            // visible to `ifdef` / attribute references — matching Asciidoctor.
+            let doc = Parser::default().parse(
+                ":backend-custom: enabled\n:basebackend-custom: on\n:filetype-custom: yes\n:doctype-draft: 1\n\nbody",
+            );
+
+            for (name, value) in [
+                ("backend-custom", "enabled"),
+                ("basebackend-custom", "on"),
+                ("filetype-custom", "yes"),
+                ("doctype-draft", "1"),
+            ] {
+                assert!(doc.has_attribute(name), "missing {name:?}");
+                assert_eq!(
+                    doc.attribute_value(name),
+                    InterpretedValue::Value(value.to_string()),
+                    "unexpected value for {name:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn unset_backend_makes_the_family_absent() {
+            // Explicitly unsetting `backend` leaves nothing to derive from, so
+            // `basebackend` / `filetype` and the backend-keyed flags are absent
+            // rather than resolving to empty traits or degenerate `backend-` /
+            // `filetype-` names.
+            let doc = Parser::default().parse(":backend!:\n\nbody");
+
+            assert_eq!(doc.attribute_value("backend"), InterpretedValue::Unset);
+            for name in ["basebackend", "filetype"] {
+                assert!(!doc.has_attribute(name), "unexpectedly present: {name:?}");
+                assert!(!doc.is_attribute_set(name), "unexpectedly set: {name:?}");
+                assert_eq!(doc.attribute_value(name), InterpretedValue::Unset);
+            }
+
+            // No degenerate empty-suffix flags, and the html5 flags are gone.
+            for name in [
+                "backend-",
+                "basebackend-",
+                "filetype-",
+                "backend-html5",
+                "basebackend-html",
+            ] {
+                assert!(!doc.has_attribute(name), "unexpectedly present: {name:?}");
+            }
+
+            // The doctype-only flag does not depend on `backend`, so it remains.
+            assert!(doc.has_attribute("doctype-article"));
         }
     }
 

--- a/parser/src/parser/resolved_attributes.rs
+++ b/parser/src/parser/resolved_attributes.rs
@@ -4,9 +4,7 @@ use crate::{
     document::InterpretedValue,
     parser::{
         AttributeValue, DatetimeContext, DatetimeInputs, ReferenceTime,
-        built_in_attrs::{
-            built_in_attr, derived_backend_value, is_derived_backend_value, synthesized_attr,
-        },
+        built_in_attrs::{built_in_attr, derived_backend_value, synthesized_attr},
         is_datetime_attribute,
     },
 };
@@ -217,7 +215,9 @@ impl ResolvedAttributes {
         if self.tracks_outfilesuffix(name) {
             return self.has_attribute("outfilesuffix");
         }
-        if is_derived_backend_value(name) {
+        // A derived `basebackend` / `filetype` is present only while `backend`
+        // resolves to a non-empty value (see [`derived_backend_value`]).
+        if derived_backend_value(name, &self.attribute_values).is_some() {
             return true;
         }
         self.effective_attribute(name).is_some() || self.resolve_datetime_attribute(name).is_some()
@@ -241,9 +241,10 @@ impl ResolvedAttributes {
             return self.is_attribute_set("outfilesuffix");
         }
 
-        // A derived `basebackend` / `filetype` always holds a concrete (set)
-        // value.
-        if is_derived_backend_value(name) {
+        // A derived `basebackend` / `filetype` holds a concrete (set) value
+        // whenever it is present, i.e. while `backend` is non-empty (see
+        // [`derived_backend_value`]).
+        if derived_backend_value(name, &self.attribute_values).is_some() {
             return true;
         }
 

--- a/parser/src/parser/resolved_attributes.rs
+++ b/parser/src/parser/resolved_attributes.rs
@@ -4,7 +4,9 @@ use crate::{
     document::InterpretedValue,
     parser::{
         AttributeValue, DatetimeContext, DatetimeInputs, ReferenceTime,
-        built_in_attrs::{built_in_attr, synthesized_attr},
+        built_in_attrs::{
+            built_in_attr, derived_backend_value, is_derived_backend_value, synthesized_attr,
+        },
         is_datetime_attribute,
     },
 };
@@ -83,6 +85,12 @@ impl ResolvedAttributes {
         // [`tracks_outfilesuffix`](Self::tracks_outfilesuffix)).
         if self.tracks_outfilesuffix(name) {
             return self.attribute_value("outfilesuffix");
+        }
+
+        // `basebackend` / `filetype` are derived on the fly from the current
+        // `backend` (see [`derived_backend_value`]) rather than stored.
+        if let Some(value) = derived_backend_value(name, &self.attribute_values) {
+            return value;
         }
 
         match self.effective_attribute(name) {
@@ -209,6 +217,9 @@ impl ResolvedAttributes {
         if self.tracks_outfilesuffix(name) {
             return self.has_attribute("outfilesuffix");
         }
+        if is_derived_backend_value(name) {
+            return true;
+        }
         self.effective_attribute(name).is_some() || self.resolve_datetime_attribute(name).is_some()
     }
 
@@ -228,6 +239,12 @@ impl ResolvedAttributes {
 
         if self.tracks_outfilesuffix(name) {
             return self.is_attribute_set("outfilesuffix");
+        }
+
+        // A derived `basebackend` / `filetype` always holds a concrete (set)
+        // value.
+        if is_derived_backend_value(name) {
+            return true;
         }
 
         self.effective_attribute(name)

--- a/parser/src/tests/asciidoc_lang/directives/ifdef_ifndef.rs
+++ b/parser/src/tests/asciidoc_lang/directives/ifdef_ifndef.rs
@@ -200,13 +200,15 @@ Otherwise, the content is not included.
 "#
     );
 
-    // OR (comma): one of the attributes is set, so the content is included.
-    let doc =
-        Parser::default().parse(":backend-html5:\n\nifdef::backend-html5,backend-docbook5[Shown.]");
+    // OR (comma): the default backend is `html5`, so the derived `backend-html5`
+    // flag is set and the content is included.
+    let doc = Parser::default().parse("ifdef::backend-html5,backend-docbook5[Shown.]");
     assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);
 
-    // OR (comma): neither attribute is set, so the content is not included.
-    let doc = Parser::default().parse("ifdef::backend-html5,backend-docbook5[Shown.]\n\nTail.");
+    // OR (comma): with a different backend neither flag is set, so the content
+    // is not included.
+    let doc = Parser::default()
+        .parse(":backend: pdf\n\nifdef::backend-html5,backend-docbook5[Shown.]\n\nTail.");
     assert_eq!(rendered_paragraphs(&doc), vec!["Tail."]);
 
     // AND (plus): all attributes are set, so the content is included.

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -1509,7 +1509,9 @@ mod assignment {
 "#
     );
 
-    // Tracked in #738.
+    // Tracked in #840 (split from #738): the `toc-position` / `toc-placement` /
+    // `toc-class` attributes are not materialized as queryable document
+    // attributes.
     #[test]
     fn verify_toc_attribute_matrix() {
         non_normative!(

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -69,10 +69,11 @@
 //!   with `_` or containing `.` are not accepted.
 //! * A counter modifies a locked (API-set or built-in) attribute rather than
 //!   leaving it unchanged.
-//! * The derived `backend*` / `basebackend*` / `filetype*` / `outfilesuffix` /
-//!   `toc-position` / `toc-placement` / `toc-class` attributes are not
-//!   materialized as queryable document attributes (this crate resolves them
-//!   through dedicated accessors).
+//! * The derived `toc-position` / `toc-placement` / `toc-class` attributes are
+//!   not materialized as queryable document attributes (this crate resolves the
+//!   table-of-contents configuration through the dedicated `Document::toc_*`
+//!   accessors). The `backend*` / `basebackend*` / `filetype*` /
+//!   `outfilesuffix` / `doctype-*` family *is* materialized (see #738).
 //! * Safe-mode masking of `docdir`/`docfile`, the unterminated-header-comment
 //!   behavior, and the transfer of trailing anchors/attributes onto a following
 //!   section all differ.
@@ -1119,10 +1120,9 @@ mod assignment {
         assert_css(&doc, "h2#_heading", 1);
     }
 
-    // Tracked in #738.
     #[test]
     fn backend_and_doctype_attributes_are_set_by_default_in_default_configuration() {
-        non_normative!(
+        verifies!(
             r#"
     test 'backend and doctype attributes are set by default in default configuration' do
       input = <<~'EOS'
@@ -1155,17 +1155,31 @@ mod assignment {
 "#
         );
 
-        // Divergence: this crate materializes only `doctype` as a queryable
-        // document attribute. It does not populate the derived `backend`,
-        // `basebackend`, `filetype`, `outfilesuffix`, or `*-doctype-*` /
-        // `*-html5` attributes that Asciidoctor sets by default, so only
-        // `doctype` can be verified here.
+        // The derived backend / basebackend / filetype / doctype family is
+        // materialized as queryable document attributes. A `''` Ruby value maps
+        // to an empty [`InterpretedValue::Value`] here; each key must be present
+        // (`has_attribute`) and resolve to the expected value.
         let doc = Parser::default().parse("= Document Title\nAuthor Name\n\ncontent");
-        assert_eq!(
-            doc.attribute_value("doctype"),
-            InterpretedValue::Value("article")
-        );
-        assert_eq!(doc.attribute_value("backend"), InterpretedValue::Unset);
+        for (key, value) in [
+            ("backend", "html5"),
+            ("backend-html5", ""),
+            ("backend-html5-doctype-article", ""),
+            ("outfilesuffix", ".html"),
+            ("basebackend", "html"),
+            ("basebackend-html", ""),
+            ("basebackend-html-doctype-article", ""),
+            ("doctype", "article"),
+            ("doctype-article", ""),
+            ("filetype", "html"),
+            ("filetype-html", ""),
+        ] {
+            assert!(doc.has_attribute(key), "missing attribute {key:?}");
+            assert_eq!(
+                doc.attribute_value(key),
+                InterpretedValue::Value(value),
+                "unexpected value for {key:?}"
+            );
+        }
     }
 
     // Out of scope: targets the DocBook backend, which is out of scope for this
@@ -1247,10 +1261,9 @@ mod assignment {
 "#
     );
 
-    // Tracked in #738.
     #[test]
     fn backend_attributes_defined_in_document_options_overrides_backend_attribute_in_document() {
-        non_normative!(
+        verifies!(
             r#"
     test 'backend attributes defined in document options overrides backend attribute in document' do
       doc = document_from_string(':backend: docbook5', safe: Asciidoctor::SafeMode::SAFE, attributes: { 'backend' => 'html5' })
@@ -1263,10 +1276,10 @@ mod assignment {
 "#
         );
 
-        // Divergence: the API-set `backend` value wins over the document
-        // assignment, but this crate does not materialize the derived
-        // `backend-html5` / `basebackend` attributes that Asciidoctor
-        // synthesizes, so only the winning `backend` value is verified.
+        // The API-set `backend` value (locked, `ApiOnly`) wins over the document
+        // `:backend: docbook5` assignment, and the derived `backend-html5` /
+        // `basebackend` / `basebackend-html` attributes are synthesized from the
+        // winning value.
         let doc = Parser::default()
             .with_safe_mode(SafeMode::Safe)
             .with_intrinsic_attribute("backend", "html5", ModificationContext::ApiOnly)
@@ -1275,6 +1288,12 @@ mod assignment {
             doc.attribute_value("backend"),
             InterpretedValue::Value("html5")
         );
+        assert!(doc.has_attribute("backend-html5"));
+        assert_eq!(
+            doc.attribute_value("basebackend"),
+            InterpretedValue::Value("html")
+        );
+        assert!(doc.has_attribute("basebackend-html"));
     }
 
     // Out of scope: exercises Ruby's mutable node attribute API (`Block.new` /


### PR DESCRIPTION
## Summary

Fixes the backend/basebackend/filetype/doctype portion of #738. (The remaining table-of-contents portion is split out into its own follow-up, #840.)

Asciidoctor exposes a family of **derived, queryable** document attributes computed from the active `backend` and `doctype`:

`backend`, `backend-<name>`, `basebackend`, `basebackend-<name>`, `filetype`, `filetype-<name>`, `doctype-<name>`, and the `backend-<name>-doctype-<doctype>` / `basebackend-<name>-doctype-<doctype>` combinations.

Previously this crate materialized only `doctype` (plus the single synthesized `backend-html5-doctype-<doctype>` flag), so the rest of the family was not visible through `attribute_value` / `has_attribute`.

## What changed

- **`backend` is now a built-in attribute** (default `html5`, unlocked / `Anywhere` — settable in the header, the body, or via the API, matching Asciidoctor where `{backend}` reflects the latest assignment; an API caller pins it with `ApiOnly`).
- **`basebackend` / `filetype` values** are resolved on the fly from the current `backend` at the attribute-reader level (in both `Parser` and the post-parse `ResolvedAttributes` snapshot), mirroring Asciidoctor's backend-trait derivation: `basebackend` strips the backend's trailing version digits (`html5` → `html`) and `filetype` maps through the `DEFAULT_EXTENSIONS` table (`docbook` → `xml`, etc.). If `backend` is explicitly unset, the whole family resolves as absent rather than as empty traits.
- **The empty-valued flags** are synthesized by `synthesized_attr` for whatever backend / basebackend / filetype / doctype is currently active, generalizing the former `backend-html5-doctype-*`-only logic (the shared `DERIVED_DOCTYPE_ATTR` static is renamed `DERIVED_FAMILY_FLAG`).
- **Read-only protection**: the *active* flag is always write-protected because `synthesized_attr` resolves it to a locked intrinsic. Beyond that, only the names that could be shadowed by a mid-parse change are reserved against assignment (`is_reserved_derived_attr`): the bare `basebackend` / `filetype` values, and the doctype-keyed `backend-<b>-doctype-<d>` / `basebackend-<bb>-doctype-<d>` flags (whose active flag shifts when a table cell resets its doctype). Author-defined attributes that merely share a prefix — `:backend-custom:`, `:filetype-draft:`, `:doctype-wip:`, etc. — are **kept**, matching Asciidoctor, so they remain visible to `ifdef` / attribute references.

Because the family is synthesized from the live `backend` / `doctype`, nothing is materialized or kept in sync when those change — including inside AsciiDoc table cells, which reset their own doctype.

## Tests

- Flips `backend_and_doctype_attributes_are_set_by_default_in_default_configuration` and `backend_attributes_defined_in_document_options_overrides_backend_attribute_in_document` from `non_normative!` divergence notes to normative (`verifies!`), asserting the full expected attribute set.
- Adds unit coverage for the default family, a non-html backend (`docbook5` → `docbook` / `xml`, with the `html5` flags falling away), the read-only protection, custom-prefixed flags staying assignable, and an unset backend leaving the family absent.
- Updates the `ifdef with multiple attributes` documentation example: with the default `html5` backend, `backend-html5` is now set, so the OR case uses a different backend to demonstrate the "not included" branch.

`cargo test --workspace`, `cargo +nightly fmt --all -- --check`, and `cargo clippy --all-features --all-targets -- -Dwarnings` are all clean.

## Out of scope — tracked in #840

The `toc-position` / `toc-placement` / `toc-class` portion of #738 is **not** included here; it is split out into #840. Those remain resolved through the dedicated `Document::toc_*` accessors, and materializing them is entangled with the `TocMode` resolution (which itself reads `toc-placement` and distinguishes never-set from an unset tombstone) and the separate tracked divergences #748 / #749. `verify_toc_attribute_matrix` therefore stays as-is (its note and a `TODO(#840)` at `TocMode::from_parser` point at the follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgX9b39UN9Gmvd1nXtx5WZ