### PR TITLE
fix: Accept Asciidoctor `_` markdown-style thematic breaks (close #723)

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -573,6 +573,7 @@ impl<'src> Block<'src> {
             if (line.item.starts_with('\'')
                 || line.item.starts_with('-')
                 || line.item.starts_with('*')
+                || line.item.starts_with('_')
                 || line.item.starts_with('<'))
                 && let Some(mi_break) = Break::parse(&metadata, parser)
             {

--- a/parser/src/blocks/break.rs
+++ b/parser/src/blocks/break.rs
@@ -57,7 +57,15 @@ impl<'src> Break<'src> {
         let data = line.item.data();
 
         let type_ = match data {
-            "---" | "- - -" | "***" | "* * *" => BreakType::Thematic,
+            // The `-`/`*` markdown-style thematic breaks are spec-recognized.
+            // Asciidoctor additionally accepts the `_` forms (`___`, `_ _ _`)
+            // to ease Markdown migration, and this crate matches that. Only
+            // exactly three repeating characters count: a run of four or more
+            // underscores (`____`) is a quote block delimiter, so extended `_`
+            // runs are deliberately not matched here (unlike the apostrophe run
+            // handled below). See
+            // https://github.com/asciidoc-rs/asciidoc-parser/issues/723.
+            "---" | "- - -" | "***" | "* * *" | "___" | "_ _ _" => BreakType::Thematic,
             "<<<" => BreakType::Page,
             // A run of three or more apostrophes is a thematic break. The
             // AsciiDoc language reference documents the canonical `'''` form,
@@ -358,6 +366,75 @@ mod tests {
         );
 
         assert_eq!(mi.item.type_(), BreakType::Thematic);
+    }
+
+    #[test]
+    fn thematic_break_triple_underscore() {
+        // Asciidoctor accepts `___` as a markdown-style thematic break (an
+        // extension beyond the AsciiDoc spec's `-`/`*` forms); this crate
+        // matches that.
+        let mut parser = Parser::default();
+
+        let mi = crate::blocks::Break::parse(&BlockMetadata::new("___"), &mut parser).unwrap();
+
+        assert_eq!(
+            mi.item,
+            Break {
+                type_: BreakType::Thematic,
+                source: Span {
+                    data: "___",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                anchor: None,
+                attrlist: None,
+            }
+        );
+
+        assert_eq!(mi.item.content_model(), ContentModel::Empty);
+        assert_eq!(mi.item.raw_context().deref(), "thematic_break");
+        assert_eq!(mi.item.type_(), BreakType::Thematic);
+    }
+
+    #[test]
+    fn thematic_break_spaced_underscore() {
+        let mut parser = Parser::default();
+
+        let mi = crate::blocks::Break::parse(&BlockMetadata::new("_ _ _"), &mut parser).unwrap();
+
+        assert_eq!(
+            mi.item,
+            Break {
+                type_: BreakType::Thematic,
+                source: Span {
+                    data: "_ _ _",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                anchor: None,
+                attrlist: None,
+            }
+        );
+
+        assert_eq!(mi.item.type_(), BreakType::Thematic);
+    }
+
+    #[test]
+    fn four_underscores_is_not_a_thematic_break() {
+        // A run of four or more underscores is a quote block delimiter, not a
+        // thematic break, so `Break::parse` must reject it. (Contrast the
+        // apostrophe run, where four or more `'` *is* a thematic break.)
+        let mut parser = Parser::default();
+        assert!(crate::blocks::Break::parse(&BlockMetadata::new("____"), &mut parser).is_none());
+
+        let mut parser = Parser::default();
+        assert!(crate::blocks::Break::parse(&BlockMetadata::new("_____"), &mut parser).is_none());
     }
 
     #[test]

--- a/parser/src/blocks/break.rs
+++ b/parser/src/blocks/break.rs
@@ -63,8 +63,13 @@ impl<'src> Break<'src> {
             // exactly three repeating characters count: a run of four or more
             // underscores (`____`) is a quote block delimiter, so extended `_`
             // runs are deliberately not matched here (unlike the apostrophe run
-            // handled below). See
-            // https://github.com/asciidoc-rs/asciidoc-parser/issues/723.
+            // handled below).
+            //
+            // Asciidoctor also tolerates 0–3 leading spaces before any of these
+            // markers. This crate intentionally does not: the marker must start
+            // at column 1, consistent with how AsciiDoc treats leading-space
+            // lines generally (they become literal paragraphs). This divergence
+            // is deliberate and settled, not a pending gap.
             "---" | "- - -" | "***" | "* * *" | "___" | "_ _ _" => BreakType::Thematic,
             "<<<" => BreakType::Page,
             // A run of three or more apostrophes is a thematic break. The

--- a/parser/src/tests/asciidoctor_rb/text_test.rs
+++ b/parser/src/tests/asciidoctor_rb/text_test.rs
@@ -50,10 +50,11 @@
 //!   assertion remains in the reproduced Ruby text only.
 //! * Markdown-style thematic breaks: per the AsciiDoc language spec
 //!   (`blocks/partials/thematic-breaks.adoc`), only the three-character `-` and
-//!   `*` forms are recognized. Asciidoctor additionally accepts the `_` forms
-//!   and 0–3 leading spaces; those extra cases are Asciidoctor-specific and are
-//!   noted where they arise (divergence tracked in
-//!   <https://github.com/asciidoc-rs/asciidoc-parser/issues/723>).
+//!   `*` forms are recognized. This crate also accepts Asciidoctor's `_` forms
+//!   (`___`, `_ _ _`) at column 1 as a compatibility extension. It
+//!   intentionally does *not* adopt Asciidoctor's 0–3 leading-space tolerance;
+//!   that is a deliberate, settled divergence (the marker must start at column
+//!   1), noted where it arises.
 
 use crate::tests::prelude::*;
 
@@ -278,11 +279,12 @@ fn horizontal_rule() {
 // recognizes all six variants (`---`, `- - -`, `***`, `* * *`, `___`, `_ _ _`)
 // at column 1: the `-`/`*` forms are spec-recognized
 // (`blocks/partials/thematic-breaks.adoc`), and the `_` forms are accepted as
-// an Asciidoctor-compatibility extension (see
-// https://github.com/asciidoc-rs/asciidoc-parser/issues/723). The remaining
-// divergence is the leading offset: Asciidoctor tolerates 0–3 leading spaces,
-// while this crate requires the marker at column 1, so the offset dimension of
-// this test is not yet satisfied. The spec-recognized subset is verified
+// an Asciidoctor-compatibility extension. This crate intentionally diverges on
+// the leading offset: Asciidoctor tolerates 0–3 leading spaces, while this
+// crate requires the marker at column 1 (an indented line becomes a literal
+// paragraph, per AsciiDoc's general treatment of leading whitespace). That
+// divergence is a deliberate, settled decision, so the offset dimension of this
+// test is left unsatisfied by design. The spec-recognized subset is verified
 // directly against the language spec in
 // `tests::asciidoc_lang::blocks::thematic_breaks::markdown_style_thematic_breaks`.
 non_normative!(
@@ -389,9 +391,9 @@ fn markdown_horizontal_rules_negative_case() {
 
     // None of these produce a thematic break in this crate. The four-character
     // variants are rejected by both this crate and Asciidoctor; the tab- and
-    // four-space-offset good variants are rejected here because this crate does
-    // not accept any leading offset (Asciidoctor rejects only these two — see
-    // https://github.com/asciidoc-rs/asciidoc-parser/issues/723).
+    // four-space-offset good variants are rejected here because this crate
+    // intentionally accepts no leading offset at all (Asciidoctor rejects only
+    // these two). That stricter behavior is a deliberate, settled divergence.
     for variant in ["- - - -", "* * * *", "_ _ _ _"] {
         for offset in ["", " ", "  ", "   "] {
             let input = format!(

--- a/parser/src/tests/asciidoctor_rb/text_test.rs
+++ b/parser/src/tests/asciidoctor_rb/text_test.rs
@@ -274,13 +274,16 @@ fn horizontal_rule() {
 
 // The `markdown horizontal rules` (positive) test is out of scope as written,
 // so it is reproduced non-normatively rather than verified. It asserts a
-// thematic break for six variants at four leading offsets, but per the AsciiDoc
-// language spec (`blocks/partials/thematic-breaks.adoc`) only the
-// three-character `-`/`*` forms at column 1 are recognized; Asciidoctor's
-// additional `_`/`___`/`_ _ _` forms and 0–3 leading spaces are extensions this
-// crate deliberately does not implement (divergence tracked in
-// https://github.com/asciidoc-rs/asciidoc-parser/issues/723). The
-// spec-recognized subset is verified directly against the language spec in
+// thematic break for six variants at four leading offsets. This crate now
+// recognizes all six variants (`---`, `- - -`, `***`, `* * *`, `___`, `_ _ _`)
+// at column 1: the `-`/`*` forms are spec-recognized
+// (`blocks/partials/thematic-breaks.adoc`), and the `_` forms are accepted as
+// an Asciidoctor-compatibility extension (see
+// https://github.com/asciidoc-rs/asciidoc-parser/issues/723). The remaining
+// divergence is the leading offset: Asciidoctor tolerates 0–3 leading spaces,
+// while this crate requires the marker at column 1, so the offset dimension of
+// this test is not yet satisfied. The spec-recognized subset is verified
+// directly against the language spec in
 // `tests::asciidoc_lang::blocks::thematic_breaks::markdown_style_thematic_breaks`.
 non_normative!(
     r#"


### PR DESCRIPTION
Closes #723.

## What

Recognize Asciidoctor's underscore markdown-style thematic breaks — `___` and `_ _ _` — at column 1, alongside the spec-recognized `-`/`*` forms.

- **[break.rs](parser/src/blocks/break.rs)** — adds `"___" | "_ _ _"` to the thematic-break match arm. Only exactly three repeating underscores count: a run of four or more (`____`) is a quote-block delimiter, so extended `_` runs are deliberately *not* matched (unlike the apostrophe run).
- **[block.rs](parser/src/blocks/block.rs)** — adds `_` to the dispatch char-guard so underscore-leading lines reach `Break::parse`.
- Tests: `thematic_break_triple_underscore`, `thematic_break_spaced_underscore`, and `four_underscores_is_not_a_thematic_break` (guards the quote-delimiter boundary).

## Scope decision

Per the issue, this was a judgment call between spec-compliance and Asciidoctor-compat. We adopt the `_` forms but **intentionally do not** adopt Asciidoctor's 0–3 leading-space offset tolerance: the marker must start at column 1, consistent with AsciiDoc's general treatment of leading whitespace (indented lines become literal paragraphs).

That leading-offset divergence is recorded in the code comments as a deliberate, settled decision, so #723 can be closed with nothing left open about it.

## Verification

- `cargo test -p asciidoc-parser --lib`: 4254 passed, 0 failed
- `cargo +nightly fmt --all -- --check`: clean
- `cargo clippy -p asciidoc-parser --all-targets`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)