### PR TITLE
fix: Fold stacked block attribute lines above the document title (close #821)

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -112,7 +112,7 @@ impl<'src> Header<'src> {
             } else if title.is_none()
                 && line.starts_with('[')
                 && line.ends_with(']')
-                && document_title_marker(line_mi.after.take_normalized_line().item).is_some()
+                && document_title_follows_block_metadata(line_mi.after)
                 && let Some((metadata, metadata_warnings)) =
                     parse_document_metadata_attrlist(line, parser)
             {
@@ -128,9 +128,12 @@ impl<'src> Header<'src> {
                 // like assigning the `title-separator` document attribute here, so
                 // both mechanisms share the same partitioning logic.
                 //
-                // The line is only intercepted when a document title immediately
-                // follows; otherwise it is block metadata for the body (e.g. a
-                // table's `separator`) and is left for the block parser.
+                // The line is only intercepted when a document title eventually
+                // follows — possibly after further stacked block attribute lines,
+                // each folded on its own pass through this loop, mirroring
+                // Asciidoctor's `parse_block_metadata_lines`. Otherwise it is
+                // block metadata for the body (e.g. a table's `separator`) and is
+                // left for the block parser.
                 if let Some(doc_id) = metadata.id {
                     id = Some(doc_id);
                 }
@@ -144,9 +147,11 @@ impl<'src> Header<'src> {
                     // Fold the role(s) into the `role` document attribute
                     // (space-joined, as Asciidoctor stores `attributes['role']`)
                     // and also retain them on the header so `Document::roles()`
-                    // agrees with the document attribute (see #820).
-                    parser.set_attribute_by_value_from_header("role", metadata.roles.join(" "));
-                    roles = metadata.roles;
+                    // agrees with the document attribute (see #820). Roles from
+                    // separate stacked block attribute lines accumulate, just as
+                    // multiple roles within a single line combine (see #821).
+                    roles.extend(metadata.roles);
+                    parser.set_attribute_by_value_from_header("role", roles.join(" "));
                 }
                 for option in metadata.options {
                     parser.set_attribute_by_value_from_header(format!("{option}-option"), "");
@@ -377,6 +382,66 @@ fn document_title_marker(line: Span<'_>) -> Option<char> {
     }
 }
 
+/// Reports whether a document title marker eventually follows the source at
+/// `after`, allowing any number of stacked block attribute lines in between.
+///
+/// Starting immediately below the block attribute line under consideration,
+/// consecutive lines that are themselves document-metadata block attribute
+/// lines (see [`is_document_metadata_line`]) are skipped, and the first line
+/// that is not is tested for a document title marker. This generalizes the
+/// original single-line lookahead so that stacked metadata lines above the
+/// title are all folded, mirroring Asciidoctor's `parse_block_metadata_lines`.
+///
+/// A line that starts with `[` and ends with `]` but is *not* a valid
+/// document-metadata line (e.g. a `[[anchor]]` block anchor or a leading-space
+/// form) stops the scan without matching, so the run of foldable lines is only
+/// ever a contiguous prefix of well-formed metadata lines terminated by the
+/// title.
+fn document_title_follows_block_metadata(after: Span<'_>) -> bool {
+    let mut next = after;
+
+    while !next.is_empty() {
+        let line_mi = next.take_normalized_line();
+        let line = line_mi.item;
+
+        if document_title_marker(line).is_some() {
+            return true;
+        }
+
+        if !is_document_metadata_line(line) {
+            return false;
+        }
+
+        next = line_mi.after;
+    }
+
+    false
+}
+
+/// Reports whether `line` is a block attribute line that this crate folds into
+/// document metadata when it appears above the document title.
+///
+/// This captures the purely syntactic acceptance rules shared by the lookahead
+/// ([`document_title_follows_block_metadata`]) and the folding step
+/// ([`parse_document_metadata_attrlist`]): the line must be bracket-delimited
+/// and its contents must not be empty, must not begin with whitespace, and must
+/// not be a `[[anchor]]` block anchor. The legacy double-bracket anchor above
+/// the document title is left unsupported (it terminates the header, as before);
+/// the single-bracket `[#id]` shorthand is the supported way to set a document
+/// ID.
+fn is_document_metadata_line(line: Span<'_>) -> bool {
+    if !(line.starts_with('[') && line.ends_with(']')) {
+        return false;
+    }
+
+    let inner = line.slice(1..line.len() - 1);
+
+    !(inner.is_empty()
+        || inner.starts_with(' ')
+        || inner.starts_with('\t')
+        || (inner.starts_with('[') && inner.ends_with(']')))
+}
+
 /// Document metadata folded from a block attribute line appearing directly
 /// above the document title.
 ///
@@ -405,23 +470,16 @@ fn parse_document_metadata_attrlist<'src>(
     line: Span<'src>,
     parser: &Parser,
 ) -> Option<(DocumentMetadata, Vec<Warning<'src>>)> {
-    // Drop the enclosing square brackets now that the caller has confirmed they
-    // are present.
-    let inner = line.slice(1..line.len() - 1);
-
-    // Reject forms that are not block attribute lists, mirroring the checks used
-    // when parsing block metadata elsewhere: a leading space or tab, an empty
-    // list, or a `[[anchor]]` block anchor. The legacy double-bracket anchor
-    // above the document title is left unsupported (it terminates the header, as
-    // before); the single-bracket `[#id]` shorthand is the supported way to set
-    // a document ID.
-    if inner.is_empty()
-        || inner.starts_with(' ')
-        || inner.starts_with('\t')
-        || (inner.starts_with('[') && inner.ends_with(']'))
-    {
+    // Reject forms that are not block attribute lists (a leading space or tab,
+    // an empty list, or a `[[anchor]]` block anchor); see
+    // [`is_document_metadata_line`] for the shared acceptance rules. The caller
+    // has already confirmed the enclosing square brackets are present.
+    if !is_document_metadata_line(line) {
         return None;
     }
+
+    // Drop the enclosing square brackets.
+    let inner = line.slice(1..line.len() - 1);
 
     let MatchAndWarnings {
         item: MatchedItem {
@@ -1222,6 +1280,69 @@ mod tests {
         // The longhand `[id=…]` form is equivalent.
         let doc = Parser::default().parse("[id=docid]\n= Document Title");
         assert_eq!(doc.header().id(), Some("docid"));
+    }
+
+    #[test]
+    fn stacked_block_attributes_above_title() {
+        // Multiple block attribute lines may stack above the document title;
+        // each folds into the document's metadata and the title is still
+        // recovered (see #821). Here an `[#id]` line and a `[reftext="…"]` line
+        // both sit above the title.
+        let doc = Parser::default()
+            .parse("[#docid]\n[reftext=\"Links and Stuff\"]\n= Links & Stuff\n\nBody.");
+        let header = doc.header();
+
+        assert_eq!(header.title(), Some("Links &amp; Stuff"));
+        assert_eq!(header.id(), Some("docid"));
+        assert_eq!(doc.id(), Some("docid"));
+        assert_eq!(
+            doc.attribute_value("reftext"),
+            InterpretedValue::Value("Links and Stuff")
+        );
+        assert_eq!(rendered_paragraphs(&doc), vec!["Body."]);
+    }
+
+    #[test]
+    fn stacked_block_attributes_combine_roles() {
+        // Roles from stacked block attribute lines all fold into the document's
+        // `role` attribute (space-joined) and are surfaced through the block
+        // API, alongside an ID set on a separate line.
+        let doc = Parser::default().parse("[#docid]\n[.one]\n[.two]\n= Document Title");
+        let header = doc.header();
+
+        assert_eq!(header.title(), Some("Document Title"));
+        assert_eq!(header.id(), Some("docid"));
+        assert_eq!(
+            doc.attribute_value("role"),
+            InterpretedValue::Value("one two")
+        );
+        assert_eq!(header.roles(), vec!["one", "two"]);
+    }
+
+    #[test]
+    fn stacked_block_attributes_require_a_following_title() {
+        // Stacked block attribute lines are only folded when a document title
+        // eventually follows. Without one, the run is left for the block parser
+        // and no title is recognized.
+        let doc = Parser::default().parse("[#docid]\n[reftext=\"Stuff\"]\n\nBody.");
+        let header = doc.header();
+
+        assert_eq!(header.title(), None);
+        assert_eq!(header.id(), None);
+        assert_eq!(doc.attribute_value("reftext"), InterpretedValue::Unset);
+    }
+
+    #[test]
+    fn stacked_block_attributes_stop_at_a_block_anchor() {
+        // A `[[anchor]]` line breaks the run of foldable metadata lines: the
+        // scan stops there without seeing the title, so nothing above it is
+        // folded and the header terminates (matching the single-line anchor
+        // rejection).
+        let doc = Parser::default().parse("[#docid]\n[[anchor]]\n= Some Title");
+        let header = doc.header();
+
+        assert_eq!(header.title(), None);
+        assert_eq!(header.id(), None);
     }
 
     #[test]

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -426,9 +426,9 @@ fn document_title_follows_block_metadata(after: Span<'_>) -> bool {
 /// ([`parse_document_metadata_attrlist`]): the line must be bracket-delimited
 /// and its contents must not be empty, must not begin with whitespace, and must
 /// not be a `[[anchor]]` block anchor. The legacy double-bracket anchor above
-/// the document title is left unsupported (it terminates the header, as before);
-/// the single-bracket `[#id]` shorthand is the supported way to set a document
-/// ID.
+/// the document title is left unsupported (it terminates the header, as
+/// before); the single-bracket `[#id]` shorthand is the supported way to set a
+/// document ID.
 fn is_document_metadata_line(line: Span<'_>) -> bool {
     if !(line.starts_with('[') && line.ends_with(']')) {
         return false;


### PR DESCRIPTION
Fixes #821.

## Problem

Following #814, `Header::parse` folds a block attribute line directly above the document title into document metadata (`id`, `reftext`, `role`, options, `separator`). But the intercept only fired when a document title marker was the *immediately* following line, so it handled **one** such line. Stacked block attribute lines were not folded:

```asciidoc
[#docid]
[reftext="Links and Stuff"]
= Links & Stuff
```

Here `[#docid]` sees `[reftext="…"]` — not a title marker — as its next line, so the intercept did not fire; parsing fell through to the branch that terminates the header, and the title was lost. Asciidoctor's `parse_block_metadata_lines` accumulates multiple block-metadata lines above the doctitle and folds them all.

## Fix

Generalize the single-line lookahead so the intercept fires when a document title *eventually* follows, allowing any number of stacked block attribute lines in between:

* New `document_title_follows_block_metadata` scans forward over consecutive well-formed metadata lines and reports whether a title marker follows the run.
* The purely-syntactic acceptance rules (bracket-delimited; not empty, leading-space, or a `[[anchor]]` block anchor) are extracted into `is_document_metadata_line`, shared by the lookahead and the existing `parse_document_metadata_attrlist` folding step, so the `[[anchor]]` / leading-space rejections and the "title must eventually follow" guard are preserved.
* Each metadata line then folds on its own pass through the header loop, as before. Roles from separate stacked lines now **accumulate** into the `role` document attribute (space-joined), matching how multiple roles within a single line (`[.one.two]`) already combine.

A `[[anchor]]` (or other non-metadata) line breaks the run: the scan stops there without seeing the title, so nothing above it is folded and the header terminates — matching the prior single-line anchor rejection.

## Tests

Added coverage in `parser/src/document/header.rs`:

* `stacked_block_attributes_above_title` — the issue's `[#docid]` + `[reftext="…"]` case; title recovered, both values folded.
* `stacked_block_attributes_combine_roles` — roles across `[.one]` / `[.two]` lines accumulate alongside an ID.
* `stacked_block_attributes_require_a_following_title` — no title ⇒ nothing folded.
* `stacked_block_attributes_stop_at_a_block_anchor` — an intervening `[[anchor]]` stops the run and terminates the header.

Full suite (4179 tests) and `cargo clippy --all-targets` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5NToooxpZfD4Np9nuq1Au

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5NToooxpZfD4Np9nuq1Au)_