### PR TITLE
chore: Remove commented-out dead code (close #705)

### DIFF
--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -397,11 +397,6 @@ impl Replacer for InlinePassReplacer<'_> {
     fn replace_append(&mut self, caps: &Captures<'_>, dest: &mut String) {
         if dest.ends_with('\\') || dest.ends_with(':') || dest.ends_with(';') {
             // Honor the prohibited prefix.
-            // let dest_ended_with_backslash = dest.ends_with('\\');
-            // if dest_ended_with_backslash {
-            //     dest.truncate(dest.len() - 1);
-            // }
-
             // EDGE CASE: Since we don't have lookarounds in Rust's regex, we have to retry
             // the inline pass replacement here. Possible it might miss a few very obscure
             // cases, but this should cover most cases where the attrlist is off-limits, but

--- a/sdd/src/main.rs
+++ b/sdd/src/main.rs
@@ -109,10 +109,6 @@ fn collect_files(root: &str, extension: &str) -> Vec<DirEntry> {
 }
 
 fn parse_rs_file(path: &Path) -> Option<(String, Vec<(String, bool)>)> {
-    // if !path.ends_with("revision_line.rs") {
-    //     return None;
-    // }
-
     let rs_file = fs::read(path).unwrap();
 
     let mut tracked_file: Option<String> = None;


### PR DESCRIPTION
Audit of commented-out code (#705). Searched the crate's own Rust source for genuinely commented-out code, excluding anything quoted from Asciidoctor or the AsciiDoc language reference (SDD blocks, ported Ruby test fixtures, `// tag::`/`// end::` include markers, XPath expressions in string literals, etc.).

Two real instances turned up, both the crate's own abandoned/debug code:

- **`parser/src/content/passthroughs.rs`** — a 3-line trailing-backslash truncation approach that was superseded by the retry logic below it.
- **`sdd/src/main.rs`** — a debugging shortcut that scoped `parse_rs_file` to a single file.

Both are trivially dead (not deferred work), so they're removed rather than converted to TODO issues. Build and `cargo +nightly fmt --check` both pass.

Closes #705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)