### PR TITLE
chore: Mark non-`article` doctypes (incl. `manpage`) as out of scope (close #721)

### DIFF
--- a/parser/src/tests/asciidoctor_rb/document_test.rs
+++ b/parser/src/tests/asciidoctor_rb/document_test.rs
@@ -57,8 +57,7 @@
 //!   into individual authors, and an explicit `:authorinitials:` override is
 //!   ignored (a base `:author:` entry and indexed `author_N` entries *are*
 //!   resolved into `authors()`, as of #713):
-//!   <https://github.com/asciidoc-rs/asciidoc-parser/issues/718>;
-//! - `manpage` doctype not implemented: <https://github.com/asciidoc-rs/asciidoc-parser/issues/721>.
+//!   <https://github.com/asciidoc-rs/asciidoc-parser/issues/718>.
 //!
 //! Those tests are left `non_normative!` so coverage is not overstated; the
 //! gaps are called out for follow-up.
@@ -66,7 +65,9 @@
 //! Some divergences are intentional and will not be addressed: asciidoc-parser
 //! does not support setext (two-line) document titles, so it neither enables
 //! compat-mode for a legacy doctitle nor parses the attribute entries / author
-//! line that may follow one.
+//! line that may follow one. It also supports only the `article` doctype, so
+//! the `manpage` doctype (and its `mantitle`/`manvolnum`/`manname`/`manpurpose`
+//! attributes and synopsis special section) is out of scope.
 
 use crate::tests::prelude::*;
 
@@ -2051,9 +2052,9 @@ mod catalog {
 // output — conversion. asciidoc-parser does not support setext (two-line)
 // document titles at all, so the attribute entries and author line beneath
 // one are not parsed — an intentional divergence that will not be addressed.
-// DIVERGENCE: the `manpage` doctype (mantitle, manvolnum, manname/manpurpose,
-// synopsis special section) is not modeled
-// (https://github.com/asciidoc-rs/asciidoc-parser/issues/721).
+// asciidoc-parser also supports only the `article` doctype, so the `manpage`
+// doctype (mantitle, manvolnum, manname/manpurpose, synopsis special section)
+// is out of scope and will not be modeled.
 mod backends_and_doctypes {
     use crate::tests::prelude::*;
 


### PR DESCRIPTION
## Summary

Reframes the `manpage` doctype from a *tracked divergence* to an *intentional, out-of-scope* decision. asciidoc-parser supports only the `article` doctype and does not plan to support others, so issue #721 (unimplemented `manpage` doctype) will not be addressed.

Both references to issue #721 in `parser/src/tests/asciidoctor_rb/document_test.rs` are removed:

- **Module-header doc comment:** dropped the `manpage` bullet from the "tracked by an issue / DIVERGENCE" list (and fixed the now-final #718 bullet's trailing `;` → `.`). Added a sentence to the existing "intentional, will not be addressed" paragraph noting only the `article` doctype is supported, so `manpage` (and its `mantitle`/`manvolnum`/`manname`/`manpurpose` attributes and synopsis special section) is out of scope.
- **`backends_and_doctypes` module comment:** replaced the `DIVERGENCE: ... (issue 721)` note with a statement that only the `article` doctype is supported, so `manpage` is out of scope and will not be modeled.

This mirrors how the existing setext-title divergence is already documented as intentional.

## Verification

- No `721` references remain in source.
- `cargo +nightly fmt --all -- --check` passes.
- `cargo build -p asciidoc-parser` builds clean.

Closes #721.

🤖 Generated with [Claude Code](https://claude.com/claude-code)