### PR TITLE
fix: Reject attribute entry whose name contains or ends with a colon (close #728)

### DIFF
--- a/parser/src/document/attribute.rs
+++ b/parser/src/document/attribute.rs
@@ -73,7 +73,13 @@ impl<'src> Attribute<'src> {
         } else if line.after.is_empty() {
             (InterpretedValue::Set, None)
         } else {
-            let raw_value = line.after.take_whitespace();
+            // Asciidoctor requires at least one space or tab between the closing
+            // colon and the value. A non-blank character immediately after the
+            // colon means the line is not a valid attribute entry: the name
+            // either contains a colon (`:foo:bar: baz`) or ends with one
+            // (`:foo:: bar`), so the whole line falls through to be parsed as an
+            // ordinary block. See #728.
+            let raw_value = line.after.take_required_whitespace()?;
             (
                 InterpretedValue::from_raw_value(&raw_value.after, parser),
                 Some(raw_value.after),

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -142,10 +142,9 @@ mod assignment {
     # NOTE AsciiDoc.py recognizes this entry
 "#
     );
-    // Tracked in #728.
     #[test]
     fn does_not_recognize_attribute_entry_if_name_contains_colon() {
-        non_normative!(
+        verifies!(
             r#"
     test 'does not recognize attribute entry if name contains colon' do
       input = ':foo:bar: baz'
@@ -158,14 +157,16 @@ mod assignment {
 "#
         );
 
-        // Divergence: Asciidoctor renders `:foo:bar: baz` as a paragraph (a name
-        // containing a colon isn't a valid attribute entry). This crate also
-        // rejects `foo:bar` as an attribute, but consumes the line into the
-        // document header, yielding no blocks — so the block count/context
-        // assertions can't be verified against it.
+        // A name containing a colon isn't a valid attribute entry (Asciidoctor
+        // requires the value to be separated from the closing colon by at least
+        // one space or tab). The whole line falls through to a paragraph.
         let doc = Parser::default().parse(":foo:bar: baz");
         assert!(!doc.has_attribute("foo:bar"));
-        assert_eq!(doc.nested_blocks().count(), 0);
+
+        let mut blocks = doc.nested_blocks();
+        let block = blocks.next().unwrap();
+        assert_eq!(block.raw_context().as_ref(), "paragraph");
+        assert!(blocks.next().is_none());
     }
 
     non_normative!(
@@ -173,10 +174,9 @@ mod assignment {
     # NOTE AsciiDoc.py recognizes this entry
 "#
     );
-    // Tracked in #728.
     #[test]
     fn does_not_recognize_attribute_entry_if_name_ends_with_colon() {
-        non_normative!(
+        verifies!(
             r#"
     test 'does not recognize attribute entry if name ends with colon' do
       input = ':foo:: bar'
@@ -189,12 +189,21 @@ mod assignment {
 "#
         );
 
-        // Divergence: Asciidoctor renders `:foo:: bar` as a description list (a
-        // name ending with a colon isn't a valid attribute entry). This crate
-        // consumes the line into the document header, yielding no blocks.
+        // A name ending with a colon isn't a valid attribute entry; `:foo:: bar`
+        // is instead a description list (`foo` is the term, `bar` the
+        // description). This crate models a description list as a `list` block
+        // whose type is `Description`, the equivalent of Asciidoctor's `:dlist`.
         let doc = Parser::default().parse(":foo:: bar");
         assert!(!doc.has_attribute("foo:"));
-        assert_eq!(doc.nested_blocks().count(), 0);
+
+        let mut blocks = doc.nested_blocks();
+        let block = blocks.next().unwrap();
+
+        let crate::blocks::Block::List(list) = block else {
+            panic!("Expected a list block, got {block:#?}");
+        };
+        assert_eq!(list.type_(), crate::blocks::ListType::Description);
+        assert!(blocks.next().is_none());
     }
 
     non_normative!(


### PR DESCRIPTION
## Summary

Fixes #728.

An attribute name that **contains** a colon (`:foo:bar: baz`) or **ends with** a colon (`:foo:: bar`) is not a valid attribute entry. Asciidoctor renders the former as a paragraph and the latter as a description list. This crate was instead parsing `foo` = `bar: baz` / `foo` = `: bar` and silently consuming the line into the document header, yielding no blocks.

The root cause: Asciidoctor's `AttributeEntryRx` requires at least one space or tab (`[ \t]+`) between the closing colon and the value, but `Attribute::parse` used `take_whitespace()` (zero-or-more). A non-blank character immediately after the closing colon was therefore accepted as the start of the value.

## Change

- `parser/src/document/attribute.rs`: use `take_required_whitespace()?` for the value branch. When a non-blank character immediately follows the closing colon, the entry is rejected and the line falls through to ordinary block parsing.
- `parser/src/tests/asciidoctor_rb/attributes_test.rs`: the two affected SDD tests move from `non_normative!` (recording a divergence) to `verifies!` and now assert the Asciidoctor-matching output — a paragraph for `:foo:bar: baz`, a description list (`list` block, `Description` type) for `:foo:: bar`.

## Verification

- Full parser suite passes (`cargo test -p asciidoc-parser`, 4219 tests).
- `cargo +nightly fmt --all -- --check` and `cargo clippy -p asciidoc-parser --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)