### PR TITLE
feat: Populate the document catalog's link registry (close #335)

### DIFF
--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -865,8 +865,7 @@ impl Replacer for InlineLinkReplacer<'_> {
                 link_suffix = link_suffix.as_str()
             );
 
-            // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/335):
-            // doc.register :links, target
+            self.0.register_link(target.clone());
 
             let link_text = if self.0.is_attribute_set("hide-uri-scheme") {
                 URI_SNIFF.replace_all(&target, "").into_owned()
@@ -1021,8 +1020,7 @@ impl Replacer for InlineLinkReplacer<'_> {
 
         let extra_roles = if bare { vec!["bare"] } else { vec![] };
 
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/335):
-        // doc.register :links, (link_opts[:target] = target)
+        self.0.register_link(target.clone());
 
         dest.push_str(&prefix);
 
@@ -1176,8 +1174,7 @@ impl Replacer for InlineLinkMacroReplacer<'_> {
             }
         }
 
-        // TO DO (https://github.com/asciidoc-rs/asciidoc-parser/issues/335):
-        // doc.register :links, (link_opts[:target] = target)
+        self.0.register_link(target.clone());
 
         let params = LinkRenderParams {
             target,
@@ -1321,6 +1318,8 @@ impl Replacer for InlineEmailReplacer<'_> {
         }
 
         let target = format!("mailto:{mailto}", mailto = &caps[2]);
+
+        self.0.register_link(target.clone());
 
         let attrlist = Attrlist::parse(Span::default(), self.0, AttrlistContext::Inline)
             .item

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -32,6 +32,17 @@ pub struct Catalog {
     /// (Asciidoctor's `catalog_assets` API option). Empty otherwise.
     pub(crate) images: Vec<ImageReference>,
 
+    /// Link targets referenced by `link:`/`mailto:` macros and by bare URL and
+    /// email autolinks, recorded in document order while substituting inline
+    /// macros – but only when the parser was configured with
+    /// [`with_catalog_assets(true)`](crate::Parser::with_catalog_assets)
+    /// (Asciidoctor's `catalog_assets` API option). Empty otherwise.
+    ///
+    /// Each entry is the final link target as it appears in the rendered `href`
+    /// (e.g. `https://example.org`, `mailto:fred@example.com`), matching
+    /// Asciidoctor's `catalog[:links]`.
+    pub(crate) links: Vec<String>,
+
     /// AsciiDoc files that were included into this document, keyed by the
     /// include target relative to the outermost document with its AsciiDoc
     /// extension removed (e.g. `other-chapters` for
@@ -65,6 +76,7 @@ impl Catalog {
             reftext_to_id: HashMap::new(),
             footnotes: Vec::new(),
             images: Vec::new(),
+            links: Vec::new(),
             includes: HashMap::new(),
         }
     }
@@ -243,6 +255,21 @@ impl Catalog {
         self.images.push(ImageReference { target, imagesdir });
     }
 
+    /// Returns the link targets referenced in this document, in document order.
+    ///
+    /// This list is populated only when the parser was configured with
+    /// [`with_catalog_assets(true)`](crate::Parser::with_catalog_assets); it is
+    /// empty otherwise.
+    pub fn links(&self) -> &[String] {
+        &self.links
+    }
+
+    /// Records a referenced link target (a `link:`/`mailto:` macro or an
+    /// autolinked bare URL or email address) in document order.
+    pub(crate) fn register_link(&mut self, target: String) {
+        self.links.push(target);
+    }
+
     /// Records that the AsciiDoc file named by `key` was included into this
     /// document.
     ///
@@ -400,6 +427,7 @@ impl std::fmt::Debug for Catalog {
             .field("reftext_to_id", &DebugHashMapFrom(&self.reftext_to_id))
             .field("footnotes", &self.footnotes)
             .field("images", &self.images)
+            .field("links", &self.links)
             .field("includes", &DebugHashMapFrom(&self.includes))
             .finish()
     }
@@ -703,6 +731,20 @@ mod tests {
         assert_eq!(images[1].target, "logo.png");
         assert_eq!(images[1].imagesdir, Some("images".to_string()));
         assert_eq!(images[1].to_string(), "logo.png");
+    }
+
+    #[test]
+    fn register_link_records_in_document_order() {
+        let mut catalog = Catalog::new();
+        assert!(catalog.links().is_empty());
+
+        catalog.register_link("https://example.org".to_string());
+        catalog.register_link("mailto:fred@example.com".to_string());
+
+        assert_eq!(
+            catalog.links(),
+            ["https://example.org", "mailto:fred@example.com"]
+        );
     }
 
     #[test]

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -1661,6 +1661,7 @@ mod tests {
         reftext_to_id: HashMap::from([]),
         footnotes: [],
         images: [],
+        links: [],
         includes: HashMap::from([]),
     },
 }"#

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1322,6 +1322,21 @@ impl Parser {
         }
     }
 
+    /// Records a referenced link target in the document catalog when
+    /// [`catalog_assets`](Self::with_catalog_assets) is enabled. A no-op
+    /// otherwise.
+    ///
+    /// `target` is the final link target as it appears in the rendered `href`
+    /// (e.g. `https://example.org`, `mailto:fred@example.com`).
+    ///
+    /// Takes `&self` so it can be called from the macros substitution step,
+    /// which only holds a shared reference to the parser.
+    pub(crate) fn register_link(&self, target: String) {
+        if self.catalog_assets {
+            self.catalog.borrow_mut().register_link(target);
+        }
+    }
+
     /// Registers a callout number defined by a verbatim block.
     ///
     /// Takes `&self` so it can be called from the callouts substitution step,

--- a/parser/src/tests/asciidoctor_rb/document_test.rs
+++ b/parser/src/tests/asciidoctor_rb/document_test.rs
@@ -2252,8 +2252,11 @@ mod structure {
 // Exercises the Ruby catalog/`references` API (`catalog.keys`,
 // `doc.register`, `resolve_id`, the `catalog_assets` option). asciidoc-parser
 // exposes a `Catalog` with a different shape; section-id registration is
-// already covered by the crate's own tests. A full link registry is tracked
-// by https://github.com/asciidoc-rs/asciidoc-parser/issues/335.
+// already covered by the crate's own tests. The crate's counterparts to the
+// asset registries are covered elsewhere: the image registry
+// (`Catalog::images`) and the link registry (`Catalog::links`) by the
+// `catalog_assets` tests in `substitutions_test.rs`, and the include registry
+// (`Catalog::was_included`) by `tests/xref.rs`.
 mod catalog {
     use crate::tests::prelude::*;
 

--- a/parser/src/tests/asciidoctor_rb/reader_test.rs
+++ b/parser/src/tests/asciidoctor_rb/reader_test.rs
@@ -1250,9 +1250,11 @@ fn should_escape_spaces_in_target_when_generating_link_from_remote_include_direc
 
 // Below `SafeMode::Secure` the directive is *not* link-replaced (contrast the
 // default-safe-mode case above): the handler is consulted and its content is
-// merged in place. (The `doc.catalog[:includes]` assertion is the include
-// registry, tracked separately by
-// https://github.com/asciidoc-rs/asciidoc-parser/issues/335.)
+// merged in place. (The `doc.catalog[:includes]` assertion checks the include
+// registry, which this crate maintains via `Catalog::was_included`; it is not
+// reproduced here because `reader_read` exercises the preprocessor and returns
+// the expanded text rather than a parsed document. The include registry is
+// covered directly by the crate's own tests in `tests/xref.rs`.)
 #[test]
 fn include_directive_is_enabled_when_safe_mode_is_less_than_secure() {
     verifies!(
@@ -1311,9 +1313,12 @@ non_normative!(
 "#
 );
 
-// Out of scope for now: asserts on `doc.catalog[:includes]`, the include/link
-// registry. This crate does not yet maintain such a registry; it is tracked by
-// https://github.com/asciidoc-rs/asciidoc-parser/issues/335.
+// Not reproduced here: this asserts on `doc.catalog[:includes]`. The crate
+// maintains an include registry (via `Catalog::was_included`), but this test
+// drives the preprocessor through `reader_read`, which returns the expanded
+// text rather than a parsed document whose catalog could be inspected. The
+// include registry is covered directly by the crate's own tests in
+// `tests/xref.rs`.
 non_normative!(
     r#"
       test 'should not track include in catalog for non-AsciiDoc include files' do

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -5899,6 +5899,43 @@ mod macros {
         assert_eq!(doc.warnings().count(), 0);
     }
 
+    // Asciidoctor's `catalog[:links]` registry: like `catalog[:images]`, link
+    // targets are recorded only when the `catalog_assets` option is enabled.
+    // This exercises the crate's equivalent `Catalog::links` across a bare URL
+    // autolink, a `link:` macro, a `mailto:` macro, and an autolinked email
+    // address. The recorded order follows the inline substitution passes: the
+    // bare-URL and `link:`/`mailto:` macro passes run before the email-autolink
+    // pass, so the autolinked address is registered last regardless of its
+    // position in the source.
+    #[test]
+    fn catalog_records_link_targets_when_catalog_assets_enabled() {
+        let doc = Parser::default().with_catalog_assets(true).parse(
+            "https://example.org is a site. link:https://example.com[Example]. fred@example.com. mailto:barney@example.com[Barney]",
+        );
+
+        assert_eq!(
+            doc.catalog().links(),
+            [
+                "https://example.org",
+                "https://example.com",
+                "mailto:barney@example.com",
+                "mailto:fred@example.com",
+            ]
+        );
+    }
+
+    // Without `catalog_assets`, the link registry stays empty (matching
+    // Asciidoctor, where `doc.register :links` is a no-op unless the option is
+    // set), even though the links still render.
+    #[test]
+    fn catalog_does_not_record_link_targets_by_default() {
+        let doc = Parser::default().parse(
+            "https://example.org is a site. link:https://example.com[Example]. fred@example.com",
+        );
+
+        assert!(doc.catalog().links().is_empty());
+    }
+
     #[test]
     fn an_icon_macro_should_be_interpreted_as_an_icon_if_icons_are_enabled() {
         verifies!(


### PR DESCRIPTION
## What

Implements the link registry requested in #335 — Asciidoctor's `doc.register :links, target`. The parser now records every link target it encounters into the document catalog, exposed via a new public `Catalog::links()` accessor.

Before this change the `Catalog` had `refs`, `footnotes`, `images`, and `includes`, but no link registry; three `TO DO (#335)` markers in `macros.rs` stood in for the deferred `doc.register :links` calls.

## Behavior

Modeled directly on the existing image registry:

- Population is **gated on the `catalog_assets` option** (`Parser::with_catalog_assets`), matching Asciidoctor, where `:links` and `:images` share the `register` method's `else` branch. Empty by default.
- All **four** Asciidoctor registration sites are now covered: bare-URL autolink, `link:` macro, `mailto:`/link macro, and email autolink. The last of these had been overlooked — the original TODOs only marked three sites.
- Recorded order follows the inline substitution passes (an autolinked email lands after bare URLs and macros regardless of source position). Asciidoctor never asserts link order, so this is a safe, deterministic choice; it is documented in the test.

## Tests

- Unit test for `Catalog::register_link` / `links()`.
- End-to-end tests: targets recorded across all four link kinds with `catalog_assets` on; empty by default.
- `cargo test -p asciidoc-parser` passes (4322 lib tests); clippy and nightly `fmt --check` clean.

## Cleanup

Removed all `#335` references from the codebase, including three stale test comments (two of which actually described the already-implemented *include* registry, now pointing at its real coverage in `tests/xref.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)