### PR TITLE
chore: Cover counter deferral for a rejected metadata run above the title

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -2113,6 +2113,27 @@ mod tests {
     }
 
     #[test]
+    fn rejected_metadata_run_does_not_fire_counter() {
+        // A block attribute line above the title is only parsed as document
+        // metadata once a title is confirmed to follow it (via
+        // `document_title_follows_block_metadata`, which scans structurally and
+        // never parses an attribute list). Here the `[[anchor]]` breaks the run
+        // before any title, so the lookahead fails and the `[reftext=…]` line's
+        // attribute list is never parsed during header parsing — its embedded
+        // `{counter:item}` must not fire at header time.
+        //
+        // The `reftext` line advances the counter exactly once when the block
+        // parser reaches it (yielding 1), so the following `{counter:item}`
+        // reference renders 2 — not 3, which is what a leaked header-time
+        // evaluation would produce.
+        let doc = Parser::default()
+            .parse("[reftext=\"See {counter:item}\"]\n[[anchor]]\n= Title\n\n{counter:item}");
+
+        assert_eq!(doc.header().title(), None);
+        assert_eq!(rendered_paragraphs(&doc), vec!["= Title", "2"]);
+    }
+
+    #[test]
     fn role_block_attribute_above_title() {
         // A `[role=…]` block attribute above the title folds into the document's
         // `role` attribute; multiple roles are space-joined. The same role(s)


### PR DESCRIPTION
Follow-up to the now-closed #833, salvaging the one piece of unique test coverage it had that #841 (which fixed #821) did not include.

## What

Adds a single regression test, `rejected_metadata_run_does_not_fire_counter`, to `parser/src/document/header.rs`. It asserts that a block attribute line above the document title whose value carries a `{counter:…}` reference does **not** advance the counter at header time when the run is ultimately rejected — here by an embedded `[[anchor]]` that breaks the run before any title:

```asciidoc
[reftext="See {counter:item}"]
[[anchor]]
= Title

{counter:item}
```

Because `document_title_follows_block_metadata` scans the run structurally without parsing any attribute list, the `[reftext=…]` line is left untouched for the block parser when no title follows. The counter therefore advances exactly once (when the block parser reaches the `reftext` line), so the trailing `{counter:item}` renders `2` — not `3`, which is what a leaked header-time evaluation would produce.

## Why

The behavior is already correct on `main`; this just pins it with a named test so a future refactor of the metadata lookahead can't silently regress it. No production code changes.

Test passes; `cargo +nightly fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)