### PR TITLE
feat: Drop YAML-style front matter when `skip-front-matter` is set (close #745)

### DIFF
--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -525,6 +525,12 @@ impl Parser {
         // fresh "now"; a parse that never references one does no datetime work.
         *self.datetime_context.borrow_mut() = None;
 
+        // Drop leading YAML/TOML front matter (and record it in the
+        // `front-matter` attribute) when `skip-front-matter` is set, before the
+        // source reaches the preprocessor or header parser.
+        let stripped_source = self.skip_front_matter(source);
+        let source = stripped_source.as_deref().unwrap_or(source);
+
         let (preprocessed_source, source_map, preprocessor_warnings, includes) =
             preprocess(source, self);
 
@@ -566,6 +572,91 @@ impl Parser {
             preprocessor_warnings,
             self,
         )
+    }
+
+    /// Drops leading YAML/TOML front matter from `source`, mirroring
+    /// Asciidoctor's `Reader#skip_front_matter!`.
+    ///
+    /// Front matter is a block opened by a line of exactly `---` at the very
+    /// start of the document and closed by a matching `---` line. It is only
+    /// removed when the `skip-front-matter` attribute is set (typically via the
+    /// API); otherwise `---` retains its ordinary meaning and this is a no-op.
+    /// When a well-formed block is found, its content (the lines between the
+    /// delimiters, joined by LF and with the delimiters excluded) is stored in
+    /// the `front-matter` document attribute, and a rewritten copy of the
+    /// source is returned in which every removed line – both delimiters and the
+    /// content – is replaced by a blank line. Preserving the line *count* keeps
+    /// every following line at its original line number, matching Asciidoctor
+    /// (whose reader advances `lineno` past the skipped block); the leading
+    /// blank lines are ignored by the header parser.
+    ///
+    /// Returns `None` (leaving the source untouched and setting no attribute)
+    /// when `skip-front-matter` is not set, when the first line is not `---`,
+    /// or when no closing `---` delimiter is found.
+    fn skip_front_matter(&mut self, source: &str) -> Option<String> {
+        if !self.is_attribute_set("skip-front-matter") {
+            return None;
+        }
+
+        // Strip a line's trailing end-of-line sequence (LF or CRLF) so the
+        // delimiter comparison and the captured content match Asciidoctor's
+        // chomped lines.
+        fn line_content(line: &str) -> &str {
+            let line = line.strip_suffix('\n').unwrap_or(line);
+            line.strip_suffix('\r').unwrap_or(line)
+        }
+
+        let mut lines = source.split_inclusive('\n');
+
+        // Front matter must open on the very first line, which must be exactly
+        // `---`.
+        let first = lines.next()?;
+        if line_content(first) != "---" {
+            return None;
+        }
+
+        // Byte offset just past the region being consumed, and the number of
+        // physical lines consumed (starting with the opening delimiter).
+        let mut consumed_end = first.len();
+        let mut consumed_lines = 1usize;
+
+        let mut front_matter = String::new();
+        let mut closed = false;
+
+        for line in lines {
+            consumed_end += line.len();
+            consumed_lines += 1;
+
+            if line_content(line) == "---" {
+                closed = true;
+                break;
+            }
+
+            if !front_matter.is_empty() {
+                front_matter.push('\n');
+            }
+
+            front_matter.push_str(line_content(line));
+        }
+
+        // Without a closing delimiter the block is malformed; leave the source
+        // (and attributes) untouched, matching Asciidoctor.
+        if !closed {
+            return None;
+        }
+
+        self.set_attribute_by_value_from_header("front-matter", &front_matter);
+
+        // Replace the consumed region with one blank line per removed physical
+        // line so the remaining content keeps its original line numbers.
+        let mut rewritten = String::with_capacity(source.len());
+        for _ in 0..consumed_lines {
+            rewritten.push('\n');
+        }
+
+        rewritten.push_str(&source[consumed_end..]);
+
+        Some(rewritten)
     }
 
     /// Retrieves the current interpreted value of a [document attribute].

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -559,7 +559,7 @@ impl Parser {
         // fresh "now"; a parse that never references one does no datetime work.
         *self.datetime_context.borrow_mut() = None;
 
-        // Drop leading YAML/TOML front matter (and record it in the
+        // Drop leading YAML-style front matter (and record it in the
         // `front-matter` attribute) when `skip-front-matter` is set, before the
         // source reaches the preprocessor or header parser.
         let stripped_source = self.skip_front_matter(source);
@@ -609,21 +609,24 @@ impl Parser {
         )
     }
 
-    /// Drops leading YAML/TOML front matter from `source`, mirroring
+    /// Drops leading YAML-style front matter from `source`, mirroring
     /// Asciidoctor's `Reader#skip_front_matter!`.
     ///
     /// Front matter is a block opened by a line of exactly `---` at the very
-    /// start of the document and closed by a matching `---` line. It is only
-    /// removed when the `skip-front-matter` attribute is set (typically via the
-    /// API); otherwise `---` retains its ordinary meaning and this is a no-op.
-    /// When a well-formed block is found, its content (the lines between the
-    /// delimiters, joined by LF and with the delimiters excluded) is stored in
-    /// the `front-matter` document attribute, and a rewritten copy of the
-    /// source is returned in which every removed line – both delimiters and the
-    /// content – is replaced by a blank line. Preserving the line *count* keeps
-    /// every following line at its original line number, matching Asciidoctor
-    /// (whose reader advances `lineno` past the skipped block); the leading
-    /// blank lines are ignored by the header parser.
+    /// start of the document and closed by a matching `---` line. Only this
+    /// `---` fence (the YAML convention) is recognized – a `+++` TOML fence is
+    /// not – and the captured content is stored verbatim, never parsed. It is
+    /// only removed when the `skip-front-matter` attribute is set
+    /// (typically via the API); otherwise `---` retains its ordinary
+    /// meaning and this is a no-op. When a well-formed block is found, its
+    /// content (the lines between the delimiters, joined by LF and with the
+    /// delimiters excluded) is stored in the `front-matter` document
+    /// attribute, and a rewritten copy of the source is returned in which
+    /// every removed line – both delimiters and the content – is replaced
+    /// by a blank line. Preserving the line *count* keeps every following
+    /// line at its original line number, matching Asciidoctor (whose reader
+    /// advances `lineno` past the skipped block); the leading blank lines
+    /// are ignored by the header parser.
     ///
     /// Returns `None` (leaving the source untouched and setting no attribute)
     /// when `skip-front-matter` is not set, when the first line is not `---`,

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -3606,4 +3606,51 @@ mod tests {
             );
         }
     }
+
+    // Crate-native `skip-front-matter` cases (no Asciidoctor analog) covering
+    // edge conditions beyond the reader-suite ports in
+    // `tests::asciidoctor_rb::reader_test`. See [`Parser::skip_front_matter`].
+    mod skip_front_matter {
+        use crate::tests::prelude::*;
+
+        #[test]
+        fn crlf_line_endings() {
+            // The front-matter delimiters are matched after a CRLF line ending
+            // is stripped, and the captured `front-matter` value is likewise
+            // chomped, so a document with `\r\n` line endings is handled the
+            // same as one with bare `\n`.
+            let doc = Parser::default()
+                .with_intrinsic_attribute_bool(
+                    "skip-front-matter",
+                    true,
+                    ModificationContext::ApiOnly,
+                )
+                .parse("---\r\nlayout: post\r\ntitle: Document Title\r\n---\r\n= Document Title\r\nAuthor Name\r\n\r\npreamble\r\n");
+
+            assert_eq!(
+                doc.attribute_value("front-matter"),
+                InterpretedValue::Value("layout: post\ntitle: Document Title")
+            );
+            assert_eq!(doc.header().title(), Some("Document Title"));
+            assert_eq!(doc.header().title_source().unwrap().line(), 5);
+        }
+
+        #[test]
+        fn first_line_is_not_a_delimiter() {
+            // With `skip-front-matter` set but no opening `---` on the first
+            // line, there is nothing to skip: the document parses normally and
+            // no `front-matter` attribute is recorded.
+            let doc = Parser::default()
+                .with_intrinsic_attribute_bool(
+                    "skip-front-matter",
+                    true,
+                    ModificationContext::ApiOnly,
+                )
+                .parse("= Document Title\nAuthor Name\n\npreamble\n");
+
+            assert_eq!(doc.attribute_value("front-matter"), InterpretedValue::Unset);
+            assert_eq!(doc.header().title(), Some("Document Title"));
+            assert_eq!(doc.header().title_source().unwrap().line(), 1);
+        }
+    }
 }

--- a/parser/src/tests/asciidoc_lang/document/header.rs
+++ b/parser/src/tests/asciidoc_lang/document/header.rs
@@ -543,8 +543,12 @@ If you don't want the header of a document to be displayed, set the `noheader` a
 "#
 );
 
-// Treating as non-normative because the parser crate doesn't support front
-// matter. (This can be handled before passing data in for parsing.)
+// Treating as non-normative because this page only describes front matter and
+// links out to the `skip-front-matter` reference; it prescribes no behavior to
+// verify here. Front matter *is* supported: setting the `skip-front-matter`
+// attribute drops a leading `---`-fenced block and records it in the
+// `front-matter` attribute, mirroring Asciidoctor's reader. That behavior is
+// verified in `tests::asciidoctor_rb::reader_test`.
 non_normative!(
     r#"
 == Front matter

--- a/parser/src/tests/asciidoctor_rb/reader_test.rs
+++ b/parser/src/tests/asciidoctor_rb/reader_test.rs
@@ -999,38 +999,6 @@ fn should_skip_front_matter_if_specified_by_skip_front_matter_attribute() {
     assert_eq!(doc.header().title_source().unwrap().line(), 7);
 }
 
-// Crate-native (no Asciidoctor analog): the front-matter delimiters are matched
-// after a CRLF line ending is stripped, and the captured `front-matter` value
-// is likewise chomped, so a document with `\r\n` line endings is handled the
-// same as one with bare `\n`.
-#[test]
-fn should_skip_front_matter_with_crlf_line_endings() {
-    let doc = Parser::default()
-        .with_intrinsic_attribute_bool("skip-front-matter", true, ModificationContext::ApiOnly)
-        .parse("---\r\nlayout: post\r\ntitle: Document Title\r\n---\r\n= Document Title\r\nAuthor Name\r\n\r\npreamble\r\n");
-
-    assert_eq!(
-        doc.attribute_value("front-matter"),
-        InterpretedValue::Value("layout: post\ntitle: Document Title")
-    );
-    assert_eq!(doc.header().title(), Some("Document Title"));
-    assert_eq!(doc.header().title_source().unwrap().line(), 5);
-}
-
-// Crate-native (no Asciidoctor analog): with `skip-front-matter` set but no
-// opening `---` on the first line, there is nothing to skip – the document
-// parses normally and no `front-matter` attribute is recorded.
-#[test]
-fn should_not_skip_front_matter_when_first_line_is_not_a_delimiter() {
-    let doc = Parser::default()
-        .with_intrinsic_attribute_bool("skip-front-matter", true, ModificationContext::ApiOnly)
-        .parse("= Document Title\nAuthor Name\n\npreamble\n");
-
-    assert_eq!(doc.attribute_value("front-matter"), InterpretedValue::Unset);
-    assert_eq!(doc.header().title(), Some("Document Title"));
-    assert_eq!(doc.header().title_source().unwrap().line(), 1);
-}
-
 non_normative!(
     r#"
     end

--- a/parser/src/tests/asciidoctor_rb/reader_test.rs
+++ b/parser/src/tests/asciidoctor_rb/reader_test.rs
@@ -46,10 +46,11 @@
 //! `push_include` include stack, and every case that inspects `reader.lines` /
 //! `reader.read` / a cursor / `doc.catalog[:includes]` — have no analog here
 //! and are reproduced verbatim in `non_normative!` blocks, each annotated with
-//! the reason it is not ported. UTF-8 BOM stripping, front-matter skipping,
-//! UTF-16 transcoding, `uri:classloader:` includes, and remote (URL) includes
-//! are likewise out of scope for this crate (see the crate README) and stay
-//! non-normative.
+//! the reason it is not ported. UTF-8 BOM stripping, UTF-16 transcoding,
+//! `uri:classloader:` includes, and remote (URL) includes are likewise out of
+//! scope for this crate (see the crate README) and stay non-normative.
+//! Front-matter skipping (the `---` fence gated on `skip-front-matter`) *is*
+//! supported and is ported below.
 //!
 //! What *is* normative and supported — and therefore ported to `verifies!`
 //! blocks driving [`Parser`](crate::Parser) — is the observable preprocessor
@@ -861,14 +862,17 @@ fn should_clean_crlf_from_end_of_lines() {
     assert!(!paras[0].contains('\r'));
 }
 
-// Out of scope: YAML front matter (the `---` fence and `skip-front-matter`
-// attribute) is not handled by this crate — front matter must be stripped
-// before the source is handed to the parser (see the crate README and the
-// `document/header` spec notes). Dropping front matter is tracked by
-// https://github.com/asciidoc-rs/asciidoc-parser/issues/745. These also inspect
-// `reader.peek_line` / `reader.lineno`.
-non_normative!(
-    r#"
+// Front matter support (https://github.com/asciidoc-rs/asciidoc-parser/issues/745):
+// a `---`-fenced YAML/TOML block at the very top of the document is dropped –
+// and captured verbatim in the `front-matter` attribute – but only when the
+// `skip-front-matter` attribute is set. This crate has no public reader, so
+// where Asciidoctor inspects `reader.peek_line` / `reader.lineno`, these ports
+// observe the parsed document instead: the `front-matter` attribute, the
+// recognized document title, and the title's (preserved) line number.
+#[test]
+fn should_not_skip_front_matter_by_default() {
+    verifies!(
+        r#"
       test 'should not skip front matter by default' do
         input = <<~'EOS'
         ---
@@ -890,6 +894,25 @@ non_normative!(
         assert_equal 1, reader.lineno
       end
 
+"#
+    );
+
+    // With `skip-front-matter` unset, the leading `---` keeps its ordinary
+    // meaning: nothing is stripped, no `front-matter` attribute is recorded, and
+    // the `= Document Title` line – no longer the first line – is not read as the
+    // document title.
+    let doc = Parser::default().parse(
+        "---\nlayout: post\ntitle: Document Title\nauthor: username\ntags: [ first, second ]\n---\n= Document Title\nAuthor Name\n\npreamble\n",
+    );
+
+    assert_eq!(doc.attribute_value("front-matter"), InterpretedValue::Unset);
+    assert_eq!(doc.header().title(), None);
+}
+
+#[test]
+fn should_not_skip_front_matter_if_ending_delimiter_is_not_found() {
+    verifies!(
+        r#"
       test 'should not skip front matter if ending delimiter is not found' do
         input = <<~'EOS'
         ---
@@ -908,6 +931,26 @@ non_normative!(
         assert_equal 1, reader.lineno
       end
 
+"#
+    );
+
+    // `skip-front-matter` is set, but the block never closes with a second
+    // `---`, so it is malformed: the source is left untouched and no
+    // `front-matter` attribute is recorded.
+    let doc = Parser::default()
+        .with_intrinsic_attribute_bool("skip-front-matter", true, ModificationContext::ApiOnly)
+        .parse(
+            "---\ntitle: Document Title\ntags: [ first, second ]\n= Document Title\nAuthor Name\n\npreamble\n",
+        );
+
+    assert_eq!(doc.attribute_value("front-matter"), InterpretedValue::Unset);
+    assert_eq!(doc.header().title(), None);
+}
+
+#[test]
+fn should_skip_front_matter_if_specified_by_skip_front_matter_attribute() {
+    verifies!(
+        r#"
       test 'should skip front matter if specified by skip-front-matter attribute' do
         front_matter = <<~'EOS'.chop
         layout: post
@@ -933,7 +976,46 @@ non_normative!(
         assert_equal 7, reader.lineno
       end
 "#
-);
+    );
+
+    // `skip-front-matter` is set and the block is well-formed: its content
+    // (delimiters excluded, lines joined by LF) is captured in the
+    // `front-matter` attribute, and parsing resumes at `= Document Title`, which
+    // – thanks to the blank lines left in place of the removed block – is still
+    // reported at its original line 7.
+    let doc = Parser::default()
+        .with_intrinsic_attribute_bool("skip-front-matter", true, ModificationContext::ApiOnly)
+        .parse(
+            "---\nlayout: post\ntitle: Document Title\nauthor: username\ntags: [ first, second ]\n---\n= Document Title\nAuthor Name\n\npreamble\n",
+        );
+
+    assert_eq!(
+        doc.attribute_value("front-matter"),
+        InterpretedValue::Value(
+            "layout: post\ntitle: Document Title\nauthor: username\ntags: [ first, second ]"
+        )
+    );
+    assert_eq!(doc.header().title(), Some("Document Title"));
+    assert_eq!(doc.header().title_source().unwrap().line(), 7);
+}
+
+// Crate-native (no Asciidoctor analog): the front-matter delimiters are matched
+// after a CRLF line ending is stripped, and the captured `front-matter` value
+// is likewise chomped, so a document with `\r\n` line endings is handled the
+// same as one with bare `\n`.
+#[test]
+fn should_skip_front_matter_with_crlf_line_endings() {
+    let doc = Parser::default()
+        .with_intrinsic_attribute_bool("skip-front-matter", true, ModificationContext::ApiOnly)
+        .parse("---\r\nlayout: post\r\ntitle: Document Title\r\n---\r\n= Document Title\r\nAuthor Name\r\n\r\npreamble\r\n");
+
+    assert_eq!(
+        doc.attribute_value("front-matter"),
+        InterpretedValue::Value("layout: post\ntitle: Document Title")
+    );
+    assert_eq!(doc.header().title(), Some("Document Title"));
+    assert_eq!(doc.header().title_source().unwrap().line(), 5);
+}
 
 non_normative!(
     r#"

--- a/parser/src/tests/asciidoctor_rb/reader_test.rs
+++ b/parser/src/tests/asciidoctor_rb/reader_test.rs
@@ -862,13 +862,13 @@ fn should_clean_crlf_from_end_of_lines() {
     assert!(!paras[0].contains('\r'));
 }
 
-// Front matter support (https://github.com/asciidoc-rs/asciidoc-parser/issues/745):
-// a `---`-fenced YAML/TOML block at the very top of the document is dropped –
-// and captured verbatim in the `front-matter` attribute – but only when the
-// `skip-front-matter` attribute is set. This crate has no public reader, so
-// where Asciidoctor inspects `reader.peek_line` / `reader.lineno`, these ports
-// observe the parsed document instead: the `front-matter` attribute, the
-// recognized document title, and the title's (preserved) line number.
+// Front matter support: a `---`-fenced YAML/TOML block at the very top of the
+// document is dropped – and captured verbatim in the `front-matter` attribute –
+// but only when the `skip-front-matter` attribute is set. This crate has no
+// public reader, so where Asciidoctor inspects `reader.peek_line` /
+// `reader.lineno`, these ports observe the parsed document instead: the
+// `front-matter` attribute, the recognized document title, and the title's
+// (preserved) line number.
 #[test]
 fn should_not_skip_front_matter_by_default() {
     verifies!(

--- a/parser/src/tests/asciidoctor_rb/reader_test.rs
+++ b/parser/src/tests/asciidoctor_rb/reader_test.rs
@@ -1017,6 +1017,20 @@ fn should_skip_front_matter_with_crlf_line_endings() {
     assert_eq!(doc.header().title_source().unwrap().line(), 5);
 }
 
+// Crate-native (no Asciidoctor analog): with `skip-front-matter` set but no
+// opening `---` on the first line, there is nothing to skip – the document
+// parses normally and no `front-matter` attribute is recorded.
+#[test]
+fn should_not_skip_front_matter_when_first_line_is_not_a_delimiter() {
+    let doc = Parser::default()
+        .with_intrinsic_attribute_bool("skip-front-matter", true, ModificationContext::ApiOnly)
+        .parse("= Document Title\nAuthor Name\n\npreamble\n");
+
+    assert_eq!(doc.attribute_value("front-matter"), InterpretedValue::Unset);
+    assert_eq!(doc.header().title(), Some("Document Title"));
+    assert_eq!(doc.header().title_source().unwrap().line(), 1);
+}
+
 non_normative!(
     r#"
     end

--- a/parser/src/tests/asciidoctor_rb/reader_test.rs
+++ b/parser/src/tests/asciidoctor_rb/reader_test.rs
@@ -862,7 +862,7 @@ fn should_clean_crlf_from_end_of_lines() {
     assert!(!paras[0].contains('\r'));
 }
 
-// Front matter support: a `---`-fenced YAML/TOML block at the very top of the
+// Front matter support: a `---`-fenced YAML-style block at the very top of the
 // document is dropped – and captured verbatim in the `front-matter` attribute –
 // but only when the `skip-front-matter` attribute is set. This crate has no
 // public reader, so where Asciidoctor inspects `reader.peek_line` /


### PR DESCRIPTION
## Summary

Adds support for dropping leading YAML-style front matter (the `---` fence), resolving #745.

When the `skip-front-matter` attribute is set (typically via the API), a `---`-fenced block at the very top of the document is removed before the source reaches the preprocessor or header parser, and its content is captured — delimiters excluded, lines joined by LF — in the `front-matter` document attribute. This mirrors Asciidoctor's `Reader#skip_front_matter!`.

When `skip-front-matter` is unset, or the opening `---` has no matching closing delimiter, nothing is stripped and `---` keeps its ordinary meaning — so existing documents are unaffected.

## Line-number fidelity

The removed lines are replaced by the same number of blank lines rather than deleted outright, so every following line keeps its original line number (Asciidoctor's reader advances `lineno` past the skipped block). The leading blank lines are ignored by the header parser, so `= Document Title` after a 6-line front-matter block is still reported at line 7.

## Tests

- Ports the three Asciidoctor `reader_test.rb` front-matter cases (previously `non_normative!` and marked out of scope) to real tests:
  - should not skip front matter by default
  - should not skip front matter if the ending delimiter is not found
  - should skip front matter when `skip-front-matter` is set
- Adds a crate-native case covering `\r\n` line endings.
- Updates the `document/header.rs` spec note that previously declared front matter unsupported.

`cargo test`, `cargo clippy --all-targets`, and `cargo +nightly fmt --all -- --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
