### PR TITLE
fix: Avoid O(n²) parse time on many repeated block delimiters (close #886)

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -35,6 +35,10 @@ name = "inline_macro"
 
 [[bench]]
 harness = false
+name = "repeated_delimiters"
+
+[[bench]]
+harness = false
 name = "section_with_two_blocks"
 
 [[bench]]

--- a/parser/benches/repeated_delimiters.rs
+++ b/parser/benches/repeated_delimiters.rs
@@ -1,0 +1,21 @@
+use asciidoc_parser::Parser;
+use codspeed_criterion_compat::{Criterion, black_box, criterion_group, criterion_main};
+
+const BENCH_NAME: &str = "repeated example delimiters";
+
+// A long run of consecutive `====` delimiter lines with no blank line between
+// them. This shape previously parsed in O(n²) time: the quoted-paragraph parser
+// rescanned the entire remaining input for every block. The bench guards that
+// the delimiter-scan / block-dispatch path stays linear.
+const DELIMITER_COUNT: usize = 4000;
+
+pub fn perf(c: &mut Criterion) {
+    let parse_text = "====\n".repeat(DELIMITER_COUNT);
+
+    c.bench_function(BENCH_NAME, |b| {
+        b.iter(|| Parser::default().parse(black_box(parse_text.as_str())))
+    });
+}
+
+criterion_group!(benches, perf);
+criterion_main!(benches);

--- a/parser/src/blocks/quote.rs
+++ b/parser/src/blocks/quote.rs
@@ -316,13 +316,22 @@ impl<'src> QuoteBlock<'src> {
         metadata: &BlockMetadata<'src>,
         parser: &mut Parser,
     ) -> Option<MatchAndWarnings<'src, Option<MatchedItem<'src, Self>>>> {
+        // A quoted paragraph must begin with a double quote. Test that on the
+        // block's first byte *before* scanning the whole paragraph. `read_paragraph`
+        // (below) walks every line up to the next blank line, so testing the first
+        // byte here avoids that scan for the common non-quoted paragraph: without
+        // it, a long run of non-blank lines that never forms a quoted paragraph is
+        // rescanned in full for every block, making the parse O(n²) on pathological
+        // input (e.g. thousands of consecutive delimiter lines with no blank line
+        // between them). `read_paragraph` starts at `block_start`, so a paragraph
+        // beginning with `"` shares this first byte — testing it here loses nothing.
+        if !metadata.block_start.data().starts_with('"') {
+            return None;
+        }
+
         // The paragraph extends to the first blank line.
         let para = read_paragraph(metadata.block_start);
         let data = para.data();
-
-        if !data.starts_with('"') {
-            return None;
-        }
 
         // Locate the attribution line: the first line that begins with `--`
         // followed by whitespace and at least one more character. Splits the
@@ -1233,5 +1242,47 @@ mod tests {
         let block = doc.nested_blocks().next().unwrap();
         let quote = as_quote(block);
         assert_eq!(quote.title(), Some("A title"));
+    }
+
+    /// The quoted-paragraph parser must reject a non-quote paragraph on its
+    /// first byte, before scanning the paragraph to the next blank line. A
+    /// document of many consecutive delimiter lines with no blank line between
+    /// them otherwise makes every block rescan the entire remaining input,
+    /// giving quadratic (O(n²)) parse time and a practical denial of service on
+    /// modestly-sized input. This guards that the parse stays roughly linear.
+    ///
+    /// The bound is deliberately loose (seconds, versus a handful of
+    /// milliseconds when linear) so the test is not flaky on a slow or loaded
+    /// machine, while still failing decisively if the quadratic behavior
+    /// returns — the quadratic parse of this input takes tens of seconds.
+    #[test]
+    fn many_consecutive_delimiters_parse_in_roughly_linear_time() {
+        use std::time::{Duration, Instant};
+
+        // Each of these patterns previously exercised the quadratic path: none
+        // contains a blank line, so the quoted-paragraph scan ran to end of
+        // input on every block.
+        let example_run = "====\n".repeat(20_000);
+
+        let mut example_run_with_text = "====\n".repeat(10_000);
+        example_run_with_text.push_str("text\n");
+        example_run_with_text.push_str(&"====\n".repeat(10_000));
+
+        let open_run = "--\n".repeat(20_000);
+
+        let budget = Duration::from_secs(10);
+
+        for source in [&example_run, &example_run_with_text, &open_run] {
+            let start = Instant::now();
+            let _ = Parser::default().parse(source);
+            let elapsed = start.elapsed();
+
+            assert!(
+                elapsed < budget,
+                "parsing {} delimiter lines took {elapsed:?}, exceeding the {budget:?} budget \
+                 (a sign the quadratic quoted-paragraph rescan has returned)",
+                source.lines().count(),
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem

[#886](https://github.com/asciidoc-rs/asciidoc-parser/issues/886): a document of many repeated block delimiters parses in **O(n²)** time — ~320 KB of input pegged a core for ~38s, a practical denial of service on untrusted input.

## Root cause

Profiling (`sample`) showed ~94% of the time in `QuoteBlock::parse`, **not** the delimiter scan the issue speculated about. `QuoteBlock::parse` runs before `CompoundDelimitedBlock` in block dispatch, so it is tried for every `====` / `--` line. Its quoted-paragraph path (`parse_quoted_paragraph`) called `read_paragraph` — a forward scan to the next blank line — **before** the cheap `starts_with('"')` guard. On input with no blank lines (thousands of consecutive delimiters), every block rescanned the entire remaining tail → quadratic.

## Fix

Hoist the "must begin with `\"`" check to the block's first byte, ahead of the paragraph scan. `read_paragraph` starts at `block_start`, so this is exactly equivalent to the prior check — only the wasted scan is avoided, no behavior change.

## Results (release build)

| pattern | before | after |
|---|---|---|
| `====` × 16000 | 2.39 s | 5.4 ms |
| `====` × n, text, `====` × n (n=8000) | 2.60 s | 4.0 ms |
| `--` × 8000 | 0.64 s | 2.1 ms |

Scaling is now linear.

## Testing

- Full suite: 4337 tests + 4 doctests pass; `cargo +nightly fmt --all --check` and `cargo clippy --all-targets` clean.
- Added a regression test with a deliberately loose 10 s bound (linear parses in ~80 ms debug; the quadratic version takes tens of seconds) so it's decisive but not flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)