### PR TITLE
fix: Complete the truncated doc comment on `LookaheadReplacer` (close #906)

### DIFF
--- a/parser/src/internal/regex.rs
+++ b/parser/src/internal/regex.rs
@@ -59,8 +59,15 @@ pub(crate) enum LookaheadResult {
     SkipAheadAndRetry(usize),
 }
 
-/// Alternative to
-// TODO: Complete this doc comment (#906).
+/// Alternative to [`regex::Replacer`] for use with
+/// [`replace_with_lookahead`].
+///
+/// Unlike [`regex::Replacer`], which can only decide _how_ to render a
+/// replacement, a `LookaheadReplacer` may also inspect the text that follows
+/// the match and, by returning [`LookaheadResult::SkipAheadAndRetry`], reject
+/// the match and resume searching further along the haystack. This models the
+/// skip-ahead-and-retry look-ahead pattern that [`regex::Replacer`] cannot
+/// express.
 pub(crate) trait LookaheadReplacer {
     fn replace_append(
         &mut self,


### PR DESCRIPTION
## Summary

Fixes #906.

The doc comment on the `LookaheadReplacer` trait in `parser/src/internal/regex.rs` was truncated — it read only `/// Alternative to` followed by a `// TODO` placeholder, so rustdoc rendered an empty/meaningless summary.

This completes the sentence, explaining that `LookaheadReplacer`:

- is an alternative to [`regex::Replacer`] for use with `replace_with_lookahead`, and
- differs by being able to inspect the text following a match and reject it via `LookaheadResult::SkipAheadAndRetry`, modeling the skip-ahead-and-retry look-ahead pattern that `regex::Replacer` cannot express.

## Verification

- `cargo doc --no-deps -p asciidoc-parser` builds with no warnings (intra-doc links resolve).
- `cargo +nightly fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)