### PR TITLE
fix: Verify link attrlist enclosure rule for invalid attribute names (close #871)

### DIFF
--- a/parser/src/tests/asciidoc_lang/macros/link_macro_attribute_parsing.rs
+++ b/parser/src/tests/asciidoc_lang/macros/link_macro_attribute_parsing.rs
@@ -398,7 +398,84 @@ https://example.org["href=\"#top\" attribute"] creates link to top of page
     non_normative!(
         r#"
 The double quote enclosure is not required in all cases when the link text contains an equals sign.
+"#
+    );
+
+    #[test]
+    fn enclosure_only_required_for_valid_attribute_name() {
+        verifies!(
+            r#"
 Strictly speaking, the enclosure is only required when the text preceding the equals sign matches a valid attribute name.
+"#
+        );
+
+        // The text preceding the `=` here is `Read this`, which is not a valid
+        // attribute name (it contains a space), so the whole unquoted attrlist is
+        // taken as the first positional attribute (the link text) even though it
+        // contains an equals sign. No double-quote enclosure is required.
+        //
+        // The complementary case – where the text before the `=` *is* a valid
+        // attribute name (e.g. `1=2 ...`, where `1` is a valid name) and therefore
+        // *does* require the enclosure – is covered by `quoted_title_only`.
+        let doc = Parser::default().parse("https://example.org[Read this=important document]");
+
+        assert_eq!(
+            doc,
+            Document {
+                header: Header {
+                    title_source: None,
+                    title: None,
+                    attributes: &[],
+                    author_line: None,
+                    revision_line: None,
+                    comments: &[],
+                    source: Span {
+                        data: "",
+                        line: 1,
+                        col: 1,
+                        offset: 0,
+                    },
+                },
+                blocks: &[Block::Simple(SimpleBlock {
+                    content: Content {
+                        original: Span {
+                            data: "https://example.org[Read this=important document]",
+                            line: 1,
+                            col: 1,
+                            offset: 0,
+                        },
+                        rendered: "<a href=\"https://example.org\">Read this=important document</a>",
+                    },
+                    source: Span {
+                        data: "https://example.org[Read this=important document]",
+                        line: 1,
+                        col: 1,
+                        offset: 0,
+                    },
+                    style: SimpleBlockStyle::Paragraph,
+                    title_source: None,
+                    title: None,
+                    caption: None,
+                    number: None,
+                    anchor: None,
+                    anchor_reftext: None,
+                    attrlist: None,
+                },),],
+                source: Span {
+                    data: "https://example.org[Read this=important document]",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                warnings: &[],
+                source_map: SourceMap(&[]),
+                catalog: Catalog::default(),
+            }
+        );
+    }
+
+    non_normative!(
+        r#"
 However, it's best to use the double quotes just to be safe.
 
 "#

--- a/parser/src/tests/sdd.rs
+++ b/parser/src/tests/sdd.rs
@@ -18,7 +18,15 @@ pub(super) use verifies;
 
 // Use the to_do_verifies macro to annotate a test block that doesn't yet verify
 // a specific section within the .adoc file that is normative.
+//
+// This currently has no call sites (every to-do block has been promoted to a
+// real `verifies!`), but it is retained as part of the SDD annotation toolkit
+// for future spec-coverage work, so the unused-macro/-import warnings are
+// silenced under `#![deny(warnings)]`.
+#[allow(unused_macros)]
 macro_rules! to_do_verifies( ($($tt:tt)*) => {} );
+
+#[allow(unused_imports)]
 pub(super) use to_do_verifies;
 
 // All lines in each .adoc file should be covered by either non_normative or


### PR DESCRIPTION
## Summary

Resolves #871, but not the way the issue anticipated. After verifying against **Asciidoctor 2.0.26** (the agreed reference point), the parser already implements the link/URL macro attribute-parsing rule correctly. This PR promotes the relevant spec sentence from a `non_normative!` note to a real `verifies!` test and documents the actual behavior.

## What #871 claimed vs. what I found

The issue states that `https://example.org[1=2 posits the problem of inequality]` is *misparsed* into a bare link, and that `1` is "not a valid attribute name."

Testing the exact input against real Asciidoctor on both available versions:

| Input (`https://example.org[…]`) | adoc-parser | Asciidoctor 2.0.26 | Asciidoctor 2.1.0.alpha.0 |
|---|---|---|---|
| `1=2 posits the problem…` | bare link | **bare link** | **bare link** |
| `foo=bar` | bare link | bare link | bare link |
| `Read this=important document` | link text | link text | link text |

`1` **is** a valid attribute name:
- `names-and-values.adoc:14` — a name may "begin with a word character (a-z, **0-9**, or _)"; `:20` calls a leading number a discouraged *best practice*, i.e. still valid.
- `positional-and-named-attributes.adoc:139` — a name is a "word character (letter **or numeral**)…".
- Asciidoctor's `NameRx` name-start is `\p{Word}`, which accepts digits.

So `1=2 …` is correctly parsed as the named attribute `1`, leaving the first positional empty → bare link. **No Asciidoctor version renders it as link text.** The double-quote enclosure demonstrated by `quoted_title_only` is genuinely required for that input. The issue's premise ("1 is not a valid attribute name") was the misunderstanding.

I ran a 34-case differential sweep (numeric/underscore/dotted/hyphenated names, spaces, carets, commas, quotes, empty names) against Asciidoctor 2.0.26 — **zero divergences**. `take_attr_name` is byte-for-byte equivalent to `NameRx` for ASCII, so the parser already "only treats `name=value` as named when `name` is a valid attribute name" (issue task 1 — already satisfied).

## Change

Issue task 2 — promote the spec sentence to a verified test — is the actionable deliverable. This PR:

- Splits the 3-line `non_normative!` block so the normative sentence ("*the enclosure is only required when the text preceding the equals sign matches a valid attribute name*") moves into a new `verifies!` test, `enclosure_only_required_for_valid_attribute_name`.
- The test verifies the converse direction: `Read this=important document` (pre-`=` text `Read this` contains a space → not a valid name) is taken whole as the positional link text, no enclosure needed. The valid-name direction is already covered by `quoted_title_only`.

Test-only change; no parser behavior is modified. The reproduced-line sequence stays byte-identical to the `.adoc`, so the SDD line-coverage tool now marks the sentence normatively verified with no downstream misalignment (0 uncovered lines).

## Verification

- `cargo test -p asciidoc-parser` — 4324 passed, 0 failed
- `cargo +nightly fmt --all -- --check` — clean
- SDD coverage: spec line 55 now `1` (verified); no line regressed to `0`

## Note for reviewer

If you'd rather the parser diverge from 2.0.26 to match 2.1.0.alpha.0 (which dropped `.` from `NameRx`, so `foo.bar=baz` becomes positional link text there), that's a separate behavioral change from this issue and I'm happy to open it as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update (rebased on latest `main`):** Merged `main`, which included the #628 `to_do_verifies!` sweep (#878, #882). That sweep had added this issue's target block as a `to_do_verifies!` whose comment claimed the `1=2` bare-link behavior was "current (incorrect) behavior" that "should flip once #871 is fixed." This PR promotes that block to `verifies!` and corrects the comment: the behavior is right, so the `1=2` assertion is retained as a regression guard. Promoting the last remaining `to_do_verifies!` left the macro with no call sites, so a small `chore` commit keeps the macro in the SDD toolkit under `#![deny(warnings)]` via `#[allow(unused)]`.
