### PR TITLE
fix: Expand tabs from `tabsize` independently of `indent` on included content (close #877)

### DIFF
--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -2019,27 +2019,42 @@ fn find_tag_directive(line: &str) -> Option<(bool, &str)> {
 }
 
 /// Normalize the block indentation of included content per the `indent`
-/// attribute, returning the adjusted text. If `indent` is absent (or negative)
-/// the text is returned unchanged. See `include-with-indent.adoc`.
+/// attribute and, when the `tabsize` attribute is set, expand tabs to spaces.
+///
+/// Tab expansion applies whenever `tabsize` is positive, regardless of whether
+/// the `indent` attribute is set. Indentation normalization is applied only
+/// when `indent` is present and non-negative. If neither adjustment applies the
+/// text is returned unchanged. See `include-with-indent.adoc`.
 fn reindent_included_lines(text: String, attrlist: &Attrlist<'_>, parser: &Parser) -> String {
-    let Some(indent) = attrlist.named_attribute("indent").map(|a| a.value()) else {
-        return text;
-    };
-
     // Asciidoctor coerces the value with `String#to_i` (a non-numeric value
-    // yields 0). A negative value disables normalization.
-    let indent: i64 = indent.trim().parse().unwrap_or(0);
-    if indent < 0 {
-        return text;
-    }
+    // yields 0). A negative value disables indentation normalization.
+    let indent: Option<i64> = attrlist
+        .named_attribute("indent")
+        .map(|a| a.value().trim().parse().unwrap_or(0));
 
     let tab_size = match parser.attribute_value("tabsize") {
         InterpretedValue::Value(v) => v.trim().parse().unwrap_or(0),
         _ => 0,
     };
 
+    let expand = tab_size > 0 && text.contains('\t');
+    let apply_indent = matches!(indent, Some(i) if i >= 0);
+    if !expand && !apply_indent {
+        return text;
+    }
+
     let mut lines: Vec<String> = text.lines().map(str::to_string).collect();
-    adjust_indentation(&mut lines, indent as usize, tab_size);
+
+    if expand {
+        for line in lines.iter_mut() {
+            *line = expand_tabs(line, tab_size);
+        }
+    }
+
+    if apply_indent {
+        // Tabs, if any, have already been expanded above.
+        adjust_indentation(&mut lines, indent.unwrap_or(0) as usize);
+    }
 
     let mut output = lines.join("\n");
     if !output.is_empty() || !text.is_empty() {
@@ -2049,20 +2064,13 @@ fn reindent_included_lines(text: String, attrlist: &Attrlist<'_>, parser: &Parse
 }
 
 /// Strip the common leading block indent from `lines` and, when `indent` is
-/// greater than zero, re-indent each non-empty line by that many spaces. When
-/// `tab_size` is greater than zero, leading tabs are first expanded to spaces.
+/// greater than zero, re-indent each non-empty line by that many spaces.
 ///
 /// Per the spec, if any line in the content is not indented (the common indent
 /// is zero) the `indent` normalization is skipped entirely.
-fn adjust_indentation(lines: &mut [String], indent: usize, tab_size: usize) {
+fn adjust_indentation(lines: &mut [String], indent: usize) {
     if lines.is_empty() {
         return;
-    }
-
-    if tab_size > 0 && lines.iter().any(|l| l.contains('\t')) {
-        for line in lines.iter_mut() {
-            *line = expand_tabs(line, tab_size);
-        }
     }
 
     // The common indent is the minimum count of leading spaces across the

--- a/parser/src/tests/asciidoc_lang/directives/include_with_indent.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include_with_indent.rs
@@ -71,30 +71,45 @@ WARNING: If any line in the verbatim content is not indented, the `indent` attri
     );
 }
 
+/// Include `content` into a listing block with the given include `attrs` and a
+/// document `tabsize` of 4, returning the resulting listing block source.
+fn listing_include_with_tabsize(attrs: &str, content: &'static str) -> String {
+    let handler = InlineFileHandler::from_pairs([("code.rb", content)]);
+    let source = format!("----\ninclude::code.rb[{attrs}]\n----");
+    let doc = Parser::default()
+        .with_safe_mode(SafeMode::Server)
+        .with_intrinsic_attribute("tabsize", "4", ModificationContext::Anywhere)
+        .with_include_file_handler(handler)
+        .parse(&source);
+    doc.nested_blocks()
+        .next()
+        .unwrap()
+        .span()
+        .data()
+        .to_string()
+}
+
 #[test]
 fn tabsize_expands_tabs() {
-    // The parser expands tabs on the included content when `indent` is also
-    // supplied; block-level tab expansion independent of `indent` is not yet
-    // implemented, so the broader claim is tracked as a to-do.
-    to_do_verifies!(
+    verifies!(
         r#"
 If the `tabsize` attribute is set on the block or the document, tabs are also replaced with the number of spaces specified by that attribute, regardless of whether the `indent` attribute is set.
 
 "#
     );
 
-    let handler = InlineFileHandler::from_pairs([("code.rb", "\tdef names\n\t  @name\n\tend")]);
-    let doc = Parser::default()
-        .with_safe_mode(SafeMode::Server)
-        .with_intrinsic_attribute("tabsize", "4", ModificationContext::Anywhere)
-        .with_include_file_handler(handler)
-        .parse("----\ninclude::code.rb[indent=0]\n----");
-
-    // Tabs are expanded to spaces (tab stop of 4), then the common indent is
-    // stripped.
+    // With `indent=0`, tabs are expanded to spaces (tab stop of 4), then the
+    // common indent is stripped.
     assert_eq!(
-        doc.nested_blocks().next().unwrap().span().data(),
+        listing_include_with_tabsize("indent=0", "\tdef names\n\t  @name\n\tend"),
         "----\ndef names\n  @name\nend\n----"
+    );
+
+    // With no `indent` attribute, tabs are still expanded to spaces (tab stop of
+    // 4), but the block indentation is left untouched.
+    assert_eq!(
+        listing_include_with_tabsize("", "\tdef names\n\t  @name\n\tend"),
+        "----\n    def names\n      @name\n    end\n----"
     );
 }
 


### PR DESCRIPTION
Fixes #877.

## Problem

`reindent_included_lines` returned included content unchanged whenever the `indent` attribute was absent, so `tabsize`-driven tab expansion only fired when `indent` was *also* supplied. The normative claim in `include-with-indent.adoc` was tracked as a `to_do_verifies!`:

> If the `tabsize` attribute is set on the block or the document, tabs are also replaced with the number of spaces specified by that attribute, regardless of whether the `indent` attribute is set.

## Change

- Tab expansion now runs whenever `tabsize` is positive, independent of the `indent` attribute. Indentation normalization is still applied separately, only when `indent` is present and non-negative.
- Moved tab expansion out of `adjust_indentation` (which now handles only indentation) up into `reindent_included_lines`, so the two concerns compose cleanly.
- Promoted the `to_do_verifies!` block to `verifies!` and added a test covering the `tabsize`-without-`indent` case.

## Testing

- `cargo test -p asciidoc-parser --lib` — 4323 passed, 0 failed.
- `cargo +nightly fmt --all -- --check` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)