### PR TITLE
feat: Embed images as `data-uri` and catalog image assets (close #697)

### DIFF
--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -267,12 +267,19 @@ impl Replacer for InlineImageMacroReplacer<'_> {
         // `alt`.
 
         if caps[0].starts_with("image:") {
-            // TO DO: Register image with parser?
-            // IMPORTANT: May require interior mutability on Parser because it looks like we
-            // can't pass mutable references to Parser in a recursive Regex replacement.
-
-            // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/335):
-            // todo!("Port this: {}", "doc.register :images, target");
+            // Record the referenced image in the document catalog when
+            // `catalog_assets` is enabled (a no-op otherwise). Attribute
+            // references in the target were already substituted by the earlier
+            // attribute-references step, so `target` is the resolved path, and
+            // the catalog stores it alongside the current `imagesdir`. Mirrors
+            // Asciidoctor's `doc.register :images, target`.
+            self.0.register_image(
+                target.to_string(),
+                self.0
+                    .attribute_value("imagesdir")
+                    .as_maybe_str()
+                    .map(str::to_owned),
+            );
 
             let params = ImageRenderParams {
                 target,

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -25,6 +25,13 @@ pub struct Catalog {
     /// footnotes defined inside a cell are *not* shared with the main document.
     pub(crate) footnotes: Vec<Footnote>,
 
+    /// Images referenced by `image:`/`image::` macros, recorded in document
+    /// order while substituting inline macros – but only when the parser was
+    /// configured with
+    /// [`with_catalog_assets(true)`](crate::Parser::with_catalog_assets)
+    /// (Asciidoctor's `catalog_assets` API option). Empty otherwise.
+    pub(crate) images: Vec<ImageReference>,
+
     /// AsciiDoc files that were included into this document, keyed by the
     /// include target relative to the outermost document with its AsciiDoc
     /// extension removed (e.g. `other-chapters` for
@@ -57,6 +64,7 @@ impl Catalog {
             refs: HashMap::new(),
             reftext_to_id: HashMap::new(),
             footnotes: Vec::new(),
+            images: Vec::new(),
             includes: HashMap::new(),
         }
     }
@@ -220,6 +228,21 @@ impl Catalog {
         self.footnotes.iter().find(|f| f.id.as_deref() == Some(id))
     }
 
+    /// Returns the images referenced in this document, in document order.
+    ///
+    /// This list is populated only when the parser was configured with
+    /// [`with_catalog_assets(true)`](crate::Parser::with_catalog_assets); it is
+    /// empty otherwise.
+    pub fn images(&self) -> &[ImageReference] {
+        &self.images
+    }
+
+    /// Records a referenced image (an `image:`/`image::` macro target) in
+    /// document order.
+    pub(crate) fn register_image(&mut self, target: String, imagesdir: Option<String>) {
+        self.images.push(ImageReference { target, imagesdir });
+    }
+
     /// Records that the AsciiDoc file named by `key` was included into this
     /// document.
     ///
@@ -376,8 +399,34 @@ impl std::fmt::Debug for Catalog {
             .field("refs", &DebugHashMapFrom(&self.refs))
             .field("reftext_to_id", &DebugHashMapFrom(&self.reftext_to_id))
             .field("footnotes", &self.footnotes)
+            .field("images", &self.images)
             .field("includes", &DebugHashMapFrom(&self.includes))
             .finish()
+    }
+}
+
+/// A reference to an image asset recorded in the document
+/// [`Catalog`](Catalog::images) when `catalog_assets` is enabled.
+///
+/// Mirrors Asciidoctor's `Document::ImageReference`: it pairs the image
+/// [`target`](Self::target) with the value of the `imagesdir` attribute in
+/// effect where the image was referenced.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ImageReference {
+    /// The image target as written in the macro, after attribute references in
+    /// the target have been substituted (e.g. `fixtures/dot.gif`).
+    pub target: String,
+
+    /// The value of the `imagesdir` document attribute at the point of
+    /// reference, or `None` when it was unset.
+    pub imagesdir: Option<String>,
+}
+
+impl std::fmt::Display for ImageReference {
+    /// Displays the image reference as its [`target`](Self::target), mirroring
+    /// Asciidoctor's `ImageReference#to_s`.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.target)
     }
 }
 /// Type of referenceable element in the document.
@@ -438,7 +487,7 @@ impl std::error::Error for DuplicateIdError {}
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::indexing_slicing, clippy::unwrap_used)]
 
     use super::*;
 
@@ -630,6 +679,29 @@ mod tests {
         catalog.register_include("tigers", false);
         assert!(catalog.was_included("tigers"));
         assert!(!catalog.include_is_full("tigers"));
+    }
+
+    #[test]
+    fn register_image_records_in_document_order() {
+        let mut catalog = Catalog::new();
+        assert!(catalog.images().is_empty());
+
+        catalog.register_image("fixtures/dot.gif".to_string(), None);
+        catalog.register_image("logo.png".to_string(), Some("images".to_string()));
+
+        let images = catalog.images();
+        assert_eq!(images.len(), 2);
+
+        // The first image carries no `imagesdir`; `to_string`/`Display` yields
+        // the bare target.
+        assert_eq!(images[0].target, "fixtures/dot.gif");
+        assert_eq!(images[0].imagesdir, None);
+        assert_eq!(images[0].to_string(), "fixtures/dot.gif");
+
+        // The second records the `imagesdir` in effect at the reference.
+        assert_eq!(images[1].target, "logo.png");
+        assert_eq!(images[1].imagesdir, Some("images".to_string()));
+        assert_eq!(images[1].to_string(), "logo.png");
     }
 
     #[test]

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -429,6 +429,7 @@ impl std::fmt::Display for ImageReference {
         f.write_str(&self.target)
     }
 }
+
 /// Type of referenceable element in the document.
 #[derive(Clone, PartialEq, Eq)]
 pub enum RefType {

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -1647,6 +1647,7 @@ mod tests {
         refs: HashMap::from([]),
         reftext_to_id: HashMap::from([]),
         footnotes: [],
+        images: [],
         includes: HashMap::from([]),
     },
 }"#

--- a/parser/src/document/mod.rs
+++ b/parser/src/document/mod.rs
@@ -13,7 +13,7 @@ pub use author_line::AuthorLine;
 mod catalog;
 #[allow(unused)] // TEMPORARY while building
 pub(crate) use catalog::DuplicateIdError;
-pub use catalog::{Catalog, Footnote, RefEntry, RefType};
+pub use catalog::{Catalog, Footnote, ImageReference, RefEntry, RefType};
 
 mod docinfo;
 pub(crate) use docinfo::Docinfo;

--- a/parser/src/internal/base64.rs
+++ b/parser/src/internal/base64.rs
@@ -1,0 +1,102 @@
+//! A minimal, dependency-free base64 encoder.
+//!
+//! This crate embeds referenced images as `data:` URIs when the `data-uri`
+//! document attribute is set (see
+//! [`image_uri`](crate::parser::InlineSubstitutionRenderer::image_uri)), which
+//! requires base64-encoding the image bytes. Rather than pull in an external
+//! crate for what is a small, well-specified transform, the standard-alphabet
+//! encoder lives here.
+//!
+//! The output matches Ruby's `[bytes].pack('m0')` (equivalently
+//! `Base64.strict_encode64`): the standard alphabet, `=` padding, and no line
+//! breaks — exactly what a `data:` URI needs.
+
+/// The standard base64 alphabet (RFC 4648), indexed by 6-bit value.
+const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/// Encodes `input` as base64 using the standard alphabet, with `=` padding and
+/// no line breaks.
+///
+/// This mirrors Ruby's `[input].pack('m0')` (a.k.a. `Base64.strict_encode64`),
+/// the form Asciidoctor uses when building a `data:` URI.
+pub(crate) fn strict_encode(input: &[u8]) -> String {
+    // Every 3 input bytes become 4 output characters, rounding up.
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+
+    let mut chunks = input.chunks_exact(3);
+
+    for chunk in chunks.by_ref() {
+        // `chunks_exact(3)` yields exactly three bytes per chunk.
+        let &[a, b, c] = chunk else { continue };
+        let n = (u32::from(a) << 16) | (u32::from(b) << 8) | u32::from(c);
+        out.push(sextet(n >> 18));
+        out.push(sextet(n >> 12));
+        out.push(sextet(n >> 6));
+        out.push(sextet(n));
+    }
+
+    // The final 1 or 2 bytes are padded out to a full 4-character group with
+    // `=`.
+    match chunks.remainder() {
+        [a] => {
+            let n = u32::from(*a) << 16;
+            out.push(sextet(n >> 18));
+            out.push(sextet(n >> 12));
+            out.push('=');
+            out.push('=');
+        }
+        [a, b] => {
+            let n = (u32::from(*a) << 16) | (u32::from(*b) << 8);
+            out.push(sextet(n >> 18));
+            out.push(sextet(n >> 12));
+            out.push(sextet(n >> 6));
+            out.push('=');
+        }
+        _ => {}
+    }
+
+    out
+}
+
+/// Maps the low 6 bits of `value` to its base64 alphabet character.
+fn sextet(value: u32) -> char {
+    // Masking to 6 bits keeps the index within `0..64`, so the alphabet lookup
+    // can never go out of bounds.
+    #[allow(clippy::indexing_slicing)]
+    let c = ALPHABET[(value & 0x3f) as usize];
+
+    c as char
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strict_encode;
+
+    #[test]
+    fn rfc4648_test_vectors() {
+        // The canonical vectors from RFC 4648 §10 exercise every padding case.
+        assert_eq!(strict_encode(b""), "");
+        assert_eq!(strict_encode(b"f"), "Zg==");
+        assert_eq!(strict_encode(b"fo"), "Zm8=");
+        assert_eq!(strict_encode(b"foo"), "Zm9v");
+        assert_eq!(strict_encode(b"foob"), "Zm9vYg==");
+        assert_eq!(strict_encode(b"fooba"), "Zm9vYmE=");
+        assert_eq!(strict_encode(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn encodes_full_byte_range() {
+        // A run of bytes spanning the high bit confirms the `+` and `/` alphabet
+        // slots and that no line breaks are emitted.
+        let bytes: Vec<u8> = (0u8..=255).collect();
+        let encoded = strict_encode(&bytes);
+
+        assert!(!encoded.contains('\n'));
+        assert!(encoded.starts_with("AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8g"));
+        assert!(encoded.contains('+'));
+        assert!(encoded.contains('/'));
+
+        // 256 bytes → 342 base64 chars (256 / 3 = 85 remainder 1 → 86 groups).
+        assert_eq!(encoded.len(), 344);
+    }
+}

--- a/parser/src/internal/mod.rs
+++ b/parser/src/internal/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod base64;
 pub(crate) mod chars;
 pub(crate) mod debug;
 mod regex;

--- a/parser/src/parser/image_file_handler.rs
+++ b/parser/src/parser/image_file_handler.rs
@@ -1,0 +1,41 @@
+use std::fmt::Debug;
+
+use crate::Parser;
+
+/// An `ImageFileHandler` is responsible for providing the raw bytes of an image
+/// file when a referenced image must be embedded directly in the output as a
+/// `data:` URI (i.e. when the `data-uri` document attribute is set and the safe
+/// mode is below [`SafeMode::Secure`]).
+///
+/// This crate is a parser, not a converter, and never reads from the filesystem
+/// itself. A client of [`Parser`] that wants images embedded as `data:` URIs
+/// must provide an `ImageFileHandler` (analogous to [`SvgFileHandler`],
+/// [`IncludeFileHandler`], and [`DocinfoFileHandler`]) that maps a resolved
+/// image path to its bytes. If no handler is provided (or the handler cannot
+/// find the file), the image degrades to an ordinary web path – the same output
+/// as when `data-uri` is not set – matching this crate's convention that a
+/// missing I/O handler is a silent, graceful degradation.
+///
+/// [`Parser`]: crate::Parser
+/// [`SafeMode::Secure`]: crate::SafeMode::Secure
+/// [`SvgFileHandler`]: crate::parser::SvgFileHandler
+/// [`IncludeFileHandler`]: crate::parser::IncludeFileHandler
+/// [`DocinfoFileHandler`]: crate::parser::DocinfoFileHandler
+pub trait ImageFileHandler: Debug {
+    /// Provide the raw bytes of an image file, if available.
+    ///
+    /// # Parameters
+    /// - `target`: The resolved path to the image file, already prefixed with
+    ///   the value of the relevant asset-directory attribute (`imagesdir` or
+    ///   `iconsdir`, as appropriate). This is the same value that would appear
+    ///   in the `src` attribute of the image were it *not* embedded.
+    /// - `parser`: An implementation may read document attribute values from
+    ///   the [`Parser`] state.
+    ///
+    /// Return the bytes of the image file if found. If no file is found (or it
+    /// is not readable), return `None`; the image will then fall back to
+    /// rendering an ordinary web path.
+    ///
+    /// [`Parser`]: crate::Parser
+    fn resolve_image(&self, target: &str, parser: &Parser) -> Option<Vec<u8>>;
+}

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -1302,6 +1302,10 @@ fn has_extname(path: &str) -> bool {
 /// extension, mirroring Asciidoctor's `generate_data_uri`: `.svg` maps to
 /// `image/svg+xml`, any other extension maps to `image/<ext>`, and a target
 /// with no extension maps to `application/octet-stream`.
+///
+/// The `image/<ext>` mapping is verbatim, matching Asciidoctor: `.jpg` yields
+/// `image/jpg` (not the IANA-registered `image/jpeg`), while `.jpeg` yields
+/// `image/jpeg`. This parity with Asciidoctor is deliberate.
 fn data_uri_mimetype(target: &str) -> String {
     match extname(target) {
         Some(".svg") => "image/svg+xml".to_string(),
@@ -1558,6 +1562,12 @@ mod tests {
         assert_eq!(data_uri_mimetype("circle.svg"), "image/svg+xml");
         assert_eq!(data_uri_mimetype("fixtures/dot.gif"), "image/gif");
         assert_eq!(data_uri_mimetype("photo.png"), "image/png");
+
+        // The extension is used verbatim (matching Asciidoctor), so `.jpg`
+        // yields `image/jpg` rather than the registered `image/jpeg`, while
+        // `.jpeg` yields `image/jpeg`.
+        assert_eq!(data_uri_mimetype("photo.jpg"), "image/jpg");
+        assert_eq!(data_uri_mimetype("photo.jpeg"), "image/jpeg");
 
         // A target with no extension falls back to a generic binary type.
         assert_eq!(data_uri_mimetype("noext"), "application/octet-stream");

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -65,13 +65,12 @@ pub trait InlineSubstitutionRenderer: Debug {
     /// The `target_image_path` is resolved relative to the directory retrieved
     /// from the specified document-scoped attribute key, if provided.
     ///
-    /// In Asciidoctor, if the `data-uri` attribute is set on the document and
-    /// the safe mode is below `SafeMode::Secure`, the image is converted to a
-    /// data URI by reading its bytes from the same directory; otherwise a
-    /// relative path (i.e., URL) is returned. The `data-uri` embedding path is
-    /// not yet implemented in this crate (tracked by
-    /// <https://github.com/asciidoc-rs/asciidoc-parser/issues/697>), so a
-    /// normalized web path is always returned.
+    /// If the `data-uri` attribute is set on the document and the safe mode is
+    /// below `SafeMode::Secure`, the image is embedded as a
+    /// `data:<mime>;base64,…` URI by reading its bytes through the
+    /// [`ImageFileHandler`](crate::parser::ImageFileHandler); otherwise (or
+    /// when no handler is registered) a normalized relative path (i.e.,
+    /// URL) is returned. A target that is itself a URI is never embedded.
     ///
     /// ## Parameters
     ///
@@ -761,7 +760,13 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
         let svg_active = (format == Some("svg") || params.target.contains(".svg"))
             && params.parser.safe_mode() < SafeMode::Secure;
 
-        let img = if svg_active && params.attrlist.has_option("inline") {
+        // An inline SVG is embedded verbatim and has no meaningful `src`, so a
+        // `link=self` on it is left as the literal `self` rather than resolved
+        // to a URI (see `render_icon_or_image`). Every other image form does
+        // have a `src` (a data URI or web path) that `link=self` resolves to.
+        let inline_svg = svg_active && params.attrlist.has_option("inline");
+
+        let img = if inline_svg {
             // Embed the SVG contents directly. When the contents cannot be read
             // (no handler is registered, or it cannot find the file), fall back
             // to the alt text, mirroring Ruby Asciidoctor.
@@ -786,7 +791,9 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
             format!(r#"<img src="{src}" alt="{alt_encoded}"{dimension_attrs}>"#)
         };
 
-        render_icon_or_image(params.attrlist, &img, "image", dest);
+        let link_self_href = if inline_svg { None } else { Some(src.as_str()) };
+
+        render_icon_or_image(params.attrlist, &img, "image", link_self_href, dest);
     }
 
     fn image_uri(
@@ -797,21 +804,38 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
     ) -> String {
         let asset_dir_key = asset_dir_key.unwrap_or("imagesdir");
 
-        // Asciidoctor embeds the image as a data URI when the `data-uri`
-        // attribute is set and the safe mode is below `SafeMode::Secure`. That
-        // requires reading the image's bytes, which this crate leaves to the
-        // caller rather than performing file/network access itself; the
-        // `data-uri` attribute is therefore not yet implemented (tracked by
-        // https://github.com/asciidoc-rs/asciidoc-parser/issues/697) and the
-        // image is always emitted as a normalized web path. Because data-uri
-        // embedding is absent, there is no safe-mode-sensitive behavior to gate
-        // here.
         let asset_dir = parser
             .attribute_value(asset_dir_key)
             .as_maybe_str()
             .map(|s| s.to_string());
 
-        normalize_web_path(target_image_path, parser, asset_dir.as_deref(), true)
+        let normalized = normalize_web_path(target_image_path, parser, asset_dir.as_deref(), true);
+
+        // Asciidoctor embeds the image as a data URI when the `data-uri`
+        // attribute is set and the safe mode is below `SafeMode::Secure`. A
+        // target that is itself a URI is never embedded – there is no local
+        // file to read – so it passes through as an ordinary web path
+        // (Asciidoctor only fetches a remote target under `allow-uri-read`,
+        // which this crate does not implement). Otherwise the image's bytes are
+        // read through the `ImageFileHandler` and base64-encoded into a
+        // `data:<mime>;base64,…` URI.
+        //
+        // This crate never performs file I/O itself, so an absent handler (or
+        // one that cannot find the file) degrades silently to the web path,
+        // mirroring how a missing `SvgFileHandler` degrades an inline SVG.
+        if parser.safe_mode() < SafeMode::Secure
+            && parser.is_attribute_set("data-uri")
+            && !is_uri_ish(target_image_path)
+            && let Some(handler) = parser.image_file_handler.as_ref()
+            && let Some(bytes) = handler.resolve_image(&normalized, parser)
+        {
+            let mimetype = data_uri_mimetype(target_image_path);
+            let encoded = crate::internal::base64::strict_encode(&bytes);
+
+            return format!("data:{mimetype};base64,{encoded}");
+        }
+
+        normalized
     }
 
     fn render_icon(&self, params: &IconRenderParams, dest: &mut String) {
@@ -877,7 +901,19 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
             format!("[{alt}&#93;", alt = params.alt)
         };
 
-        render_icon_or_image(params.attrlist, &img, "icon", dest);
+        // `src` is only a real image URI in the image-icon branch (icons enabled
+        // and not font-based); the font (`<i>`) and text (`[alt]`) branches have
+        // no `src`, so a `link=self` on them stays literal (see
+        // `render_icon_or_image`).
+        let link_self_href = if params.parser.is_attribute_set("icons")
+            && params.parser.attribute_value("icons").as_maybe_str() != Some("font")
+        {
+            Some(src.as_str())
+        } else {
+            None
+        };
+
+        render_icon_or_image(params.attrlist, &img, "icon", link_self_href, dest);
     }
 
     fn render_link(&self, params: &LinkRenderParams, dest: &mut String) {
@@ -1156,16 +1192,31 @@ fn wrap_body_in_html_tag(
     dest.push('>');
 }
 
-fn render_icon_or_image(attrlist: &Attrlist, img: &str, type_: &'static str, dest: &mut String) {
+fn render_icon_or_image(
+    attrlist: &Attrlist,
+    img: &str,
+    type_: &'static str,
+    link_self_href: Option<&str>,
+    dest: &mut String,
+) {
     let mut img = img.to_string();
 
-    // The `link` attribute value is used verbatim as the `href` (matching Ruby
-    // Asciidoctor, which does not special-case `link=self`). This applies to
-    // every image, including an inline SVG embedded in the flow of text.
+    // The `link` attribute value is used verbatim as the `href`, except that a
+    // `link=self` resolves to the image's own `src` (its data URI or web path)
+    // when one is available. An inline SVG (and a font/text icon) has no `src`
+    // to resolve to, so `link_self_href` is `None` there and the literal `self`
+    // is kept. (Ruby Asciidoctor, where `src` is undefined in those branches,
+    // instead drops the anchor entirely; this crate keeps it with the literal
+    // `self` target.)
     if let Some(link) = attrlist.named_attribute("link") {
+        let href = if link.value() == "self" {
+            link_self_href.unwrap_or("self")
+        } else {
+            link.value()
+        };
+
         img = format!(
-            r#"<a class="image" href="{link}"{link_constraint_attrs}>{img}</a>"#,
-            link = link.value(),
+            r#"<a class="image" href="{href}"{link_constraint_attrs}>{img}</a>"#,
             link_constraint_attrs = link_constraint_attrs(attrlist, None)
         );
     }
@@ -1228,15 +1279,35 @@ fn is_uri_ish(path: &str) -> bool {
     path.contains(':') && URI_SNIFF.is_match(path)
 }
 
-/// Reports whether the final path segment of `path` carries a file extension,
-/// i.e. it contains a `.` that is neither the first nor the last character of
-/// the segment. Mirrors Asciidoctor's `Helpers.extname?`, used by the icon
-/// macro to decide whether the `icontype` attribute should be appended.
-fn has_extname(path: &str) -> bool {
+/// Returns the file extension (including the leading `.`) of the final path
+/// segment of `path`, or `None` when that segment carries no extension (its `.`
+/// is the first or last character of the segment, or there is no `.`). Mirrors
+/// Asciidoctor's `Helpers.extname`.
+fn extname(path: &str) -> Option<&str> {
     let segment = path.rsplit(['/', '\\']).next().unwrap_or(path);
     match segment.rfind('.') {
-        Some(i) => i > 0 && i < segment.len() - 1,
-        None => false,
+        Some(i) if i > 0 && i < segment.len() - 1 => Some(&segment[i..]),
+        _ => None,
+    }
+}
+
+/// Reports whether the final path segment of `path` carries a file extension.
+/// Mirrors Asciidoctor's `Helpers.extname?`, used by the icon macro to decide
+/// whether the `icontype` attribute should be appended.
+fn has_extname(path: &str) -> bool {
+    extname(path).is_some()
+}
+
+/// Determines the MIME type for a `data:` URI from the target image's file
+/// extension, mirroring Asciidoctor's `generate_data_uri`: `.svg` maps to
+/// `image/svg+xml`, any other extension maps to `image/<ext>`, and a target
+/// with no extension maps to `application/octet-stream`.
+fn data_uri_mimetype(target: &str) -> String {
+    match extname(target) {
+        Some(".svg") => "image/svg+xml".to_string(),
+        // `extname` always includes the leading `.`, which is dropped here.
+        Some(ext) => format!("image/{ext}", ext = ext.strip_prefix('.').unwrap_or(ext)),
+        None => "application/octet-stream".to_string(),
     }
 }
 
@@ -1457,7 +1528,40 @@ fn link_constraint_attrs(attrlist: &Attrlist<'_>, window: Option<&'static str>) 
 
 #[cfg(test)]
 mod tests {
-    use super::{drop_anchor_tags, encode_html_attribute};
+    use super::{data_uri_mimetype, drop_anchor_tags, encode_html_attribute, extname, has_extname};
+
+    #[test]
+    fn extname_extracts_final_segment_extension() {
+        // A normal extension on the final path segment.
+        assert_eq!(extname("fixtures/dot.gif"), Some(".gif"));
+        assert_eq!(extname("circle.svg"), Some(".svg"));
+
+        // A dot in an earlier segment does not count; only the final segment's
+        // extension does.
+        assert_eq!(extname("a.b/c"), None);
+
+        // A leading or trailing dot in the segment is not an extension.
+        assert_eq!(extname(".hidden"), None);
+        assert_eq!(extname("trailing."), None);
+
+        // No dot at all.
+        assert_eq!(extname("plain"), None);
+
+        // `has_extname` is the boolean form.
+        assert!(has_extname("a/b.png"));
+        assert!(!has_extname("a.b/c"));
+    }
+
+    #[test]
+    fn data_uri_mimetype_maps_extension() {
+        // `.svg` is special-cased; every other extension maps to `image/<ext>`.
+        assert_eq!(data_uri_mimetype("circle.svg"), "image/svg+xml");
+        assert_eq!(data_uri_mimetype("fixtures/dot.gif"), "image/gif");
+        assert_eq!(data_uri_mimetype("photo.png"), "image/png");
+
+        // A target with no extension falls back to a generic binary type.
+        assert_eq!(data_uri_mimetype("noext"), "application/octet-stream");
+    }
 
     #[test]
     fn encode_html_attribute_escapes_special_characters() {

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -11,6 +11,9 @@ pub(crate) use built_in_attrs::{built_in_attr, built_in_attrs_iter};
 mod docinfo_file_handler;
 pub use docinfo_file_handler::DocinfoFileHandler;
 
+mod image_file_handler;
+pub use image_file_handler::ImageFileHandler;
+
 mod include_file_handler;
 pub use include_file_handler::{IncludeContent, IncludeFileHandler};
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -13,7 +13,7 @@ use crate::{
     document::{Attribute, Catalog, InterpretedValue, RefType},
     parser::{
         AllowableValue, AttributeValue, DatetimeContext, DocinfoFileHandler,
-        HtmlSubstitutionRenderer, IncludeFileHandler, InlineSubstitutionRenderer,
+        HtmlSubstitutionRenderer, ImageFileHandler, IncludeFileHandler, InlineSubstitutionRenderer,
         ModificationContext, PathResolver, ReferenceTime, ResolvedAttributes, SafeMode, SourceLine,
         SourceMap, SvgFileHandler,
         built_in_attrs::{
@@ -78,6 +78,18 @@ pub struct Parser {
     /// image with the `inline` option. If absent, inline SVG images fall back
     /// to rendering their alt text.
     pub(crate) svg_file_handler: Option<Rc<dyn SvgFileHandler>>,
+
+    /// Handler for reading the bytes of an image file that must be embedded as
+    /// a `data:` URI (when the `data-uri` attribute is set below
+    /// [`SafeMode::Secure`]). If absent, such images fall back to an ordinary
+    /// web path.
+    pub(crate) image_file_handler: Option<Rc<dyn ImageFileHandler>>,
+
+    /// Whether referenced images are recorded in the document catalog as they
+    /// are encountered (Asciidoctor's `catalog_assets` API option). When
+    /// `false` (the default), the `image:`/`image::` macros do not populate
+    /// [`Catalog::images`](crate::document::Catalog::images).
+    pub(crate) catalog_assets: bool,
 
     /// The safe mode under which the document is parsed and rendered. Controls
     /// security-sensitive rendering behavior (such as whether an interactive
@@ -431,6 +443,8 @@ impl Default for Parser {
             include_file_handler: None,
             docinfo_file_handler: None,
             svg_file_handler: None,
+            image_file_handler: None,
+            catalog_assets: false,
             safe: SafeMode::default(),
             catalog: RefCell::new(Catalog::new()),
             last_section_number: SectionNumber::default(),
@@ -1166,6 +1180,22 @@ impl Parser {
         self.catalog.borrow_mut().set_signifier(id, signifier);
     }
 
+    /// Records a referenced image in the document catalog when
+    /// [`catalog_assets`](Self::with_catalog_assets) is enabled. A no-op
+    /// otherwise.
+    ///
+    /// `target` is the (already attribute-substituted) image target as written
+    /// in the macro; `imagesdir` is the value of the document `imagesdir`
+    /// attribute at the point of reference, or `None` when it is unset.
+    ///
+    /// Takes `&self` so it can be called from the macros substitution step,
+    /// which only holds a shared reference to the parser.
+    pub(crate) fn register_image(&self, target: String, imagesdir: Option<String>) {
+        if self.catalog_assets {
+            self.catalog.borrow_mut().register_image(target, imagesdir);
+        }
+    }
+
     /// Registers a callout number defined by a verbatim block.
     ///
     /// Takes `&self` so it can be called from the callouts substitution step,
@@ -1733,6 +1763,36 @@ impl Parser {
     /// [`SvgFileHandler`]: crate::parser::SvgFileHandler
     pub fn with_svg_file_handler<SFH: SvgFileHandler + 'static>(mut self, handler: SFH) -> Self {
         self.svg_file_handler = Some(Rc::new(handler));
+        self
+    }
+
+    /// Sets the [`ImageFileHandler`] for this parser.
+    ///
+    /// The image file handler is responsible for providing the raw bytes of an
+    /// image that must be embedded as a `data:` URI – i.e. when the `data-uri`
+    /// document attribute is set and the safe mode is below
+    /// [`SafeMode::Secure`]. If no handler is provided (or it cannot find the
+    /// file), such images fall back to an ordinary web path, exactly as if
+    /// `data-uri` were not set.
+    ///
+    /// [`ImageFileHandler`]: crate::parser::ImageFileHandler
+    pub fn with_image_file_handler<IFH: ImageFileHandler + 'static>(
+        mut self,
+        handler: IFH,
+    ) -> Self {
+        self.image_file_handler = Some(Rc::new(handler));
+        self
+    }
+
+    /// Enables or disables cataloging of referenced image assets.
+    ///
+    /// When enabled (Asciidoctor's `catalog_assets` API option), each image
+    /// referenced by an `image:`/`image::` macro is recorded in the document
+    /// catalog and can be retrieved afterward via
+    /// [`Catalog::images`](crate::document::Catalog::images). The default is
+    /// disabled, in which case no image references are recorded.
+    pub fn with_catalog_assets(mut self, catalog_assets: bool) -> Self {
+        self.catalog_assets = catalog_assets;
         self
     }
 

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -4971,6 +4971,17 @@ mod macros {
     #[test]
     fn a_single_line_image_macro_with_text_and_link_to_self_should_be_interpreted_as_a_self_referencing_image_with_alt_text()
      {
+        verifies!(
+            r#"
+    test 'a single-line image macro with text and link to self should be interpreted as a self-referencing image with alt text' do
+      para = block_from_string 'image:tiger.png[Tiger, link=self]', attributes: { 'imagesdir' => 'img' }
+      assert_equal '<span class="image"><a class="image" href="img/tiger.png"><img src="img/tiger.png" alt="Tiger"></a></span>',
+        para.sub_macros(para.source).gsub(/>\s+</, '><')
+    end
+
+"#
+        );
+
         let mut p = Parser::default().with_intrinsic_attribute(
             "imagesdir",
             "img",
@@ -4984,6 +4995,8 @@ mod macros {
 
         let block = maw.item.unwrap().item;
 
+        // `link=self` resolves to the image's own resolved `src`
+        // (`img/tiger.png`), not the literal string `self`.
         assert_eq!(
             block,
             Block::Simple(SimpleBlock {
@@ -4994,7 +5007,7 @@ mod macros {
                         col: 1,
                         offset: 0,
                     },
-                    rendered: r#"<span class="image"><a class="image" href="self"><img src="img/tiger.png" alt="Tiger"></a></span>"#,
+                    rendered: r#"<span class="image"><a class="image" href="img/tiger.png"><img src="img/tiger.png" alt="Tiger"></a></span>"#,
                 },
                 source: Span {
                     data: r#"image:tiger.png[Tiger, link=self]"#,
@@ -5014,11 +5027,9 @@ mod macros {
         );
     }
 
-    #[ignore]
     #[test]
     fn should_link_to_data_uri_if_value_of_link_attribute_is_self_and_inline_image_is_embedded() {
-        todo!(
-            "Port when `data-uri` image embedding and `link=self` data-URI resolution are implemented (asciidoc-rs/asciidoc-parser#697): {}",
+        verifies!(
             r###"
         test 'should link to data URI if value of link attribute is self and inline image is embedded' do
             para = block_from_string 'image:circle.svg[Tiger,100,link=self]', safe: Asciidoctor::SafeMode::SERVER, attributes: { 'data-uri' => '', 'imagesdir' => 'fixtures', 'docdir' => testdir }
@@ -5028,6 +5039,55 @@ mod macros {
         end
             "###
         );
+
+        use crate::tests::fixtures::image_file_handler::ImageFileHandlerFixture;
+
+        // The bytes the image file handler returns for `circle.svg`. This crate
+        // reads no files itself, so the handler supplies what Asciidoctor would
+        // read from disk; `data-uri` embedding base64-encodes exactly these
+        // bytes.
+        const CIRCLE_SVG: &str = concat!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"500\" height=\"500\" ",
+            "style=\"fill:red\" viewBox=\"0 0 500 500\">",
+            "<circle cx=\"250\" cy=\"250\" r=\"200\"/></svg>",
+        );
+
+        // Base64 (strict, `pack 'm0'`) of `CIRCLE_SVG`, the `data:` URI payload.
+        const CIRCLE_SVG_BASE64: &str = concat!(
+            "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0",
+            "cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1MDAiIGhlaWdodD0iNTAwIiBzdHls",
+            "ZT0iZmlsbDpyZWQiIHZpZXdCb3g9IjAgMCA1MDAgNTAwIj48Y2lyY2xlIGN4PSIyNTAiIGN5",
+            "PSIyNTAiIHI9IjIwMCIvPjwvc3ZnPg==",
+        );
+
+        let mut content = crate::content::Content::from(crate::Span::new(
+            "image:circle.svg[Tiger,100,link=self]",
+        ));
+
+        // Below `Secure`, with `data-uri` set, the (non-inline) SVG image is
+        // embedded as a data URI, and `link=self` resolves to that same data
+        // URI for the anchor's `href`.
+        let p = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_intrinsic_attribute_bool("data-uri", true, ModificationContext::Anywhere)
+            .with_intrinsic_attribute("imagesdir", "fixtures", ModificationContext::Anywhere)
+            .with_image_file_handler(ImageFileHandlerFixture::from_pairs([(
+                "fixtures/circle.svg",
+                CIRCLE_SVG.as_bytes(),
+            )]));
+
+        SubstitutionStep::Macros.apply(&mut content, &p, None);
+
+        let expected = format!(
+            concat!(
+                r#"<span class="image"><a class="image" href="data:image/svg+xml;base64,{b64}">"#,
+                r#"<img src="data:image/svg+xml;base64,{b64}" alt="Tiger" width="100"></a></span>"#,
+            ),
+            b64 = CIRCLE_SVG_BASE64,
+        );
+
+        assert_eq!(content.rendered, CowStr::Boxed(expected.into_boxed_str()));
     }
 
     // Not ported to this crate:
@@ -5796,7 +5856,6 @@ mod macros {
 "#
     );
 
-    #[ignore]
     #[test]
     fn should_substitute_attributes_in_target_of_inline_image_in_section_title() {
         verifies!(
@@ -5816,23 +5875,28 @@ mod macros {
 "#
         );
 
-        todo!(
-            "Port when `data-uri` embedding and `catalog_assets` are implemented (asciidoc-rs/asciidoc-parser#697): {}",
-            r###"
-            # NOTE this test verifies attributes get substituted eagerly in target of image in title
-            test 'should substitute attributes in target of inline image in section title' do
-                input = '== image:{iconsdir}/dot.gif[dot] Title'
+        // With `catalog_assets` enabled, the `image:` macro in the section title
+        // records its target in the document catalog. The `{iconsdir}` reference
+        // in the target is resolved (to `fixtures`) by the attribute-references
+        // step, which runs before the macros step, so the catalog records the
+        // resolved `fixtures/dot.gif`. `imagesdir` is unset here, so the
+        // reference carries no `imagesdir`.
+        let doc = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_intrinsic_attribute_bool("data-uri", true, ModificationContext::Anywhere)
+            .with_intrinsic_attribute("iconsdir", "fixtures", ModificationContext::Anywhere)
+            .with_catalog_assets(true)
+            .parse("== image:{iconsdir}/dot.gif[dot] Title");
 
-                using_memory_logger do |logger|
-                sect = block_from_string input, attributes: { 'data-uri' => '', 'iconsdir' => 'fixtures', 'docdir' => testdir }, safe: :server, catalog_assets: true
-                assert_equal 1, sect.document.catalog[:images].size
-                assert_equal 'fixtures/dot.gif', sect.document.catalog[:images][0].to_s
-                assert_nil sect.document.catalog[:images][0].imagesdir
-                assert_empty logger
-                end
-            end
-        "###
-        );
+        let images = doc.catalog().images();
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].to_string(), "fixtures/dot.gif");
+        assert_eq!(images[0].imagesdir, None);
+
+        // `data-uri` is set but no image file handler is registered, so the
+        // image degrades silently to a web path – no warning is emitted
+        // (mirroring `assert logger.empty?`).
+        assert_eq!(doc.warnings().count(), 0);
     }
 
     #[test]

--- a/parser/src/tests/fixtures/image_file_handler.rs
+++ b/parser/src/tests/fixtures/image_file_handler.rs
@@ -1,0 +1,20 @@
+use std::collections::HashMap;
+
+use crate::{parser::ImageFileHandler, tests::prelude::*};
+
+/// A test [`ImageFileHandler`] that resolves a fixed set of resolved image
+/// paths to raw image bytes.
+#[derive(Debug)]
+pub(crate) struct ImageFileHandlerFixture(HashMap<&'static str, &'static [u8]>);
+
+impl ImageFileHandlerFixture {
+    pub(crate) fn from_pairs<const N: usize>(pairs: [(&'static str, &'static [u8]); N]) -> Self {
+        Self(pairs.into_iter().collect())
+    }
+}
+
+impl ImageFileHandler for ImageFileHandlerFixture {
+    fn resolve_image(&self, target: &str, _parser: &Parser) -> Option<Vec<u8>> {
+        self.0.get(target).map(|v| v.to_vec())
+    }
+}

--- a/parser/src/tests/fixtures/mod.rs
+++ b/parser/src/tests/fixtures/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod attributes;
 pub(crate) mod blocks;
 pub(crate) mod content;
 pub(crate) mod document;
+pub(crate) mod image_file_handler;
 pub(crate) mod inline_file_handler;
 pub(crate) mod parser;
 pub(crate) mod svg_file_handler;


### PR DESCRIPTION
Closes #697.

Implements the two remaining asset-embedding pieces split out from #277 (safe-mode handling, already complete).

## `data-uri` embedding
- New public `ImageFileHandler` trait (`resolve_image(target) -> Option<Vec<u8>>`), analogous to `SvgFileHandler` — this crate performs no file I/O itself, so a client supplies the image bytes. Wired via `Parser::with_image_file_handler(...)`.
- `image_uri()` embeds `data:<mime>;base64,…` when `data-uri` is set and the safe mode is below `Secure`. MIME type is derived from the file extension (`.svg` → `image/svg+xml`, else `image/<ext>`, else `application/octet-stream`); bytes are base64-encoded by a small, dependency-free strict encoder (`internal::base64`, RFC 4648 vectors) rather than adding a crate dependency.
- A URI target is never embedded. An absent or failing handler **degrades silently to an ordinary web path** (consistent with how a missing `SvgFileHandler` degrades an inline SVG — no spurious warnings).

## `link=self`
- Now resolves to the image's own resolved `src` (its data URI or web path), matching Asciidoctor, instead of the literal string `self`. An inline SVG / font icon (no `src`) keeps the literal value.

## `catalog_assets`
- `Parser::with_catalog_assets(true)` records referenced images in the document catalog, exposed via `Catalog::images()` as new public `ImageReference` values (target + the `imagesdir` in effect at the reference).

## Tests
- Enables the two `#[ignore]`d ported tests in `substitutions_test.rs`:
  - `should_link_to_data_uri_if_value_of_link_attribute_is_self_and_inline_image_is_embedded`
  - `should_substitute_attributes_in_target_of_inline_image_in_section_title`
- Corrects an existing `link=self` test (`a_single_line_image_macro_with_text_and_link_to_self...`) that asserted the pre-fix `href="self"`; upstream Asciidoctor emits `href="img/tiger.png"`. Added the missing `verifies!` block.
- New unit tests for base64 encoding, MIME detection, and catalog image registration.

Full suite passes (4258 tests); `cargo +nightly fmt --check` and clippy are clean.

## Notes for review
- New public API surface: `ImageFileHandler`, `ImageReference`, and two `Parser` builder methods.
- `allow-uri-read` (Asciidoctor's optional remote-fetch path) is intentionally not implemented — out of scope for this no-I/O crate; URI targets pass through unembedded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)