### PR TITLE
fix: Match Asciidoctor's first-delimiter rule for mixed ifdef/ifndef combinators (close #866)

### DIFF
--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -1324,17 +1324,33 @@ impl<'p> PreprocessorState<'p> {
     /// content should be included.
     ///
     /// Multiple attribute names may be combined with `,` (any is set — logical
-    /// OR) or `+` (all are set — logical AND); the two combinators cannot be
-    /// mixed. `ifndef` is the logical negation of `ifdef`.
+    /// OR) or `+` (all are set — logical AND). The spec forbids mixing the two
+    /// combinators in a single expression; when they are mixed anyway, the
+    /// combinator that appears *first* governs the whole expression and the
+    /// target is split on that delimiter alone, so the other delimiter becomes
+    /// part of a (never-set) literal attribute name. This mirrors Asciidoctor,
+    /// whose `ConditionalDirectiveRx` captures only the first `,`/`+` in the
+    /// target. `ifndef` is the logical negation of `ifdef`.
     fn eval_ifdef(&self, keyword: &str, target: &str) -> bool {
         // Attribute names are case-insensitive: the parser stores them
         // lowercased, so the directive's target names are lowercased to match
         // (`ifdef::showScript[]` resolves the `showscript` attribute).
         let is_set = |name: &str| self.parser.is_attribute_set(name.to_lowercase());
 
-        let defined = if target.contains(',') {
+        // Whichever of `,`/`+` appears first in the target selects the
+        // combinator; the target is then split on that delimiter alone.
+        let comma = target.find(',');
+        let plus = target.find('+');
+
+        let comma_first = match (comma, plus) {
+            (Some(c), Some(p)) => c < p,
+            (Some(_), None) => true,
+            _ => false,
+        };
+
+        let defined = if comma_first {
             target.split(',').any(is_set)
-        } else if target.contains('+') {
+        } else if plus.is_some() {
             target.split('+').all(is_set)
         } else {
             is_set(target)

--- a/parser/src/tests/asciidoc_lang/directives/ifdef_ifndef.rs
+++ b/parser/src/tests/asciidoc_lang/directives/ifdef_ifndef.rs
@@ -166,10 +166,37 @@ non_normative!(
 
 Both the `ifdef` and `ifndef` directives accept multiple attribute names.
 The combinator can be "`and`" or "`or`".
+"#
+);
+
+#[test]
+fn combinators_cannot_be_mixed() {
+    verifies!(
+        r#"
 The two combinators cannot be combined in the same expression.
 
 "#
-);
+    );
+
+    // The spec forbids mixing the `,` (or) and `+` (and) combinators in a single
+    // expression, but the parser does not reject (or warn about) a mixed
+    // expression. Instead, the `,` (or) combinator takes precedence: the target
+    // is split on commas first and each comma-delimited segment is resolved as a
+    // single attribute name. A `+` therefore becomes part of that literal name
+    // rather than an "`and`" combinator, and since no attribute is ever named
+    // `b+c`, such a segment can never match.
+
+    // The first comma segment (`a`) is set, so the content is included — the
+    // `b+c` segment is never consulted.
+    let doc = Parser::default().parse(":a:\n:b:\n:c:\n\nifdef::a,b+c[Shown.]");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);
+
+    // With `a` unset, the `b+c` segment is treated as a single (never-set)
+    // attribute name — the `+` is not honored as an "`and`" combinator — so even
+    // though both `b` and `c` are set, the content is excluded.
+    let doc = Parser::default().parse(":b:\n:c:\n\nifdef::a,b+c[Shown.]\n\nTail.");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Tail."]);
+}
 
 #[test]
 fn ifdef_with_multiple_attributes() {

--- a/parser/src/tests/asciidoc_lang/directives/ifdef_ifndef.rs
+++ b/parser/src/tests/asciidoc_lang/directives/ifdef_ifndef.rs
@@ -179,22 +179,29 @@ The two combinators cannot be combined in the same expression.
     );
 
     // The spec forbids mixing the `,` (or) and `+` (and) combinators in a single
-    // expression, but the parser does not reject (or warn about) a mixed
-    // expression. Instead, the `,` (or) combinator takes precedence: the target
-    // is split on commas first and each comma-delimited segment is resolved as a
-    // single attribute name. A `+` therefore becomes part of that literal name
-    // rather than an "`and`" combinator, and since no attribute is ever named
-    // `b+c`, such a segment can never match.
+    // expression, but the parser (like Asciidoctor) neither rejects nor warns
+    // about a mixed expression. Instead, whichever combinator appears *first*
+    // governs the whole expression, and the target is split on that delimiter
+    // alone — so the other delimiter becomes part of a single literal attribute
+    // name. Since no attribute is ever named (for example) `b+c`, such a segment
+    // can never match.
 
-    // The first comma segment (`a`) is set, so the content is included — the
-    // `b+c` segment is never consulted.
+    // `,` appears first, so this is an "`or`": the `a` segment is set, so the
+    // content is included (the `b+c` segment is never consulted).
     let doc = Parser::default().parse(":a:\n:b:\n:c:\n\nifdef::a,b+c[Shown.]");
     assert_eq!(rendered_paragraphs(&doc), vec!["Shown."]);
 
-    // With `a` unset, the `b+c` segment is treated as a single (never-set)
-    // attribute name — the `+` is not honored as an "`and`" combinator — so even
-    // though both `b` and `c` are set, the content is excluded.
+    // Still an "`or`" (`,` first): with `a` unset, the `b+c` segment is a single
+    // never-set attribute name — the `+` is not honored as an "`and`" — so the
+    // content is excluded even though both `b` and `c` are set.
     let doc = Parser::default().parse(":b:\n:c:\n\nifdef::a,b+c[Shown.]\n\nTail.");
+    assert_eq!(rendered_paragraphs(&doc), vec!["Tail."]);
+
+    // `+` appears first, so this is an "`and`": the `b,c` segment is a single
+    // never-set attribute name — the `,` is not honored as an "`or`" — so the
+    // content is excluded even though every real attribute (`a`, `b`, `c`) is
+    // set.
+    let doc = Parser::default().parse(":a:\n:b:\n:c:\n\nifdef::a+b,c[Shown.]\n\nTail.");
     assert_eq!(rendered_paragraphs(&doc), vec!["Tail."]);
 }
 


### PR DESCRIPTION
Fixes #866.

## Problem

The `non_normative!` block in `parser/src/tests/asciidoc_lang/directives/ifdef_ifndef.rs` stated a normative rule from the spec:

> The two combinators cannot be combined in the same expression.

…but no test asserted what the parser does with a mixed `,`/`+` expression, and investigating that surfaced a divergence from Asciidoctor.

## Asciidoctor's actual behavior

Asciidoctor does **not** reject or warn on a mixed expression. Its [`ConditionalDirectiveRx`](https://github.com/asciidoctor/asciidoctor/blob/main/lib/asciidoctor/rx.rb):

```ruby
/^(\\)?(ifdef|ifndef|ifeval|endif)::(\S*?(?:([,+])\S*?)?)\[(#{CC_ANY}+)?\]$/
```

captures **only the first** `,`/`+` in the target (the leading `\S*?` is non-greedy). That single delimiter selects the combinator — `,` → any set (or), `+` → all set (and) — and the full target is then split on that delimiter alone, so a segment containing the *other* delimiter becomes a single literal attribute name (never defined). Precedence is therefore **first-delimiter-wins**, not comma-wins:

| Expression | First delimiter | Split | Effective meaning |
|---|---|---|---|
| `ifdef::a,b+c[]` | `,` (or)  | `["a", "b+c"]` | include if `a` set |
| `ifdef::a+b,c[]` | `+` (and) | `["a", "b,c"]` | `a` AND `b,c` → effectively never |

## What was wrong here

`eval_ifdef` checked `contains(',')` **before** `+`, so comma always won regardless of order. That agreed with Asciidoctor when `,` came first (`a,b+c`) but diverged when `+` came first (`a+b,c` was treated as an "or" instead of an "and").

## Change

- **`parser/src/parser/preprocessor.rs`** — select the combinator by the earlier delimiter *position* (`str::find`), matching Asciidoctor's first-delimiter rule. Expressions using a single combinator are unaffected; the vendored Asciidoctor `reader_test` cases (leading/trailing/repeat operators) still pass.
- **`ifdef_ifndef.rs`** — split the normative sentence out of the `non_normative!` block into a `verifies!` block, and add `combinators_cannot_be_mixed`, asserting both orderings:
  - `ifdef::a,b+c[…]` → "or" on the comma (included iff `a` set).
  - `ifdef::a+b,c[…]` → "and" on the plus (excluded even when `a`, `b`, `c` are all set, because `b,c` is a single never-set name).

Note this is a behavior change confined to **invalid-but-tolerated** mixed expressions, which the spec leaves undefined; single-combinator expressions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)