### PR TITLE
chore: Confirm per-line dialogue `--` example matches Asciidoctor (close #440)

### DIFF
--- a/parser/src/tests/asciidoc_lang/blocks/hard_line_breaks.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/hard_line_breaks.rs
@@ -542,8 +542,7 @@ Then each dialog will appear on its own line.
     // dash replacement for the ` -- ` at the start of the second line matches (and
     // consumes) the preceding newline, so both source lines render on one output
     // line. Because the newline is gone, the trailing ` +` is no longer at the end
-    // of a line and is left literal rather than becoming a `<br>`. See
-    // https://github.com/asciidoc-rs/asciidoc-parser/issues/440.
+    // of a line and is left literal rather than becoming a `<br>`.
     let doc =
         Parser::default().parse("-- Come here! -- I said. +\n-- What is it? -- replied Lance.");
 

--- a/parser/src/tests/asciidoc_lang/blocks/hard_line_breaks.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/hard_line_breaks.rs
@@ -509,9 +509,7 @@ Note that `empty` is a built-in document attribute in AsciiDoc.
 }
 
 #[test]
-#[ignore]
 fn per_line_dialogue_syntax() {
-    // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/440): Await spec clarity on correct behavior for this example.
     verifies!(
         r#"
 If you're writing a story with dialogue, and you want to prefix the dialogue lines with `--`, be aware that you are going to get a conflict between the hard line break and the automatic endash replacement.
@@ -540,11 +538,71 @@ Then each dialog will appear on its own line.
 "#
     );
 
+    // No hard line break is generated here, matching Asciidoctor. The spaced em
+    // dash replacement for the ` -- ` at the start of the second line matches (and
+    // consumes) the preceding newline, so both source lines render on one output
+    // line. Because the newline is gone, the trailing ` +` is no longer at the end
+    // of a line and is left literal rather than becoming a `<br>`. See
+    // https://github.com/asciidoc-rs/asciidoc-parser/issues/440.
     let doc =
         Parser::default().parse("-- Come here! -- I said. +\n-- What is it? -- replied Lance.");
 
-    dbg!(&doc);
-    todo!("This appears to be generating wrong results");
+    assert_eq!(
+        doc,
+        Document {
+            header: Header {
+                title_source: None,
+                title: None,
+                attributes: &[],
+                author_line: None,
+                revision_line: None,
+                comments: &[],
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+            },
+            blocks: &[Block::Simple(SimpleBlock {
+                content: Content {
+                    original: Span {
+                        data: "-- Come here! -- I said. +\n-- What is it? -- replied Lance.",
+                        line: 1,
+                        col: 1,
+                        offset: 0,
+                    },
+                    rendered: "&#8201;&#8212;&#8201;Come here!&#8201;&#8212;&#8201;I said. +&#8201;&#8212;&#8201;What is it?&#8201;&#8212;&#8201;replied Lance.",
+                },
+                source: Span {
+                    data: "-- Come here! -- I said. +\n-- What is it? -- replied Lance.",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                style: SimpleBlockStyle::Paragraph,
+                title_source: None,
+                title: None,
+                caption: None,
+                number: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: None,
+            },),],
+            source: Span {
+                data: "-- Come here! -- I said. +\n-- What is it? -- replied Lance.",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            warnings: &[],
+            source_map: SourceMap(&[]),
+            catalog: Catalog {
+                refs: HashMap::from([]),
+                reftext_to_id: HashMap::from([]),
+            },
+        }
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Resolves the spec-clarity question in #440: does the trailing ` +` in the per-line dialogue example produce a hard line break?

```
-- Come here! -- I said. +
-- What is it? -- replied Lance.
```

**Answer (verified against Asciidoctor 2.0.26): no line break, and that is correct.**

- The ` -- ` at the **start of the second line** triggers Asciidoctor's *spaced em dash* replacement, whose pattern matches and **consumes the preceding newline**, collapsing both source lines onto one output line.
- With that newline gone, the trailing ` +` is no longer at end-of-line, so it is left **literal** rather than becoming a `<br>`.

Asciidoctor output:

```html
<p>&#8201;&#8212;&#8201;Come here!&#8201;&#8212;&#8201;I said. +&#8201;&#8212;&#8201;What is it?&#8201;&#8212;&#8201;replied Lance.</p>
```

This parser already produces **byte-for-byte identical** output, so **no parser change is needed**. The old `todo!("This appears to be generating wrong results")` was a false alarm.

## Change

Convert the previously `#[ignore]`d `todo!()` stub in `per_line_dialogue_syntax` into a real `assert_eq!` that locks in the Asciidoctor-matching behavior, with an explanatory comment.

## Notes

- The replacement character is an **em dash** (`&#8212;`, U+2014), not an en dash, even though the spec prose and the linked eclipse issue [#61](https://gitlab.eclipse.org/eclipse/asciidoc-lang/asciidoc-lang/-/issues/61) loosely call it "endash."
- The upstream eclipse `asciidoc-lang` doc has **already been corrected** to describe this conflict; the `verifies!` prose in the test matches that corrected text.

## Testing

- `cargo test -p asciidoc-parser hard_line_breaks` — 10 passed
- `cargo +nightly fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)