### PR TITLE
fix: Reject a dangerous image/icon target promoted to an href via link=self (close #919)

### DIFF
--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -18,6 +18,7 @@ use crate::{
     parser::{
         FootnoteRenderParams, IconRenderParams, ImageRenderParams, IndexTermRenderParams,
         LinkRenderParams, LinkRenderType, MenuRenderParams, XrefStyle, has_dangerous_scheme,
+        has_dangerous_self_href,
     },
     warnings::WarningType,
 };
@@ -276,15 +277,22 @@ impl Replacer for InlineImageMacroReplacer<'_, '_> {
         // A `link=` destination whose scheme could execute script is rejected by
         // the renderer (the image is emitted without the wrapping link); record
         // the warning here, where the parser and a document span are available.
-        // `link=self` names the image's own `src`, so it is exempt.
-        if let Some(link) = attrlist.named_attribute("link")
-            && link.value() != "self"
-            && has_dangerous_scheme(link.value())
-        {
-            self.parser.record_substitution_warning(
-                self.source,
-                WarningType::UnsafeLinkSchemeRejected(link.value().to_owned()),
-            );
+        // `link=self` names the image's own `src`, which resolves from `target`,
+        // so it is checked against the target (exempting a legitimately embedded
+        // `data:image/*`) rather than the literal `self`.
+        if let Some(link) = attrlist.named_attribute("link") {
+            let rejected = if link.value() == "self" {
+                has_dangerous_self_href(target).then_some(target)
+            } else {
+                has_dangerous_scheme(link.value()).then_some(link.value())
+            };
+
+            if let Some(rejected) = rejected {
+                self.parser.record_substitution_warning(
+                    self.source,
+                    WarningType::UnsafeLinkSchemeRejected(rejected.to_owned()),
+                );
+            }
         }
 
         let default_alt = basename(&target.replace(['_', '-'], " "));

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -18,7 +18,7 @@ use crate::{
     parser::{
         FootnoteRenderParams, IconRenderParams, ImageRenderParams, IndexTermRenderParams,
         LinkRenderParams, MenuRenderParams, XrefStyle, has_dangerous_scheme,
-        has_dangerous_self_href,
+        has_dangerous_self_href, is_uri_ish,
     },
     warnings::WarningType,
 };
@@ -299,15 +299,16 @@ impl Replacer for InlineImageMacroReplacer<'_, '_> {
         // the warning here, where the parser and a document span are available.
         // `link=self` names the image's own `src`, which resolves from `target`,
         // so it is checked against the target (exempting a legitimately embedded
-        // `data:image/*`) rather than the literal `self` – but only when the
-        // renderer actually promotes that `src` into the `href`. A font (`<i>`)
-        // or text (`[alt]`) icon has no `src`, so `link=self` stays the literal
-        // `self` there and nothing is rejected (see `render_icon_or_image`); a
-        // warning would be spurious.
+        // `data:image/*`, but not an author-supplied SVG data URI) rather than
+        // the literal `self` – and only when the renderer actually promotes that
+        // `src` into the `href`. A font (`<i>`) or text (`[alt]`) icon has no
+        // `src`, so `link=self` stays the literal `self` there and nothing is
+        // rejected (see `render_icon_or_image`); a warning would be spurious.
         if let Some(link) = attrlist.named_attribute("link") {
             let rejected = if link.value() == "self" {
-                (self.link_self_resolves_to_src(&caps[0]) && has_dangerous_self_href(target))
-                    .then_some(target)
+                (self.link_self_resolves_to_src(&caps[0])
+                    && has_dangerous_self_href(target, is_uri_ish(target)))
+                .then_some(target)
             } else {
                 has_dangerous_scheme(link.value()).then_some(link.value())
             };

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -260,6 +260,26 @@ struct InlineImageMacroReplacer<'p, 's> {
     source: Span<'s>,
 }
 
+impl InlineImageMacroReplacer<'_, '_> {
+    /// Reports whether `link=self` on the macro `caps0` (the full match text,
+    /// e.g. `image:…` or `icon:…`) resolves to a real image `src` that the
+    /// renderer promotes into the anchor `href`.
+    ///
+    /// Mirrors the `link_self_href` selection in `render_image`/`render_icon`:
+    /// an `image:` has a `src`, while an `icon:` has one only in image-icon
+    /// mode (icons enabled and not font-based). A font (`<i>`) or text
+    /// (`[alt]`) icon keeps the literal `self`, so a dangerous target is
+    /// never promoted there and no warning should be recorded. (An inline
+    /// SVG also keeps the literal `self`, but that path requires a
+    /// `.svg`-ish target below `Secure`, which a script-capable scheme
+    /// never is, so it needs no special case here.)
+    fn link_self_resolves_to_src(&self, caps0: &str) -> bool {
+        caps0.starts_with("image:")
+            || (self.parser.is_attribute_set("icons")
+                && self.parser.attribute_value("icons").as_maybe_str() != Some("font"))
+    }
+}
+
 impl Replacer for InlineImageMacroReplacer<'_, '_> {
     fn replace_append(&mut self, caps: &Captures<'_>, dest: &mut String) {
         if caps[0].starts_with('\\') {
@@ -279,10 +299,15 @@ impl Replacer for InlineImageMacroReplacer<'_, '_> {
         // the warning here, where the parser and a document span are available.
         // `link=self` names the image's own `src`, which resolves from `target`,
         // so it is checked against the target (exempting a legitimately embedded
-        // `data:image/*`) rather than the literal `self`.
+        // `data:image/*`) rather than the literal `self` – but only when the
+        // renderer actually promotes that `src` into the `href`. A font (`<i>`)
+        // or text (`[alt]`) icon has no `src`, so `link=self` stays the literal
+        // `self` there and nothing is rejected (see `render_icon_or_image`); a
+        // warning would be spurious.
         if let Some(link) = attrlist.named_attribute("link") {
             let rejected = if link.value() == "self" {
-                has_dangerous_self_href(target).then_some(target)
+                (self.link_self_resolves_to_src(&caps[0]) && has_dangerous_self_href(target))
+                    .then_some(target)
             } else {
                 has_dangerous_scheme(link.value()).then_some(link.value())
             };

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -796,7 +796,20 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
 
         let link_self_href = if inline_svg { None } else { Some(src.as_str()) };
 
-        render_icon_or_image(params.attrlist, &img, "image", link_self_href, dest);
+        // A URI-ish target passes through to `src` verbatim (it is never
+        // embedded), so a `link=self` resolving to it is author-supplied and
+        // subject to the stricter SVG-data-URI check; a plain path target is
+        // resolved to a web path or a trusted embedded `data-uri`.
+        let self_href_from_uri_target = is_uri_ish(params.target);
+
+        render_icon_or_image(
+            params.attrlist,
+            &img,
+            "image",
+            link_self_href,
+            self_href_from_uri_target,
+            dest,
+        );
     }
 
     fn image_uri(
@@ -947,7 +960,19 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
             None
         };
 
-        render_icon_or_image(params.attrlist, &img, "icon", link_self_href, dest);
+        // As in `render_image`: a URI-ish target passes through to the icon
+        // `src` verbatim, so a `link=self` resolving to it is author-supplied
+        // and gets the stricter SVG-data-URI check.
+        let self_href_from_uri_target = is_uri_ish(params.target);
+
+        render_icon_or_image(
+            params.attrlist,
+            &img,
+            "icon",
+            link_self_href,
+            self_href_from_uri_target,
+            dest,
+        );
     }
 
     fn render_link(&self, params: &LinkRenderParams, dest: &mut String) {
@@ -1242,6 +1267,7 @@ fn render_icon_or_image(
     img: &str,
     type_: &'static str,
     link_self_href: Option<&str>,
+    self_href_from_uri_target: bool,
     dest: &mut String,
 ) {
     let mut img = img.to_string();
@@ -1270,10 +1296,11 @@ fn render_icon_or_image(
         // records the accompanying warning. `link=self` resolves to the image's
         // own `src`, which may legitimately be a `data:image/*` URI, so it is
         // checked with the more permissive [`has_dangerous_self_href`] (a
-        // `javascript:` or non-image `data:` target still resolves to a live
-        // script URI here and is rejected).
+        // `javascript:` or non-image `data:` src – or an author-supplied SVG
+        // data URI target – still resolves to a live script URI here and is
+        // rejected).
         let rejected = if is_self {
-            has_dangerous_self_href(href)
+            has_dangerous_self_href(href, self_href_from_uri_target)
         } else {
             has_dangerous_scheme(link.value())
         };
@@ -1335,19 +1362,40 @@ pub(crate) fn has_dangerous_scheme(target: &str) -> bool {
     })
 }
 
-/// Reports whether `href` – resolved from a `link=self` image/icon target –
+/// Reports whether `href` – the `src` a `link=self` image/icon resolves to –
 /// would place a script-capable URI in the wrapping anchor's `href`.
 ///
 /// `link=self` names the image's own `src`, so it cannot simply be run through
 /// [`has_dangerous_scheme`]: an embedded image (`data-uri`) legitimately
 /// resolves to a `data:image/*` URI, and there is an Asciidoctor-parity test
-/// for exactly that. That one form is therefore exempt. Every other dangerous
-/// scheme – `javascript:`, `vbscript:`, or a non-image `data:` such as
-/// `data:text/html,…` – is never a valid image source, so promoting it into an
-/// `href` is rejected: only the anchor is dropped (the harmless `<img src>` is
-/// left intact), mirroring the `link=` policy above.
-pub(crate) fn has_dangerous_self_href(href: &str) -> bool {
-    has_dangerous_scheme(href) && !is_image_data_uri(href)
+/// for exactly that. A `data:image/*` source is therefore exempt. Every other
+/// dangerous scheme – `javascript:`, `vbscript:`, or a non-image `data:` such
+/// as `data:text/html,…` – is never a valid image source, so promoting it into
+/// an `href` is rejected: only the anchor is dropped (the harmless `<img src>`
+/// is left intact), mirroring the `link=` policy above.
+///
+/// `from_uri_target` narrows that exemption. It is set when the `src` was
+/// passed through verbatim from an author-supplied URI target, rather than
+/// resolved from a local file path (a plain web path, or a crate-embedded
+/// `data-uri`). A `data:image/svg+xml` document *executes* its embedded script
+/// when it is navigated to – which following the `href` on click does – unlike
+/// a raster image data URI, which merely displays. An embedded SVG comes from a
+/// trusted local file (the parity case) and stays exempt; an author-supplied
+/// `data:image/svg…` target is script-navigable and is rejected.
+pub(crate) fn has_dangerous_self_href(href: &str, from_uri_target: bool) -> bool {
+    if !has_dangerous_scheme(href) {
+        return false;
+    }
+
+    // A dangerous scheme that is not a `data:image/*` source (`javascript:`,
+    // `vbscript:`, `data:text/html`, …) is always rejected.
+    if !is_image_data_uri(href) {
+        return true;
+    }
+
+    // A `data:image/*` source is exempt, except an author-supplied SVG data URI,
+    // whose script runs when the anchor is followed.
+    from_uri_target && is_svg_data_uri(href)
 }
 
 /// Reports whether `href` is a `data:image/*` URI (the leading control/space
@@ -1361,6 +1409,20 @@ fn is_image_data_uri(href: &str) -> bool {
 
     href.get(..IMAGE_DATA_PREFIX.len())
         .is_some_and(|prefix| prefix.eq_ignore_ascii_case(IMAGE_DATA_PREFIX))
+}
+
+/// Reports whether `href` is a `data:image/svg…` URI. SVG is the one image
+/// media type that executes embedded script when the URI is opened as a
+/// top-level document, so an author-supplied SVG data URI is not a safe
+/// `link=self` target (see [`has_dangerous_self_href`]). Raster image data URIs
+/// never begin with `svg`, so they are unaffected.
+fn is_svg_data_uri(href: &str) -> bool {
+    let href = href.trim_start_matches(|c: char| c <= ' ');
+
+    const SVG_DATA_PREFIX: &str = "data:image/svg";
+
+    href.get(..SVG_DATA_PREFIX.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(SVG_DATA_PREFIX))
 }
 
 /// Escapes a value for safe interpolation into an HTML attribute.
@@ -1398,7 +1460,7 @@ fn normalize_web_path(
     }
 }
 
-fn is_uri_ish(path: &str) -> bool {
+pub(crate) fn is_uri_ish(path: &str) -> bool {
     path.contains(':') && URI_SNIFF.is_match(path)
 }
 

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -1277,10 +1277,18 @@ fn render_icon_or_image(
         // wrapping anchor. Escaping the `"` delimiter alone would still leave a
         // live `javascript:` URI, so the destination is rejected outright – the
         // same policy the explicit `link:` macro applies, and the macro layer
-        // records the accompanying warning. `link=self` names the image's own
-        // `src` (which may legitimately be a `data:` image URI), so it is
-        // exempt.
-        if is_self || !has_dangerous_scheme(link.value()) {
+        // records the accompanying warning. `link=self` resolves to the image's
+        // own `src`, which may legitimately be a `data:image/*` URI, so it is
+        // checked with the more permissive [`has_dangerous_self_href`] (a
+        // `javascript:` or non-image `data:` target still resolves to a live
+        // script URI here and is rejected).
+        let rejected = if is_self {
+            has_dangerous_self_href(href)
+        } else {
+            has_dangerous_scheme(link.value())
+        };
+
+        if !rejected {
             img = format!(
                 r#"<a class="image" href="{href}"{link_constraint_attrs}>{img}</a>"#,
                 // Both sources of `href` – the image's own `src` (a resolved web
@@ -1335,6 +1343,34 @@ pub(crate) fn has_dangerous_scheme(target: &str) -> bool {
             .get(..scheme.len())
             .is_some_and(|prefix| prefix.eq_ignore_ascii_case(scheme))
     })
+}
+
+/// Reports whether `href` – resolved from a `link=self` image/icon target –
+/// would place a script-capable URI in the wrapping anchor's `href`.
+///
+/// `link=self` names the image's own `src`, so it cannot simply be run through
+/// [`has_dangerous_scheme`]: an embedded image (`data-uri`) legitimately
+/// resolves to a `data:image/*` URI, and there is an Asciidoctor-parity test
+/// for exactly that. That one form is therefore exempt. Every other dangerous
+/// scheme – `javascript:`, `vbscript:`, or a non-image `data:` such as
+/// `data:text/html,…` – is never a valid image source, so promoting it into an
+/// `href` is rejected: only the anchor is dropped (the harmless `<img src>` is
+/// left intact), mirroring the `link=` policy above.
+pub(crate) fn has_dangerous_self_href(href: &str) -> bool {
+    has_dangerous_scheme(href) && !is_image_data_uri(href)
+}
+
+/// Reports whether `href` is a `data:image/*` URI (the leading control/space
+/// characters are ignored and the comparison is ASCII-case-insensitive, as in
+/// [`has_dangerous_scheme`]). This is the one `data:` form that is a legitimate
+/// image source, so it is exempt from the `link=self` rejection above.
+fn is_image_data_uri(href: &str) -> bool {
+    let href = href.trim_start_matches(|c: char| c <= ' ');
+
+    const IMAGE_DATA_PREFIX: &str = "data:image/";
+
+    href.get(..IMAGE_DATA_PREFIX.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(IMAGE_DATA_PREFIX))
 }
 
 /// Escapes a value for safe interpolation into an HTML attribute.

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -18,13 +18,13 @@ mod include_file_handler;
 pub use include_file_handler::{IncludeContent, IncludeFileHandler};
 
 mod inline_substitution_renderer;
-pub(crate) use inline_substitution_renderer::has_dangerous_scheme;
 pub use inline_substitution_renderer::{
     CalloutGuard, CalloutRenderParams, CharacterReplacementType, FootnoteRenderParams,
     HtmlSubstitutionRenderer, IconRenderParams, ImageRenderParams, IndexTermRenderParams,
     InlineSubstitutionRenderer, LinkRenderParams, LinkRenderType, MenuRenderParams, QuoteScope,
     QuoteType, SpecialCharacter, XrefRenderParams,
 };
+pub(crate) use inline_substitution_renderer::{has_dangerous_scheme, has_dangerous_self_href};
 
 mod parser;
 pub(crate) use parser::DeferredWarning;

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -24,7 +24,9 @@ pub use inline_substitution_renderer::{
     InlineSubstitutionRenderer, LinkRenderParams, MenuRenderParams, QuoteScope, QuoteType,
     SpecialCharacter, XrefRenderParams,
 };
-pub(crate) use inline_substitution_renderer::{has_dangerous_scheme, has_dangerous_self_href};
+pub(crate) use inline_substitution_renderer::{
+    has_dangerous_scheme, has_dangerous_self_href, is_uri_ish,
+};
 
 mod parser;
 pub(crate) use parser::DeferredWarning;

--- a/parser/src/tests/security.rs
+++ b/parser/src/tests/security.rs
@@ -250,6 +250,23 @@ fn icon_link_self_with_dangerous_target_drops_the_wrapping_link() {
 }
 
 #[test]
+fn font_icon_link_self_with_dangerous_target_keeps_literal_self_without_warning() {
+    // A font icon has no `src`, so `link=self` resolves to the literal `self`
+    // (a harmless relative URL), not to the dangerous target. Nothing is
+    // rejected, so no `UnsafeLinkSchemeRejected` warning is recorded.
+    assert_eq!(
+        render_icon("icon:javascript:alert(1)[link=self]", "font"),
+        r#"<span class="icon"><a class="image" href="self"><i class="fa fa-javascript:alert(1)"></i></a></span>"#
+    );
+
+    let mut parser =
+        Parser::default().with_intrinsic_attribute("icons", "font", ModificationContext::ApiOnly);
+    let doc = parser.parse("icon:javascript:alert(1)[link=self]");
+
+    assert_eq!(doc.warnings().count(), 0);
+}
+
+#[test]
 fn image_link_self_is_not_rejected() {
     // `link=self` names the image's own (safe) `src`, so it stays a live link.
     assert_eq!(

--- a/parser/src/tests/security.rs
+++ b/parser/src/tests/security.rs
@@ -320,13 +320,44 @@ fn image_link_self_dangerous_target_rejection_is_case_insensitive() {
 }
 
 #[test]
-fn image_link_self_with_inline_data_image_target_stays_a_live_link() {
-    // `data:image/*` is a legitimate image source, so an author-supplied inline
-    // image target keeps its `link=self` anchor (the same exemption that lets
-    // an embedded `data-uri` image link to itself).
+fn image_link_self_with_inline_raster_data_image_target_stays_a_live_link() {
+    // A raster `data:image/*` is a legitimate image source that displays (never
+    // executes) when navigated to, so an author-supplied inline image target
+    // keeps its `link=self` anchor (the same exemption that lets an embedded
+    // `data-uri` image link to itself).
     assert_eq!(
         render_macros("image:data:image/png;base64,iVBORw0KGgo=[alt,link=self]"),
         r#"<span class="image"><a class="image" href="data:image/png;base64,iVBORw0KGgo="><img src="data:image/png;base64,iVBORw0KGgo=" alt="alt"></a></span>"#
+    );
+}
+
+#[test]
+fn image_link_self_with_author_supplied_svg_data_uri_drops_the_wrapping_link() {
+    // An SVG opened as a top-level document runs its embedded script, so an
+    // author-supplied `data:image/svg+xml` target – which `link=self` would
+    // promote into a followable `href` – is rejected, unlike a raster data URI
+    // (above) or a trusted embedded SVG (which is resolved from a file target,
+    // not passed through as a URI). Only the anchor is dropped. (The `<` `>`
+    // reaching the `src` are escaped by the special-characters step.)
+    assert_eq!(
+        render_macros("image:data:image/svg+xml,<svg onload='alert(1)'></svg>[alt,link=self]"),
+        // The space in the target is percent-encoded in the resolved `src`.
+        r#"<span class="image"><img src="data:image/svg+xml,&lt;svg%20onload='alert(1)'&gt;&lt;/svg&gt;" alt="alt"></span>"#
+    );
+}
+
+#[test]
+fn image_link_self_with_author_supplied_svg_data_uri_records_a_warning() {
+    let mut parser = Parser::default();
+    let doc = parser.parse("image:data:image/svg+xml,<svg onload='alert(1)'></svg>[alt,link=self]");
+
+    let warnings: Vec<_> = doc.warnings().collect();
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(
+        warnings[0].warning,
+        WarningType::UnsafeLinkSchemeRejected(
+            "data:image/svg+xml,&lt;svg onload='alert(1)'&gt;&lt;/svg&gt;".to_string()
+        )
     );
 }
 

--- a/parser/src/tests/security.rs
+++ b/parser/src/tests/security.rs
@@ -239,11 +239,77 @@ fn icon_link_with_dangerous_scheme_drops_the_wrapping_link() {
 }
 
 #[test]
+fn icon_link_self_with_dangerous_target_drops_the_wrapping_link() {
+    // A dangerous `icon:` target that `link=self` would promote into the anchor
+    // `href` is rejected too; the icon `<img>` is left intact. (The resolved
+    // `src` gains the default `.png` icon extension.)
+    assert_eq!(
+        render_icon("icon:javascript:alert(1)[link=self]", ""),
+        r#"<span class="icon"><img src="javascript:alert(1).png" alt="javascript:alert(1)"></span>"#
+    );
+}
+
+#[test]
 fn image_link_self_is_not_rejected() {
     // `link=self` names the image's own (safe) `src`, so it stays a live link.
     assert_eq!(
         render_macros("image:safe.png[alt,link=self]"),
         r#"<span class="image"><a class="image" href="safe.png"><img src="safe.png" alt="alt"></a></span>"#
+    );
+}
+
+#[test]
+fn image_link_self_with_dangerous_target_drops_the_wrapping_link() {
+    // A `javascript:` target is harmless in `<img src>` (a `src` does not
+    // execute script), but `link=self` would otherwise promote it into a live
+    // `href`. The anchor is dropped while the `<img>` is left intact.
+    assert_eq!(
+        render_macros("image:javascript:alert(1)[alt,link=self]"),
+        r#"<span class="image"><img src="javascript:alert(1)" alt="alt"></span>"#
+    );
+}
+
+#[test]
+fn image_link_self_with_dangerous_target_records_a_warning() {
+    let mut parser = Parser::default();
+    let doc = parser.parse("image:javascript:alert(1)[alt,link=self]");
+
+    let warnings: Vec<_> = doc.warnings().collect();
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(
+        warnings[0].warning,
+        WarningType::UnsafeLinkSchemeRejected("javascript:alert(1)".to_string())
+    );
+}
+
+#[test]
+fn image_link_self_with_data_text_html_target_drops_the_wrapping_link() {
+    // A `data:` target is dual-use: `data:image/*` is a legitimate image
+    // source, but `data:text/html,…` is not, and would be a live script URI in
+    // the self-href. Only the anchor is dropped. (The `<` `>` reaching the
+    // `src` are escaped by the special-characters step.)
+    assert_eq!(
+        render_macros("image:data:text/html,<script>alert(1)</script>[alt,link=self]"),
+        r#"<span class="image"><img src="data:text/html,&lt;script&gt;alert(1)&lt;/script&gt;" alt="alt"></span>"#
+    );
+}
+
+#[test]
+fn image_link_self_dangerous_target_rejection_is_case_insensitive() {
+    assert_eq!(
+        render_macros("image:JavaScript:alert(1)[alt,link=self]"),
+        r#"<span class="image"><img src="JavaScript:alert(1)" alt="alt"></span>"#
+    );
+}
+
+#[test]
+fn image_link_self_with_inline_data_image_target_stays_a_live_link() {
+    // `data:image/*` is a legitimate image source, so an author-supplied inline
+    // image target keeps its `link=self` anchor (the same exemption that lets
+    // an embedded `data-uri` image link to itself).
+    assert_eq!(
+        render_macros("image:data:image/png;base64,iVBORw0KGgo=[alt,link=self]"),
+        r#"<span class="image"><a class="image" href="data:image/png;base64,iVBORw0KGgo="><img src="data:image/png;base64,iVBORw0KGgo=" alt="alt"></a></span>"#
     );
 }
 


### PR DESCRIPTION
## Problem

Closes #919.

An `image:`/`icon:` macro whose **target** carries a script-capable scheme resolves that target into the `<img src>` (harmless — an `<img>` `src` does not execute script), but `link=self` then promoted the same value into the wrapping anchor's `href`, producing a live script URI at `SafeMode::Secure` defaults:

```
image:javascript:alert(1)[alt,link=self]
```

previously rendered a live `<a href="javascript:alert(1)">`. The same held for a `data:text/html,…` target.

This is a distinct vector from the `link=` scheme rejection closed by #911, which deliberately exempts `link=self` (because `self` names the image's own `src`, legitimately a `data:image/*` URI for an embedded `data-uri` image).

## Fix

Guard the **resolved self-href** rather than blanket-rejecting `data:`. A new `has_dangerous_self_href` returns true for a `has_dangerous_scheme` target **except** a `data:image/*` URI (the one dual-use `data:` form that is a valid image source). This follows option 2 in the issue:

- `render_icon_or_image` now rejects a dangerous `link=self` href, dropping **only** the wrapping anchor and leaving the harmless `<img src>` intact — consistent with the existing `link=` handling.
- The macro layer records the existing `WarningType::UnsafeLinkSchemeRejected` for a `link=self` whose target is dangerous, checking the target (which is what the self-href resolves to).

The Asciidoctor-parity path (`should_link_to_data_uri_if_value_of_link_attribute_is_self_and_inline_image_is_embedded`, a `data:image/svg+xml` embed) is preserved.

### Known edge

An extensionless local file embedded via `data-uri` resolves to `data:application/octet-stream;base64,…`, which is not `data:image/*` and so has its `link=self` anchor dropped (the `<img>` is unaffected). This is safe (`application/octet-stream` cannot execute), rare, and matches the issue's stated `data:image/*` exemption; no existing test covers it.

## Tests

Added to `parser/src/tests/security.rs`:
- `image:`/`icon:` `javascript:` target + `link=self` drops the anchor (case-insensitive) and records a warning
- `data:text/html,…` target + `link=self` drops the anchor
- `data:image/png;base64,…` target + `link=self` stays a live link

Full suite (4412 tests) passes; `cargo +nightly fmt --check` and `cargo clippy --all-targets` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)