### PR TITLE
chore: Resolve remaining to_do_verifies! blocks from the #628 sweep

### DIFF
--- a/parser/src/tests/asciidoc_lang/blocks/delimited.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/delimited.rs
@@ -408,7 +408,7 @@ The table below lists the structural containers, documenting the name, default c
     assert_eq!(mi.item.raw_context().as_ref(), "sidebar");
     assert_eq!(mi.item.resolved_context().as_ref(), "sidebar");
 
-    to_do_verifies!(
+    verifies!(
         r#"
 |table
 |:table
@@ -421,8 +421,21 @@ The table below lists the structural containers, documenting the name, default c
 "#
     );
 
-    if false {
-        todo!("Support for table parsing");
+    // Each of the four table delimiters (`|===` for PSV, `,===` for CSV, `:===`
+    // for DSV, and `!===` for a nested table) resolves to the `table` context
+    // with the `table` content model.
+    for delimiter in ["|===", ",===", ":===", "!==="] {
+        let mut parser = Parser::default();
+
+        let source = format!("{delimiter}\n{delimiter}");
+
+        let mi = crate::blocks::Block::parse(crate::Span::new(&source), &mut parser)
+            .unwrap_if_no_warnings()
+            .unwrap();
+
+        assert_eq!(mi.item.content_model(), ContentModel::Table);
+        assert_eq!(mi.item.raw_context().as_ref(), "table");
+        assert_eq!(mi.item.resolved_context().as_ref(), "table");
     }
 
     verifies!(

--- a/parser/src/tests/asciidoc_lang/blocks/index.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/index.rs
@@ -125,11 +125,12 @@ We'll cover that modifier shortly.
         todo!("Redundant: Covered by block_style test below.");
     }
 
-    #[test]
-    #[ignore]
-    fn block_name() {
-        to_do_verifies!(
-            r#"
+    // Block extensions are out of scope for the 1.0 release, so the block name →
+    // context mapping described here – an arbitrary block name mapped to one or
+    // more contexts by an extension's process method – has no corresponding
+    // parser behavior to verify. Treated as non-normative for now.
+    non_normative!(
+        r#"
 For blocks, the context is sometimes referred to as the block name.
 This comes up in particular when talking about custom blocks.
 The block name is just another layer of abstraction.
@@ -139,10 +140,7 @@ Which context is ultimately used depends on what is returned from the extension'
 In the end, it's the context that determines how the block is converted.
 
 "#
-        );
-
-        todo!("Revisit when we support block extensions.");
-    }
+    );
 
     #[test]
     fn sections_are_compound() {

--- a/parser/src/tests/asciidoc_lang/directives/include_with_indent.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include_with_indent.rs
@@ -75,7 +75,7 @@ WARNING: If any line in the verbatim content is not indented, the `indent` attri
 fn tabsize_expands_tabs() {
     // The parser expands tabs on the included content when `indent` is also
     // supplied; block-level tab expansion independent of `indent` is not yet
-    // implemented, so the broader claim is tracked as a to-do.
+    // implemented, so the broader claim is tracked as a to-do (#877).
     to_do_verifies!(
         r#"
 If the `tabsize` attribute is set on the block or the document, tabs are also replaced with the number of spaces specified by that attribute, regardless of whether the `indent` attribute is set.

--- a/parser/src/tests/asciidoc_lang/subs/index.rs
+++ b/parser/src/tests/asciidoc_lang/subs/index.rs
@@ -93,13 +93,14 @@ The normal substitution group (`normal`) is applied to the majority of the Ascii
         assert_eq!(block1.substitution_group(), SubstitutionGroup::Normal);
     }
 
-    #[ignore]
-    #[test]
-    fn header_group() {
-        // We don't describe the substitution group for header lines, so this isn't
-        // directly verifiable.
-        to_do_verifies!(
-            r#"
+    // Unlike the other substitution groups in this section, the `header` group
+    // applies to document-header metadata lines (author/revision) and to
+    // attribute-entry values rather than to a parsed block. There's no block that
+    // exposes a `header` substitution group to assert against – the way the normal
+    // and verbatim groups are checked below – so this paragraph is out of scope
+    // for verification and is treated as non-normative.
+    non_normative!(
+        r#"
 [#header-group]
 === Header substitution group
 
@@ -110,8 +111,7 @@ Only special characters, attribute references, and the inline pass macro are rep
 TIP: You can use the inline pass macro in attribute entries to xref:apply-subs-to-text.adoc[customize the substitution types applied to the attribute's value].
 
 "#
-        );
-    }
+    );
 
     #[test]
     fn verbatim_group() {

--- a/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
+++ b/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
@@ -388,22 +388,19 @@ mod default_post_replacements_substitution {
         assert_eq!(literal_cell.rendered(), "abc +\nghi");
     }
 
-    #[ignore]
-    #[test]
-    fn titles() {
-        // A block title cannot span multiple lines via a trailing `+`: a title is
-        // a single line, and a trailing ` +` is retained literally rather than
-        // joined to the following line. Because a title never spans lines, the
-        // post_replacements line-break substitution has nothing to act on here, so
-        // the `|Titles |{y}` row isn't directly verifiable.
-        to_do_verifies!(
-            r#"
+    // A block title cannot span multiple lines via a trailing `+`: a title is a
+    // single line, and a trailing ` +` is retained literally rather than joined to
+    // the following line. Because a title never spans lines, the post_replacements
+    // line-break substitution has nothing to act on here, so the `|Titles |{y}`
+    // row has no observable effect to assert and is out of scope for verification.
+    // Treated as non-normative.
+    non_normative!(
+        r#"
 |Titles |{y}
 |===
 
 "#
-        );
-    }
+    );
 }
 
 mod post_replacements_substitution_value {

--- a/parser/src/tests/asciidoctor_rb/document_test.rs
+++ b/parser/src/tests/asciidoctor_rb/document_test.rs
@@ -1240,6 +1240,9 @@ mod structure {
         assert_eq!(doc.doctitle(), Some("Title"));
     }
 
+    // Tracked as #876: needs the `include-with-leading-blank-line.adoc` fixture
+    // plus title-recognition and `lines=` assertions before this can become a
+    // `verifies!`.
     to_do_verifies!(
         r##"
     test 'should recognize document title in include file when preceded by blank lines' do


### PR DESCRIPTION
Resolves the remaining `to_do_verifies!` blocks found in the #628 sweep.

## What changed

**Stale → `verifies!`** (table parsing landed in #296):
- `blocks/delimited.rs` — the table structural-container row now asserts that all four table delimiters (`|===` PSV, `,===` CSV, `:===` DSV, `!===` nested) resolve to the `table` context with the `table` content model. Removed the dead `if false { todo!(...) }` guard.

**Out of scope / not directly verifiable → `non_normative!` with justification:**
- `blocks/index.rs` — block name → context mapping is a block-extension feature; **block extensions are out of scope for 1.0** (#262 stays closed).
- `subs/index.rs` — the `header` substitution group applies to header metadata and attribute-entry values, not a parsed block, so there's no block exposing a `header` group to assert against.
- `subs/post_replacements.rs` — a title never spans lines, so the `post_replacements` line-break substitution has nothing to act on.

**Still deferred, now issue-linked** (left as `to_do_verifies!`):
- `asciidoctor_rb/document_test.rs` — include-file doctitle recognition → tracked in #876.
- `directives/include_with_indent.rs` — block-level `tabsize` independent of `indent` → tracked in #877.

## Notes
- Spec-text strings inside each macro are preserved verbatim; only the macro name and surrounding scaffolding changed.
- `cargo +nightly fmt --all -- --check` clean; full `asciidoc-parser` lib test suite passes.

Closes #628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
