### PR TITLE
fix: Warn on an unterminated `////` comment block in the document header (close #731)

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -64,7 +64,7 @@ impl<'src> Header<'src> {
                 comments.push(line);
                 source = line_mi.after;
             } else if title.is_some()
-                && let Some(after) = skip_block_comment(line, line_mi.after)
+                && let Some((after, terminated)) = skip_block_comment(line, line_mi.after)
             {
                 // Once a title has been seen, a `////` block comment delimiter
                 // opens a comment block within the header. Skip every line
@@ -78,6 +78,20 @@ impl<'src> Header<'src> {
                 // context to protect, so a leading `////` is left for the block
                 // parser, which retains it as a body-level comment block.
                 comments.push(source.trim_remainder(after).trim_trailing_line_end());
+
+                // An unterminated comment block swallows the rest of the header
+                // (any following attribute entries are never applied), so warn
+                // as Asciidoctor does, anchoring the warning at the opening
+                // delimiter. This mirrors the body-level comment block path,
+                // which reports the same `UnterminatedDelimitedBlock` warning.
+                if !terminated {
+                    warnings.push(Warning {
+                        source: line,
+                        warning: WarningType::UnterminatedDelimitedBlock,
+                        origin: None,
+                    });
+                }
+
                 source = after;
             } else if line.starts_with(':')
                 && let Some(attr) = Attribute::parse(source, parser)
@@ -362,33 +376,37 @@ impl<'src> HasSpan<'src> for Header<'src> {
 }
 
 /// If `line` opens a `////` block comment, consume the comment block and
-/// return the source position immediately after its closing delimiter;
-/// otherwise return `None`.
+/// return the source position immediately after its closing delimiter together
+/// with a flag reporting whether a closing delimiter was found; otherwise
+/// return `None`.
 ///
 /// A block comment delimiter is a line of four or more forward slashes and
 /// nothing else, matching Asciidoctor's comment-block delimiter (a line of
 /// exactly three slashes instead terminates the header and is handled by the
 /// caller). The closing delimiter must repeat the opening line exactly; when
 /// it is absent the block runs to the end of the input, mirroring
-/// Asciidoctor's `read_lines_until`.
+/// Asciidoctor's `read_lines_until`, and the returned flag is `false` so the
+/// caller can warn that the comment block was never terminated.
 ///
 /// `after` is the source immediately following `line` (the opening delimiter).
-fn skip_block_comment<'src>(line: Span<'src>, after: Span<'src>) -> Option<Span<'src>> {
+fn skip_block_comment<'src>(line: Span<'src>, after: Span<'src>) -> Option<(Span<'src>, bool)> {
     let delimiter = line.data();
     if delimiter.len() < 4 || !delimiter.bytes().all(|b| b == b'/') {
         return None;
     }
 
     let mut next = after;
+    let mut terminated = false;
     while !next.is_empty() {
         let line_mi = next.take_normalized_line();
         next = line_mi.after;
         if line_mi.item.data() == delimiter {
+            terminated = true;
             break;
         }
     }
 
-    Some(next)
+    Some((next, terminated))
 }
 
 /// Returns the ATX marker character that introduces `line` as a document

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -2268,10 +2268,9 @@ mod interpolation {
         assert_rendered_contains(&doc, "2010-01-01 == 2010-01-01");
     }
 
-    // Tracked in #731.
     #[test]
     fn should_warn_if_unterminated_block_comment_is_detected_in_document_header() {
-        non_normative!(
+        verifies!(
             r#"
     test 'should warn if unterminated block comment is detected in document header' do
       input = <<~'EOS'
@@ -2293,11 +2292,19 @@ mod interpolation {
         // As in Asciidoctor, the unterminated `////` opens a comment block that
         // swallows the rest of the header, so `:hey: there` is never applied
         // (see https://github.com/asciidoc-rs/asciidoc-parser/issues/760).
-        // Remaining divergence: the `unterminated comment block` warning is not
-        // yet modeled (tracked in #731).
+        //
+        // The `unterminated comment block` warning is modeled as the crate's
+        // generic `UnterminatedDelimitedBlock`, anchored at the opening `////`
+        // delimiter (line 3), matching the body-level comment block path
+        // (see https://github.com/asciidoc-rs/asciidoc-parser/issues/731).
         let doc =
             Parser::default().parse("= Document Title\n:foo: bar\n////\n:hey: there\n\ncontent");
         assert_eq!(doc.attribute_value("hey"), InterpretedValue::Unset);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].warning, WarningType::UnterminatedDelimitedBlock);
+        assert_eq!(warnings[0].source.line(), 3);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #731.

An unterminated `////` comment block that appears after the document title opens a comment block that swallows the rest of the header — a following `:hey: there` is never applied — matching Asciidoctor. That swallowing behavior was already correct; the remaining divergence noted in #731 was that the parser did so **silently**, without the warning Asciidoctor emits.

The header now emits an `UnterminatedDelimitedBlock` warning anchored at the opening `////` delimiter when the comment block is never closed. This reuses the same generic warning the body-level comment block path already reports for Asciidoctor's `unterminated comment block` message (see `should_warn_if_unterminated_comment_block_is_detected_in_body`), keeping the two paths consistent.

## Changes

- `parser/src/document/header.rs`: `skip_block_comment` now returns a `(Span, terminated)` tuple; the header loop pushes an `UnterminatedDelimitedBlock` warning (anchored at the opening delimiter line) when a header comment block runs to end-of-input without a closing delimiter.
- `parser/src/tests/asciidoctor_rb/attributes_test.rs`: promoted `should_warn_if_unterminated_block_comment_is_detected_in_document_header` from a `non_normative!` divergence note to a `verifies!` test that asserts both the swallowed `:hey:` attribute and the newly-emitted warning at line 3.

## Testing

- `cargo test -p asciidoc-parser --lib` — 4219 passed, 0 failed
- `cargo +nightly fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)