### PR TITLE
fix: Resolve attribute references case-insensitively (close #724)

### DIFF
--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -699,7 +699,15 @@ impl Replacer for AttributeReplacer<'_> {
             return;
         }
 
-        if !self.parser.has_attribute(attr_name) {
+        // Resolve the reference case-insensitively: attribute names are stored
+        // lower-cased (both an attribute-entry definition and an API-supplied
+        // attribute fold their name), so the lookup name is folded the same way
+        // here. This mirrors Asciidoctor's `sub_attributes`, which looks up
+        // `key = $2.downcase`. The original spelling is still what is emitted
+        // literally for a skipped or missing reference below.
+        let lookup_name = attr_name.to_lowercase();
+
+        if !self.parser.has_attribute(&lookup_name) {
             match self.mode {
                 AttributeMissing::Skip => dest.push_str(&caps[0]),
                 AttributeMissing::Drop => {
@@ -725,7 +733,7 @@ impl Replacer for AttributeReplacer<'_> {
             return;
         }
 
-        if let InterpretedValue::Value(value) = self.parser.attribute_value(attr_name) {
+        if let InterpretedValue::Value(value) = self.parser.attribute_value(&lookup_name) {
             dest.push_str(value.as_ref());
         }
         // Language description is unclear as to what happens for "set" and

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2268,14 +2268,16 @@ fn remap_attr_name<N: AsRef<str>>(raw_attr_name: N) -> String {
     // Bar[:` set `foo3-bar`, and `:My frog:` set `myfrog`. Unicode word
     // characters are preserved, so `:café:` sets `café` and `:سمن:` sets `سمن`.
     //
-    // Only ASCII case is folded (not Asciidoctor's Unicode `downcase`): a
-    // reference is looked up under its raw, case-sensitive spelling (see the
-    // case-sensitivity divergence in the tests), so folding non-ASCII case here
-    // — which can also expand a character, e.g. `İ` -> `i` + combining dot —
-    // would leave a Unicode-named entry unreachable by its own spelling.
+    // The full Unicode case fold (Asciidoctor's `downcase`, not merely ASCII)
+    // is what makes an attribute reference case-insensitive: an entry written
+    // `:He-Man:` is reachable as `{he-man}` or `{HE-MAN}`. A reference is folded
+    // through this same `to_lowercase()` before lookup (see `AttributeReplacer`
+    // in `content::substitution_step`), so definition and reference stay
+    // symmetric even when a fold expands a character (e.g. `İ` -> `i` + combining
+    // dot): both sides land on the identical key.
     let attr_name: String = INVALID_ATTR_NAME_CHARS
         .replace_all(raw_attr_name.as_ref(), "")
-        .to_ascii_lowercase();
+        .to_lowercase();
 
     // Some attribute names have aliases. Remap to the primary name.
     //
@@ -2366,12 +2368,37 @@ mod tests {
         }
 
         #[test]
-        fn folds_only_ascii_case() {
-            // Non-ASCII case is left intact so a Unicode-named entry stays
-            // reachable by its own (case-sensitive) spelling: `İ` would expand
-            // under a Unicode `downcase`, but a reference is not folded.
-            assert_eq!(remap_attr_name("İstanbul"), "İstanbul");
+        fn folds_case_with_full_unicode() {
+            // The name is folded with the full Unicode `to_lowercase()`, so a
+            // reference lookup is case-insensitive. A fold that expands a
+            // character (`İ` -> `i` + U+0307 combining dot above) is harmless:
+            // an attribute reference is folded through the same function, so
+            // definition and reference still land on the identical key.
+            assert_eq!(remap_attr_name("He-Man"), "he-man");
+            assert_eq!(remap_attr_name("İstanbul"), "i\u{307}stanbul");
+            assert_eq!(remap_attr_name("İstanbul"), "İstanbul".to_lowercase());
         }
+    }
+
+    #[test]
+    fn attribute_reference_resolves_case_insensitively() {
+        // A reference is folded with the same Unicode `to_lowercase()` used to
+        // store the name, so any casing of the reference resolves the entry
+        // (close #724).
+        let doc = Parser::default().parse(":He-Man: the foe\n\n{he-man} / {HE-MAN} / {He-Man}");
+        assert_eq!(
+            rendered_paragraphs(&doc),
+            vec!["the foe / the foe / the foe"]
+        );
+    }
+
+    #[test]
+    fn attribute_reference_case_fold_round_trips_when_it_expands() {
+        // `İ` folds to `i` + U+0307 under `to_lowercase()`. Because both the
+        // definition and the reference fold through that same function, the
+        // entry stays reachable by its own spelling despite the expansion.
+        let doc = Parser::default().parse(":İ: dotted\n\n{İ}");
+        assert_eq!(rendered_paragraphs(&doc), vec!["dotted"]);
     }
 
     #[test]
@@ -2382,6 +2409,16 @@ mod tests {
         // `ifeval` condition. See #726.
         let doc = Parser::default()
             .parse(":café: yes\n\nifeval::[\"{café}\" == \"yes\"]\nShown.\nendif::[]");
+        assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);
+    }
+
+    #[test]
+    fn case_insensitive_attribute_reference_resolves_in_preprocessor() {
+        // The preprocessor folds a `{name}` reference the same way the main
+        // substitution pass does, so a mismatched-case reference still drives an
+        // `ifeval` condition (close #724).
+        let doc = Parser::default()
+            .parse(":Answer: yes\n\nifeval::[\"{answer}\" == \"yes\"]\nShown.\nendif::[]");
         assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);
     }
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2383,8 +2383,7 @@ mod tests {
     #[test]
     fn attribute_reference_resolves_case_insensitively() {
         // A reference is folded with the same Unicode `to_lowercase()` used to
-        // store the name, so any casing of the reference resolves the entry
-        // (close #724).
+        // store the name, so any casing of the reference resolves the entry.
         let doc = Parser::default().parse(":He-Man: the foe\n\n{he-man} / {HE-MAN} / {He-Man}");
         assert_eq!(
             rendered_paragraphs(&doc),
@@ -2416,7 +2415,7 @@ mod tests {
     fn case_insensitive_attribute_reference_resolves_in_preprocessor() {
         // The preprocessor folds a `{name}` reference the same way the main
         // substitution pass does, so a mismatched-case reference still drives an
-        // `ifeval` condition (close #724).
+        // `ifeval` condition.
         let doc = Parser::default()
             .parse(":Answer: yes\n\nifeval::[\"{answer}\" == \"yes\"]\nShown.\nendif::[]");
         assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -930,7 +930,13 @@ impl<'p> PreprocessorState<'p> {
                     return;
                 }
 
-                if !self.parser.has_attribute(attr_name) {
+                // Resolve case-insensitively: attribute names are stored
+                // lower-cased, so the lookup name is folded the same way (see the
+                // content-substitution path in `content::substitution_step` and
+                // Asciidoctor's `key = $2.downcase`).
+                let lookup_name = attr_name.to_lowercase();
+
+                if !self.parser.has_attribute(&lookup_name) {
                     self.missing_reference = true;
 
                     if matches!(self.missing, MissingAttribute::KeepLiteral) {
@@ -939,7 +945,7 @@ impl<'p> PreprocessorState<'p> {
                     return;
                 }
 
-                if let InterpretedValue::Value(value) = self.parser.attribute_value(attr_name) {
+                if let InterpretedValue::Value(value) = self.parser.attribute_value(&lookup_name) {
                     dest.push_str(value.as_ref());
                 }
             }

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -60,8 +60,6 @@
 //! The remainder are tracked as issues (see the `sddbugfind` label). Each such
 //! test carries an inline `Divergence:` note; the notable ones are:
 //!
-//! * Attribute *references* are case-sensitive, so `{He-Man}` does not resolve
-//!   the lowercased `:He-Man:` entry.
 //! * Multi-line attribute values fuse only the modern backslash continuation,
 //!   not the legacy `+`, so a legacy `+`-continued value keeps only its first
 //!   line.
@@ -1796,10 +1794,9 @@ mod interpolation {
         assert_xpath(&doc, "//p[text()=\"Yo, Tanglefoot!\nBeat Spiderman!\"]", 1);
     }
 
-    // Tracked in #724.
     #[test]
     fn attribute_lookup_is_not_case_sensitive() {
-        non_normative!(
+        verifies!(
             r#"
     test 'attribute lookup is not case sensitive' do
       input = <<~'EOS'
@@ -1817,6 +1814,10 @@ mod interpolation {
 "#
         );
 
+        // An attribute-entry name and an API-supplied attribute name are both
+        // stored lower-cased; a reference is folded the same way before lookup,
+        // so `{He-Man}` resolves the `:He-Man:` entry and `{She-Ra}` resolves the
+        // API attribute stored as `she-ra`.
         let doc = Parser::default()
             .with_intrinsic_attribute(
                 "She-Ra",
@@ -1826,12 +1827,13 @@ mod interpolation {
             .parse(
                 ":He-Man: The most powerful man in the universe\n\nHe-Man: {He-Man}\n\nShe-Ra: {She-Ra}",
             );
-        // Divergence: attribute *references* are case-sensitive in this crate,
-        // so `{He-Man}` does not resolve against the lowercased `:He-Man:` entry
-        // and `{She-Ra}` does not match the API attribute stored as `she-ra`;
-        // both are left literal. Asciidoctor performs a case-insensitive lookup.
-        assert_xpath(&doc, "//p[text()=\"He-Man: {He-Man}\"]", 1);
-        assert_xpath(&doc, "//p[text()=\"She-Ra: {She-Ra}\"]", 1);
+
+        assert_xpath(
+            &doc,
+            "//p[text()=\"He-Man: The most powerful man in the universe\"]",
+            1,
+        );
+        assert_xpath(&doc, "//p[text()=\"She-Ra: The Princess of Power\"]", 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #724.

Attribute definitions store their name lower-cased (both an attribute-entry `:He-Man:` and an API-supplied `She-Ra`), but a reference such as `{He-Man}` / `{She-Ra}` was looked up **verbatim**, so it never matched the stored `he-man` / `she-ra` key and was left literal. Asciidoctor resolves references case-insensitively (`key = $2.downcase`).

This folds the reference name through the same Unicode `to_lowercase()` used to store the name, at both `{name}` resolution sites.

## Changes

- **`content::substitution_step`** – fold the plain-attribute-reference name before `has_attribute` / `attribute_value`. The original spelling is still emitted literally for a skipped/missing reference.
- **`parser::preprocessor`** – same fold in the preprocessor's reference resolver (conditional directives, include targets).
- **`remap_attr_name`** – switch the definition path from ASCII-only folding to the full Unicode `to_lowercase()`. Because a reference now folds through the same function, definition and reference stay symmetric even when a fold expands a character (`İ` → `i` + combining dot), so a Unicode-named entry stays reachable by its own spelling — this removes the constraint that originally justified ASCII-only folding under #726.

## Tests

- Promoted the upstream `attribute_lookup_is_not_case_sensitive` test from `non_normative!` to `verifies!` (now asserts the resolved text), and dropped the two case-sensitivity divergence notes.
- Added native tests: mixed-case (`{he-man}` / `{HE-MAN}` / `{He-Man}`), the `İ` case-fold round-trip, and a case-insensitive reference driving an `ifeval` in the preprocessor.
- Updated the `remap_attr_name` unit test for the Unicode fold.

Full workspace tests, `cargo +nightly fmt --all --check`, and clippy all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)