### PR TITLE
fix: Formal `role=` replaces roles set via shorthand `.role` (close #732)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,11 @@
+codecov:
+  # Post coverage statuses as soon as the uploads arrive rather than waiting
+  # for a CI-completion webhook. The wait occasionally never resolves (the
+  # webhook is missed), leaving a commit's coverage status unposted and the PR
+  # showing a stale status from an earlier commit.
+  notify:
+    wait_for_ci: false
+
 coverage:
   status:
     project:

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -225,11 +225,60 @@ impl<'src> Attrlist<'src> {
     ///   additionally carries the block style and shorthand items (`#id`,
     ///   `.role`, `%option`), which are merged via
     ///   [`ElementAttribute::merge_block_style_shorthand`].
+    /// * **Roles** follow Asciidoctor's running model once a formal `role=`
+    ///   entry is in play: a formal `role=` *replaces* every role accumulated
+    ///   so far, while shorthand `.role` entries *append*. Because a replacing
+    ///   `role=` on one line can sit between shorthand roles on earlier and
+    ///   later lines, the resolved (ordered) role list is folded into the
+    ///   formal `role` attribute and the first positional is left free of role
+    ///   shorthand, so [`roles`](Self::roles) reports the resolved list. When
+    ///   no formal `role=` is involved, shorthand roles simply accumulate as
+    ///   above.
     /// * The **anchor** is taken from the later line if it specifies one.
     ///
     /// The `source` span is left pointing at the first line, since the merged
     /// attributes no longer correspond to a single contiguous span.
     pub(crate) fn merge_block_attribute_line(&mut self, later: Attrlist<'src>) {
+        // Roles only need the running-model treatment once a formal `role=`
+        // entry appears (on this line or an earlier, already-folded one).
+        // Otherwise shorthand roles accumulate through the ordinary first-
+        // positional merge below, unchanged.
+        let fold_roles =
+            self.named_attribute("role").is_some() || later.named_attribute("role").is_some();
+
+        let resolved_roles: Option<Vec<String>> = if fold_roles {
+            // The roles accumulated so far, in resolved order (a folded `role`
+            // attribute holds them; failing that, `self`'s shorthand/formal
+            // roles are read the ordinary way).
+            let current: Vec<String> = self.roles().iter().map(|r| r.to_string()).collect();
+
+            // A formal `role=` on the later line replaces the running list;
+            // otherwise it carries forward. The later line's shorthand roles
+            // then append (matching Asciidoctor, where a line's `role=` is set
+            // before its shorthand roles are appended).
+            let later_formal: Option<Vec<String>> = later
+                .named_attribute("role")
+                .map(|attr| split_roles(attr.value()));
+
+            let later_shorthand: Vec<String> = later
+                .nth_attribute(1)
+                .map(|attr| attr.roles().iter().map(|r| r.to_string()).collect())
+                .unwrap_or_default();
+
+            let mut resolved = later_formal.unwrap_or(current);
+            resolved.extend(later_shorthand);
+
+            // Strip role shorthand from our own first positional so the formal
+            // `role` attribute set below is the only remaining source of roles.
+            if let Some(existing) = self.nth_positional_mut(1) {
+                *existing = existing.without_shorthand_roles();
+            }
+
+            Some(resolved)
+        } else {
+            None
+        };
+
         let Attrlist {
             attributes: later_attributes,
             anchor: later_anchor,
@@ -241,6 +290,13 @@ impl<'src> Attrlist<'src> {
         }
 
         for attr in later_attributes {
+            // When folding roles, the resolved role list is applied afterward,
+            // so skip the later line's formal `role` attribute here (it is
+            // accounted for in `resolved_roles`).
+            if fold_roles && attr.name_str() == Some("role") {
+                continue;
+            }
+
             // An attribute carries a positional index exactly when it is a
             // positional (unnamed) attribute; a named attribute has `None`.
             // Dispatching on the index keeps a positional at its Asciidoctor
@@ -265,7 +321,15 @@ impl<'src> Attrlist<'src> {
 
                 // The first positional additionally carries the block style and
                 // shorthand items (`#id`, `.role`, `%option`), which are merged.
+                // While folding roles, its role shorthand is dropped so roles
+                // flow solely through the formal `role` attribute.
                 Some(1) => {
+                    let attr = if fold_roles {
+                        attr.without_shorthand_roles()
+                    } else {
+                        attr
+                    };
+
                     if let Some(existing) = self.nth_positional_mut(1) {
                         *existing = ElementAttribute::merge_block_style_shorthand(existing, &attr);
                     } else {
@@ -283,6 +347,33 @@ impl<'src> Attrlist<'src> {
                     }
                 }
             }
+        }
+
+        // Record the resolved roles in the formal `role` attribute.
+        if let Some(resolved) = resolved_roles {
+            self.set_role_attribute(resolved);
+        }
+    }
+
+    /// Replace (or clear) the formal `role` attribute with the given resolved
+    /// role list. Called by [`merge_block_attribute_line`] once roles have been
+    /// resolved under Asciidoctor's running model. An empty list removes any
+    /// existing `role` attribute.
+    fn set_role_attribute(&mut self, roles: Vec<String>) {
+        if roles.is_empty() {
+            self.attributes.retain(|a| a.name_str() != Some("role"));
+            return;
+        }
+
+        let attr = ElementAttribute::synthesized_role(roles.join(" "));
+        if let Some(existing) = self
+            .attributes
+            .iter_mut()
+            .find(|a| a.name_str() == Some("role"))
+        {
+            *existing = attr;
+        } else {
+            self.attributes.push(attr);
         }
     }
 
@@ -585,6 +676,17 @@ fn split_options(value: &str) -> Vec<&str> {
         .split(',')
         .map(str::trim)
         .filter(|opt| !opt.is_empty())
+        .collect()
+}
+
+/// Split a formal `role` attribute value into individual role names, matching
+/// how [`Attrlist::roles`] reads a `role=` value: split on spaces and drop
+/// empty tokens. So `'role1  role2'` yields `role1`, `role2`.
+fn split_roles(value: &str) -> Vec<String> {
+    value
+        .split(' ')
+        .filter(|role| !role.is_empty())
+        .map(str::to_string)
         .collect()
 }
 

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -258,7 +258,7 @@ impl<'src> Attrlist<'src> {
             // before its shorthand roles are appended).
             let later_formal: Option<Vec<String>> = later
                 .named_attribute("role")
-                .map(|attr| split_roles(attr.value()));
+                .map(|attr| split_role_value(attr.value()).map(str::to_string).collect());
 
             let later_shorthand: Vec<String> = later
                 .nth_attribute(1)
@@ -536,19 +536,7 @@ impl<'src> Attrlist<'src> {
             .unwrap_or_default();
 
         if let Some(role_attr) = self.named_attribute("role") {
-            let mut role_span = Span::new(role_attr.value());
-            let mut formal_roles: Vec<&'src str> = vec![];
-            role_span = role_span.take_while(|c| c == ' ').after;
-
-            while !role_span.is_empty() {
-                let mi = role_span.take_while(|c| c != ' ');
-                if !mi.item.is_empty() {
-                    formal_roles.push(mi.item.data());
-                }
-                role_span = mi.after.take_while(|c| c == ' ').after;
-            }
-
-            roles.append(&mut formal_roles);
+            roles.extend(split_role_value(role_attr.value()));
         }
 
         roles
@@ -680,15 +668,15 @@ fn split_options(value: &str) -> Vec<&str> {
         .collect()
 }
 
-/// Split a formal `role` attribute value into individual role names, matching
-/// how [`Attrlist::roles`] reads a `role=` value: split on spaces and drop
-/// empty tokens. So `'role1  role2'` yields `role1`, `role2`.
-fn split_roles(value: &str) -> Vec<String> {
-    value
-        .split(' ')
-        .filter(|role| !role.is_empty())
-        .map(str::to_string)
-        .collect()
+/// Split a formal `role` attribute value into its individual role names: split
+/// on ASCII spaces and drop empty tokens. So `'role1  role2'` yields `role1`,
+/// `role2`.
+///
+/// This is the single source of truth for how a `role=` value is tokenized,
+/// shared by [`Attrlist::roles`] (which borrows the names) and the
+/// block-attribute merge (which owns them), so the two can never diverge.
+fn split_role_value(value: &str) -> impl Iterator<Item = &str> {
+    value.split(' ').filter(|role| !role.is_empty())
 }
 
 /// Context for attribute list parsing.

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -356,9 +356,10 @@ impl<'src> Attrlist<'src> {
     }
 
     /// Replace (or clear) the formal `role` attribute with the given resolved
-    /// role list. Called by [`merge_block_attribute_line`] once roles have been
-    /// resolved under Asciidoctor's running model. An empty list removes any
-    /// existing `role` attribute.
+    /// role list. Called by
+    /// [`merge_block_attribute_line`](Self::merge_block_attribute_line) once
+    /// roles have been resolved under Asciidoctor's running model. An empty
+    /// list removes any existing `role` attribute.
     fn set_role_attribute(&mut self, roles: Vec<String>) {
         if roles.is_empty() {
             self.attributes.retain(|a| a.name_str() != Some("role"));

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -522,6 +522,75 @@ impl<'src> ElementAttribute<'src> {
         }
     }
 
+    /// Return a copy of this first-position (block style) attribute with its
+    /// role shorthand (`.role`) items removed, retaining the block style, ID,
+    /// and options. Used while merging block attribute lines, where a formal
+    /// `role=` entry takes ownership of the resolved role list and the
+    /// shorthand must therefore no longer contribute roles of its own.
+    ///
+    /// If the attribute carries no role shorthand, it is returned unchanged.
+    pub(crate) fn without_shorthand_roles(&self) -> Self {
+        if self.roles_internal().is_empty() {
+            return self.clone();
+        }
+
+        let block_style = self.block_style_internal();
+        let id = self.id_internal();
+        let options = self.options_internal();
+
+        let mut value = String::new();
+        if let Some(block_style) = block_style {
+            value.push_str(block_style);
+        }
+        if let Some(id) = id {
+            value.push('#');
+            value.push_str(id);
+        }
+        for option in &options {
+            value.push('%');
+            value.push_str(option);
+        }
+
+        // The shorthand string is synthesized from components that were already
+        // parsed and validated when the source line was read, so re-parsing it
+        // can never warn (see `merge_block_style_shorthand`).
+        let mut warnings: Vec<WarningType> = vec![];
+        let shorthand_item_indices = if value.is_empty() {
+            vec![]
+        } else {
+            parse_shorthand_items(&value, &mut warnings)
+        };
+
+        debug_assert!(
+            warnings.is_empty(),
+            "stripping shorthand roles should not produce warnings, got: {warnings:?}"
+        );
+
+        Self {
+            name: None,
+            value: CowStr::from(value),
+            shorthand_item_indices,
+            positional_index: self.positional_index,
+            value_is_quoted: false,
+            value_is_substituted: false,
+        }
+    }
+
+    /// Synthesize a named `role` attribute whose value is the space-separated
+    /// list of resolved roles. Used while merging block attribute lines to
+    /// record the roles resolved under Asciidoctor's running model (a formal
+    /// `role=` replaces, shorthand `.role` appends).
+    pub(crate) fn synthesized_role(value: String) -> Self {
+        Self {
+            name: Some(CowStr::from("role")),
+            value: CowStr::from(value),
+            shorthand_item_indices: vec![],
+            positional_index: None,
+            value_is_quoted: false,
+            value_is_substituted: false,
+        }
+    }
+
     /// Return the 1-based positional index of this attribute, if it is a
     /// positional (unnamed) attribute whose position is known. See the
     /// [`positional_index`](Self::positional_index) field for the numbering
@@ -1799,6 +1868,57 @@ mod tests {
             assert!(merged.id().is_none());
             assert!(merged.roles().is_empty());
             assert!(merged.options().is_empty());
+        }
+    }
+
+    mod without_shorthand_roles {
+        use crate::{
+            attributes::{AttrlistContext, element_attribute::ParseShorthand},
+            strings::CowStr,
+            tests::prelude::*,
+        };
+
+        fn parse(value: &str) -> crate::attributes::ElementAttribute<'_> {
+            let p = Parser::default();
+            crate::attributes::ElementAttribute::parse(
+                &CowStr::from(value),
+                0,
+                &p,
+                ParseShorthand(true),
+                AttrlistContext::Block,
+            )
+            .0
+        }
+
+        #[test]
+        fn drops_roles_keeps_style_id_and_options() {
+            let attr = parse("sidebar#myid.role1.role2%opt1");
+            let stripped = attr.without_shorthand_roles();
+
+            assert_eq!(stripped.block_style().unwrap(), "sidebar");
+            assert_eq!(stripped.id().unwrap(), "myid");
+            assert!(stripped.roles().is_empty());
+            assert_eq!(stripped.options(), vec!["opt1"]);
+        }
+
+        #[test]
+        fn returns_clone_when_no_roles_present() {
+            // With no role shorthand to strip, the attribute is returned as-is.
+            let attr = parse("sidebar#myid%opt1");
+            let stripped = attr.without_shorthand_roles();
+
+            assert_eq!(stripped, attr);
+        }
+
+        #[test]
+        fn roles_only_becomes_empty() {
+            let attr = parse(".role1.role2");
+            let stripped = attr.without_shorthand_roles();
+
+            assert!(stripped.block_style().is_none());
+            assert!(stripped.id().is_none());
+            assert!(stripped.roles().is_empty());
+            assert!(stripped.options().is_empty());
         }
     }
 }

--- a/parser/src/attributes/element_attribute.rs
+++ b/parser/src/attributes/element_attribute.rs
@@ -538,33 +538,29 @@ impl<'src> ElementAttribute<'src> {
         let id = self.id_internal();
         let options = self.options_internal();
 
+        // Rebuild the shorthand string from the retained components, recording
+        // the start offset of each shorthand item as it is appended. The
+        // components were validated (and stripped of their delimiters) when the
+        // source line was parsed, so these offsets match what
+        // `parse_shorthand_items` would produce for the same string — without
+        // re-parsing it (or having to discard its always-empty warnings).
         let mut value = String::new();
+        let mut shorthand_item_indices: Vec<usize> = vec![];
+
         if let Some(block_style) = block_style {
+            shorthand_item_indices.push(value.len());
             value.push_str(block_style);
         }
         if let Some(id) = id {
+            shorthand_item_indices.push(value.len());
             value.push('#');
             value.push_str(id);
         }
         for option in &options {
+            shorthand_item_indices.push(value.len());
             value.push('%');
             value.push_str(option);
         }
-
-        // The shorthand string is synthesized from components that were already
-        // parsed and validated when the source line was read, so re-parsing it
-        // can never warn (see `merge_block_style_shorthand`).
-        let mut warnings: Vec<WarningType> = vec![];
-        let shorthand_item_indices = if value.is_empty() {
-            vec![]
-        } else {
-            parse_shorthand_items(&value, &mut warnings)
-        };
-
-        debug_assert!(
-            warnings.is_empty(),
-            "stripping shorthand roles should not produce warnings, got: {warnings:?}"
-        );
 
         Self {
             name: None,

--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -658,6 +658,75 @@ mod tests {
         }
 
         #[test]
+        fn formal_role_replaces_earlier_shorthand_roles() {
+            // A formal `role=` entry replaces roles set by an earlier shorthand
+            // `.role`; a shorthand `.role` on a still-later line then appends.
+            // (Tracks #732.)
+            let metadata = crate::blocks::metadata::BlockMetadata::new(
+                "[.role1]\n[role=role2]\n[.role3]\ncontent\n",
+            );
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.roles(), vec!["role2", "role3"]);
+        }
+
+        #[test]
+        fn formal_role_replaces_and_multiple_values_are_kept() {
+            // A multi-valued formal `role=` replaces every earlier role, in
+            // order.
+            let metadata = crate::blocks::metadata::BlockMetadata::new(
+                "[.role1.role2]\n[role=\"r3 r4\"]\ncontent\n",
+            );
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.roles(), vec!["r3", "r4"]);
+        }
+
+        #[test]
+        fn later_formal_role_replaces_earlier_formal_role() {
+            let metadata = crate::blocks::metadata::BlockMetadata::new(
+                "[role=role1]\n[role=role2]\ncontent\n",
+            );
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.roles(), vec!["role2"]);
+        }
+
+        #[test]
+        fn shorthand_role_appends_to_earlier_formal_role() {
+            let metadata =
+                crate::blocks::metadata::BlockMetadata::new("[role=role1]\n[.role2]\ncontent\n");
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.roles(), vec!["role1", "role2"]);
+        }
+
+        #[test]
+        fn empty_formal_role_clears_earlier_roles() {
+            // An explicitly empty `role=` replaces the running role list with
+            // nothing, clearing roles set by an earlier shorthand `.role`.
+            let metadata =
+                crate::blocks::metadata::BlockMetadata::new("[.role1]\n[role=]\ncontent\n");
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert!(attrlist.roles().is_empty());
+        }
+
+        #[test]
+        fn formal_role_replaces_but_preserves_id_and_options() {
+            // Replacing roles must not disturb the ID or options carried on the
+            // first positional.
+            let metadata = crate::blocks::metadata::BlockMetadata::new(
+                "[#id1.role1%opt1]\n[role=role2]\ncontent\n",
+            );
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.id().unwrap(), "id1");
+            assert_eq!(attrlist.roles(), vec!["role2"]);
+            assert_eq!(attrlist.options(), vec!["opt1"]);
+        }
+
+        #[test]
         fn shorthand_id_later_wins() {
             let metadata = crate::blocks::metadata::BlockMetadata::new("[#id1]\n[#id2]\ncontent\n");
 

--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -788,6 +788,19 @@ mod tests {
         }
 
         #[test]
+        fn later_line_carrying_both_formal_and_shorthand_roles() {
+            // When a single later line carries both a formal `role=` and a
+            // shorthand `.role`, the formal value replaces the running roles and
+            // that same line's shorthand then appends after it.
+            let metadata = crate::blocks::metadata::BlockMetadata::new(
+                "[role=formal]\n[.sh,role=formal2]\ncontent\n",
+            );
+
+            let attrlist = metadata.attrlist.as_ref().unwrap();
+            assert_eq!(attrlist.roles(), vec!["formal2", "sh"]);
+        }
+
+        #[test]
         fn empty_formal_role_clears_earlier_roles() {
             // An explicitly empty `role=` replaces the running role list with
             // nothing, clearing roles set by an earlier shorthand `.role`.

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -4072,10 +4072,9 @@ mod block_attributes {
         assert_eq!(first_block(&doc).roles(), vec!["role1", "role2", "role3"]);
     }
 
-    // Tracked in #732.
     #[test]
     fn setting_a_role_using_the_role_attribute_replaces_any_existing_roles() {
-        non_normative!(
+        verifies!(
             r#"
     test 'setting a role using the role attribute replaces any existing roles' do
       input = <<~'EOS'
@@ -4093,12 +4092,11 @@ mod block_attributes {
 "#
         );
 
-        // Divergence: in Asciidoctor a formal `role=` entry replaces any roles
-        // already set by shorthand `.role`, so `.role1` is cleared and the
-        // result is `role2 role3`. This crate treats every role source as
-        // additive, so all three accumulate (in encounter order).
+        // A formal `role=` entry replaces any roles already set by an earlier
+        // shorthand `.role`, so `.role1` is cleared by `role=role2`; the later
+        // `.role3` shorthand then appends, yielding `role2 role3`.
         let doc = Parser::default().parse("[.role1]\n[role=role2]\n[.role3]\nText");
-        assert_eq!(first_block(&doc).roles(), vec!["role1", "role3", "role2"]);
+        assert_eq!(first_block(&doc).roles(), vec!["role2", "role3"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #732. When a block is preceded by multiple attribute lines, a formal `[role=..]` entry now **replaces** any roles previously assigned via the shorthand `.role` syntax, matching Asciidoctor. Previously all role sources were additive, so:

```asciidoc
[.role1]
[role=role2]
[.role3]
Text
```

yielded `role1 role3 role2` instead of the correct `role2 role3`.

## Approach

Role merging in `Attrlist::merge_block_attribute_line` now follows Asciidoctor's running model, processing attribute lines in order:

- a formal `role=` entry **replaces** every role accumulated so far;
- shorthand `.role` entries **append** (a line's `role=` is applied before that same line's shorthand, matching Asciidoctor).

Once a formal `role=` is in play, the resolved, ordered role list is folded into the formal `role` attribute and the first positional is stripped of role shorthand, so `roles()` (and `named_attribute("role")`) report the resolved list. When no formal `role=` is involved, shorthand roles accumulate through the existing first-positional merge path, unchanged – so the pure-shorthand additive behavior (and its representation) is untouched.

New helpers: `ElementAttribute::without_shorthand_roles` (drop `.role` items, keep style/id/options) and `ElementAttribute::synthesized_role`.

## Tests

- Converted the tracked upstream test `setting_a_role_using_the_role_attribute_replaces_any_existing_roles` from `non_normative!` (recorded divergence) to `verifies!`, now asserting `role2 role3`.
- Added `merge_attribute_lines` cases: replace-then-append, multi-valued replace, later-formal-wins, shorthand-appends-to-formal, id/options preserved across a role replace, and empty `role=` clearing roles.
- Added `without_shorthand_roles` unit tests.
- Full workspace suite passes (`cargo test --workspace`); `cargo +nightly fmt --all -- --check` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)