### PR TITLE
fix: Derive author attributes from `:author:`/`:authors:`/`author_N` entries and set `authorcount` (close #718)

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -45,6 +45,7 @@ impl<'src> Header<'src> {
         let mut attributes: Vec<Attribute> = vec![];
         let mut author_line: Option<AuthorLine<'src>> = None;
         let mut author_attribute: Option<Author> = None;
+        let mut authorinitials_from_entry = false;
         let mut revision_line: Option<RevisionLine<'src>> = None;
         let mut comments: Vec<Span<'src>> = vec![];
         let mut warnings: Vec<Warning<'src>> = vec![];
@@ -96,6 +97,23 @@ impl<'src> Header<'src> {
             } else if line.starts_with(':')
                 && let Some(attr) = Attribute::parse(source, parser)
             {
+                // Track an explicit `:authorinitials:` entry so a `:author:`
+                // entry (whether it precedes or follows this one) does not
+                // overwrite it with initials re-derived from the author's name.
+                // Asciidoctor preserves an explicit `authorinitials` for a
+                // single `author`; an empty value (`:authorinitials:`) still
+                // counts as explicit, only an unset (`:authorinitials!:`) does
+                // not.
+                if attr
+                    .item
+                    .name()
+                    .data()
+                    .eq_ignore_ascii_case("authorinitials")
+                {
+                    authorinitials_from_entry =
+                        !matches!(attr.item.value(), InterpretedValue::Unset);
+                }
+
                 // Special handling for :author: attribute to populate individual author
                 // attributes.
                 //
@@ -116,7 +134,16 @@ impl<'src> Header<'src> {
                     if let Some(lastname) = author.lastname() {
                         parser.set_attribute_by_value_from_header("lastname", lastname);
                     }
-                    parser.set_attribute_by_value_from_header("authorinitials", author.initials());
+
+                    // Do not re-derive `authorinitials` when the document has
+                    // supplied its own via an explicit entry (see above).
+                    if !authorinitials_from_entry {
+                        parser.set_attribute_by_value_from_header(
+                            "authorinitials",
+                            author.initials(),
+                        );
+                    }
+
                     if let Some(email) = author.email() {
                         parser.set_attribute_by_value_from_header("email", email);
                     }
@@ -248,9 +275,14 @@ impl<'src> Header<'src> {
         };
 
         // Resolve the document's author list. The author line, when present, is
-        // the source of truth; otherwise the list is derived from the `author`
-        // and indexed `author_N` document attributes (see [`resolve_authors`]).
+        // the source of truth; otherwise the list is derived from the `author`,
+        // `authors`, and indexed `author_N` document attributes (see
+        // [`resolve_authors`]).
         let authors = resolve_authors(author_line.as_ref(), author_attribute, parser);
+
+        // Asciidoctor exposes the number of resolved authors via the
+        // `authorcount` document attribute (0 when the document has none).
+        parser.set_attribute_by_value_from_header("authorcount", authors.len().to_string());
 
         MatchAndWarnings {
             item: MatchedItem {
@@ -585,11 +617,18 @@ fn partition_title(title: &str, parser: &Parser) -> (String, Option<String>) {
 /// When an [`AuthorLine`] is present it is authoritative (and has already
 /// populated the `author_N` attributes). Otherwise the list is reconstructed
 /// from document attributes, mirroring Asciidoctor's `parse_header_metadata`
-/// reconciliation: a directly-assigned `author` attribute stands in for a
-/// single author, and failing that a contiguous run of indexed `author_N`
-/// attributes (`author_1`, `author_2`, …) each contributes one author. In
-/// either case the email is taken from the companion `email`/`email_N`
-/// attribute, reflecting its final value.
+/// reconciliation in precedence order: a directly-assigned `author` attribute
+/// stands in for a single author; failing that a semicolon-separated `authors`
+/// attribute is split into individual authors; and failing that a contiguous
+/// run of indexed `author_N` attributes (`author_1`, `author_2`, …) each
+/// contributes one author. In each case the email is taken from the companion
+/// `email`/`email_N` attribute, reflecting its final value.
+///
+/// For the `authors` and `author_N` forms this also populates the derived
+/// author attributes (`author`, `firstname`, `authorinitials`, the `authors`
+/// list, the per-author `author_N` companions, …) so that references such as
+/// `{author}` resolve, matching Asciidoctor's `process_authors` (see issue
+/// #718).
 ///
 /// `author_attribute` is the author already parsed from the raw `author`
 /// attribute value (see the header parse loop); it is reused rather than
@@ -597,40 +636,168 @@ fn partition_title(title: &str, parser: &Parser) -> (String, Option<String>) {
 fn resolve_authors(
     author_line: Option<&AuthorLine>,
     author_attribute: Option<Author>,
-    parser: &Parser,
+    parser: &mut Parser,
 ) -> Vec<Author> {
     if let Some(author_line) = author_line {
         return author_line.authors().cloned().collect();
     }
 
-    let value = |name: &str| match parser.attribute_value(name) {
-        InterpretedValue::Value(value) => Some(value),
-        _ => None,
-    };
-
     // A directly-assigned `author` attribute describes a single author — but
     // only while it remains set. A later `:author!:` unsets the attribute
     // without carrying a raw value to refresh `author_attribute`, so consult
-    // the attribute's final state rather than trusting the cached parse.
-    if value("author").is_some()
+    // the attribute's final state rather than trusting the cached parse. The
+    // per-author attributes for this form were already populated inline as the
+    // `:author:` entry was parsed.
+    if attribute_string(parser, "author").is_some()
         && let Some(author) = author_attribute
     {
-        return vec![author.with_email(value("email"))];
+        return vec![author.with_email(attribute_string(parser, "email"))];
+    }
+
+    // A semicolon-separated `authors` attribute entry contributes one author
+    // per entry (Asciidoctor's `process_authors` with `multiple` set).
+    if let Some(authors_value) = attribute_string(parser, "authors") {
+        let authors = collect_indexed_authors(
+            split_author_entries(&authors_value)
+                .into_iter()
+                .filter_map(|entry| Author::parse(entry, parser, true)),
+            parser,
+        );
+
+        if !authors.is_empty() {
+            set_author_metadata(parser, &authors);
+            return authors;
+        }
     }
 
     // Otherwise, walk the indexed `author_N` attributes until one is missing.
-    let mut authors = vec![];
+    let mut raw_names = vec![];
     let mut index = 1;
 
-    while let Some(name) = value(&format!("author_{index}")) {
-        if let Some(author) = Author::parse(&name, parser, true) {
-            authors.push(author.with_email(value(&format!("email_{index}"))));
-        }
-
+    while let Some(name) = attribute_string(parser, &format!("author_{index}")) {
+        raw_names.push(name);
         index += 1;
     }
 
+    let authors = collect_indexed_authors(
+        raw_names
+            .iter()
+            .filter_map(|name| Author::parse(name, parser, true)),
+        parser,
+    );
+
+    if !authors.is_empty() {
+        set_author_metadata(parser, &authors);
+    }
+
     authors
+}
+
+/// Reads the string value of a document attribute, or `None` when it is unset
+/// or set without a value.
+fn attribute_string(parser: &Parser, name: &str) -> Option<String> {
+    match parser.attribute_value(name) {
+        InterpretedValue::Value(value) => Some(value),
+        _ => None,
+    }
+}
+
+/// Attaches each parsed author's companion `email_N` attribute (`email_1` for
+/// the first author, `email_2` for the second, …) so the resolved list carries
+/// the emails supplied through separate attribute entries.
+fn collect_indexed_authors(authors: impl Iterator<Item = Author>, parser: &Parser) -> Vec<Author> {
+    authors
+        .enumerate()
+        .map(|(idx, author)| {
+            author.with_email(attribute_string(parser, &format!("email_{}", idx + 1)))
+        })
+        .collect()
+}
+
+/// Splits an `authors` attribute value into raw author entries.
+///
+/// A semicolon separates authors only when it is immediately followed by a
+/// space or the end of the value, matching Asciidoctor's `AuthorDelimiterRx`
+/// (`/;(?: |$)/`). Blank entries are left in place; [`Author::parse`] trims
+/// each entry and discards the empty ones.
+fn split_author_entries(value: &str) -> Vec<&str> {
+    let bytes = value.as_bytes();
+    let mut entries: Vec<&str> = Vec::new();
+    let mut start = 0;
+
+    for (index, c) in value.char_indices() {
+        if c != ';' {
+            continue;
+        }
+
+        let is_separator = match bytes.get(index + 1) {
+            Some(next) => *next == b' ',
+            None => true,
+        };
+
+        if is_separator {
+            entries.push(&value[start..index]);
+            start = index + 1;
+        }
+    }
+
+    entries.push(&value[start..]);
+    entries
+}
+
+/// Populates the derived author document attributes from a resolved author
+/// list, mirroring Asciidoctor's `process_authors`.
+///
+/// The first author sets the unsuffixed keys (`author`, `firstname`,
+/// `authorinitials`, …); each subsequent author sets its `_N` companions. Once
+/// a second author appears, the first author is also mirrored onto its `_1`
+/// companions. The `authors` attribute is rewritten to the comma-joined list of
+/// resolved author names.
+fn set_author_metadata(parser: &mut Parser, authors: &[Author]) {
+    for (idx, author) in authors.iter().enumerate() {
+        set_author_keys(parser, author, if idx == 0 { None } else { Some(idx + 1) });
+
+        // The `_1` companions are only assigned once a second author is seen.
+        if idx == 1
+            && let Some(first) = authors.first()
+        {
+            set_author_keys(parser, first, Some(1));
+        }
+    }
+
+    let joined = authors
+        .iter()
+        .map(Author::name)
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    parser.set_attribute_by_value_from_header("authors", joined);
+}
+
+/// Sets the author attributes for a single author, either as the unsuffixed
+/// keys (`index` is `None`) or the `_N` companions (`index` is `Some(n)`).
+fn set_author_keys(parser: &mut Parser, author: &Author, index: Option<usize>) {
+    let key = |name: &str| match index {
+        None => name.to_string(),
+        Some(n) => format!("{name}_{n}"),
+    };
+
+    parser.set_attribute_by_value_from_header(key("author"), author.name());
+    parser.set_attribute_by_value_from_header(key("firstname"), author.firstname());
+
+    if let Some(middlename) = author.middlename() {
+        parser.set_attribute_by_value_from_header(key("middlename"), middlename);
+    }
+
+    if let Some(lastname) = author.lastname() {
+        parser.set_attribute_by_value_from_header(key("lastname"), lastname);
+    }
+
+    parser.set_attribute_by_value_from_header(key("authorinitials"), author.initials());
+
+    if let Some(email) = author.email() {
+        parser.set_attribute_by_value_from_header(key("email"), email);
+    }
 }
 
 fn apply_header_subs(source: &str, parser: &Parser) -> String {
@@ -1331,6 +1498,159 @@ mod tests {
         let doc = Parser::default().parse("= Title\n\nBody.");
 
         assert!(doc.authors().is_empty());
+    }
+
+    #[test]
+    fn authorcount_reflects_author_line() {
+        // The `authorcount` attribute counts the resolved authors, whether they
+        // come from the author line …
+        let doc = Parser::default().parse("= Title\nJane Doe; John Smith\n\nBody.");
+
+        assert_eq!(doc.authors().len(), 2);
+        assert_eq!(
+            doc.attribute_value("authorcount"),
+            InterpretedValue::Value("2")
+        );
+
+        // … or from a single `:author:` attribute entry.
+        let doc = Parser::default().parse(":author: Jane Doe\n\nBody.");
+
+        assert_eq!(
+            doc.attribute_value("authorcount"),
+            InterpretedValue::Value("1")
+        );
+
+        // A document with no author information reports a count of zero.
+        let doc = Parser::default().parse("= Title\n\nBody.");
+
+        assert_eq!(
+            doc.attribute_value("authorcount"),
+            InterpretedValue::Value("0")
+        );
+    }
+
+    #[test]
+    fn explicit_authorinitials_after_author_still_wins() {
+        // An explicit `:authorinitials:` entry is honored regardless of whether
+        // it precedes or follows the `:author:` entry.
+        let doc = Parser::default().parse(":author: Doc Writer\n:authorinitials: DOC\n\nBody.");
+
+        assert_eq!(
+            doc.attribute_value("authorinitials"),
+            InterpretedValue::Value("DOC")
+        );
+
+        // A second `:author:` entry after the explicit initials does not clobber
+        // them.
+        let doc = Parser::default()
+            .parse(":author: Jane Roe\n:authorinitials: DOC\n:author: Doc Writer\n\nBody.");
+
+        assert_eq!(
+            doc.attribute_value("author"),
+            InterpretedValue::Value("Doc Writer")
+        );
+        assert_eq!(
+            doc.attribute_value("authorinitials"),
+            InterpretedValue::Value("DOC")
+        );
+    }
+
+    #[test]
+    fn later_author_entry_redrives_initials_without_explicit_override() {
+        // Without an explicit `:authorinitials:` entry, a later `:author:`
+        // overwrites the initials derived from the earlier one.
+        let doc = Parser::default().parse(":author: Jane Roe\n:author: Doc Writer\n\nBody.");
+
+        assert_eq!(
+            doc.attribute_value("authorinitials"),
+            InterpretedValue::Value("DW")
+        );
+    }
+
+    #[test]
+    fn authors_attribute_splits_into_indexed_authors() {
+        // A semicolon-separated `:authors:` entry populates the author list and
+        // the derived per-author attributes.
+        let doc = Parser::default().parse(":authors: Jane Doe; John Q. Smith\n\nBody.");
+
+        assert_eq!(doc.authors().len(), 2);
+        assert_eq!(
+            doc.attribute_value("authors"),
+            InterpretedValue::Value("Jane Doe, John Q. Smith")
+        );
+        assert_eq!(
+            doc.attribute_value("author"),
+            InterpretedValue::Value("Jane Doe")
+        );
+        assert_eq!(
+            doc.attribute_value("author_2"),
+            InterpretedValue::Value("John Q. Smith")
+        );
+        assert_eq!(
+            doc.attribute_value("middlename_2"),
+            InterpretedValue::Value("Q.")
+        );
+        assert_eq!(
+            doc.attribute_value("authorinitials_2"),
+            InterpretedValue::Value("JQS")
+        );
+    }
+
+    #[test]
+    fn authors_attribute_attaches_companion_emails_and_base_middlename() {
+        // Companion `:email_N:` entries attach to each split author (`email_1`
+        // also fills the base `email`), and the first author's middle name lands
+        // on the unsuffixed `middlename`.
+        let doc = Parser::default().parse(
+            ":authors: Jane Q. Doe; John Smith\n:email_1: jane@example.com\n:email_2: john@example.com\n\nBody.",
+        );
+
+        let authors = doc.authors();
+        assert_eq!(authors.len(), 2);
+        assert_eq!(authors.first().unwrap().email(), Some("jane@example.com"));
+        assert_eq!(authors.get(1).unwrap().email(), Some("john@example.com"));
+
+        assert_eq!(
+            doc.attribute_value("middlename"),
+            InterpretedValue::Value("Q.")
+        );
+        assert_eq!(
+            doc.attribute_value("email"),
+            InterpretedValue::Value("jane@example.com")
+        );
+        assert_eq!(
+            doc.attribute_value("email_2"),
+            InterpretedValue::Value("john@example.com")
+        );
+    }
+
+    #[test]
+    fn authors_attribute_semicolon_without_space_is_one_author() {
+        // A semicolon that is not followed by a space (or the end of the value)
+        // does not separate authors.
+        let doc = Parser::default().parse(":authors: Joe Doe;Smith Johnson\n\nBody.");
+
+        assert_eq!(doc.authors().len(), 1);
+        assert_eq!(
+            doc.attribute_value("authorcount"),
+            InterpretedValue::Value("1")
+        );
+    }
+
+    #[test]
+    fn author_attribute_takes_precedence_over_authors() {
+        // A base `:author:` entry wins over a semicolon-separated `:authors:`
+        // entry (matching Asciidoctor's `if author … elsif authors` order), so
+        // only the single author is resolved.
+        let doc = Parser::default()
+            .parse(":author: Solo Writer\n:authors: Jane Doe; John Smith\n\nBody.");
+
+        assert_eq!(doc.authors().len(), 1);
+        assert_eq!(
+            doc.attribute_value("author"),
+            InterpretedValue::Value("Solo Writer")
+        );
+        assert_eq!(doc.attribute_value("author_2"), InterpretedValue::Unset);
     }
 
     #[test]

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -277,12 +277,22 @@ impl<'src> Header<'src> {
         // Resolve the document's author list. The author line, when present, is
         // the source of truth; otherwise the list is derived from the `author`,
         // `authors`, and indexed `author_N` document attributes (see
-        // [`resolve_authors`]).
-        let authors = resolve_authors(author_line.as_ref(), author_attribute, parser);
+        // [`resolve_authors`]). Those attributes can only be set by header
+        // attribute entries, so a header with none needs no reconciliation.
+        let authors = resolve_authors(
+            author_line.as_ref(),
+            author_attribute,
+            !attributes.is_empty(),
+            parser,
+        );
 
         // Asciidoctor exposes the number of resolved authors via the
-        // `authorcount` document attribute (0 when the document has none).
-        parser.set_attribute_by_value_from_header("authorcount", authors.len().to_string());
+        // `authorcount` document attribute. It defaults to `0` (a built-in
+        // default), so only a non-zero count is materialized here — this keeps an
+        // author-less parse from touching the attribute map at all.
+        if !authors.is_empty() {
+            parser.set_attribute_by_value_from_header("authorcount", authors.len().to_string());
+        }
 
         MatchAndWarnings {
             item: MatchedItem {
@@ -633,13 +643,23 @@ fn partition_title(title: &str, parser: &Parser) -> (String, Option<String>) {
 /// `author_attribute` is the author already parsed from the raw `author`
 /// attribute value (see the header parse loop); it is reused rather than
 /// re-parsing the HTML-encoded stored value.
+///
+/// `header_has_attributes` reports whether the header carried any attribute
+/// entries. When it did not, none of the `author` / `authors` / `author_N`
+/// attributes can be set, so the attribute lookups are skipped — the common
+/// case for a document whose header is just a title (or absent).
 fn resolve_authors(
     author_line: Option<&AuthorLine>,
     author_attribute: Option<Author>,
+    header_has_attributes: bool,
     parser: &mut Parser,
 ) -> Vec<Author> {
     if let Some(author_line) = author_line {
         return author_line.authors().cloned().collect();
+    }
+
+    if !header_has_attributes {
+        return vec![];
     }
 
     // A directly-assigned `author` attribute describes a single author — but
@@ -1634,6 +1654,51 @@ mod tests {
         assert_eq!(
             doc.attribute_value("authorcount"),
             InterpretedValue::Value("1")
+        );
+    }
+
+    #[test]
+    fn authors_attribute_single_name_authors_and_trailing_separator() {
+        // Single-name authors carry no last name, and a trailing `;` (a
+        // separator at the end of the value) contributes no extra author.
+        let doc = Parser::default().parse(":authors: Cher; Madonna;\n\nBody.");
+
+        assert_eq!(doc.authors().len(), 2);
+        assert_eq!(
+            doc.attribute_value("authors"),
+            InterpretedValue::Value("Cher, Madonna")
+        );
+        assert_eq!(
+            doc.attribute_value("author"),
+            InterpretedValue::Value("Cher")
+        );
+        assert_eq!(doc.attribute_value("lastname"), InterpretedValue::Unset);
+        assert_eq!(
+            doc.attribute_value("authorinitials"),
+            InterpretedValue::Value("C")
+        );
+        assert_eq!(
+            doc.attribute_value("author_2"),
+            InterpretedValue::Value("Madonna")
+        );
+        assert_eq!(doc.attribute_value("lastname_2"), InterpretedValue::Unset);
+        assert_eq!(
+            doc.attribute_value("authorcount"),
+            InterpretedValue::Value("2")
+        );
+    }
+
+    #[test]
+    fn authors_attribute_with_only_empty_entries_yields_no_authors() {
+        // An `:authors:` value that splits into only empty entries resolves to no
+        // authors, so the derived attributes stay unset and `authorcount` is 0.
+        let doc = Parser::default().parse(":authors: ;\n\nBody.");
+
+        assert!(doc.authors().is_empty());
+        assert_eq!(doc.attribute_value("author"), InterpretedValue::Unset);
+        assert_eq!(
+            doc.attribute_value("authorcount"),
+            InterpretedValue::Value("0")
         );
     }
 

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -896,6 +896,14 @@ fn split_author_entries(value: &str) -> Vec<&str> {
 /// a second author appears, the first author is also mirrored onto its `_1`
 /// companions. The `authors` attribute is rewritten to the comma-joined list of
 /// resolved author names.
+///
+/// This intentionally does **not** honor `authorinitials_from_entry`: the
+/// derived `authorinitials` always overwrites an explicit `:authorinitials:`
+/// entry for the `authors` and `author_N` forms. Only a single `:author:` entry
+/// (handled inline in [`Header::parse`]) preserves an explicit override,
+/// exactly as Asciidoctor does — its `authorinitials` deletion guard lives only
+/// in the `author` branch of `process_authors`, not the `authors`/indexed
+/// branches.
 fn set_author_metadata(parser: &mut Parser, authors: &[Author]) {
     for (idx, author) in authors.iter().enumerate() {
         set_author_keys(parser, author, if idx == 0 { None } else { Some(idx + 1) });
@@ -1712,6 +1720,24 @@ mod tests {
     }
 
     #[test]
+    fn explicit_authorinitials_not_preserved_for_indexed_or_authors_forms() {
+        // The explicit-`:authorinitials:` override is honored only for a single
+        // `:author:` entry. For the indexed `author_N` form (and, as tested
+        // elsewhere, the `:authors:` form) the derived initials overwrite it,
+        // matching Asciidoctor (see [`set_author_metadata`]).
+        let doc = Parser::default().parse(":authorinitials: DOC\n:author_1: Doc Writer\n\nBody.");
+
+        assert_eq!(
+            doc.attribute_value("author"),
+            InterpretedValue::Value("Doc Writer")
+        );
+        assert_eq!(
+            doc.attribute_value("authorinitials"),
+            InterpretedValue::Value("DW")
+        );
+    }
+
+    #[test]
     fn authors_attribute_splits_into_indexed_authors() {
         // A semicolon-separated `:authors:` entry populates the author list and
         // the derived per-author attributes.
@@ -1824,6 +1850,11 @@ mod tests {
             doc.attribute_value("authorcount"),
             InterpretedValue::Value("0")
         );
+
+        // With no authors resolved, the raw `authors` value is left as written
+        // (never rewritten to a comma-joined list) — matching Asciidoctor, whose
+        // `process_authors` returns only `authorcount` for an all-empty value.
+        assert_eq!(doc.attribute_value("authors"), InterpretedValue::Value(";"));
     }
 
     #[test]

--- a/parser/src/parser/built_in_attrs.rs
+++ b/parser/src/parser/built_in_attrs.rs
@@ -473,6 +473,16 @@ fn build_built_in_attrs() -> HashMap<String, AttributeValue> {
     );
     attrs.insert("toc".to_owned(), any(ApiOrHeader, Unset));
 
+    // ### Author attributes
+    //
+    // `authorcount` reflects the number of resolved authors and defaults to `0`
+    // for a document with none. Registering the default here (rather than
+    // writing it during every header parse) lets an author-less document resolve
+    // `{authorcount}` to `0` without materializing the attribute — the header
+    // parser only writes `authorcount` when the count is non-zero (see
+    // [`Header::parse`](crate::document::Header)).
+    attrs.insert("authorcount".to_owned(), set(Anywhere, "0"));
+
     // ### General content and formatting attributes
     //
     // The active backend defaults to `html5` (the only backend this crate

--- a/parser/src/tests/asciidoctor_rb/document_test.rs
+++ b/parser/src/tests/asciidoctor_rb/document_test.rs
@@ -51,12 +51,9 @@
 //!
 //! - doctitle not derived/overridden from `:doctitle:`/`:title:` attribute
 //!   entries: <https://github.com/asciidoc-rs/asciidoc-parser/issues/716>;
-//! - author-attribute gaps — the `authorcount` attribute is unset (the count
-//!   is available via `authors()`), the `author` attribute is not derived from
-//!   an indexed `author_1`, a semicolon-separated `:authors:` list is not split
-//!   into individual authors, and an explicit `:authorinitials:` override is
-//!   ignored (a base `:author:` entry and indexed `author_N` entries *are*
-//!   resolved into `authors()`, as of #713):
+//! - author-attribute handling (`authorcount`, deriving `author` from an
+//!   indexed `author_1`, splitting a semicolon-separated `:authors:` list, and
+//!   honoring an explicit `:authorinitials:` override) was resolved in
 //!   <https://github.com/asciidoc-rs/asciidoc-parser/issues/718>;
 //! - `manpage` doctype not implemented: <https://github.com/asciidoc-rs/asciidoc-parser/issues/721>.
 //!
@@ -1460,9 +1457,11 @@ mod structure {
         let doc = Parser::default()
             .parse(":author: Doc Writer\n\n{lastname}, {firstname} ({authorinitials})");
 
-        // Asciidoctor asserts `authorcount == 1`; asciidoc-parser does not set the
-        // `authorcount` attribute, so the count is observed via `authors()`.
         assert_eq!(doc.authors().len(), 1);
+        assert_eq!(
+            doc.attribute_value("authorcount"),
+            InterpretedValue::Value("1")
+        );
         assert_eq!(
             doc.attribute_value("author"),
             InterpretedValue::Value("Doc Writer")
@@ -1483,14 +1482,10 @@ mod structure {
         assert_eq!(rendered_paragraphs(&doc), ["Writer, Doc (DW)"]);
     }
 
-    // DIVERGENCE (https://github.com/asciidoc-rs/asciidoc-parser/issues/718):
-    // an explicit `:authorinitials:` entry that precedes `:author:` is
-    // overwritten by initials re-derived from the author name (Asciidoctor keeps
-    // the explicit value), and a semicolon-separated `:authors:` entry is not
-    // split into individual authors (`author`/`author_1`/`author_2`/… and the
-    // per-author initials remain unset).
-    non_normative!(
-        r##"
+    #[test]
+    fn should_process_author_and_authorinitials_defined_by_attribute() {
+        verifies!(
+            r##"
     test 'should process author and authorinitials defined by attribute when implicit doctitle is absent' do
       input = <<~'EOS'
       :authorinitials: DOC
@@ -1507,6 +1502,34 @@ mod structure {
       assert_xpath '//p[text()="Writer, Doc (DOC)"]', output, 1
     end
 
+"##
+        );
+
+        // An explicit `:authorinitials:` entry preceding `:author:` is preserved
+        // rather than re-derived from the author name.
+        let doc = Parser::default().parse(
+            ":authorinitials: DOC\n:author: Doc Writer\n\n{lastname}, {firstname} ({authorinitials})",
+        );
+
+        assert_eq!(
+            doc.attribute_value("author"),
+            InterpretedValue::Value("Doc Writer")
+        );
+        assert_eq!(
+            doc.attribute_value("authorinitials"),
+            InterpretedValue::Value("DOC")
+        );
+        assert_eq!(
+            doc.attribute_value("authorcount"),
+            InterpretedValue::Value("1")
+        );
+        assert_eq!(rendered_paragraphs(&doc), ["Writer, Doc (DOC)"]);
+    }
+
+    #[test]
+    fn should_process_authors_defined_by_attribute() {
+        verifies!(
+            r##"
     test 'should process authors defined by attribute when implicit doctitle is absent' do
       input = <<~'EOS'
       :authors: Doc Writer; Other Author
@@ -1531,6 +1554,71 @@ mod structure {
       assert_xpath '//p[text()="Writer, Doc (DW)"]', output, 1
     end
 
+"##
+        );
+
+        // A semicolon-separated `:authors:` entry splits into individual authors,
+        // populating the base and per-author `_N` attributes.
+        let doc = Parser::default().parse(
+            ":authors: Doc Writer; Other Author\n\n{lastname}, {firstname} ({authorinitials})",
+        );
+
+        assert_eq!(doc.authors().len(), 2);
+        assert_eq!(
+            doc.attribute_value("author"),
+            InterpretedValue::Value("Doc Writer")
+        );
+        assert_eq!(
+            doc.attribute_value("authors"),
+            InterpretedValue::Value("Doc Writer, Other Author")
+        );
+        assert_eq!(
+            doc.attribute_value("author_1"),
+            InterpretedValue::Value("Doc Writer")
+        );
+        assert_eq!(
+            doc.attribute_value("lastname"),
+            InterpretedValue::Value("Writer")
+        );
+        assert_eq!(
+            doc.attribute_value("lastname_1"),
+            InterpretedValue::Value("Writer")
+        );
+        assert_eq!(
+            doc.attribute_value("firstname"),
+            InterpretedValue::Value("Doc")
+        );
+        assert_eq!(
+            doc.attribute_value("firstname_1"),
+            InterpretedValue::Value("Doc")
+        );
+        assert_eq!(
+            doc.attribute_value("authorinitials"),
+            InterpretedValue::Value("DW")
+        );
+        assert_eq!(
+            doc.attribute_value("authorinitials_1"),
+            InterpretedValue::Value("DW")
+        );
+        assert_eq!(
+            doc.attribute_value("author_2"),
+            InterpretedValue::Value("Other Author")
+        );
+        assert_eq!(
+            doc.attribute_value("authorinitials_2"),
+            InterpretedValue::Value("OA")
+        );
+        assert_eq!(
+            doc.attribute_value("authorcount"),
+            InterpretedValue::Value("2")
+        );
+        assert_eq!(rendered_paragraphs(&doc), ["Writer, Doc (DW)"]);
+    }
+
+    #[test]
+    fn should_process_authors_and_authorinitials_defined_by_attribute() {
+        verifies!(
+            r##"
     test 'should process authors and authorinitials defined by attribute when implicit doctitle is absent' do
       input = <<~'EOS'
       :authorinitials: DOC
@@ -1553,7 +1641,37 @@ mod structure {
     end
 
 "##
-    );
+        );
+
+        // As in Asciidoctor, an explicit `:authorinitials:` is *not* preserved
+        // for a semicolon-separated `:authors:` entry (only for a single
+        // `:author:`); it is overwritten by the derived initials.
+        let doc = Parser::default().parse(
+            ":authorinitials: DOC\n:authors: Doc Writer; Other Author\n\n{lastname}, {firstname} ({authorinitials})",
+        );
+
+        assert_eq!(
+            doc.attribute_value("author"),
+            InterpretedValue::Value("Doc Writer")
+        );
+        assert_eq!(
+            doc.attribute_value("author_1"),
+            InterpretedValue::Value("Doc Writer")
+        );
+        assert_eq!(
+            doc.attribute_value("authorinitials"),
+            InterpretedValue::Value("DW")
+        );
+        assert_eq!(
+            doc.attribute_value("author_2"),
+            InterpretedValue::Value("Other Author")
+        );
+        assert_eq!(
+            doc.attribute_value("authorcount"),
+            InterpretedValue::Value("2")
+        );
+        assert_eq!(rendered_paragraphs(&doc), ["Writer, Doc (DW)"]);
+    }
 
     #[test]
     fn should_set_authorcount_to_0_if_document_has_no_header() {
@@ -1569,8 +1687,11 @@ mod structure {
 
         let doc = Parser::default().parse("content");
 
-        // Asciidoctor asserts `authorcount == 0`; observed here via `authors()`.
         assert_eq!(doc.authors().len(), 0);
+        assert_eq!(
+            doc.attribute_value("authorcount"),
+            InterpretedValue::Value("0")
+        );
     }
 
     #[test]
@@ -1595,6 +1716,10 @@ mod structure {
         let doc = Parser::default().parse(":idprefix:\n\n== Section Title\n\ncontent");
 
         assert_eq!(doc.authors().len(), 0);
+        assert_eq!(
+            doc.attribute_value("authorcount"),
+            InterpretedValue::Value("0")
+        );
     }
 
     #[test]
@@ -1628,15 +1753,16 @@ mod structure {
         );
 
         assert_eq!(doc.authors().len(), 0);
+        assert_eq!(
+            doc.attribute_value("authorcount"),
+            InterpretedValue::Value("0")
+        );
     }
 
-    // DIVERGENCE (https://github.com/asciidoc-rs/asciidoc-parser/issues/718): an
-    // indexed `author_1` attribute entry populates `authors()` but does not set
-    // the `author` attribute, so `{author}` does not resolve. The remainder of
-    // the suite is out of scope — DocBook author/revision entries, standalone
-    // header/footer rendering, copyright, and footnote-footer output.
-    non_normative!(
-        r##"
+    #[test]
+    fn with_author_defined_by_indexed_attribute_name() {
+        verifies!(
+            r##"
     test 'with author defined by indexed attribute name' do
       input = <<~'EOS'
       = Document Title
@@ -1650,6 +1776,29 @@ mod structure {
       assert_equal 'Doc Writer', (doc.attr 'author_1')
     end
 
+"##
+        );
+
+        // An indexed `author_1` entry with no base `author` derives the base
+        // `author` attribute, so `{author}` resolves in the body.
+        let doc = Parser::default().parse("= Document Title\n:author_1: Doc Writer\n\n{author}");
+
+        assert_eq!(
+            doc.attribute_value("author"),
+            InterpretedValue::Value("Doc Writer")
+        );
+        assert_eq!(
+            doc.attribute_value("author_1"),
+            InterpretedValue::Value("Doc Writer")
+        );
+        assert_eq!(rendered_paragraphs(&doc), ["Doc Writer"]);
+    }
+
+    // The remainder of the suite is out of scope — DocBook author/revision
+    // entries, standalone header/footer rendering, copyright, and
+    // footnote-footer output.
+    non_normative!(
+        r##"
     test 'with authors defined using attribute entry to DocBook' do
       input = <<~'EOS'
       = Document Title


### PR DESCRIPTION
Fixes #718.

Author metadata derived from attribute entries (i.e. with no author line) diverged from Asciidoctor in four ways. Each is traced to Asciidoctor's `process_authors` / `parse_header_metadata` reconciliation and fixed to match.

## Changes

- **`authorcount` now set** — resolved to the number of authors (0 when the document has none), across every resolution path: author line, `:author:`, `:authors:`, `author_N`, and no-author.
- **`author` derived from indexed `author_1`** — the `author_N` walk now populates the base `author`/`firstname`/`authorinitials`/… attributes, so `{author}` resolves in the body.
- **`:authors:` semicolon-split** — a `:authors: A; B` entry splits into individual authors (using Asciidoctor's `AuthorDelimiterRx` rule: `;` followed by a space or end of value), setting `author`/`author_1`/`author_2`, the per-author `firstname_N`/`lastname_N`/`authorinitials_N`, and rewriting `authors` to the comma-joined name list.
- **Explicit `:authorinitials:` preserved** — an explicit entry is no longer clobbered by initials re-derived from `:author:`, regardless of entry order (matching Asciidoctor, which preserves it for a single `:author:` but not for `:authors:`).

Precedence follows Asciidoctor (`author` > `authors` > `author_N`). The existing single-`:author:` inline path (including the #758 stored-value handling) is left intact.

## Performance

The first cut wrote `authorcount` on every parse, which regressed the author-less parse benchmarks (~13% on `section with 2 blocks`) by forcing the first attribute-map allocation. Resolved by:

- registering `authorcount` as a built-in attribute defaulting to `0` and only materializing it when the count is non-zero (idiomatic for this codebase's "don't materialize defaults" design); and
- skipping the `author`/`authors`/`author_N` lookups when the header had no attribute entries.

Back-to-back Criterion runs now show this branch **slightly faster than `main`** on the author-less benchmarks (the skipped lookups more than offset the feature).

## Tests & coverage

- Converted the four `non_normative!` / `DIVERGENCE` ported cases in `document_test.rs` to `verifies!` with real assertions, and strengthened the `authorcount == 0` cases plus the single-author case to assert the attribute directly.
- Added focused unit tests in `header.rs` (precedence, order-independence of the initials override, companion emails, non-separator/trailing semicolons, single-name authors, empty `:authors:`), bringing `header.rs` to full line/region coverage.
- Full suite: **4264 pass, 0 fail**; `cargo clippy` clean; `cargo +nightly fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)