### PR TITLE
fix: Emit auto-generated section id only on the heading, not the wrapper (close #734)

### DIFF
--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -1168,9 +1168,9 @@ mod assignment {
             .with_intrinsic_attribute_bool("sectids", false, ModificationContext::Anywhere)
             .parse(":sectids:\n\n== Heading");
         assert!(doc.is_attribute_set("sectids"));
-        // The generated section id lands on the heading `h2` (this crate also
-        // mirrors it onto the section wrapper, so a bare `#_heading` matches
-        // twice — the heading anchor is the meaningful target here).
+        // The generated section id lands on the heading `h2` only, not on the
+        // section wrapper `div`, so a bare `#_heading` matches exactly once.
+        assert_css(&doc, "#_heading", 1);
         assert_css(&doc, "h2#_heading", 1);
     }
 

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -1327,9 +1327,9 @@ fn section_to_node<'a>(section: &'a SectionBlock<'a>) -> VirtualNode {
         node = node.with_class(role);
     }
 
-    if let Some(id) = section.id() {
-        node = node.with_id(id);
-    }
+    // The section id lands on the heading (`<h2>`) only, not on this wrapper
+    // `<div>`, matching Asciidoctor's HTML5 converter. The heading id is added
+    // in the `Block::Section` match arm.
 
     // TODO: Section title heading is added in the Block::Section match arm
     // using section.level() to determine the heading level (h2-h6) and


### PR DESCRIPTION
## Summary

Fixes #734.

Asciidoctor's HTML5 converter places a section's generated id on the heading element (`<h2 id="_heading">`) **only**. This crate's virtual-DOM builder mirrored the id onto the section wrapper `<div class="sect1">` as well, so an `#_heading` selector matched two elements instead of one.

## Change

- In `section_to_node` (`parser/src/tests/assert_dom/virtual_dom.rs`), stop applying the id to the section wrapper `<div>`. The heading id continues to be applied in the `Block::Section` match arm, so `<h2 id="...">` is unaffected. Roles/classes on the wrapper are untouched.
- Update the divergence note in `can_soft_unset_built_in_attribute_from_api_and_still_override_in_document` (`parser/src/tests/asciidoctor_rb/attributes_test.rs`) to assert a bare `#_heading` now matches exactly once, matching the upstream Asciidoctor assertion (`assert_css '#_heading', ..., 1`).

## Testing

- `cargo test -p asciidoc-parser` — all 4175 tests pass (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wz73FGiySUT8fNXSwE1EPx)_