### PR TITLE
chore: Remove resolved #308 reference from post_replacements titles stub

### DIFF
--- a/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
+++ b/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
@@ -391,29 +391,17 @@ mod default_post_replacements_substitution {
     #[ignore]
     #[test]
     fn titles() {
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/308):
-        //
-        // Not sure if a block title can span multiple lines. If so, what does that
-        // syntax look like and how does it interact with post-replacement substitution?
+        // A block title cannot span multiple lines via a trailing `+`: a title is
+        // a single line, and a trailing ` +` is retained literally rather than
+        // joined to the following line. Because a title never spans lines, the
+        // post_replacements line-break substitution has nothing to act on here, so
+        // the `|Titles |{y}` row isn't directly verifiable.
         to_do_verifies!(
             r#"
 |Titles |{y}
 |===
 
 "#
-        );
-
-        let doc = Parser::default().parse(".Title abc +\ndef\n****\nStuff > nonsense\n****");
-
-        let block1 = doc.nested_blocks().next().unwrap();
-
-        let Block::CompoundDelimited(block1) = block1 else {
-            panic!("Unexpected block type: {block1:?}");
-        };
-
-        assert_eq!(
-            block1.title().unwrap(),
-            r#"Title <span class="icon"><img src="./images/icons/heart.png" alt="heart"></span> such"#
         );
     }
 }


### PR DESCRIPTION
Closes #308

## Summary

Sweeps the codebase to remove the last remaining reference to issue #308 ("Can a block title span multiple lines via `+` escaping?").

There was exactly one code reference: a `TO DO` comment in `parser/src/tests/asciidoc_lang/subs/post_replacements.rs`. Issue #308's own answer is **No** — a block title cannot span multiple lines. I confirmed this against the parser: parsing `.Title abc +\ndef\n****\n...` yields a paragraph whose single-line title is `Title abc +` (the trailing ` +` retained literally, not converted to `<br>` and not joined to `def`), followed by a separate sidebar.

## Changes

- Removed the `TO DO` comment linking to #308 and replaced it with a factual comment recording the resolved behavior.
- Removed the stale placeholder assertion (a copied "heart icon" expectation) and its parse, leaving a clean `#[ignore]` + `to_do_verifies!` stub — matching the convention used by other spec-coverage stubs (e.g. `header_group` in `subs/index.rs`).

The `|Titles |{y}` spec-coverage marker stays in place; that genuinely-unverifiable gap is tracked separately by the `to_do_verifies!` sweep in #628, not by #308.

## Verification

- No `#308` / `issues/308` references remain anywhere.
- `cargo +nightly fmt --all -- --check` clean.
- `cargo test -p asciidoc-parser post_replacements` passes (23 passed, 1 ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)