### PR TITLE
fix: Give the `link:` prefix its own bracket-required INLINE_LINK branch

### DIFF
--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -747,8 +747,13 @@ fn strip_see_and_seealso(term: &str) -> String {
 // the scheme. A plain ASCII `[\ \t]` would leave such a URL as literal text
 // (see #768).
 //
-// `InlineLinkReplacer` normalizes the two capture-group sets into a single view
-// (see `NormalizedCaps`), so the numbering below is only referenced there.
+// The `link:` prefix is broken out into its own branch (below) that *requires*
+// a trailing `[…]`, so a `link:` with no brackets simply fails to match here
+// rather than matching as a bare link and then being rejected as invalid macro
+// syntax in the replacer.
+//
+// `InlineLinkReplacer` normalizes the three capture-group sets into a single
+// view (see `NormalizedCaps`), so the numbering below is only referenced there.
 static INLINE_LINK: LazyLock<Regex> = LazyLock::new(|| {
     #[allow(clippy::unwrap_used)]
     Regex::new(
@@ -765,14 +770,24 @@ static INLINE_LINK: LazyLock<Regex> = LazyLock::new(|| {
                                                               # group 7: trailing char
             )
           |
-            #### NON-ANGLE branch: no `&gt;` alternative (unreachable without `&lt;`).
-            ( ^ | link: | [\ \t\p{Zs}] | [>\(\)\[\];"'] )     # group 8: prefix
+            #### LINK-MACRO branch: a `link:` prefix, which REQUIRES a trailing
+            #### `[…]`. Because this branch has no bare-link alternative, a
+            #### `link:` followed by a URL but no brackets does not match at all
+            #### (it is left as literal text), so it can never reach the
+            #### invalid-macro-syntax path in the replacer.
+            ( link: )                                         # group 8: prefix
             ( \\? (?: https? | file | ftp | irc ):// )        # group 9: scheme
+            ( [^\s\[\]]+ )                                    # group 10: target
+            \[ ( | .*?[^\\] ) \]                              # group 11: attrlist
+          |
+            #### NON-ANGLE branch: no `&gt;` alternative (unreachable without `&lt;`).
+            ( ^ | [\ \t\p{Zs}] | [>\(\)\[\];"'] )             # group 12: prefix
+            ( \\? (?: https? | file | ftp | irc ):// )        # group 13: scheme
             (?:
-                ( [^\s\[\]]+ )                                # group 10: target
-                \[ ( | .*?[^\\] ) \]                          # group 11: attrlist
-              | ( [^\s\[\]<]* ( [^\s,.?!\[\]<\)] ) )          # group 12: bare link,
-                                                              # group 13: trailing char
+                ( [^\s\[\]]+ )                                # group 14: target
+                \[ ( | .*?[^\\] ) \]                          # group 15: attrlist
+              | ( [^\s\[\]<]* ( [^\s,.?!\[\]<\)] ) )          # group 16: bare link,
+                                                              # group 17: trailing char
             )
         )
     "#,
@@ -781,9 +796,10 @@ static INLINE_LINK: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 /// A branch-agnostic view over the capture groups of [`INLINE_LINK`], which has
-/// two parallel top-level branches (angle / non-angle). Exactly one branch
-/// participates in any given match; this resolves the relevant groups so the
-/// replacer doesn't have to special-case the branch numbering everywhere.
+/// three parallel top-level branches (angle / link-macro / non-angle). Exactly
+/// one branch participates in any given match; this resolves the relevant
+/// groups so the replacer doesn't have to special-case the branch numbering
+/// everywhere.
 struct NormalizedCaps<'c, 't> {
     caps: &'c Captures<'t>,
 
@@ -800,13 +816,15 @@ struct NormalizedCaps<'c, 't> {
     /// URL captured inside `<…&gt;`; only present in the ANGLE branch.
     angle_url: Option<usize>,
 
-    /// Bare (auto-linked) URL.
-    bare: usize,
+    /// Bare (auto-linked) URL; absent in the LINK-MACRO branch, which always
+    /// has a trailing attrlist.
+    bare: Option<usize>,
 }
 
 impl<'c, 't> NormalizedCaps<'c, 't> {
     fn new(caps: &'c Captures<'t>) -> Self {
         if caps.get(1).is_some() {
+            // ANGLE branch.
             NormalizedCaps {
                 caps,
                 is_angle: true,
@@ -815,9 +833,11 @@ impl<'c, 't> NormalizedCaps<'c, 't> {
                 target: 3,
                 attrlist: 4,
                 angle_url: Some(5),
-                bare: 6,
+                bare: Some(6),
             }
-        } else {
+        } else if caps.get(8).is_some() {
+            // LINK-MACRO branch: a `link:` prefix always paired with a trailing
+            // attrlist, so there is no bare-link group.
             NormalizedCaps {
                 caps,
                 is_angle: false,
@@ -826,7 +846,19 @@ impl<'c, 't> NormalizedCaps<'c, 't> {
                 target: 10,
                 attrlist: 11,
                 angle_url: None,
-                bare: 12,
+                bare: None,
+            }
+        } else {
+            // NON-ANGLE branch.
+            NormalizedCaps {
+                caps,
+                is_angle: false,
+                prefix: 12,
+                scheme: 13,
+                target: 14,
+                attrlist: 15,
+                angle_url: None,
+                bare: Some(16),
             }
         }
     }
@@ -852,7 +884,7 @@ impl<'c, 't> NormalizedCaps<'c, 't> {
     }
 
     fn bare(&self) -> Option<Match<'t>> {
-        self.caps.get(self.bare)
+        self.bare.and_then(|g| self.caps.get(g))
     }
 }
 
@@ -865,9 +897,9 @@ impl Replacer for InlineLinkReplacer<'_> {
             .item
             .item;
 
-        // `INLINE_LINK` has two parallel top-level branches (angle / non-angle);
-        // resolve which one matched so the logic below can stay branch-agnostic.
-        // See the note on `INLINE_LINK` and issue #503.
+        // `INLINE_LINK` has three parallel top-level branches (angle /
+        // link-macro / non-angle); resolve which one matched so the logic below
+        // can stay branch-agnostic. See the note on `INLINE_LINK` and issue #503.
         let n = NormalizedCaps::new(caps);
         let prefix_match = n.prefix();
         let scheme_match = n.scheme();
@@ -959,14 +991,12 @@ impl Replacer for InlineLinkReplacer<'_> {
                 link_text = Some(attrlist.as_str().to_owned());
             }
         } else {
-            if prefix == "link:" || prefix == "\"" || prefix == "'" {
-                // Note from the Ruby implementation which also applies to this if clause:
-
-                // Invalid macro syntax (link: prefix w/o trailing square brackets or URL
-                // enclosed in quotes).
-
-                // FIXME: We probably shouldn't even get here when the link: prefix is present.
-                // The regex is doing too much (#908).
+            // Invalid macro syntax: a URL enclosed in quotes (a `"` or `'`
+            // prefix with no trailing square brackets). Asciidoctor also lists
+            // a bracket-less `link:` prefix here, but our `INLINE_LINK` routes
+            // that through a dedicated branch that requires a trailing `[…]`, so
+            // a `link:` prefix can never reach this point.
+            if prefix == "\"" || prefix == "'" {
                 dest.push_str(&caps[0]);
                 return;
             }


### PR DESCRIPTION
Closes #908.

## Problem

The invalid-macro-syntax `else` branch in `InlineLinkReplacer` carried a `// FIXME:` noting that a `link:` prefix probably should not reach it, because the inline-link regex was "doing too much":

```rust
// FIXME: We probably shouldn't even get here when the link: prefix is present.
// The regex is doing too much (#908).
dest.push_str(&caps[0]);
return;
```

The shared NON-ANGLE branch of `INLINE_LINK` listed `link:` as one of its allowed prefixes. When a `link:` prefixed a bare (bracket-less) URL, that branch's bare-link alternative matched, and the match was then rejected as invalid macro syntax in the replacer.

## Fix

`link:` is now broken out into its own LINK-MACRO branch that **requires** a trailing `[…]`. Because that branch has no bare-link alternative:

- `link:https://example.org[text]` → matches as before (formal macro).
- `link:https://example.org` (no brackets) → does not match `INLINE_LINK` at all and is left as literal text.

That literal output is identical to what the FIXME branch produced, so behavior is unchanged — but a `link:` prefix can no longer reach the invalid-macro-syntax path. The `"`/`'` (quoted-URL) prefixes still route through that path, so it stays for them.

`NormalizedCaps` gains a third branch mapping (angle / link-macro / non-angle) and its `bare` group becomes `Option` (the LINK-MACRO branch always carries a trailing attrlist).

## Testing

- `cargo test -p asciidoc-parser` — all 4406 tests pass (0 failures), including the directly relevant `qualified_url_using_invalid_link_macro_should_not_create_link` (`link:http://asciidoc.org …` stays literal) and the many `link:<scheme>://…[…]` formal-macro tests.
- `cargo +nightly fmt --all -- --check` clean.
- `cargo clippy -p asciidoc-parser` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)