### PR TITLE
chore: Close mislabeled-normative coverage gaps (doctitle fallback, shorthand ID/role order, AsciiDoc-cell directive)

### DIFF
--- a/parser/src/tests/asciidoc_lang/attributes/id.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/id.rs
@@ -732,12 +732,42 @@ ____
         );
     }
 
-    non_normative!(
-        r#"
+    #[test]
+    fn shorthand_id_role_order_independent() {
+        verifies!(
+            r#"
 TIP: The order of ID and role values in the shorthand syntax does not matter.
 
 "#
-    );
+        );
+
+        // The role-then-id ordering from the example above (`.movie#roads`) and
+        // the reverse, id-then-role ordering (`#roads.movie`) assign the same ID
+        // and role: the shorthand is order-independent.
+        let mut parser = Parser::default();
+        let role_then_id = crate::blocks::Block::parse(
+            crate::Span::new("[quote.movie#roads]\n____\nRoads?\n____"),
+            &mut parser,
+        )
+        .unwrap_if_no_warnings()
+        .unwrap()
+        .item;
+
+        let mut parser = Parser::default();
+        let id_then_role = crate::blocks::Block::parse(
+            crate::Span::new("[quote#roads.movie]\n____\nRoads?\n____"),
+            &mut parser,
+        )
+        .unwrap_if_no_warnings()
+        .unwrap()
+        .item;
+
+        assert_eq!(role_then_id.id(), Some("roads"));
+        assert_eq!(role_then_id.roles(), vec!["movie"]);
+
+        assert_eq!(id_then_role.id(), role_then_id.id());
+        assert_eq!(id_then_role.roles(), role_then_id.roles());
+    }
 
     #[test]
     fn block_id_containing_dot() {

--- a/parser/src/tests/asciidoc_lang/document/title.rs
+++ b/parser/src/tests/asciidoc_lang/document/title.rs
@@ -247,6 +247,22 @@ non_normative!(
 
 By default, the text of the document title is used as the value of the HTML `<title>` element and main DocBook `<info>` element.
 You can override this behavior by setting the `title` attribute in the header with an attribute entry.
-If neither a level 0 section title or `doctitle` is specified in the header, but `title` is, its value is used as a fallback document title.
 "#
 );
+
+#[test]
+fn title_attribute_fallback() {
+    verifies!(
+        r#"
+If neither a level 0 section title or `doctitle` is specified in the header, but `title` is, its value is used as a fallback document title.
+"#
+    );
+
+    // With no level 0 section title (`= …`) and no `doctitle` attribute in the
+    // header, a `title` attribute entry supplies the document title: there is no
+    // section title, and the effective doctitle falls back to the `title` value.
+    let doc = Parser::default().parse(":title: The Intrepid Chronicles\n\nA frigid morning.");
+
+    assert_eq!(doc.header().title(), None);
+    assert_eq!(doc.doctitle(), Some("The Intrepid Chronicles"));
+}

--- a/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
@@ -482,8 +482,33 @@ Instead, these attributes are scoped to the table cell.
         r#"
 If the AsciiDoc table cell starts with a preprocessor directive, that directive should be placed on the line after the cell separator.
 While it can be placed on the same line as the cell separator, that style is not recommended.
+"#
+    );
+
+    verifies!(
+        r#"
 That's because the preprocessor directive that starts after the cell separator must be treated with special handling and is thus limited to a single line (for example, a multiline preprocessor conditional is not allow in this case).
 By starting the contents of the AsciiDoc table cell on the line after the cell separator, the contents will be parsed as normal.
 "#
     );
+
+    // A preprocessor conditional that opens on the cell-separator line is limited
+    // to that single line: the `ifdef::[]` is retained as literal cell text
+    // rather than opening a multiline conditional, so the guarded body is neither
+    // included nor excluded by the attribute test. The `endif::[]` on a later
+    // line is then left unmatched.
+    let doc = Parser::default().parse("|===\na|ifdef::showit[]\nvisible\nendif::[]\n|===");
+    assert_eq!(asciidoc_cell_text(&doc), "ifdef::showit[]\nvisible");
+    assert!(doc.warnings().any(|w| matches!(
+        &w.warning,
+        WarningType::UnmatchedConditionalDirective(d) if d == "endif::[]"
+    )));
+
+    // By contrast, starting the cell contents on the line after the cell
+    // separator lets the directive act as a normal multiline conditional: with
+    // `showit` unset the guarded body is excluded, leaving the cell empty, and no
+    // unmatched-directive warning is raised.
+    let doc = Parser::default().parse("|===\na|\nifdef::showit[]\nvisible\nendif::[]\n|===");
+    assert_eq!(asciidoc_cell_text(&doc), "");
+    assert!(doc.warnings().next().is_none());
 }


### PR DESCRIPTION
Closes #867.

Three unrelated spec pages each wrapped a small **normative parser rule** in `non_normative!` with no covering test. This splits each block so the normative sentence is verified while genuinely out-of-scope prose stays non-normative. Behavior was confirmed against the current parser first; no parser changes were needed.

## Findings addressed

1. **Document title fallback to the `title` attribute** — [title.rs](parser/src/tests/asciidoc_lang/document/title.rs)
   With no level 0 section title and no `doctitle` attribute, a `title` attribute entry supplies the document title (`header().title()` is `None`; `doctitle()` falls back to the `title` value). The surrounding HTML `<title>` / DocBook `<info>` sentences remain non-normative.

2. **Shorthand ID/role order-independence** — [id.rs](parser/src/tests/asciidoc_lang/attributes/id.rs)
   Asserts that `.movie#roads` (role-then-id) and `#roads.movie` (id-then-role) assign the same ID and role.

3. **Preprocessor directive on an AsciiDoc cell-separator line** — [format_cell_content.rs](parser/src/tests/asciidoc_lang/tables/format_cell_content.rs)
   A conditional opened on the cell-separator line (`a|ifdef::…`) is limited to a single line — kept as literal cell text, leaving its `endif::[]` unmatched — whereas the same directive on the following line acts as a normal multiline conditional.

## Verification
- `cargo test -p asciidoc-parser --lib` — all pass.
- `cargo +nightly fmt --all -- --check` — clean.
- `cargo clippy -p asciidoc-parser --tests` — clean.
- The `sdd` spec-coverage tool now reports the three target lines as verified (`1`), with no downstream coverage regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)