### PR TITLE
fix: Last-wins block anchors and trailing metadata transfer across comments to a following section (close #733)

### DIFF
--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -3,6 +3,7 @@ use std::ops::{RangeFrom, RangeTo};
 use crate::{
     Parser, Span,
     attributes::{Attrlist, AttrlistContext},
+    blocks::simple::is_section_header,
     content::{Content, SubstitutionGroup},
     span::MatchedItem,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -80,8 +81,12 @@ impl<'src> BlockMetadata<'src> {
                 }
             }
 
-            // Try to parse a block anchor.
-            if anchor.is_none() {
+            // Try to parse a block anchor. Consecutive block anchors are
+            // permitted and the last one wins (`[[bar]]` / `[[foo]]` → `foo`),
+            // matching Asciidoctor, which simply overwrites the running `id`
+            // (and its reftext) for each anchor line. The earlier `anchor.is_none()`
+            // guard is therefore intentionally gone: a later anchor overrides.
+            {
                 let mut anchor_maw = parse_maybe_block_anchor(block_start);
 
                 // Collect any warnings from the anchor parsing (e.g., empty anchor).
@@ -116,6 +121,11 @@ impl<'src> BlockMetadata<'src> {
                         // Validate anchor name.
                         if mi.item.is_xml_name() {
                             anchor = Some(mi.item);
+
+                            // A later plain anchor (`[[foo]]`) clears any reftext
+                            // carried by an earlier `[[bar,text]]`, keeping the
+                            // last-wins semantics consistent across both fields.
+                            reftext = None;
                             block_start = mi.after;
                         } else {
                             warnings.push(Warning {
@@ -154,6 +164,29 @@ impl<'src> BlockMetadata<'src> {
                     None => attrlist = Some(attrlist_item),
                 }
                 block_start = new_block_start;
+                continue;
+            }
+
+            // A comment line (`//`) or comment block (`////`) sitting between
+            // already-collected metadata and a *following section heading* is
+            // transparent: the metadata transfers across the comment to that
+            // section (e.g. `[[sub]]` / `// comment` / `=== Sub-section` gives
+            // the section id `sub`, and `[role=…]` / `////…////` / `== Section`
+            // gives the section the role). Asciidoctor skips comments while
+            // gathering block metadata; this crate deliberately *retains*
+            // comment blocks as ordinary blocks, so the transparency is scoped
+            // to the section-transfer case the wider divergence would otherwise
+            // break. A comment that a metadata line directly decorates (with no
+            // following section) is therefore left in place for normal dispatch.
+            //
+            // This only applies once at least one metadata item has been
+            // collected, so a standalone comment (with no preceding metadata) is
+            // untouched.
+            if !(title_source.is_none() && anchor.is_none() && attrlist.is_none())
+                && let Some(after_comments) =
+                    skip_comments_before_section(block_start, parser.level_offset())
+            {
+                block_start = after_comments;
                 continue;
             }
 
@@ -237,6 +270,61 @@ impl<'src> BlockMetadata<'src> {
         } else {
             false
         }
+    }
+}
+
+/// Looks past a run of comment lines (`//`) and comment blocks (`////`),
+/// together with the blank lines around them, to a following section heading.
+/// On success, returns the source span at that heading so already-collected
+/// block metadata attaches to the section rather than to the intervening
+/// comment.
+///
+/// Returns `None` unless at least one comment was skipped *and* the run lands
+/// on a section heading — every other case (no comment, or a comment that a
+/// metadata line directly decorates with no following section) leaves the
+/// comment in place for normal block dispatch, preserving this crate's
+/// retention of comment blocks as ordinary blocks.
+fn skip_comments_before_section(source: Span<'_>, level_offset: i32) -> Option<Span<'_>> {
+    let mut cursor = source;
+    let mut skipped_any = false;
+
+    loop {
+        let probe = cursor.discard_empty_lines();
+        if probe.is_empty() {
+            return None;
+        }
+
+        let line = probe.take_normalized_line();
+        let data = line.item.data();
+
+        // A comment block (`////`, or a longer run of slashes) is consumed
+        // through its matching closing delimiter — or to end of input if it is
+        // never closed, matching Asciidoctor's `read_lines_until terminator`.
+        if data.len() >= 4 && data.chars().all(|c| c == '/') {
+            let mut next = line.after;
+            while !next.is_empty() {
+                let inner = next.take_normalized_line();
+                next = inner.after;
+                if inner.item.data() == data {
+                    break;
+                }
+            }
+            cursor = next;
+            skipped_any = true;
+            continue;
+        }
+
+        // A comment line begins with `//` but is not the `///` (or longer) run
+        // that opens neither a comment line nor a valid comment block.
+        if data.starts_with("//") && !data.starts_with("///") {
+            cursor = line.after;
+            skipped_any = true;
+            continue;
+        }
+
+        // A non-comment line ends the run. The metadata transfers across the
+        // skipped comments only when they precede a section heading.
+        return (skipped_any && is_section_header(data, level_offset)).then_some(probe);
     }
 }
 

--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -84,61 +84,59 @@ impl<'src> BlockMetadata<'src> {
             // Try to parse a block anchor. Consecutive block anchors are
             // permitted and the last one wins (`[[bar]]` / `[[foo]]` → `foo`),
             // matching Asciidoctor, which simply overwrites the running `id`
-            // (and its reftext) for each anchor line. The earlier `anchor.is_none()`
-            // guard is therefore intentionally gone: a later anchor overrides.
-            {
-                let mut anchor_maw = parse_maybe_block_anchor(block_start);
+            // (and its reftext) for each anchor line. There is deliberately no
+            // `anchor.is_none()` guard: a later anchor overrides an earlier one.
+            let mut anchor_maw = parse_maybe_block_anchor(block_start);
 
-                // Collect any warnings from the anchor parsing (e.g., empty anchor).
-                if !anchor_maw.warnings.is_empty() {
-                    warnings.append(&mut anchor_maw.warnings);
+            // Collect any warnings from the anchor parsing (e.g., empty anchor).
+            if !anchor_maw.warnings.is_empty() {
+                warnings.append(&mut anchor_maw.warnings);
+            }
+
+            if let Some(mi) = anchor_maw.item {
+                if let Some(comma_position) = mi.item.position(|c| c == ',')
+                    && comma_position < mi.item.len() - 1
+                {
+                    let anchor_span = mi.item.slice_to(RangeTo {
+                        end: comma_position,
+                    });
+                    let reftext_span = mi.item.slice_from(RangeFrom {
+                        start: comma_position + 1,
+                    });
+
+                    // Validate anchor name.
+                    if anchor_span.is_xml_name() {
+                        anchor = Some(anchor_span);
+                        reftext = Some(reftext_span);
+                        block_start = mi.after;
+                    } else {
+                        warnings.push(Warning {
+                            source: anchor_span,
+                            warning: WarningType::InvalidBlockAnchorName,
+                            origin: None,
+                        });
+                    }
+                } else {
+                    // Validate anchor name.
+                    if mi.item.is_xml_name() {
+                        anchor = Some(mi.item);
+
+                        // A later plain anchor (`[[foo]]`) clears any reftext
+                        // carried by an earlier `[[bar,text]]`, keeping the
+                        // last-wins semantics consistent across both fields.
+                        reftext = None;
+                        block_start = mi.after;
+                    } else {
+                        warnings.push(Warning {
+                            source: mi.item,
+                            warning: WarningType::InvalidBlockAnchorName,
+                            origin: None,
+                        });
+                    }
                 }
 
-                if let Some(mi) = anchor_maw.item {
-                    if let Some(comma_position) = mi.item.position(|c| c == ',')
-                        && comma_position < mi.item.len() - 1
-                    {
-                        let anchor_span = mi.item.slice_to(RangeTo {
-                            end: comma_position,
-                        });
-                        let reftext_span = mi.item.slice_from(RangeFrom {
-                            start: comma_position + 1,
-                        });
-
-                        // Validate anchor name.
-                        if anchor_span.is_xml_name() {
-                            anchor = Some(anchor_span);
-                            reftext = Some(reftext_span);
-                            block_start = mi.after;
-                        } else {
-                            warnings.push(Warning {
-                                source: anchor_span,
-                                warning: WarningType::InvalidBlockAnchorName,
-                                origin: None,
-                            });
-                        }
-                    } else {
-                        // Validate anchor name.
-                        if mi.item.is_xml_name() {
-                            anchor = Some(mi.item);
-
-                            // A later plain anchor (`[[foo]]`) clears any reftext
-                            // carried by an earlier `[[bar,text]]`, keeping the
-                            // last-wins semantics consistent across both fields.
-                            reftext = None;
-                            block_start = mi.after;
-                        } else {
-                            warnings.push(Warning {
-                                source: mi.item,
-                                warning: WarningType::InvalidBlockAnchorName,
-                                origin: None,
-                            });
-                        }
-                    }
-
-                    if block_start != original_block_start {
-                        continue;
-                    }
+                if block_start != original_block_start {
+                    continue;
                 }
             }
 

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -427,19 +427,16 @@ impl<'src> SectionBlock<'src> {
     /// Returns the ID under which this section is registered in the catalog, if
     /// any, as an owned string.
     ///
-    /// Mirrors the effective-ID precedence of [`IsBlock::id`] (explicit anchor,
-    /// then attribute-list ID, then the auto-generated section ID) but without
-    /// the `&'src self` borrow, so the document-order title resolution pass can
-    /// key titles by ID while walking `&mut` blocks.
+    /// Mirrors the effective-ID precedence of [`IsBlock::id`] (attribute-list
+    /// ID, then explicit anchor, then the auto-generated section ID) but
+    /// without the `&'src self` borrow, so the document-order title
+    /// resolution pass can key titles by ID while walking `&mut` blocks.
     pub(crate) fn reference_id(&self) -> Option<String> {
-        self.anchor
-            .map(|a| a.data().to_string())
-            .or_else(|| {
-                self.attrlist
-                    .as_ref()
-                    .and_then(|attrlist| attrlist.id())
-                    .map(str::to_string)
-            })
+        self.attrlist
+            .as_ref()
+            .and_then(|attrlist| attrlist.id())
+            .map(str::to_string)
+            .or_else(|| self.anchor.map(|a| a.data().to_string()))
             .or_else(|| self.section_id.clone())
     }
 
@@ -532,11 +529,15 @@ impl<'src> IsBlock<'src> for SectionBlock<'src> {
     }
 
     fn id(&'src self) -> Option<&'src str> {
-        // First try the default implementation (explicit IDs from anchor or attrlist)
-        self.anchor()
-            .map(|a| a.data())
-            .or_else(|| self.attrlist().and_then(|attrlist| attrlist.id()))
-            // Fall back to auto-generated ID if no explicit ID is set
+        // An explicit ID above the heading wins, and an attribute-list ID
+        // (`[id=…]`/`[#id]`) takes precedence over a `[[id]]` block anchor —
+        // matching the precedence used when the section registers itself in the
+        // catalog (see `attr_or_anchor_id` in `SectionBlock::parse`), so this
+        // accessor reports the same ID the section is cross-referenced under.
+        self.attrlist()
+            .and_then(|attrlist| attrlist.id())
+            .or_else(|| self.anchor().map(|a| a.data()))
+            // Fall back to auto-generated ID if no explicit ID is set.
             .or(self.section_id.as_deref())
     }
 }
@@ -794,7 +795,14 @@ fn peer_or_ancestor_section<'src>(
         return false;
     }
 
-    let source_after_metadata = block_metadata.block_start;
+    // Discard any blank lines between the collected metadata and the heading,
+    // mirroring the tolerance `Block::parse_internal` applies on the live parse
+    // path. Block metadata may be separated from its block by blank lines
+    // (including the blank lines around a comment that block-metadata parsing
+    // skips over), and `parse_title_line` requires a non-blank first line, so
+    // without this the boundary check would miss such a heading and wrongly fold
+    // the following peer/ancestor section into the current one.
+    let source_after_metadata = block_metadata.block_start.discard_empty_lines();
 
     // Compare effective levels: the boundary heading's `leveloffset` is read
     // from the *live* parser (every block up to this point, including any

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -788,6 +788,19 @@ fn peer_or_ancestor_section<'src>(
     // parser state.
     let mut temp_parser = Parser::default();
 
+    // Block-metadata parsing consults `leveloffset` to decide whether a comment
+    // separating collected metadata from a following heading is transparent
+    // (see `skip_comments_before_section`): a bare `=` counts as a section only
+    // when a positive offset promotes it. Mirror the live parser's offset onto
+    // the temporary parser so the boundary look-ahead makes the same decision
+    // the real parse will — otherwise a peer/ancestor section reached across
+    // such a comment would be missed and wrongly nested. The stored offset is
+    // already an absolute integer, so it needs no further resolution.
+    let level_offset = parser.level_offset();
+    if level_offset != 0 {
+        temp_parser.set_attribute_by_value_from_header("leveloffset", level_offset.to_string());
+    }
+
     let block_metadata_maw = BlockMetadata::parse(source, &mut temp_parser);
 
     let block_metadata = block_metadata_maw.item;
@@ -1903,6 +1916,37 @@ mod tests {
                     col: 1,
                     offset: 24
                 }
+            );
+        }
+
+        #[test]
+        fn comment_transfer_boundary_respects_leveloffset() {
+            // Under `:leveloffset: +2`, `== Parent` is level 3 and a bare
+            // `= Child` is level 2 — an ancestor that must end Parent. The
+            // `[[x]]` anchor and the `// comment` before `= Child` transfer to
+            // it, and the section-boundary look-ahead must apply the active
+            // `leveloffset` (rather than a default offset of zero) so `= Child`
+            // is recognized as the boundary and lands as a sibling of Parent,
+            // not nested inside it. Regression test for the boundary check
+            // reading the offset from its throwaway parser.
+            let doc = Parser::default().parse(
+                "= Doc\n:leveloffset: +2\n\n== Parent\n\npara\n\n[[x]]\n// comment\n= Child\n\nbody",
+            );
+
+            let top: Vec<_> = doc.nested_blocks().collect();
+            assert_eq!(top.len(), 2, "Child must be a sibling of Parent");
+
+            let parent = top.first().unwrap();
+            let child = top.last().unwrap();
+            assert_eq!(parent.id(), Some("_parent"));
+
+            // The transferred anchor gives Child its id, and Child owns the
+            // following paragraph as a child rather than sitting under Parent.
+            assert_eq!(child.id(), Some("x"));
+            assert!(
+                parent
+                    .nested_blocks()
+                    .all(|b| b.raw_context().as_ref() != "section")
             );
         }
 

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -601,7 +601,7 @@ impl<'src> HasSpan<'src> for SimpleBlock<'src> {
 /// a document title rather than a section *unless* a positive offset lifts it
 /// to level 1 or beyond — mirroring the level-0 rule in
 /// [`parse_title_line`](crate::blocks::section).
-fn is_section_header(line: &str, level_offset: i32) -> bool {
+pub(crate) fn is_section_header(line: &str, level_offset: i32) -> bool {
     // AsciiDoc `=` style or Markdown `#` style.
     let rest = if line.starts_with('=') {
         line.trim_start_matches('=')

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -68,9 +68,8 @@
 //! * Non-ASCII attribute names and names with spaces are not accepted.
 //! * A counter modifies a locked (API-set or built-in) attribute rather than
 //!   leaving it unchanged.
-//! * Safe-mode masking of `docdir`/`docfile`, the unterminated-header-comment
-//!   behavior, and the transfer of trailing anchors/attributes onto a following
-//!   section all differ.
+//! * Safe-mode masking of `docdir`/`docfile` and the
+//!   unterminated-header-comment behavior differ.
 //!
 //! Separately, block captions/titles are exposed via `caption()` / `title()`
 //! rather than as `<div class="title">` DOM nodes — a documented architectural
@@ -4363,10 +4362,9 @@ mod block_attributes {
         assert_eq!(p.roles(), vec!["lead"]);
     }
 
-    // Tracked in #733.
     #[test]
     fn last_wins_for_id_attribute() {
-        non_normative!(
+        verifies!(
             r#"
     test "Last wins for id attribute" do
       input = <<~'EOS'
@@ -4390,20 +4388,24 @@ mod block_attributes {
 "#
         );
 
-        // Divergence: Asciidoctor keeps the *last* of consecutive block anchors,
-        // so the section id resolves to `foo`. This crate keeps the *first*
-        // anchor, so the id is `bar`, and it does not collapse the stacked
-        // anchors/attributes onto the following section the same way.
+        // Of consecutive block anchors the last wins (`[[bar]]` / `[[foo]]`
+        // resolves to `foo`), and an `[id=…]` attribute list following a `[[id]]`
+        // anchor likewise wins (`[[baz]]` / `[id='coolio']` resolves to
+        // `coolio`).
         let doc = Parser::default().parse(
             "[[bar]]\n[[foo]]\n== Section\n\nparagraph\n\n[[baz]]\n[id='coolio']\n=== Section",
         );
-        assert_eq!(first_block(&doc).id(), Some("bar"));
+
+        let sec = first_block(&doc);
+        assert_eq!(sec.id(), Some("foo"));
+
+        let subsec = sec.nested_blocks().last().expect("expected a sub-section");
+        assert_eq!(subsec.id(), Some("coolio"));
     }
 
-    // Tracked in #733.
     #[test]
     fn trailing_block_attributes_transfer_to_the_following_section() {
-        non_normative!(
+        verifies!(
             r#"
     test "trailing block attributes transfer to the following section" do
       input = <<~'EOS'
@@ -4441,20 +4443,27 @@ mod block_attributes {
 "#
         );
 
-        // Divergence: Asciidoctor transfers a trailing block anchor / attribute
-        // list (separated from the heading by a comment or block) to the
-        // *following* section, so the sub-section gets id `sub` and Section Two
-        // gets role `classy`. This crate attaches them to standalone blocks
-        // instead, so the sub-section keeps its auto-generated id and Section Two
-        // has no role. The top-level section ids that this crate does assign are
-        // verified here.
+        // A trailing block anchor or attribute list separated from a heading by
+        // a comment (line or block) transfers to the *following* section: the
+        // sub-section gets id `sub` across the `// …` line comment, and Section
+        // Two gets role `classy` across the `////…////` comment block.
         let doc = Parser::default().parse(
             "[[one]]\n\n== Section One\n\nparagraph\n\n[[sub]]\n// try to mess this up!\n\n=== Sub-section\n\nparagraph\n\n[role='classy']\n\n////\nblock comment\n////\n\n== Section Two\n\ncontent",
         );
+
         let blocks: Vec<_> = doc.nested_blocks().collect();
-        assert_eq!(blocks[0].id(), Some("one"));
-        assert_eq!(blocks.last().unwrap().id(), Some("_section_two"));
-        assert!(blocks.last().unwrap().roles().is_empty());
+
+        let section_one = blocks.first().expect("expected Section One");
+        assert_eq!(section_one.id(), Some("one"));
+
+        let subsection = section_one
+            .nested_blocks()
+            .last()
+            .expect("expected a sub-section");
+        assert_eq!(subsection.id(), Some("sub"));
+
+        let section_two = blocks.last().expect("expected Section Two");
+        assert_eq!(section_two.roles(), vec!["classy"]);
     }
 }
 


### PR DESCRIPTION
Fixes #733.

## Problem

Two related divergences from Asciidoctor, both surfaced while porting `attributes_test.rb` under SDD:

1. **Stacked block anchors kept the *first*, not the last.** `[[bar]]` / `[[foo]]` / `== Section` yielded id `bar`; Asciidoctor keeps `foo`. Worse, the second anchor line was not recognized as metadata at all, so `[[foo]]\n== Section` collapsed into a paragraph and the heading was lost.
2. **Trailing anchors/attributes did not transfer to a following section across a comment.** A `[[id]]` / `[id=…]` separated from a heading by a `//` line comment or a `////` comment block attached to a standalone comment block instead of the section, so a sub-section kept its auto-generated id and a following section received no role.

## Fix

- **Last-wins anchors** (`blocks/metadata.rs`): the block-metadata loop no longer stops at the first anchor; a later `[[id]]` overrides an earlier one (and clears a stale reftext), matching Asciidoctor's overwrite-the-running-`id` behavior.
- **Section id precedence** (`blocks/section.rs`): `SectionBlock::id()` / `reference_id()` now prefer an attribute-list id (`[id=…]`/`[#id]`) over a `[[id]]` anchor, so a section reports the same id it is registered and cross-referenced under (the registration path already used this precedence). This makes `[[baz]]` / `[id='coolio']` resolve to `coolio`.
- **Comment-transparent metadata transfer** (`blocks/metadata.rs`): once at least one metadata item is collected, block-metadata parsing looks past a run of comment lines/blocks (and surrounding blank lines) **when they precede a section heading**, attaching the metadata to that section. The rule is deliberately scoped to the section-transfer case so this crate's retention of comment blocks as ordinary decoratable blocks (a documented divergence) is preserved — a comment a metadata line directly decorates, with no following section, is untouched.
- **Boundary look-ahead** (`blocks/section.rs`): `peer_or_ancestor_section` now discards blank lines before the heading it inspects (mirroring the live parse path), so the metadata+comment gap no longer folds a following peer/ancestor section into the current one.

## Tests

The two affected upstream ports — `last_wins_for_id_attribute` and `trailing_block_attributes_transfer_to_the_following_section` — are converted from `non_normative!` divergence notes to normative `verifies!` tests asserting the Asciidoctor-matching output. The module divergence summary is updated accordingly.

Full workspace test suite passes (4219 parser tests), plus `cargo +nightly fmt --all --check` and `cargo clippy --workspace --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)