### PR TITLE
fix: Honor char boundary when skipping constrained-monospace look-ahead (close #887)

### DIFF
--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -318,7 +318,19 @@ impl LookaheadReplacer for QuoteReplacer<'_> {
             && self.scope == QuoteScope::Constrained
             && after.starts_with(['"', '\'', '`'])
         {
-            let skip_ahead = if caps[0].starts_with('\\') { 2 } else { 1 };
+            // The leading boundary group `[^\w&;:"'`}]` matches any non-word
+            // Unicode scalar, so it can be a multi-byte character. Skip the full
+            // width of that leading character rather than assuming one byte;
+            // otherwise the slice below (and the matching offset in
+            // `SkipAheadAndRetry`) would land inside the character and panic.
+            let skip_ahead = if caps[0].starts_with('\\') {
+                // Escape case: skip the backslash plus the following byte, which
+                // is always an ASCII `[` or `` ` ``.
+                2
+            } else {
+                caps[0].chars().next().map_or(1, char::len_utf8)
+            };
+
             dest.push_str(&caps[0][0..skip_ahead]);
             return LookaheadResult::SkipAheadAndRetry(skip_ahead);
         }
@@ -1547,6 +1559,25 @@ mod tests {
             );
 
             assert!(doc.catalog().contains_id("the_id"));
+        }
+
+        #[test]
+        fn multibyte_leading_char_before_constrained_monospace() {
+            // The constrained-monospace leading boundary group matches any
+            // non-word Unicode scalar, so it can begin with a multi-byte
+            // character. When the failed look-ahead skips past that leading
+            // character, the skip width must honor the character boundary
+            // rather than assuming a single byte.
+            for leading in ["€", "中", "🎉"] {
+                let source = format!("{leading}`code``");
+                let mut content = Content::from(crate::Span::new(&source));
+                let p = Parser::default();
+
+                // Must not panic on the multi-byte leading character.
+                SubstitutionStep::Quotes.apply(&mut content, &p, None);
+
+                assert!(content.rendered.starts_with(leading));
+            }
         }
     }
 

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -1579,6 +1579,23 @@ mod tests {
                 assert!(content.rendered.starts_with(leading));
             }
         }
+
+        #[test]
+        fn escaped_leading_backtick_before_constrained_monospace() {
+            // When the leading boundary character is a backslash, the failed
+            // look-ahead skips the backslash plus the following backtick (both
+            // ASCII, so two bytes). Exercises the escape branch of the skip
+            // width and confirms the escaped text is preserved verbatim.
+            let mut content = Content::from(crate::Span::new(r"\`code``"));
+            let p = Parser::default();
+
+            SubstitutionStep::Quotes.apply(&mut content, &p, None);
+
+            assert_eq!(
+                content.rendered,
+                CowStr::Boxed(r"\`code``".to_string().into_boxed_str())
+            );
+        }
     }
 
     mod attribute_references {


### PR DESCRIPTION
## Problem

The constrained-monospace quote regex's leading boundary group `[^\w&;:"'`}]` matches **any** non-word Unicode scalar, including multi-byte characters. When a failed look-ahead skipped the leading character, the skip width was hard-coded to 1 byte (2 for the escape case). A multi-byte leading char (`€`, CJK, emoji) followed by `"`, `'`, or `` ` `` made `caps[0][0..1]` slice *inside* the character, panicking on a plain `Parser::default().parse(...)`.

Reproduction (from #887):

```rust
asciidoc_parser::Parser::default().parse("€`code``");
// panic: end byte index 1 is not a char boundary; it is inside '€' (bytes 0..3)
```

## Fix

Compute `skip_ahead` from the leading character's `len_utf8()` rather than assuming one byte:

```rust
let skip_ahead = if caps[0].starts_with('\\') {
    2 // escape: backslash + an always-ASCII `[` or backtick
} else {
    caps[0].chars().next().map_or(1, char::len_utf8)
};
```

The same value flows into `SkipAheadAndRetry(skip_ahead)`, which is exactly the `n` used at `parser/src/internal/regex.rs:39`. `QuoteReplacer` is the only production replacer that returns it, so the corrected width makes `m.start() + n` land on a char boundary there too — the second site called out in the issue is covered by this single change, no separate edit needed.

## Testing

- Added regression test `multibyte_leading_char_before_constrained_monospace` (covers `€`, `中`, `🎉`); it panics without the fix.
- Full parser suite: 4337 passed, 0 failed.
- `cargo +nightly fmt --all --check` clean; `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)