### PR TITLE
fix: Do not let counters modify locked (API-set / built-in) attributes (close #725)

### DIFF
--- a/parser/src/blocks/caption.rs
+++ b/parser/src/blocks/caption.rs
@@ -168,7 +168,10 @@ pub(crate) fn assign_caption(
         InterpretedValue::Value(label) if !label.is_empty() => {
             // The caption number is the counter named `<context>-number`, shared
             // with any `{counter:<context>-number}` reference in the document.
-            let value = parser.counter(&format!("{context}-number"), None);
+            // A captioning counter advances (and stays readable as) its
+            // attribute even when locked, mirroring Asciidoctor's
+            // `increment_and_store_counter`.
+            let value = parser.counter_for_caption(&format!("{context}-number"), None);
             let prefix = format!("{label} {value}. ");
             Some(Caption {
                 prefix,

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -194,6 +194,23 @@ pub struct Parser {
     /// leaving `@attributes` untouched for a locked attribute (see
     /// [`counter_impl`](Self::counter_impl)). A captioning counter is exempt:
     /// its value is committed to the readable overlay even when locked.
+    ///
+    /// Accepted limitation: a locked inline counter tracks its sequence here
+    /// while a captioning counter tracks it in
+    /// [`counter_values`](Self::counter_values), so the two sequences diverge
+    /// when the *same* locked attribute is advanced both ways in one document
+    /// (e.g. an API-locked `example-number` driven by both example blocks and
+    /// inline `{counter:example-number}` references) — Asciidoctor keeps a
+    /// single `@counters` sequence shared across both. This is left unmatched
+    /// deliberately. The scenario — API-locking a `<context>-number` attribute
+    /// *and* mixing caption and inline use — is pathological, and exact parity
+    /// is unreachable regardless: this crate resolves inline counters during
+    /// parsing, whereas Asciidoctor advances captions during parsing but inline
+    /// references during conversion, so the two sequences interleave
+    /// differently no matter how the state is stored. Unifying the maps would
+    /// therefore add read-path complexity (the gate would have to be threaded
+    /// through [`ResolvedAttributes`] too) without actually matching
+    /// Asciidoctor's output here.
     pub(crate) locked_counter_values: RefCell<HashMap<String, String>>,
 
     /// Canonical names of attributes that are locked against modification from

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -183,6 +183,19 @@ pub struct Parser {
     /// [`attribute_value()`]: Self::attribute_value
     pub(crate) counter_values: RefCell<HashMap<String, String>>,
 
+    /// Running state for inline `{counter:…}` / `{counter2:…}` counters whose
+    /// target attribute is *locked* (API-set or a locked built-in).
+    ///
+    /// Such a counter must keep advancing across repeated references, but it
+    /// must not overwrite the locked attribute's readable value — so its
+    /// sequence is tracked here rather than in the readable
+    /// [`counter_values`](Self::counter_values) overlay. This mirrors
+    /// Asciidoctor's `Document#counter`, which advances `@counters` while
+    /// leaving `@attributes` untouched for a locked attribute (see
+    /// [`counter_impl`](Self::counter_impl)). A captioning counter is exempt:
+    /// its value is committed to the readable overlay even when locked.
+    pub(crate) locked_counter_values: RefCell<HashMap<String, String>>,
+
     /// Canonical names of attributes that are locked against modification from
     /// the document body for the current scope.
     ///
@@ -446,6 +459,7 @@ impl Default for Parser {
             mark_footnote_spans: Cell::new(false),
             pending_block_title: None,
             counter_values: RefCell::new(HashMap::new()),
+            locked_counter_values: RefCell::new(HashMap::new()),
             locked_attribute_names: HashSet::new(),
             nested_document_depth: 0,
             owned_subsource_depth: 0,
@@ -562,6 +576,7 @@ impl Parser {
 
         // Reset counter (and captioned-block) numbering for each new document.
         self.counter_values.borrow_mut().clear();
+        self.locked_counter_values.borrow_mut().clear();
 
         Document::parse(
             &preprocessed_source,
@@ -2137,19 +2152,102 @@ impl Parser {
     ///
     /// [counter]: https://docs.asciidoctor.org/asciidoc/latest/attributes/counters/
     pub(crate) fn counter(&self, name: &str, seed: Option<&str>) -> String {
-        let next = match self.attribute_value(name) {
-            InterpretedValue::Value(current) if !current.is_empty() => next_counter_value(&current),
-            _ => match seed {
+        self.counter_impl(name, seed, false)
+    }
+
+    /// Like [`counter`](Self::counter), but the advanced value stays readable
+    /// as the attribute of the same name even when that attribute is
+    /// *locked* (API-set or a locked built-in). This is the captioning
+    /// counter, used for the `<context>-number` of a numbered block.
+    ///
+    /// Mirrors Asciidoctor's `increment_and_store_counter`: it too advances a
+    /// locked counter, and its block attribute entry is replayed onto the
+    /// document attributes during conversion, so a locked `example-number`
+    /// reads back as its latest counter value (unlike a plain inline
+    /// `{counter:…}`, which leaves the locked value in place).
+    pub(crate) fn counter_for_caption(&self, name: &str, seed: Option<&str>) -> String {
+        self.counter_impl(name, seed, true)
+    }
+
+    /// Advances the `name` counter and returns its new value. `seed` supplies
+    /// the starting value when the counter has no current value to advance
+    /// from.
+    ///
+    /// A counter reads the current value to produce (and display) the next one.
+    /// For an unlocked attribute the advanced value is stored in the readable
+    /// [`counter_values`](Self::counter_values) overlay, so a later reference
+    /// reads it. For a *locked* attribute — one set via the API, or a locked
+    /// built-in such as `max-include-depth` — the write path depends on the
+    /// caller:
+    ///
+    /// * `commit_when_locked` (the captioning counter): the value is stored in
+    ///   the readable overlay anyway, matching Asciidoctor's
+    ///   `increment_and_store_counter`, whose block attribute entry is replayed
+    ///   onto the document attributes during conversion.
+    /// * otherwise (an inline `{counter:…}` / `{counter2:…}` directive): the
+    ///   running value is kept in the private
+    ///   [`locked_counter_values`](Self::locked_counter_values) map instead, so
+    ///   the sequence still advances across repeated references while a plain
+    ///   reference to the attribute continues to read the locked value. This
+    ///   mirrors Asciidoctor's `Document#counter`, which advances `@counters`
+    ///   but leaves `@attributes` untouched while the attribute is
+    ///   `attribute_locked?`.
+    fn counter_impl(&self, name: &str, seed: Option<&str>, commit_when_locked: bool) -> String {
+        let use_private_state = !commit_when_locked && self.attribute_is_locked(name);
+
+        // The value to advance from: the private running state first (only
+        // populated when it is in use), otherwise the current readable value of
+        // the attribute (which, for an unlocked counter, already reflects the
+        // overlay).
+        let current = if use_private_state {
+            self.locked_counter_values.borrow().get(name).cloned()
+        } else {
+            None
+        }
+        .or_else(|| match self.attribute_value(name) {
+            InterpretedValue::Value(current) if !current.is_empty() => Some(current),
+            _ => None,
+        });
+
+        let next = match current {
+            Some(current) => next_counter_value(&current),
+            None => match seed {
                 Some(seed) if !seed.is_empty() => seed.to_string(),
                 _ => "1".to_string(),
             },
         };
 
-        self.counter_values
-            .borrow_mut()
-            .insert(name.to_string(), next.clone());
+        if use_private_state {
+            self.locked_counter_values
+                .borrow_mut()
+                .insert(name.to_string(), next.clone());
+        } else {
+            self.counter_values
+                .borrow_mut()
+                .insert(name.to_string(), next.clone());
+        }
 
         next
+    }
+
+    /// Reports whether `name` currently resolves to an attribute that is
+    /// *locked* against modification by a counter: it has an effective value
+    /// whose [`ModificationContext`] is
+    /// [`ApiOnly`](ModificationContext::ApiOnly) — an API-set override or a
+    /// locked built-in such as `max-include-depth`.
+    ///
+    /// This mirrors Asciidoctor's `Document#attribute_locked?`, which is `true`
+    /// exactly for an attribute supplied through the API (its
+    /// `@attribute_overrides`). It is deliberately *narrower* than the
+    /// write-permission check in
+    /// [`set_attribute_from_body`](Self::set_attribute_from_body): a
+    /// header-only attribute such as an unset `outfilesuffix`
+    /// ([`ApiOrHeader`](ModificationContext::ApiOrHeader)) cannot be assigned
+    /// from the body, yet a counter *may* advance it (matching Asciidoctor,
+    /// where `{counter:outfilesuffix}` moves it while it is not API-locked).
+    fn attribute_is_locked(&self, name: &str) -> bool {
+        self.effective_attribute(name)
+            .is_some_and(|a| a.modification_context == ModificationContext::ApiOnly)
     }
 }
 

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -65,8 +65,6 @@
 //! * Multi-line attribute values fuse only the modern backslash continuation,
 //!   not the legacy `+`, so a legacy `+`-continued value keeps only its first
 //!   line.
-//! * A counter modifies a locked (API-set or built-in) attribute rather than
-//!   leaving it unchanged.
 //! * Safe-mode masking of `docdir`/`docfile` and the
 //!   unterminated-header-comment behavior differ.
 //!
@@ -3245,10 +3243,9 @@ mod intrinsic_attributes {
         assert_eq!(blocks[2].caption(), Some("Figure 4. "));
     }
 
-    // Tracked in #725.
     #[test]
     fn should_not_allow_counter_to_modify_locked_attribute() {
-        non_normative!(
+        verifies!(
             r#"
     test 'should not allow counter to modify locked attribute' do
       input = <<~'EOS'
@@ -3262,20 +3259,18 @@ mod intrinsic_attributes {
 "#
         );
 
-        // Divergence: Asciidoctor does not let a counter modify a locked
-        // (API-set) attribute, so `{foo}` stays `bar`. This crate's counter
-        // reads and increments the current value (`bar` → `bas`) and also stores
-        // it, so both references render `bas`.
+        // A counter reads and increments the current value (`bar` → `bas`) for
+        // display, but the API-locked `foo` is not overwritten, so `{foo}` still
+        // reads `bar`.
         let doc = Parser::default()
             .with_intrinsic_attribute("foo", "bar", ModificationContext::ApiOnly)
             .parse("{counter:foo:ignored} is not {foo}");
-        assert_xpath(&doc, "//p[text()=\"bas is not bas\"]", 1);
+        assert_xpath(&doc, "//p[text()=\"bas is not bar\"]", 1);
     }
 
-    // Tracked in #725.
     #[test]
     fn should_not_allow_counter2_to_modify_locked_attribute() {
-        non_normative!(
+        verifies!(
             r#"
     test 'should not allow counter2 to modify locked attribute' do
       input = <<~'EOS'
@@ -3289,18 +3284,17 @@ mod intrinsic_attributes {
 "#
         );
 
-        // Divergence: as with `counter`, this crate's `counter2` modifies the
-        // locked `foo` (Asciidoctor leaves it `bar`), so `{foo}` renders `bas`.
+        // `counter2` advances silently and, like `counter`, does not overwrite
+        // the API-locked `foo`, so `{foo}` still reads `bar`.
         let doc = Parser::default()
             .with_intrinsic_attribute("foo", "bar", ModificationContext::ApiOnly)
             .parse("{counter2:foo:ignored}{foo}");
-        assert_xpath(&doc, "//p[text()=\"bas\"]", 1);
+        assert_xpath(&doc, "//p[text()=\"bar\"]", 1);
     }
 
-    // Tracked in #725.
     #[test]
     fn should_not_allow_counter_to_modify_built_in_locked_attribute() {
-        non_normative!(
+        verifies!(
             r#"
     test 'should not allow counter to modify built-in locked attribute' do
       input = <<~'EOS'
@@ -3316,22 +3310,21 @@ mod intrinsic_attributes {
 "#
         );
 
-        // Divergence: Asciidoctor does not let a counter modify the built-in
-        // locked `max-include-depth`, so it stays 64. This crate increments and
-        // stores it, so both the counter output and the later reference read 65.
+        // The counter reads and increments the locked built-in `max-include-depth`
+        // (64 → 65) for display — its seed `128` is ignored while a current value
+        // exists — but the stored value is not overwritten, so it stays 64.
         let doc = Parser::default()
             .parse("{counter:max-include-depth:128} is one more than {max-include-depth}");
-        assert_xpath(&doc, "//p[text()=\"65 is one more than 65\"]", 1);
+        assert_xpath(&doc, "//p[text()=\"65 is one more than 64\"]", 1);
         assert_eq!(
             doc.attribute_value("max-include-depth"),
-            InterpretedValue::Value("65")
+            InterpretedValue::Value("64")
         );
     }
 
-    // Tracked in #725.
     #[test]
     fn should_not_allow_counter2_to_modify_built_in_locked_attribute() {
-        non_normative!(
+        verifies!(
             r#"
     test 'should not allow counter2 to modify built-in locked attribute' do
       input = <<~'EOS'
@@ -3346,13 +3339,13 @@ mod intrinsic_attributes {
 "#
         );
 
-        // Divergence: as with `counter`, this crate's `counter2` modifies the
-        // built-in locked `max-include-depth` (Asciidoctor leaves it 64).
+        // `counter2` advances silently and, like `counter`, does not overwrite
+        // the locked built-in `max-include-depth`, so it stays 64.
         let doc = Parser::default().parse("{counter2:max-include-depth:128}{max-include-depth}");
-        assert_xpath(&doc, "//p[text()=\"65\"]", 1);
+        assert_xpath(&doc, "//p[text()=\"64\"]", 1);
         assert_eq!(
             doc.attribute_value("max-include-depth"),
-            InterpretedValue::Value("65")
+            InterpretedValue::Value("64")
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #725. A counter (`{counter:name}` / `{counter2:name}`) was incrementing **and storing** even a *locked* attribute: `{counter:foo}` with `foo` API-locked to `bar` rendered `bas` and overwrote `foo`; `{counter:max-include-depth}` changed the built-in from 64 to 65. Asciidoctor reads the current value to produce the counter's output but leaves a locked attribute's stored value unchanged.

## Root cause

The crate stores counter state in a single `counter_values` map that plays two roles: the counter's running sequence **and** the read overlay for `{name}` references (it must, since `counter()` only has `&self` and can't mutate the `attribute_values` map). Asciidoctor keeps these separate — `@counters` advances the sequence while `@attributes` holds the readable value, and `Document#counter` skips the `@attributes` write while `attribute_locked?` is true.

Confirmed empirically against Asciidoctor 2.0.26, including the key subtlety: an inline `{counter:foo}` must **not** expose the counter value for a locked attribute, but a **block-caption** counter (`example-number`) **must** — Asciidoctor's `increment_and_store_counter` replays a block attribute entry onto the document during conversion, so a locked `example-number` reads back as its latest value.

## The fix

- Inline counters targeting a **locked** attribute advance a new private `locked_counter_values` map — the sequence still progresses across repeated references, but the value is not read as an overlay, so a plain reference keeps reading the locked value.
- Block captioning uses a new `counter_for_caption`, which commits the advanced value to the readable overlay even when locked (matching entry-replay).
- `attribute_is_locked` keys precisely on `ModificationContext::ApiOnly`, matching Asciidoctor's `attribute_locked?` (API-set only) — deliberately narrower than the body-write permission, so `{counter:outfilesuffix}` (header-only `ApiOrHeader`) still advances.

## Tests

The four upstream tests previously recorded as `non_normative!` divergences (`should_not_allow_counter{,2}_to_modify_{,built_in_}locked_attribute`) are promoted to `verifies!` and now assert Asciidoctor's actual output. Full workspace: 4251 passed / 0 failed; `cargo +nightly fmt --all --check` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)