### PR TITLE
fix: Fuse legacy `+`-continued multi-line attribute values (close #729)

### DIFF
--- a/parser/src/document/attribute.rs
+++ b/parser/src/document/attribute.rs
@@ -1163,6 +1163,60 @@ mod tests {
         assert!(warnings.next().is_none());
     }
 
+    mod fold_continuation_value {
+        use super::super::fold_continuation_value;
+
+        #[test]
+        fn no_marker_returns_none() {
+            // A plain single-line value has no continuation marker and needs no
+            // folding.
+            assert_eq!(fold_continuation_value("bar"), None);
+            assert_eq!(fold_continuation_value("bar+"), None);
+            assert_eq!(fold_continuation_value("bar ++"), None);
+        }
+
+        #[test]
+        fn modern_soft_wrap_folds_with_space() {
+            assert_eq!(
+                fold_continuation_value("bar \\\nblah"),
+                Some("bar blah".to_string())
+            );
+        }
+
+        #[test]
+        fn legacy_marker_folds_with_space() {
+            assert_eq!(
+                fold_continuation_value("This is the first +\nRuby implementation of +\nAsciiDoc."),
+                Some("This is the first Ruby implementation of AsciiDoc.".to_string())
+            );
+        }
+
+        #[test]
+        fn hard_line_break_joins_with_newline() {
+            // A soft-wrap value whose text ends in a hard line break marker
+            // (` +`) is joined with a newline rather than a space.
+            assert_eq!(
+                fold_continuation_value("bar + \\\nblah"),
+                Some("bar +\nblah".to_string())
+            );
+        }
+
+        #[test]
+        fn blank_line_terminates_value() {
+            // A blank line inside the (already-extent-trimmed) data terminates
+            // the fold without consuming further lines.
+            assert_eq!(fold_continuation_value("a +\n\nb"), Some("a".to_string()));
+        }
+
+        #[test]
+        fn crlf_line_endings_are_normalized() {
+            assert_eq!(
+                fold_continuation_value("bar +\r\nblah"),
+                Some("bar blah".to_string())
+            );
+        }
+    }
+
     mod interpreted_value {
         mod impl_debug {
             use crate::document::InterpretedValue;

--- a/parser/src/document/attribute.rs
+++ b/parser/src/document/attribute.rs
@@ -229,6 +229,11 @@ impl InterpretedValue {
 /// ASCII whitespace stripped by Ruby's `String#lstrip` / `#rstrip`, which
 /// Asciidoctor applies while fusing a continued attribute value. Unicode
 /// whitespace (e.g. a non-breaking space) is significant and is preserved.
+///
+/// This MUST stay identical to `CONTINUATION_WHITESPACE` in `span::line` (which
+/// the extent scanner `Span::take_value_with_continuation` uses) so the extent
+/// that scanner consumes and the lines this folder actually joins can never
+/// disagree.
 const ASCII_WHITESPACE: [char; 6] = [' ', '\t', '\n', '\r', '\x0C', '\x0B'];
 
 /// Fold an attribute entry value that carries a soft-wrap (`\`) or legacy (`+`)
@@ -257,7 +262,13 @@ fn fold_continuation_value(data: &str) -> Option<String> {
         .map(|line| line.strip_suffix('\r').unwrap_or(line));
 
     // `str::split` always yields at least one item, so `first` is always present.
-    let first = lines.next().unwrap_or_default();
+    // The first line is never left-trimmed (its leading whitespace was consumed
+    // with the `:name:` prefix), but it is right-trimmed so marker detection
+    // tolerates trailing whitespace, matching the extent scanner.
+    let first = lines
+        .next()
+        .unwrap_or_default()
+        .trim_end_matches(ASCII_WHITESPACE);
 
     // The continuation marker is fixed by the first line. Without one, the value
     // is a single line and needs no folding.
@@ -269,7 +280,7 @@ fn fold_continuation_value(data: &str) -> Option<String> {
         return None;
     };
 
-    // Drop the marker from the first line and right-trim (Ruby `rstrip`).
+    // Drop the marker from the first line (already right-trimmed above).
     let mut value = first[..first.len() - con.len()]
         .trim_end_matches(ASCII_WHITESPACE)
         .to_string();
@@ -280,8 +291,10 @@ fn fold_continuation_value(data: &str) -> Option<String> {
             break;
         }
 
-        // Continuation lines are left-trimmed (Ruby `lstrip`).
-        let line = line.trim_start_matches(ASCII_WHITESPACE);
+        // Continuation lines are left- and right-trimmed before the marker is
+        // tested, matching the extent scanner (`take_value_with_continuation`) so
+        // the two never disagree about where the value ends.
+        let line = line.trim_matches(ASCII_WHITESPACE);
 
         // A line still carrying the marker keeps the value open; strip the
         // marker (and right-trim) before appending.
@@ -975,6 +988,55 @@ mod tests {
     }
 
     #[test]
+    fn bare_marker_only_continuation_line_does_not_swallow_next_line() {
+        // A continuation line that is only a bare marker (` +`) terminates the
+        // value. The line after it must remain in the stream, not be consumed by
+        // the extent scanner and then dropped by the folder. The extent scanner
+        // and the folder must agree on where the value ends.
+        let mi = crate::document::Attribute::parse(
+            crate::Span::new(":foo: text +\n +\nmore"),
+            &Parser::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            mi.item,
+            Attribute {
+                name: Span {
+                    data: "foo",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+                value_source: Some(Span {
+                    data: "text +\n +",
+                    line: 1,
+                    col: 7,
+                    offset: 6,
+                }),
+                value: InterpretedValue::Value("text +"),
+                source: Span {
+                    data: ":foo: text +\n +",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                }
+            }
+        );
+
+        // `more` is preserved for the following block, not swallowed.
+        assert_eq!(
+            mi.after,
+            Span {
+                data: "more",
+                line: 3,
+                col: 1,
+                offset: 16,
+            }
+        );
+    }
+
+    #[test]
     fn is_block() {
         let mut parser = Parser::default();
         let maw = crate::blocks::Block::parse(crate::Span::new(":foo: bar\nblah"), &mut parser);
@@ -1241,6 +1303,30 @@ mod tests {
             assert_eq!(
                 fold_continuation_value("bar +\r\nblah"),
                 Some("bar blah".to_string())
+            );
+        }
+
+        #[test]
+        fn bare_marker_only_line_terminates_value() {
+            // A continuation line that is *only* the marker (a bare ` +` after
+            // left-trimming) does not keep the value open. It terminates the fold
+            // and its literal `+` is appended, matching Asciidoctor. The folder
+            // and `Span::take_value_with_continuation` must agree on this so the
+            // line after the bare marker is not consumed-then-dropped.
+            assert_eq!(
+                fold_continuation_value("text +\n +\nmore"),
+                Some("text +".to_string())
+            );
+        }
+
+        #[test]
+        fn trailing_whitespace_after_marker_still_continues() {
+            // Trailing whitespace after the marker is tolerated (right-trimmed)
+            // consistently with the extent scanner, so the following line is still
+            // folded in rather than dropped.
+            assert_eq!(
+                fold_continuation_value("a +\nb + \nmore"),
+                Some("a b more".to_string())
             );
         }
     }

--- a/parser/src/document/attribute.rs
+++ b/parser/src/document/attribute.rs
@@ -248,7 +248,8 @@ fn fold_continuation_value(data: &str) -> Option<String> {
         .split('\n')
         .map(|line| line.strip_suffix('\r').unwrap_or(line));
 
-    let first = lines.next()?;
+    // `str::split` always yields at least one item, so `first` is always present.
+    let first = lines.next().unwrap_or_default();
 
     // The continuation marker is fixed by the first line. Without one, the value
     // is a single line and needs no folding.
@@ -543,6 +544,25 @@ mod tests {
                 &Parser::default()
             )
             .is_none()
+        );
+    }
+
+    #[test]
+    fn err_missing_closing_colon() {
+        // A valid attribute name that is not followed by a closing colon is not
+        // an attribute entry.
+        assert!(
+            crate::document::Attribute::parse(
+                crate::Span::new(":foo bar\nblah"),
+                &Parser::default()
+            )
+            .is_none()
+        );
+
+        // ... including at end of input.
+        assert!(
+            crate::document::Attribute::parse(crate::Span::new(":foo"), &Parser::default())
+                .is_none()
         );
     }
 

--- a/parser/src/document/attribute.rs
+++ b/parser/src/document/attribute.rs
@@ -38,8 +38,7 @@ pub struct Attribute<'src> {
 
 impl<'src> Attribute<'src> {
     pub(crate) fn parse(source: Span<'src>, parser: &Parser) -> Option<MatchedItem<'src, Self>> {
-        let attr_line = source.take_line_with_continuation()?;
-        let colon = attr_line.item.take_prefix(":")?;
+        let colon = source.take_prefix(":")?;
 
         let mut unset = false;
         let line = if colon.after.starts_with('!') {
@@ -65,22 +64,41 @@ impl<'src> Attribute<'src> {
             (name.item, name.after)
         };
 
+        // `line.after` begins immediately after the closing `:` and runs to the
+        // end of the source. The value (and any continuation lines) live here.
         let line = after_name.take_prefix(":")?;
 
-        let (value, value_source) = if unset {
-            // Ensure line is now empty except for comment.
-            (InterpretedValue::Unset, None)
-        } else if line.after.is_empty() {
-            (InterpretedValue::Set, None)
+        let (value, value_source, after) = if unset {
+            // The value (if any) is ignored, but any continuation lines are
+            // still consumed so they don't leak into the block stream.
+            let extent = line
+                .after
+                .take_whitespace()
+                .after
+                .take_value_with_continuation();
+            (InterpretedValue::Unset, None, extent.after)
         } else {
-            let raw_value = line.after.take_whitespace();
-            (
-                InterpretedValue::from_raw_value(&raw_value.after, parser),
-                Some(raw_value.after),
-            )
+            let first_line = line.after.take_line();
+
+            if first_line.item.is_empty() {
+                // `:name:` with nothing after the closing colon (before any
+                // newline) is a set-only entry.
+                (InterpretedValue::Set, None, first_line.after)
+            } else {
+                let extent = line
+                    .after
+                    .take_whitespace()
+                    .after
+                    .take_value_with_continuation();
+                (
+                    InterpretedValue::from_raw_value(&extent.item, parser),
+                    Some(extent.item),
+                    extent.after,
+                )
+            }
         };
 
-        let source = source.trim_remainder(attr_line.after);
+        let source = source.trim_remainder(after);
         Some(MatchedItem {
             item: Self {
                 name: name_item,
@@ -88,7 +106,7 @@ impl<'src> Attribute<'src> {
                 value,
                 source: source.trim_trailing_whitespace(),
             },
-            after: attr_line.after,
+            after,
         })
     }
 
@@ -178,68 +196,13 @@ impl std::fmt::Debug for InterpretedValue {
 
 impl InterpretedValue {
     fn from_raw_value(raw_value: &Span<'_>, parser: &Parser) -> Self {
-        let data = raw_value.data();
         let mut content = Content::from(*raw_value);
 
-        if data.contains('\n') {
-            let lines: Vec<&str> = data.lines().collect();
-            let last_count = lines.len() - 1;
-
-            let value: Vec<String> = lines
-                .iter()
-                .enumerate()
-                .map(|(count, line)| {
-                    let line = if count > 0 {
-                        line.trim_start_matches(' ')
-                    } else {
-                        line
-                    };
-
-                    let line = line.trim_start_matches('\r').trim_end_matches(' ');
-
-                    // Strip the soft-wrap line continuation marker (a space
-                    // followed by a backslash). Only non-final lines carry a
-                    // continuation; a trailing backslash on the final line is a
-                    // literal character and is preserved.
-                    let line = if count < last_count {
-                        line.trim_end_matches('\\').trim_end_matches(' ')
-                    } else {
-                        line
-                    };
-
-                    // A hard line break marker (a space followed by `+`) before
-                    // a line continuation preserves the newline instead of
-                    // folding it into a space. The `+` itself is left in the
-                    // value verbatim: the post_replacements substitution step is
-                    // not applied to attribute entry values, so the `+` is only
-                    // interpreted as a line break later, when the value is used
-                    // in a block whose substitutions include post_replacements.
-                    if line.ends_with(" +") {
-                        format!("{line}\n")
-                    } else if count < last_count {
-                        format!("{line} ")
-                    } else {
-                        line.to_string()
-                    }
-                })
-                .collect();
-
-            content.rendered = CowStr::Boxed(value.join("").into_boxed_str());
-        } else if let Some(stripped) = data.strip_suffix(" +") {
-            // A single-line value ending in a bare hard line break marker (a
-            // space followed by a single `+`) has that marker stripped. This
-            // mirrors Asciidoctor, where ` +` at the end of an attribute value
-            // is treated as a legacy line-continuation marker: it is removed and
-            // the remaining value is right-trimmed. Contrast with a multi-line
-            // (continued) value, where the marker is preserved so it can drive
-            // post_replacements when the value is later used.
-            //
-            // Trim only ASCII whitespace (matching Ruby's `rstrip`, which
-            // Asciidoctor applies here); Unicode whitespace such as a
-            // non-breaking space is significant and must be preserved.
-            content.rendered = stripped
-                .trim_end_matches([' ', '\t', '\n', '\r', '\x0C', '\x0B'])
-                .into();
+        // Fold any soft-wrap (`\`) or legacy (`+`) line continuation. When there
+        // is no continuation marker, the value is a plain single line and is
+        // left untouched.
+        if let Some(folded) = fold_continuation_value(raw_value.data()) {
+            content.rendered = CowStr::Boxed(folded.into_boxed_str());
         }
 
         SubstitutionGroup::Header.apply(&mut content, parser, None);
@@ -253,6 +216,89 @@ impl InterpretedValue {
             _ => None,
         }
     }
+}
+
+/// ASCII whitespace stripped by Ruby's `String#lstrip` / `#rstrip`, which
+/// Asciidoctor applies while fusing a continued attribute value. Unicode
+/// whitespace (e.g. a non-breaking space) is significant and is preserved.
+const ASCII_WHITESPACE: [char; 6] = [' ', '\t', '\n', '\r', '\x0C', '\x0B'];
+
+/// Fold an attribute entry value that carries a soft-wrap (`\`) or legacy (`+`)
+/// line continuation across physical lines, mirroring Asciidoctor's
+/// `Parser.process_attribute_entry`.
+///
+/// The continuation marker is fixed by the first line: a modern soft-wrap
+/// marker (a space followed by `\`) or a legacy marker (a space followed by
+/// `+`). Continued lines are left-trimmed and, while they carry the same
+/// marker, keep the value open. Lines are joined with a newline when the
+/// accumulated value ends in a hard line break marker (` +`), otherwise they
+/// are folded into a single space.
+///
+/// The `+` of a preserved hard line break is left in the value verbatim: the
+/// `post_replacements` substitution step is not applied to attribute entry
+/// values, so the `+` is only interpreted as a line break later, when the value
+/// is used in a block whose substitutions include `post_replacements`.
+///
+/// Returns `None` when the value has no continuation marker (a plain
+/// single-line value that needs no folding).
+fn fold_continuation_value(data: &str) -> Option<String> {
+    const HARD_LINE_BREAK: &str = " +";
+
+    let mut lines = data
+        .split('\n')
+        .map(|line| line.strip_suffix('\r').unwrap_or(line));
+
+    let first = lines.next()?;
+
+    // The continuation marker is fixed by the first line. Without one, the value
+    // is a single line and needs no folding.
+    let con: &str = if first.ends_with(" \\") {
+        " \\"
+    } else if first.ends_with(" +") {
+        " +"
+    } else {
+        return None;
+    };
+
+    // Drop the marker from the first line and right-trim (Ruby `rstrip`).
+    let mut value = first[..first.len() - con.len()]
+        .trim_end_matches(ASCII_WHITESPACE)
+        .to_string();
+
+    for line in lines {
+        // A blank line (or end of input) terminates the value.
+        if line.is_empty() {
+            break;
+        }
+
+        // Continuation lines are left-trimmed (Ruby `lstrip`).
+        let line = line.trim_start_matches(ASCII_WHITESPACE);
+
+        // A line still carrying the marker keeps the value open; strip the
+        // marker (and right-trim) before appending.
+        let keep_open = line.ends_with(con);
+        let piece = if keep_open {
+            line[..line.len() - con.len()].trim_end_matches(ASCII_WHITESPACE)
+        } else {
+            line
+        };
+
+        // Join with a newline when the accumulated value ends in a hard line
+        // break marker (` +`), otherwise fold into a single space.
+        value.push_str(if value.ends_with(HARD_LINE_BREAK) {
+            "\n"
+        } else {
+            " "
+        });
+
+        value.push_str(piece);
+
+        if !keep_open {
+            break;
+        }
+    }
+
+    Some(value)
 }
 
 #[cfg(test)]
@@ -752,16 +798,15 @@ mod tests {
 
     #[test]
     fn single_line_trailing_hard_break_marker_is_stripped() {
-        // A single-line value ending in a bare hard line break marker (a space
-        // followed by a single `+`) has that marker stripped from the
-        // interpreted value, matching Asciidoctor. The raw `value_source` still
-        // contains the literal ` +`. Contrast with `value_with_hard_wrap`, where
-        // a ` +` on a *continued* (multi-line) value is preserved as a newline.
-        let mi = crate::document::Attribute::parse(
-            crate::Span::new(":foo: bar +\nblah"),
-            &Parser::default(),
-        )
-        .unwrap();
+        // A single-line value ending in a legacy continuation marker (a space
+        // followed by a single `+`) with no following non-blank line has that
+        // marker stripped from the interpreted value, matching Asciidoctor. The
+        // raw `value_source` still contains the literal ` +`. Contrast with
+        // `legacy_multi_line_value_is_fused`, where a following line _is_ folded
+        // in.
+        let mi =
+            crate::document::Attribute::parse(crate::Span::new(":foo: bar +"), &Parser::default())
+                .unwrap();
 
         assert_eq!(
             mi.item,
@@ -790,24 +835,74 @@ mod tests {
 
         assert_eq!(mi.item.value(), InterpretedValue::Value("bar"));
 
-        // `blah` is a separate line, not folded into the value (there is no line
-        // continuation).
         assert_eq!(
             mi.after,
             Span {
-                data: "blah",
-                line: 2,
-                col: 1,
-                offset: 12
+                data: "",
+                line: 1,
+                col: 12,
+                offset: 11
             }
         );
     }
 
     #[test]
-    fn single_line_hard_break_marker_edge_cases() {
-        // The marker is exactly a space followed by a single `+`. Any leading
-        // whitespace before the `+` (including tabs) is trimmed from the result,
-        // but only the single trailing ` +` is removed (not a repeated marker).
+    fn legacy_multi_line_value_is_fused() {
+        // A legacy `+`-continued value fuses the following line: the trailing
+        // ` +` marker is stripped and the lines are folded with a space (the
+        // value does not end in a hard line break marker after the strip). The
+        // following line is consumed, so `after` is empty. See #729.
+        let mi = crate::document::Attribute::parse(
+            crate::Span::new(":foo: bar +\nblah"),
+            &Parser::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            mi.item,
+            Attribute {
+                name: Span {
+                    data: "foo",
+                    line: 1,
+                    col: 2,
+                    offset: 1,
+                },
+                value_source: Some(Span {
+                    data: "bar +\nblah",
+                    line: 1,
+                    col: 7,
+                    offset: 6,
+                }),
+                value: InterpretedValue::Value("bar blah"),
+                source: Span {
+                    data: ":foo: bar +\nblah",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                }
+            }
+        );
+
+        assert_eq!(mi.item.value(), InterpretedValue::Value("bar blah"));
+
+        assert_eq!(
+            mi.after,
+            Span {
+                data: "",
+                line: 2,
+                col: 5,
+                offset: 16
+            }
+        );
+    }
+
+    #[test]
+    fn legacy_hard_break_marker_edge_cases() {
+        // The legacy continuation marker is exactly a space followed by a single
+        // `+`. When a following non-blank line is present, the marker fuses the
+        // lines (stripping the marker and right-trimming). Contrast with markers
+        // that are _not_ legacy continuations (`++`, a bare `+`, a tab before the
+        // `+`, or a lone `+`), which leave the value on a single line.
         let value = |src| {
             crate::document::Attribute::parse(crate::Span::new(src), &Parser::default())
                 .unwrap()
@@ -816,32 +911,38 @@ mod tests {
                 .clone()
         };
 
-        // Extra space(s) before the `+` are trimmed away with the marker.
-        assert_eq!(value(":foo: bar  +\nx"), InterpretedValue::Value("bar"));
+        // Extra space(s) before the `+` are trimmed away with the marker, and the
+        // following line is folded in with a single space.
+        assert_eq!(value(":foo: bar  +\nx"), InterpretedValue::Value("bar x"));
 
         // A tab preceding the marker's space is also trimmed.
-        assert_eq!(value(":foo: bar\t +\nx"), InterpretedValue::Value("bar"));
+        assert_eq!(value(":foo: bar\t +\nx"), InterpretedValue::Value("bar x"));
 
-        // `++` is not a hard line break marker; it is preserved verbatim.
+        // `++` is not a continuation marker; the value stays on one line verbatim.
         assert_eq!(value(":foo: bar ++\nx"), InterpretedValue::Value("bar ++"));
 
-        // A `+` with no preceding space is a literal character.
+        // A `+` with no preceding space is a literal character (no continuation).
         assert_eq!(value(":foo: bar+\nx"), InterpretedValue::Value("bar+"));
 
         // A tab (rather than a space) before the `+` does not form a marker.
         assert_eq!(value(":foo: bar\t+\nx"), InterpretedValue::Value("bar\t+"));
 
-        // A lone `+` (nothing before the space) is preserved.
+        // A lone `+` (nothing before it) is not a marker; it is preserved.
         assert_eq!(value(":foo: +\nx"), InterpretedValue::Value("+"));
 
-        // Only the final ` +` is stripped; an earlier ` +` remains literal.
-        assert_eq!(value(":foo: bar + +\nx"), InterpretedValue::Value("bar +"));
+        // An earlier ` +` in the fused first line ends in a hard line break
+        // marker, so the following line is joined with a newline rather than a
+        // space.
+        assert_eq!(
+            value(":foo: bar + +\nx"),
+            InterpretedValue::Value("bar +\nx")
+        );
 
-        // Trimming after the marker uses ASCII whitespace rules (Ruby `rstrip`);
-        // a preceding non-breaking space is significant and is preserved.
+        // Right-trimming after the marker uses ASCII whitespace rules (Ruby
+        // `rstrip`); a preceding non-breaking space is significant and preserved.
         assert_eq!(
             value(":foo: bar\u{00a0} +\nx"),
-            InterpretedValue::Value("bar\u{00a0}")
+            InterpretedValue::Value("bar\u{00a0} x")
         );
     }
 

--- a/parser/src/span/line.rs
+++ b/parser/src/span/line.rs
@@ -1,5 +1,12 @@
 use super::{MatchedItem, Span};
 
+/// ASCII whitespace trimmed from an attribute-entry continuation line before
+/// its continuation marker is tested. This MUST stay identical to the set
+/// trimmed by the folder (`InterpretedValue::fold_continuation_value`, whose
+/// local `ASCII_WHITESPACE` mirrors this) so the multi-line extent consumed
+/// here and the lines the folder actually joins can never disagree.
+const CONTINUATION_WHITESPACE: [char; 6] = [' ', '\t', '\n', '\r', '\x0C', '\x0B'];
+
 impl<'src> Span<'src> {
     /// Split the span, consuming a single line from the source.
     ///
@@ -126,7 +133,19 @@ impl<'src> Span<'src> {
                     break;
                 }
 
-                let keep_open = next.item.ends_with(con);
+                // Left- and right-trim the line before testing for the marker so
+                // this agrees exactly with `fold_continuation_value`, which trims
+                // each continuation line the same way. Without the left trim a
+                // line that is *only* the marker (e.g. a bare ` +`) would be kept
+                // open here but treated as a terminating line by the folder,
+                // causing the following line to be consumed from the stream yet
+                // silently dropped from the value.
+                let keep_open = next
+                    .item
+                    .data()
+                    .trim_matches(CONTINUATION_WHITESPACE)
+                    .ends_with(con);
+
                 cursor = next;
 
                 // The first continuation line lacking the marker terminates the
@@ -1586,6 +1605,37 @@ mod tests {
                     line: 1,
                     col: 1,
                     offset: 0
+                }
+            );
+        }
+
+        #[test]
+        fn bare_marker_only_line_terminates_extent() {
+            // A continuation line that is *only* the marker (a bare ` +` once
+            // left-trimmed) terminates the value. The extent must stop after that
+            // line so the following line stays in the stream; otherwise the folder
+            // (which left-trims and treats the bare marker as terminating) would
+            // drop it. Extent = `text +\n +`; `more` is left for the next block.
+            let span = crate::Span::new("text +\n +\nmore");
+            let line = span.take_value_with_continuation();
+
+            assert_eq!(
+                line.item,
+                Span {
+                    data: "text +\n +",
+                    line: 1,
+                    col: 1,
+                    offset: 0
+                }
+            );
+
+            assert_eq!(
+                line.after,
+                Span {
+                    data: "more",
+                    line: 3,
+                    col: 1,
+                    offset: 10
                 }
             );
         }

--- a/parser/src/span/line.rs
+++ b/parser/src/span/line.rs
@@ -80,53 +80,72 @@ impl<'src> Span<'src> {
         i
     }
 
-    /// Split the span, consuming one normalized, non-empty line that may be
-    /// continued onto subsequent lines with an explicit continuation marker.
+    /// Split the span, consuming an attribute entry value that may be continued
+    /// onto subsequent lines with an explicit continuation marker.
     ///
-    /// A line is terminated by end-of-input or a single `\n` character
-    /// or a single `\r\n` sequence. The end of line sequence is consumed
-    /// but not included in the returned line.
+    /// The continuation marker is fixed by the first line: a modern soft-wrap
+    /// marker (a space immediately followed by `\`) or a legacy marker (a space
+    /// immediately followed by `+`). When the first line carries a marker,
+    /// subsequent non-blank lines are consumed while they carry the _same_
+    /// marker; the first line lacking it is still consumed (it terminates the
+    /// value), and a blank line terminates the value without being consumed.
+    /// This mirrors Asciidoctor's `Parser.process_attribute_entry`.
     ///
-    /// A line is _not_ terminated by `\n` when preceded by a `\` character.
+    /// A bare trailing marker with no preceding space (e.g. `foo\`) is a
+    /// literal character and does not continue the line.
     ///
-    /// SPEC QUESTION: Is it allowed to have a `+` character followed by
-    /// white space? For now, I'm saying yes.
-    ///
-    /// Trailing white spaces are removed from the final line and are not
-    /// removed from any lines with continuations.
-    ///
-    /// Returns `None` if the line becomes empty after trailing spaces have been
-    /// removed.
-    pub(crate) fn take_line_with_continuation(self) -> Option<MatchedItem<'src, Self>> {
-        // Consume any number of lines terminated by '\\'.
-        let mut mi = self.into_parse_result(0);
-        while let Some(new_pr) = mi.after.one_line_with_continuation() {
-            mi = new_pr;
-        }
+    /// The returned `item` spans the raw source of the (possibly multi-line)
+    /// value with the trailing end-of-line and trailing spaces removed; the
+    /// embedded continuation markers and interior newlines are preserved so the
+    /// value can be folded later (see `InterpretedValue::from_raw_value`).
+    /// Trailing spaces are _not_ removed from interior (continued) lines.
+    /// Callers are responsible for treating an empty `item` as "no value".
+    pub(crate) fn take_value_with_continuation(self) -> MatchedItem<'src, Self> {
+        let first = self.take_normalized_line();
 
-        // Consume at most one line without a `\\` terminator.
-        mi = mi.after.take_line();
-
-        let mi = self
-            .into_parse_result(mi.after.byte_offset() - self.byte_offset())
-            .trim_item_end_matches('\n')
-            .trim_item_end_matches('\r')
-            .trim_item_trailing_spaces();
-
-        if mi.item.is_empty() { None } else { Some(mi) }
-    }
-
-    fn one_line_with_continuation(self) -> Option<MatchedItem<'src, Self>> {
-        let line = self.take_normalized_line();
-
-        // A soft-wrap line continuation is a *space* immediately followed by a
-        // trailing backslash. A bare trailing backslash (no preceding space) is a
-        // literal character and does not continue the line (matching Asciidoctor).
-        if line.item.ends_with(" \\") {
-            Some(line)
+        // A continuation marker is a *space* immediately followed by a trailing
+        // backslash (modern) or plus (legacy). A bare trailing marker with no
+        // preceding space is a literal character (matching Asciidoctor).
+        let con = if first.item.ends_with(" \\") {
+            Some(" \\")
+        } else if first.item.ends_with(" +") {
+            Some(" +")
         } else {
             None
-        }
+        };
+
+        let end_after = if let Some(con) = con {
+            let mut cursor = first;
+
+            loop {
+                let next = cursor.after.take_normalized_line();
+
+                // A blank line (or end of input) terminates the value and is not
+                // consumed.
+                if next.item.is_empty() {
+                    break;
+                }
+
+                let keep_open = next.item.ends_with(con);
+                cursor = next;
+
+                // The first continuation line lacking the marker terminates the
+                // value (but is still part of it).
+                if !keep_open {
+                    break;
+                }
+            }
+
+            cursor.after
+        } else {
+            // No continuation marker: a single line.
+            self.take_line().after
+        };
+
+        self.into_parse_result(end_after.byte_offset() - self.byte_offset())
+            .trim_item_end_matches('\n')
+            .trim_item_end_matches('\r')
+            .trim_item_trailing_spaces()
     }
 }
 
@@ -1079,25 +1098,37 @@ mod tests {
         }
     }
 
-    mod take_line_with_continuation {
+    mod take_value_with_continuation {
         use crate::tests::prelude::*;
 
         #[test]
         fn empty_source() {
             let span = crate::Span::default();
-            assert!(span.take_line_with_continuation().is_none());
+            let line = span.take_value_with_continuation();
+            assert!(line.item.is_empty());
         }
 
         #[test]
         fn only_spaces() {
             let span = crate::Span::new("   ");
-            assert!(span.take_line_with_continuation().is_none());
+            let line = span.take_value_with_continuation();
+            assert!(line.item.is_empty());
+
+            assert_eq!(
+                line.after,
+                Span {
+                    data: "",
+                    line: 1,
+                    col: 4,
+                    offset: 3
+                }
+            );
         }
 
         #[test]
         fn simple_line() {
             let span = crate::Span::new("abc");
-            let line = span.take_line_with_continuation().unwrap();
+            let line = span.take_value_with_continuation();
 
             assert_eq!(
                 line.after,
@@ -1123,7 +1154,7 @@ mod tests {
         #[test]
         fn discards_trailing_space() {
             let span = crate::Span::new("abc ");
-            let line = span.take_line_with_continuation().unwrap();
+            let line = span.take_value_with_continuation();
 
             assert_eq!(
                 line.after,
@@ -1151,7 +1182,7 @@ mod tests {
             // Should consume but not return \n.
 
             let span = crate::Span::new("abc  \ndef");
-            let line = span.take_line_with_continuation().unwrap();
+            let line = span.take_value_with_continuation();
 
             assert_eq!(
                 line.after,
@@ -1179,7 +1210,7 @@ mod tests {
             // Should consume but not return \r\n.
 
             let span = crate::Span::new("abc  \r\ndef");
-            let line = span.take_line_with_continuation().unwrap();
+            let line = span.take_value_with_continuation();
 
             assert_eq!(
                 line.after,
@@ -1207,7 +1238,7 @@ mod tests {
             // Should consume \n but not a subsequent \r.
 
             let span = crate::Span::new("abc  \n\rdef");
-            let line = span.take_line_with_continuation().unwrap();
+            let line = span.take_value_with_continuation();
 
             assert_eq!(
                 line.after,
@@ -1235,7 +1266,7 @@ mod tests {
             // Shouldn't terminate line at \r without \n.
 
             let span = crate::Span::new("abc   \rdef");
-            let line = span.take_line_with_continuation().unwrap();
+            let line = span.take_value_with_continuation();
 
             assert_eq!(
                 line.after,
@@ -1261,7 +1292,7 @@ mod tests {
         #[test]
         fn simple_continuation() {
             let span = crate::Span::new("abc \\\ndef");
-            let line = span.take_line_with_continuation().unwrap();
+            let line = span.take_value_with_continuation();
 
             assert_eq!(
                 line.after,
@@ -1287,7 +1318,7 @@ mod tests {
         #[test]
         fn simple_continuation_with_crlf() {
             let span = crate::Span::new("abc \\\r\ndef");
-            let line = span.take_line_with_continuation().unwrap();
+            let line = span.take_value_with_continuation();
 
             assert_eq!(
                 line.after,
@@ -1313,7 +1344,7 @@ mod tests {
         #[test]
         fn continuation_with_trailing_space() {
             let span = crate::Span::new("abc \\   \ndef");
-            let line = span.take_line_with_continuation().unwrap();
+            let line = span.take_value_with_continuation();
 
             assert_eq!(
                 line.after,
@@ -1339,7 +1370,7 @@ mod tests {
         #[test]
         fn multiple_continuations() {
             let span = crate::Span::new("abc \\\ndef \\\nghi");
-            let line = span.take_line_with_continuation().unwrap();
+            let line = span.take_value_with_continuation();
 
             assert_eq!(
                 line.after,
@@ -1369,7 +1400,7 @@ mod tests {
             // terminates the line; the next line is not folded in.
             // See https://github.com/asciidoc-rs/asciidoc-parser/issues/666.
             let span = crate::Span::new("abc\\\ndef");
-            let line = span.take_line_with_continuation().unwrap();
+            let line = span.take_value_with_continuation();
 
             assert_eq!(
                 line.after,
@@ -1395,7 +1426,7 @@ mod tests {
         #[test]
         fn terminates_on_line_without_trailing_slash() {
             let span = crate::Span::new("abc \\\ndef  \nghi");
-            let line = span.take_line_with_continuation().unwrap();
+            let line = span.take_value_with_continuation();
 
             assert_eq!(
                 line.after,
@@ -1421,7 +1452,7 @@ mod tests {
         #[test]
         fn doesnt_consume_empty_line() {
             let span = crate::Span::new("abc \\\ndef\n\nghi");
-            let line = span.take_line_with_continuation().unwrap();
+            let line = span.take_value_with_continuation();
 
             assert_eq!(
                 line.after,
@@ -1437,6 +1468,121 @@ mod tests {
                 line.item,
                 Span {
                     data: "abc \\\ndef",
+                    line: 1,
+                    col: 1,
+                    offset: 0
+                }
+            );
+        }
+
+        #[test]
+        fn legacy_plus_continuation() {
+            // A legacy `+` continuation (a space followed by `+`) fuses lines just
+            // like the modern `\` marker. The raw item preserves the markers and
+            // interior newlines; folding happens later.
+            let span = crate::Span::new("abc +\ndef +\nghi");
+            let line = span.take_value_with_continuation();
+
+            assert_eq!(
+                line.after,
+                Span {
+                    data: "",
+                    line: 3,
+                    col: 4,
+                    offset: 15
+                }
+            );
+
+            assert_eq!(
+                line.item,
+                Span {
+                    data: "abc +\ndef +\nghi",
+                    line: 1,
+                    col: 1,
+                    offset: 0
+                }
+            );
+        }
+
+        #[test]
+        fn legacy_plus_terminates_on_line_without_marker() {
+            // The continuation stops after the first line that no longer carries
+            // the legacy `+` marker (that line is still consumed).
+            let span = crate::Span::new("abc +\ndef\nghi");
+            let line = span.take_value_with_continuation();
+
+            assert_eq!(
+                line.after,
+                Span {
+                    data: "ghi",
+                    line: 3,
+                    col: 1,
+                    offset: 10
+                }
+            );
+
+            assert_eq!(
+                line.item,
+                Span {
+                    data: "abc +\ndef",
+                    line: 1,
+                    col: 1,
+                    offset: 0
+                }
+            );
+        }
+
+        #[test]
+        fn legacy_plus_marker_is_fixed_by_first_line() {
+            // The marker is fixed by the first line. When the first line has no
+            // marker, a trailing `\` on a *later* line is not a continuation: the
+            // value is just the first line.
+            let span = crate::Span::new("abc\ndef \\\nghi");
+            let line = span.take_value_with_continuation();
+
+            assert_eq!(
+                line.after,
+                Span {
+                    data: "def \\\nghi",
+                    line: 2,
+                    col: 1,
+                    offset: 4
+                }
+            );
+
+            assert_eq!(
+                line.item,
+                Span {
+                    data: "abc",
+                    line: 1,
+                    col: 1,
+                    offset: 0
+                }
+            );
+        }
+
+        #[test]
+        fn bare_plus_is_not_a_continuation() {
+            // A legacy continuation requires a *space* before the trailing `+`. A
+            // bare `+` (no preceding space) is a literal character and terminates
+            // the line; the next line is not folded in.
+            let span = crate::Span::new("abc+\ndef");
+            let line = span.take_value_with_continuation();
+
+            assert_eq!(
+                line.after,
+                Span {
+                    data: "def",
+                    line: 2,
+                    col: 1,
+                    offset: 5
+                }
+            );
+
+            assert_eq!(
+                line.item,
+                Span {
+                    data: "abc+",
                     line: 1,
                     col: 1,
                     offset: 0

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -234,10 +234,9 @@ mod assignment {
         }
     }
 
-    // Tracked in #729.
     #[test]
     fn creates_an_attribute_by_fusing_a_legacy_multi_line_value() {
-        non_normative!(
+        verifies!(
             r#"
     test 'creates an attribute by fusing a legacy multi-line value' do
       str = <<~'EOS'
@@ -252,17 +251,12 @@ mod assignment {
 "#
         );
 
-        // Divergence: Asciidoctor fuses a legacy `+`-terminated multi-line
-        // attribute value; this crate only fuses the modern backslash
-        // continuation, so the `+`-continued lines are not joined, and the
-        // trailing `+` is treated as a hard-break marker and stripped, leaving
-        // just the first line's text.
         let doc = Parser::default().parse(
             ":description: This is the first      +\n              Ruby implementation of +\n              AsciiDoc.",
         );
         assert_eq!(
             doc.attribute_value("description"),
-            InterpretedValue::Value("This is the first")
+            InterpretedValue::Value("This is the first Ruby implementation of AsciiDoc.")
         );
     }
 
@@ -516,10 +510,9 @@ mod assignment {
         assert_eq!(doc.attribute_value("release"), InterpretedValue::Value(""));
     }
 
-    // Tracked in #729.
     #[test]
     fn assigns_multi_line_attribute_to_empty_string_if_substitution_fails_to_resolve_attribute() {
-        non_normative!(
+        verifies!(
             r#"
     test 'assigns multi-line attribute to empty string if substitution fails to resolve attribute' do
       input = <<~'EOS'
@@ -534,11 +527,10 @@ mod assignment {
 "#
         );
 
-        // Divergence: this crate only fuses the modern backslash continuation,
-        // not the legacy `+` continuation, so the `{version}` line never
-        // participates in the header value; the trailing `+` is treated as a
-        // hard-break marker and stripped, leaving just `Asciidoctor`. (The INFO
-        // drop-line log is also not modeled.)
+        // The legacy `+` continuation fuses the `{version}` line into the header
+        // value (`Asciidoctor {version}`); the unresolved `{version}` reference
+        // then drops the line under `attribute-missing=drop-line`, leaving the
+        // empty string. (The INFO drop-line log is not modeled.)
         let doc = Parser::default()
             .with_intrinsic_attribute(
                 "attribute-missing",
@@ -546,10 +538,7 @@ mod assignment {
                 ModificationContext::ApiOnly,
             )
             .parse(":release: Asciidoctor +\n          {version}\n");
-        assert_eq!(
-            doc.attribute_value("release"),
-            InterpretedValue::Value("Asciidoctor")
-        );
+        assert_eq!(doc.attribute_value("release"), InterpretedValue::Value(""));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #729.

## Problem

An attribute entry value can be continued across lines with a trailing ` +` (legacy) as well as ` \` (modern), fusing the lines into a single value. Only the `\` continuation was being fused. A legacy `+`-continued value was not joined: the trailing `+` was treated as a hard-break marker and stripped, so only the first line's text survived.

## Fix

Rework attribute-entry continuation to mirror Asciidoctor's `Parser.process_attribute_entry`:

- **Marker is fixed by the first line.** The first line's value determines whether we're in modern (` \`) or legacy (` +`) mode; subsequent non-blank lines are consumed while they carry that *same* marker. The first line lacking the marker still terminates (and belongs to) the value; a blank line terminates it without being consumed.
- **Value-aware detection.** Marker detection now runs on the value (after the `:name:` prefix), not the raw source line. This keeps a degenerate `:foo: +` as a literal single-line value (`+`) rather than a spurious continuation.
- **Correct folding.** Continued lines are joined with a newline when the accumulated value ends in a hard line break marker (` +`), and with a single space otherwise — matching Asciidoctor's legacy-vs-hard-break behavior, including the `rstrip`/`lstrip` whitespace rules (ASCII only; a non-breaking space is preserved).

Implementation:

- `Span::take_line_with_continuation` → value-aware `take_value_with_continuation`.
- `InterpretedValue::from_raw_value` folding extracted into `fold_continuation_value`, a faithful port of the upstream algorithm.

## Behavior change worth noting

A single-line value ending in ` +` that is *followed by a non-blank line* now fuses that line in (e.g. `:foo: bar +` / `blah` → `bar blah`), which is what Asciidoctor does. The value ending at EOF (or before a blank line) still strips the marker to `bar`. The affected `attribute.rs` unit tests are updated to the corrected expectations.

## Tests

- The two upstream ports in `attributes_test.rb` — `creates_an_attribute_by_fusing_a_legacy_multi_line_value` and `assigns_multi_line_attribute_to_empty_string_if_substitution_fails_to_resolve_attribute` — are promoted from `non_normative!` to `verifies!`.
- Added span-level coverage for legacy `+` continuation and marker edge cases.
- Full workspace suite passes (`cargo test`), `cargo clippy` clean, `cargo +nightly fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)