### PR TITLE
fix: Mask docdir and relativize docfile under SERVER safe mode (close #735)

### DIFF
--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -1756,6 +1756,37 @@ mod tests {
         }
 
         #[test]
+        fn matches_parser_state_for_masked_docdir_and_docfile() {
+            // Under `SafeMode::Server` the `Document` snapshot must report the
+            // same masked `docdir` / `docfile` the parser does, so the host path
+            // never leaks through the public `Document::attribute_value` (#735).
+            let mut parser = Parser::default()
+                .with_safe_mode(SafeMode::Server)
+                .with_intrinsic_attribute("docdir", "/some/dir", ModificationContext::ApiOnly)
+                .with_intrinsic_attribute(
+                    "docfile",
+                    "/some/dir/sample.adoc",
+                    ModificationContext::ApiOnly,
+                );
+            let doc = parser.parse("Body.");
+
+            for name in ["docdir", "docfile"] {
+                assert_eq!(doc.attribute_value(name), parser.attribute_value(name));
+                assert_eq!(doc.has_attribute(name), parser.has_attribute(name));
+                assert_eq!(doc.is_attribute_set(name), parser.is_attribute_set(name));
+            }
+
+            assert_eq!(
+                doc.attribute_value("docdir"),
+                InterpretedValue::Value(String::new())
+            );
+            assert_eq!(
+                doc.attribute_value("docfile"),
+                InterpretedValue::Value("sample.adoc".to_string())
+            );
+        }
+
+        #[test]
         fn counter_value() {
             // A counter's current value is part of the resolved attribute state
             // and supersedes any like-named attribute.

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -20,6 +20,7 @@ use crate::{
         },
         is_datetime_attribute,
         preprocessor::preprocess,
+        safe_mode::masked_doc_path,
     },
     warnings::{Warning, WarningType},
 };
@@ -609,6 +610,20 @@ impl Parser {
             return self.attribute_value("outfilesuffix");
         }
 
+        // Under `SafeMode::Server` or greater, `docdir` reads as empty and
+        // `docfile` is relativized (its `docdir` prefix stripped), matching
+        // Ruby Asciidoctor's document-init masking. Resolved here at read time
+        // (like `relfilesuffix` above and `max-attribute-value-size`) so the
+        // API-provided values are never rewritten and builder-call order does
+        // not matter (see [`masked_doc_path`]).
+        //
+        // [`masked_doc_path`]: crate::parser::safe_mode::masked_doc_path
+        if self.safe >= SafeMode::Server
+            && let Some(masked) = masked_doc_path(name, |n| self.raw_set_value(n))
+        {
+            return masked;
+        }
+
         match self.effective_attribute(name) {
             Some(av) => {
                 if let InterpretedValue::Set = av.value
@@ -624,6 +639,22 @@ impl Parser {
             None => self
                 .resolve_datetime_attribute(name)
                 .unwrap_or(InterpretedValue::Unset),
+        }
+    }
+
+    /// Returns the raw stored string value of `name` if it currently resolves
+    /// to a plain [`Value`](InterpretedValue::Value), *before* any
+    /// safe-mode masking is applied. Returns `None` when the attribute is unset
+    /// or resolves to a non-value form.
+    ///
+    /// This feeds
+    /// [`masked_doc_path`](crate::parser::safe_mode::masked_doc_path),
+    /// which must compute the `docfile` relativization from the *original*
+    /// API-provided `docdir` rather than its masked (blanked) form.
+    fn raw_set_value(&self, name: &str) -> Option<String> {
+        match self.effective_attribute(name)?.value {
+            InterpretedValue::Value(ref v) => Some(v.clone()),
+            _ => None,
         }
     }
 
@@ -883,6 +914,7 @@ impl Parser {
             self.counter_values.borrow().clone(),
             self.reference_time.clone(),
             self.input_mtime.clone(),
+            self.safe,
         )
     }
 
@@ -2340,6 +2372,97 @@ mod tests {
         assert!(p.is_attribute_set("foo"));
         assert!(!p.is_attribute_set("foo2"));
         assert!(!p.is_attribute_set("xyz"));
+    }
+
+    // Under `SafeMode::Server` or greater, `docdir` reads as empty and
+    // `docfile` is relativized against `docdir`; see #735 and the ported
+    // upstream tests in `tests/asciidoctor_rb/attributes_test.rs`. These cover
+    // crate-specific edge cases not exercised by the single upstream test.
+    #[test]
+    fn masks_docdir_and_docfile_under_secure_mode() {
+        // Secure (the default) is stricter than Server, so masking also applies.
+        let p = Parser::default()
+            .with_intrinsic_attribute("docdir", "/some/dir", ModificationContext::ApiOnly)
+            .with_intrinsic_attribute(
+                "docfile",
+                "/some/dir/sample.adoc",
+                ModificationContext::ApiOnly,
+            );
+        assert_eq!(p.safe_mode(), SafeMode::Secure);
+        assert_eq!(p.attribute_value("docdir"), InterpretedValue::Value(""));
+        assert_eq!(
+            p.attribute_value("docfile"),
+            InterpretedValue::Value("sample.adoc")
+        );
+        // The masked `docdir` is still a *set* (present) attribute.
+        assert!(p.is_attribute_set("docdir"));
+        assert!(p.has_attribute("docfile"));
+    }
+
+    #[test]
+    fn relativizes_docfile_in_a_subdirectory_of_docdir() {
+        // A `docfile` nested below `docdir` keeps its sub-path relative to
+        // `docdir` (not merely its base name), matching Asciidoctor's
+        // `docfile[(docdir.length + 1)..-1]` slice.
+        let p = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_intrinsic_attribute("docdir", "/some/dir", ModificationContext::ApiOnly)
+            .with_intrinsic_attribute(
+                "docfile",
+                "/some/dir/sub/sample.adoc",
+                ModificationContext::ApiOnly,
+            );
+        assert_eq!(
+            p.attribute_value("docfile"),
+            InterpretedValue::Value("sub/sample.adoc")
+        );
+    }
+
+    #[test]
+    fn docfile_without_docdir_falls_back_to_basename_under_server_mode() {
+        let p = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_intrinsic_attribute(
+                "docfile",
+                "/some/dir/sample.adoc",
+                ModificationContext::ApiOnly,
+            );
+        assert_eq!(
+            p.attribute_value("docfile"),
+            InterpretedValue::Value("sample.adoc")
+        );
+    }
+
+    #[test]
+    fn does_not_mask_docdir_and_docfile_below_server_mode() {
+        // Below Server, the API-provided values pass through verbatim.
+        let p = Parser::default()
+            .with_safe_mode(SafeMode::Safe)
+            .with_intrinsic_attribute("docdir", "/some/dir", ModificationContext::ApiOnly)
+            .with_intrinsic_attribute(
+                "docfile",
+                "/some/dir/sample.adoc",
+                ModificationContext::ApiOnly,
+            );
+        assert_eq!(
+            p.attribute_value("docdir"),
+            InterpretedValue::Value("/some/dir")
+        );
+        assert_eq!(
+            p.attribute_value("docfile"),
+            InterpretedValue::Value("/some/dir/sample.adoc")
+        );
+    }
+
+    #[test]
+    fn unset_docdir_and_docfile_stay_missing_under_server_mode() {
+        // Masking never conjures a value for an attribute that was never set, so
+        // a reference to an unset `docdir` / `docfile` still resolves as missing.
+        let p = Parser::default().with_safe_mode(SafeMode::Server);
+        assert_eq!(p.attribute_value("docdir"), InterpretedValue::Unset);
+        assert_eq!(p.attribute_value("docfile"), InterpretedValue::Unset);
+        assert!(!p.has_attribute("docdir"));
+        assert!(!p.has_attribute("docfile"));
     }
 
     #[test]

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -654,10 +654,9 @@ impl Parser {
     /// safe-mode masking is applied. Returns `None` when the attribute is unset
     /// or resolves to a non-value form.
     ///
-    /// This feeds
-    /// [`masked_doc_path`](crate::parser::safe_mode::masked_doc_path),
-    /// which must compute the `docfile` relativization from the *original*
-    /// API-provided `docdir` rather than its masked (blanked) form.
+    /// This feeds [`masked_doc_path`], which must compute the `docfile`
+    /// relativization from the *original* API-provided `docdir` rather than its
+    /// masked (blanked) form.
     fn raw_set_value(&self, name: &str) -> Option<String> {
         match self.effective_attribute(name)?.value {
             InterpretedValue::Value(ref v) => Some(v.clone()),

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2448,6 +2448,25 @@ mod tests {
     }
 
     #[test]
+    fn relativizes_docfile_not_under_docdir_to_its_basename() {
+        // An inconsistent `docdir` / `docfile` pairing (docfile not under
+        // docdir) must not be truncated at an unrelated byte offset; it
+        // relativizes to the base name instead (see #735 review feedback).
+        let p = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_intrinsic_attribute("docdir", "/some/dir", ModificationContext::ApiOnly)
+            .with_intrinsic_attribute(
+                "docfile",
+                "/some/different/file.adoc",
+                ModificationContext::ApiOnly,
+            );
+        assert_eq!(
+            p.attribute_value("docfile"),
+            InterpretedValue::Value("file.adoc")
+        );
+    }
+
+    #[test]
     fn docfile_without_docdir_falls_back_to_basename_under_server_mode() {
         let p = Parser::default()
             .with_safe_mode(SafeMode::Server)

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2466,6 +2466,19 @@ mod tests {
     }
 
     #[test]
+    fn leaves_non_string_docdir_and_docfile_untouched_under_server_mode() {
+        // A `docdir` / `docfile` present as a boolean flag (not a path string)
+        // carries no host path to leak, so the masking has nothing to blank or
+        // relativize and leaves the (empty) `Set` value as-is.
+        let p = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_intrinsic_attribute_bool("docdir", true, ModificationContext::ApiOnly)
+            .with_intrinsic_attribute_bool("docfile", true, ModificationContext::ApiOnly);
+        assert_eq!(p.attribute_value("docdir"), InterpretedValue::Set);
+        assert_eq!(p.attribute_value("docfile"), InterpretedValue::Set);
+    }
+
+    #[test]
     fn with_intrinsic_attribute_set() {
         let p = Parser::default().with_intrinsic_attribute_bool(
             "foo",

--- a/parser/src/parser/resolved_attributes.rs
+++ b/parser/src/parser/resolved_attributes.rs
@@ -410,6 +410,28 @@ mod tests {
     }
 
     #[test]
+    fn leaves_non_string_docdir_and_docfile_untouched_under_server_safe_mode() {
+        // A `docdir` / `docfile` present as a value-less `Set` flag carries no
+        // path to relativize, so the masking leaves it untouched (mirroring
+        // `Parser`).
+        let mut attribute_values: HashMap<String, AttributeValue> = HashMap::new();
+        attribute_values.insert("docdir".to_string(), attr(InterpretedValue::Set));
+        attribute_values.insert("docfile".to_string(), attr(InterpretedValue::Set));
+
+        let attrs = ResolvedAttributes::new(
+            Arc::new(attribute_values),
+            Arc::new(HashMap::new()),
+            HashMap::new(),
+            None,
+            None,
+            SafeMode::Server,
+        );
+
+        assert_eq!(attrs.attribute_value("docdir"), InterpretedValue::Set);
+        assert_eq!(attrs.attribute_value("docfile"), InterpretedValue::Set);
+    }
+
+    #[test]
     fn does_not_mask_docdir_and_docfile_below_server_safe_mode() {
         let mut attribute_values: HashMap<String, AttributeValue> = HashMap::new();
         attribute_values.insert(

--- a/parser/src/parser/resolved_attributes.rs
+++ b/parser/src/parser/resolved_attributes.rs
@@ -3,9 +3,10 @@ use std::{collections::HashMap, sync::Arc};
 use crate::{
     document::InterpretedValue,
     parser::{
-        AttributeValue, DatetimeContext, DatetimeInputs, ReferenceTime,
+        AttributeValue, DatetimeContext, DatetimeInputs, ReferenceTime, SafeMode,
         built_in_attrs::{built_in_attr, synthesized_attr},
         is_datetime_attribute,
+        safe_mode::masked_doc_path,
     },
 };
 
@@ -47,6 +48,13 @@ pub(crate) struct ResolvedAttributes {
     /// costs only a pointer here — this snapshot is embedded in a
     /// size-sensitive cell enum.
     datetime_inputs: Option<Box<DatetimeInputs>>,
+
+    /// The safe mode the parser ran under, so a snapshot read applies the same
+    /// `SafeMode::Server`-and-greater masking of `docdir` / `docfile` the
+    /// parser does (see [`masked_doc_path`]). Without it,
+    /// `Document::attribute_value` would leak the unmasked host path that
+    /// the parser hides.
+    safe: SafeMode,
 }
 
 impl ResolvedAttributes {
@@ -56,12 +64,14 @@ impl ResolvedAttributes {
         counter_values: HashMap<String, String>,
         reference_time: Option<ReferenceTime>,
         input_mtime: Option<ReferenceTime>,
+        safe: SafeMode,
     ) -> Self {
         Self {
             attribute_values,
             default_attribute_values,
             counter_values,
             datetime_inputs: DatetimeInputs::new(reference_time, input_mtime),
+            safe,
         }
     }
 
@@ -83,6 +93,15 @@ impl ResolvedAttributes {
         // [`tracks_outfilesuffix`](Self::tracks_outfilesuffix)).
         if self.tracks_outfilesuffix(name) {
             return self.attribute_value("outfilesuffix");
+        }
+
+        // Under `SafeMode::Server` or greater, `docdir` reads as empty and
+        // `docfile` is relativized, exactly as the parser reports it (see
+        // [`masked_doc_path`]).
+        if self.safe >= SafeMode::Server
+            && let Some(masked) = masked_doc_path(name, |n| self.raw_set_value(n))
+        {
+            return masked;
         }
 
         match self.effective_attribute(name) {
@@ -170,6 +189,17 @@ impl ResolvedAttributes {
             })
     }
 
+    /// Returns the raw stored string value of `name` if it currently resolves
+    /// to a plain [`Value`](InterpretedValue::Value), *before* any safe-mode
+    /// masking is applied. Mirrors `Parser::raw_set_value`, so the `docfile`
+    /// relativization is computed from the *original* API-provided `docdir`.
+    fn raw_set_value(&self, name: &str) -> Option<String> {
+        match self.effective_attribute(name)?.value {
+            InterpretedValue::Value(ref v) => Some(v.clone()),
+            _ => None,
+        }
+    }
+
     /// Returns the effective attribute definition for `name`, falling back to
     /// the shared built-in defaults (and the synthesized derived doctype
     /// attribute) exactly as [`Parser::effective_attribute`] does.
@@ -242,7 +272,9 @@ mod tests {
 
     use crate::{
         document::InterpretedValue,
-        parser::{AllowableValue, AttributeValue, ModificationContext, ResolvedAttributes},
+        parser::{
+            AllowableValue, AttributeValue, ModificationContext, ResolvedAttributes, SafeMode,
+        },
     };
 
     fn attr(value: InterpretedValue) -> AttributeValue {
@@ -285,6 +317,7 @@ mod tests {
             counter_values,
             None,
             None,
+            SafeMode::Secure,
         )
     }
 
@@ -337,6 +370,66 @@ mod tests {
         assert!(attrs.has_attribute("unset"));
         assert!(attrs.has_attribute("count"));
         assert!(!attrs.has_attribute("absent"));
+    }
+
+    #[test]
+    fn masks_docdir_and_docfile_under_server_safe_mode() {
+        // A snapshot taken from a `SafeMode::Server` parser masks `docdir`
+        // (blanked) and `docfile` (relativized) exactly as the parser does, so
+        // `Document::attribute_value` never leaks the host path.
+        let mut attribute_values: HashMap<String, AttributeValue> = HashMap::new();
+        attribute_values.insert(
+            "docdir".to_string(),
+            attr(InterpretedValue::Value("/some/dir".to_string())),
+        );
+        attribute_values.insert(
+            "docfile".to_string(),
+            attr(InterpretedValue::Value("/some/dir/sample.adoc".to_string())),
+        );
+
+        let attrs = ResolvedAttributes::new(
+            Arc::new(attribute_values),
+            Arc::new(HashMap::new()),
+            HashMap::new(),
+            None,
+            None,
+            SafeMode::Server,
+        );
+
+        assert_eq!(
+            attrs.attribute_value("docdir"),
+            InterpretedValue::Value(String::new())
+        );
+        assert_eq!(
+            attrs.attribute_value("docfile"),
+            InterpretedValue::Value("sample.adoc".to_string())
+        );
+        // Masking changes only the value; the attributes stay present and set.
+        assert!(attrs.has_attribute("docdir"));
+        assert!(attrs.is_attribute_set("docfile"));
+    }
+
+    #[test]
+    fn does_not_mask_docdir_and_docfile_below_server_safe_mode() {
+        let mut attribute_values: HashMap<String, AttributeValue> = HashMap::new();
+        attribute_values.insert(
+            "docdir".to_string(),
+            attr(InterpretedValue::Value("/some/dir".to_string())),
+        );
+
+        let attrs = ResolvedAttributes::new(
+            Arc::new(attribute_values),
+            Arc::new(HashMap::new()),
+            HashMap::new(),
+            None,
+            None,
+            SafeMode::Safe,
+        );
+
+        assert_eq!(
+            attrs.attribute_value("docdir"),
+            InterpretedValue::Value("/some/dir".to_string())
+        );
     }
 
     #[test]

--- a/parser/src/parser/resolved_attributes.rs
+++ b/parser/src/parser/resolved_attributes.rs
@@ -428,6 +428,26 @@ mod tests {
     }
 
     #[test]
+    fn absent_docdir_and_docfile_stay_missing_under_server_safe_mode() {
+        // With no `docdir` / `docfile` stored, the masking finds nothing to mask
+        // (`raw_set_value` short-circuits on the absent attribute) and they stay
+        // missing — mirroring the parser.
+        let attrs = ResolvedAttributes::new(
+            Arc::new(HashMap::new()),
+            Arc::new(HashMap::new()),
+            HashMap::new(),
+            None,
+            None,
+            SafeMode::Server,
+        );
+
+        assert_eq!(attrs.attribute_value("docdir"), InterpretedValue::Unset);
+        assert_eq!(attrs.attribute_value("docfile"), InterpretedValue::Unset);
+        assert!(!attrs.has_attribute("docdir"));
+        assert!(!attrs.has_attribute("docfile"));
+    }
+
+    #[test]
     fn leaves_non_string_docdir_and_docfile_untouched_under_server_safe_mode() {
         // A `docdir` / `docfile` present as a value-less `Set` flag carries no
         // path to relativize, so the masking leaves it untouched (mirroring

--- a/parser/src/parser/safe_mode.rs
+++ b/parser/src/parser/safe_mode.rs
@@ -1,3 +1,5 @@
+use crate::document::InterpretedValue;
+
 /// Describes the safe mode under which a document is parsed and rendered.
 ///
 /// Safe modes provide a security model that controls how much a document is
@@ -69,5 +71,61 @@ impl SafeMode {
     /// attribute. Higher numbers indicate a more restrictive (safer) mode.
     pub(crate) fn level(self) -> u8 {
         self as u8
+    }
+}
+
+/// Applies Ruby Asciidoctor's `SafeMode::Server`-and-greater masking of the
+/// `docdir` / `docfile` intrinsic attributes for a *read*.
+///
+/// Returns `Some(masked)` only when `name` is `docdir` or `docfile` and that
+/// attribute is currently set to a plain value (as reported by `raw_set_value`,
+/// which yields the *unmasked* stored value or `None` when the attribute is
+/// unset):
+///
+/// * `docdir` is masked to an empty value, so the host directory never leaks
+///   into rendered output.
+/// * `docfile` is relativized by stripping its `docdir` prefix and the
+///   following separator (`docfile[(docdir.length + 1)..]`), matching
+///   Asciidoctor. When no `docdir` is available to strip against, it falls back
+///   to the file's base name.
+///
+/// Returns `None` for any other name, and for an *unset* `docdir` / `docfile`
+/// (so a reference to one still resolves as missing rather than empty). Because
+/// the computation reads the *raw* stored values, the API-provided attributes
+/// are left untouched — a non-`Server` parser still reads them back verbatim.
+///
+/// Both [`Parser`](crate::Parser) and its
+/// [`ResolvedAttributes`](crate::parser::ResolvedAttributes) snapshot funnel
+/// their `docdir` / `docfile` reads through this one function (after confirming
+/// `safe >= SafeMode::Server`), so the two report identical values.
+pub(crate) fn masked_doc_path(
+    name: &str,
+    raw_set_value: impl Fn(&str) -> Option<String>,
+) -> Option<InterpretedValue> {
+    match name {
+        // `docdir` is blanked whenever it is set, regardless of its value.
+        "docdir" => raw_set_value("docdir").map(|_| InterpretedValue::Value(String::new())),
+
+        "docfile" => {
+            let docfile = raw_set_value("docfile")?;
+            let relative = match raw_set_value("docdir") {
+                // Strip the `docdir` prefix plus its trailing separator, matching
+                // Asciidoctor's `docfile[(docdir.length + 1)..-1]`. `get` keeps
+                // this panic-safe for any out-of-range or non-boundary index (a
+                // `docfile` not actually under `docdir`), yielding an empty
+                // relative path in that case.
+                Some(docdir) => docfile.get(docdir.len() + 1..).unwrap_or("").to_owned(),
+                // No `docdir` to relativize against: fall back to the base name
+                // (the trailing path segment).
+                None => docfile
+                    .rsplit(['/', '\\'])
+                    .next()
+                    .unwrap_or(&docfile)
+                    .to_owned(),
+            };
+            Some(InterpretedValue::Value(relative))
+        }
+
+        _ => None,
     }
 }

--- a/parser/src/parser/safe_mode.rs
+++ b/parser/src/parser/safe_mode.rs
@@ -124,6 +124,10 @@ pub(crate) fn masked_doc_path(
 /// (which keeps any intermediate sub-directories, not just the base name). This
 /// is the normal case, since Asciidoctor derives `docdir` from `docfile`.
 ///
+/// A trailing separator on `docdir` (e.g. `/some/dir/`) is ignored so the match
+/// still lands on a path-component boundary and nested components are
+/// preserved.
+///
 /// Unlike Asciidoctor, this crate exposes `docdir` and `docfile` as independent
 /// API attributes, so a caller can pair them inconsistently. Rather than slice
 /// at an unrelated byte offset (truncating the path, or dropping the first byte
@@ -131,7 +135,12 @@ pub(crate) fn masked_doc_path(
 /// actual prefix falls back to the file's base name (its trailing path
 /// segment).
 fn relativize_docfile(docfile: &str, docdir: Option<&str>) -> String {
-    if let Some(docdir) = docdir.filter(|d| !d.is_empty())
+    // Normalize away any trailing separator(s) on `docdir` so a directory
+    // written as `/some/dir/` matches at the same component boundary as
+    // `/some/dir`; without this the relative remainder loses its leading
+    // separator and nested components would collapse to the base name.
+    if let Some(docdir) = docdir.map(|d| d.trim_end_matches(['/', '\\']))
+        && !docdir.is_empty()
         && let Some(rest) = docfile.strip_prefix(docdir)
         && let Some(after) = rest.strip_prefix(['/', '\\'])
     {
@@ -191,6 +200,29 @@ mod tests {
         assert_eq!(
             relativize_docfile("/some/dirfile.adoc", Some("/some/dir")),
             "dirfile.adoc"
+        );
+    }
+
+    #[test]
+    fn ignores_a_trailing_separator_on_docdir() {
+        // A `docdir` written with a trailing separator still relativizes to the
+        // same component boundary, preserving nested path components.
+        assert_eq!(
+            relativize_docfile("/some/dir/sub/sample.adoc", Some("/some/dir/")),
+            "sub/sample.adoc"
+        );
+        assert_eq!(
+            relativize_docfile("/some/dir/sample.adoc", Some("/some/dir/")),
+            "sample.adoc"
+        );
+        // Multiple trailing separators, and the Windows separator, too.
+        assert_eq!(
+            relativize_docfile("/some/dir/sub/sample.adoc", Some("/some/dir///")),
+            "sub/sample.adoc"
+        );
+        assert_eq!(
+            relativize_docfile(r"C:\some\dir\sub\sample.adoc", Some(r"C:\some\dir\")),
+            r"sub\sample.adoc"
         );
     }
 

--- a/parser/src/parser/safe_mode.rs
+++ b/parser/src/parser/safe_mode.rs
@@ -84,10 +84,10 @@ impl SafeMode {
 ///
 /// * `docdir` is masked to an empty value, so the host directory never leaks
 ///   into rendered output.
-/// * `docfile` is relativized by stripping its `docdir` prefix and the
-///   following separator (`docfile[(docdir.length + 1)..]`), matching
-///   Asciidoctor. When no `docdir` is available to strip against, it falls back
-///   to the file's base name.
+/// * `docfile` is relativized against `docdir` (see [`relativize_docfile`]),
+///   matching Asciidoctor's `docfile[(docdir.length + 1)..]` for the usual case
+///   where `docfile` sits under `docdir`, and falling back to the base name
+///   otherwise.
 ///
 /// Returns `None` for any other name, and for an *unset* `docdir` / `docfile`
 /// (so a reference to one still resolves as missing rather than empty). Because
@@ -108,24 +108,116 @@ pub(crate) fn masked_doc_path(
 
         "docfile" => {
             let docfile = raw_set_value("docfile")?;
-            let relative = match raw_set_value("docdir") {
-                // Strip the `docdir` prefix plus its trailing separator, matching
-                // Asciidoctor's `docfile[(docdir.length + 1)..-1]`. `get` keeps
-                // this panic-safe for any out-of-range or non-boundary index (a
-                // `docfile` not actually under `docdir`), yielding an empty
-                // relative path in that case.
-                Some(docdir) => docfile.get(docdir.len() + 1..).unwrap_or("").to_owned(),
-                // No `docdir` to relativize against: fall back to the base name
-                // (the trailing path segment).
-                None => docfile
-                    .rsplit(['/', '\\'])
-                    .next()
-                    .unwrap_or(&docfile)
-                    .to_owned(),
-            };
+            let relative = relativize_docfile(&docfile, raw_set_value("docdir").as_deref());
             Some(InterpretedValue::Value(relative))
         }
 
         _ => None,
+    }
+}
+
+/// Relativizes `docfile` against `docdir` for `SafeMode::Server` masking.
+///
+/// When `docfile` sits directly under `docdir` — i.e. it begins with the exact
+/// `docdir` prefix followed by a path separator — the prefix and separator are
+/// stripped, matching Ruby Asciidoctor's `docfile[(docdir.length + 1)..-1]`
+/// (which keeps any intermediate sub-directories, not just the base name). This
+/// is the normal case, since Asciidoctor derives `docdir` from `docfile`.
+///
+/// Unlike Asciidoctor, this crate exposes `docdir` and `docfile` as independent
+/// API attributes, so a caller can pair them inconsistently. Rather than slice
+/// at an unrelated byte offset (truncating the path, or dropping the first byte
+/// when `docdir` is empty), any `docdir` that is absent, empty, or not an
+/// actual prefix falls back to the file's base name (its trailing path
+/// segment).
+fn relativize_docfile(docfile: &str, docdir: Option<&str>) -> String {
+    if let Some(docdir) = docdir.filter(|d| !d.is_empty())
+        && let Some(rest) = docfile.strip_prefix(docdir)
+        && let Some(after) = rest.strip_prefix(['/', '\\'])
+    {
+        return after.to_owned();
+    }
+
+    // No usable `docdir` prefix: use the base name (trailing path segment).
+    docfile
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(docfile)
+        .to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::relativize_docfile;
+
+    #[test]
+    fn strips_exact_docdir_prefix() {
+        assert_eq!(
+            relativize_docfile("/some/dir/sample.adoc", Some("/some/dir")),
+            "sample.adoc"
+        );
+    }
+
+    #[test]
+    fn keeps_subdirectories_below_docdir() {
+        assert_eq!(
+            relativize_docfile("/some/dir/sub/sample.adoc", Some("/some/dir")),
+            "sub/sample.adoc"
+        );
+    }
+
+    #[test]
+    fn strips_a_backslash_separated_prefix() {
+        assert_eq!(
+            relativize_docfile(r"C:\some\dir\sample.adoc", Some(r"C:\some\dir")),
+            "sample.adoc"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_base_name_when_docfile_is_not_under_docdir() {
+        // A `docfile` outside `docdir` must not be truncated at an unrelated
+        // offset; it relativizes to its base name instead.
+        assert_eq!(
+            relativize_docfile("/some/different/file.adoc", Some("/some/dir")),
+            "file.adoc"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_base_name_when_prefix_is_not_separator_aligned() {
+        // `docdir` is a leading substring of `docfile` but not a path component
+        // (no separator follows), so the slice would corrupt the name.
+        assert_eq!(
+            relativize_docfile("/some/dirfile.adoc", Some("/some/dir")),
+            "dirfile.adoc"
+        );
+    }
+
+    #[test]
+    fn treats_empty_docdir_as_no_prefix() {
+        // An empty `docdir` must not drop the first byte of `docfile`.
+        assert_eq!(
+            relativize_docfile("/some/dir/sample.adoc", Some("")),
+            "sample.adoc"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_base_name_without_a_docdir() {
+        assert_eq!(
+            relativize_docfile("/some/dir/sample.adoc", None),
+            "sample.adoc"
+        );
+    }
+
+    #[test]
+    fn returns_a_bare_docfile_unchanged() {
+        // A `docfile` with no directory component is its own base name.
+        assert_eq!(relativize_docfile("sample.adoc", None), "sample.adoc");
+        assert_eq!(
+            relativize_docfile("sample.adoc", Some("/some/dir")),
+            "sample.adoc"
+        );
     }
 }

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -2398,10 +2398,9 @@ mod interpolation {
         assert_rendered_contains(&doc, "{foo}");
     }
 
-    // Tracked in #735.
     #[test]
     fn does_not_show_docdir_and_shows_relative_docfile_if_safe_mode_is_server_or_greater() {
-        non_normative!(
+        verifies!(
             r#"
     test 'does not show docdir and shows relative docfile if safe mode is SERVER or greater' do
       input = <<~'EOS'
@@ -2419,6 +2418,8 @@ mod interpolation {
 "#
         );
 
+        // Under `SafeMode::Server` or greater, `docdir` renders empty and
+        // `docfile` is relativized to strip its `docdir` prefix (see #735).
         let doc = Parser::default()
             .with_safe_mode(SafeMode::Server)
             .with_intrinsic_attribute("docdir", "/some/dir", ModificationContext::ApiOnly)
@@ -2428,15 +2429,9 @@ mod interpolation {
                 ModificationContext::ApiOnly,
             )
             .parse("* docdir: {docdir}\n* docfile: {docfile}");
-        // Divergence: this crate does not apply Asciidoctor's SERVER-safe-mode
-        // masking of `docdir` (blanked) and `docfile` (relativized); the
-        // API-provided values are substituted verbatim.
         assert_eq!(
             rendered_paragraphs(&doc),
-            vec![
-                "docdir: /some/dir".to_string(),
-                "docfile: /some/dir/sample.adoc".to_string(),
-            ]
+            vec!["docdir: ".to_string(), "docfile: sample.adoc".to_string(),]
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #735.

Under `SafeMode::Server` or greater, Ruby Asciidoctor blanks the `docdir` attribute and relativizes `docfile` (stripping its `docdir` prefix), so the host directory never leaks into rendered output:

```ruby
if @safe >= SafeMode::SERVER
  # restrict document from seeing the docdir and trim docfile to relative path
  if !parent_doc && (attr_overrides.key? 'docfile')
    attr_overrides['docfile'] = attr_overrides['docfile'][(attr_overrides['docdir'].length + 1)..-1]
  end
  attr_overrides['docdir'] = ''
```

This crate previously substituted the API-provided `docdir`/`docfile` values verbatim regardless of safe mode.

## Approach

- Added a shared `masked_doc_path` helper in `parser::safe_mode` that blanks `docdir` and relativizes `docfile` (`docfile[(docdir.len + 1)..]`, falling back to the base name when no `docdir` is available).
- Applied it at attribute **read** time — the same pattern already used for `relfilesuffix` and `max-attribute-value-size` — rather than mutating stored values at set time. This keeps the API-provided values intact and makes the result independent of builder-call order (`with_safe_mode` vs `with_intrinsic_attribute`).
- Both `Parser::attribute_value` and its `ResolvedAttributes` snapshot funnel their `docdir`/`docfile` reads through the one helper, so the public `Document::attribute_value` (the embed/`convert_document` path) reports the same masked value the parser does and can never leak the unmasked host path. `ResolvedAttributes` now carries the parser's `SafeMode`.

## Tests

- Promoted the ported upstream test `does_not_show_docdir_and_shows_relative_docfile_if_safe_mode_is_server_or_greater` from a `non_normative!` divergence to a passing `verifies!` test.
- Added crate-level coverage for: Secure mode (stricter than Server), a `docfile` nested in a sub-directory of `docdir` (keeps the sub-path, not just the base name), the `docfile`-without-`docdir` base-name fallback, unset attributes staying missing, snapshot masking, and `Document`/`Parser` parity.

Full suite passes (`cargo test`), `cargo clippy --all-targets` clean, formatting via nightly `rustfmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXkr1b3k7HArqPEzR4cnbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXkr1b3k7HArqPEzR4cnbQ)_