### PR TITLE
feat!: Polish public rendering API ahead of 1.0 (close #897)

### DIFF
--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -17,7 +17,7 @@ use crate::{
     internal::{LookaheadReplacer, LookaheadResult, replace_with_lookahead},
     parser::{
         FootnoteRenderParams, IconRenderParams, ImageRenderParams, IndexTermRenderParams,
-        LinkRenderParams, LinkRenderType, MenuRenderParams, XrefStyle, has_dangerous_scheme,
+        LinkRenderParams, MenuRenderParams, XrefStyle, has_dangerous_scheme,
     },
     warnings::WarningType,
 };
@@ -909,7 +909,6 @@ impl Replacer for InlineLinkReplacer<'_> {
                 link_text,
                 extra_roles: vec!["bare"],
                 window: None,
-                type_: LinkRenderType::Link,
                 attrlist: &attrlist,
                 parser: self.0,
             };
@@ -1060,7 +1059,6 @@ impl Replacer for InlineLinkReplacer<'_> {
             link_text,
             extra_roles,
             window,
-            type_: LinkRenderType::Link,
             attrlist: &attrlist,
             parser: self.0,
         };
@@ -1151,7 +1149,6 @@ impl Replacer for InlineLinkMacroReplacer<'_, '_> {
         }
 
         let mut attrlist: Option<Attrlist<'_>> = None;
-        let link_type = LinkRenderType::Link;
 
         let mut link_text = caps
             .get(5)
@@ -1235,7 +1232,6 @@ impl Replacer for InlineLinkMacroReplacer<'_, '_> {
             link_text: link_text.clone(),
             extra_roles,
             window,
-            type_: link_type,
             attrlist: &attrlist,
             parser: self.parser,
         };
@@ -1384,7 +1380,6 @@ impl Replacer for InlineEmailReplacer<'_> {
             link_text: caps[2].to_owned(),
             extra_roles: vec![],
             window: None,
-            type_: LinkRenderType::Link,
             attrlist: &attrlist,
             parser: self.0,
         };

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -626,7 +626,7 @@ impl Replacer for PassthroughRestoreReplacer<'_> {
                 .and_then(|attrlist| attrlist.id().map(|id| id.to_string()));
 
             let mut new_text = String::default();
-            self.1.renderer.render_quoted_substitition(
+            self.1.renderer.render_quoted_substitution(
                 type_,
                 QuoteScope::Unconstrained,
                 attrlist,

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -359,7 +359,7 @@ impl LookaheadReplacer for QuoteReplacer<'_> {
             QuoteScope::Constrained => {
                 if let Some(attrs) = unescaped_attrs {
                     dest.push_str(&attrs);
-                    self.parser.renderer.render_quoted_substitition(
+                    self.parser.renderer.render_quoted_substitution(
                         self.type_, self.scope, None, None, &caps[3], dest,
                     );
                 } else {
@@ -403,7 +403,7 @@ impl LookaheadReplacer for QuoteReplacer<'_> {
                         let _ = self.parser.register_ref(id, None, RefType::Anchor);
                     }
 
-                    self.parser.renderer.render_quoted_substitition(
+                    self.parser.renderer.render_quoted_substitution(
                         type_, self.scope, attrlist, id, &caps[3], dest,
                     );
                 }
@@ -448,7 +448,7 @@ impl LookaheadReplacer for QuoteReplacer<'_> {
 
                 self.parser
                     .renderer
-                    .render_quoted_substitition(type_, self.scope, attrlist, id, &caps[2], dest);
+                    .render_quoted_substitution(type_, self.scope, attrlist, id, &caps[2], dest);
             }
         }
 

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -2292,7 +2292,7 @@ mod tests {
         // of the header, but instead the author and revision lines before it
         // are captured as before.
         let mut parser = Parser::default();
-        parser.parse("= Title\nJoe Cool\nv1.0\n///\nstuff");
+        let _ = parser.parse("= Title\nJoe Cool\nv1.0\n///\nstuff");
 
         assert_eq!(
             parser.attribute_value("author"),

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -25,7 +25,7 @@ pub trait InlineSubstitutionRenderer: Debug {
     /// The renderer should write the appropriate rendering to `dest`.
     ///
     /// [quote substitution]: https://docs.asciidoctor.org/asciidoc/latest/subs/quotes/
-    fn render_quoted_substitition(
+    fn render_quoted_substitution(
         &self,
         type_: QuoteType,
         scope: QuoteScope,
@@ -376,10 +376,7 @@ pub struct LinkRenderParams<'a> {
     pub extra_roles: Vec<&'a str>,
 
     /// Target window selection (passed through to `window` function in HTML).
-    pub window: Option<&'static str>,
-
-    /// What type of link is being rendered?
-    pub type_: LinkRenderType,
+    pub window: Option<&'a str>,
 
     /// Attribute list.
     pub attrlist: &'a Attrlist<'a>,
@@ -387,13 +384,6 @@ pub struct LinkRenderParams<'a> {
     /// Parser. The rendered may find document settings (such as an image
     /// directory) in the parser's document attributes.
     pub parser: &'a Parser,
-}
-
-/// What type of link is being rendered?
-#[derive(Clone, Debug)]
-pub enum LinkRenderType {
-    /// TEMPORARY: I don't know the different types of links yet.
-    Link,
 }
 
 /// Provides parameters for rendering a [callout] number.
@@ -575,7 +565,7 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
         }
     }
 
-    fn render_quoted_substitition(
+    fn render_quoted_substitution(
         &self,
         type_: QuoteType,
         _scope: QuoteScope,
@@ -1598,7 +1588,7 @@ fn xref_constraint_attrs(window: Option<&str>) -> String {
     )
 }
 
-fn link_constraint_attrs(attrlist: &Attrlist<'_>, window: Option<&'static str>) -> String {
+fn link_constraint_attrs(attrlist: &Attrlist<'_>, window: Option<&str>) -> String {
     let rel = if attrlist.has_option("nofollow") {
         Some("nofollow")
     } else {

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -22,8 +22,8 @@ pub(crate) use inline_substitution_renderer::has_dangerous_scheme;
 pub use inline_substitution_renderer::{
     CalloutGuard, CalloutRenderParams, CharacterReplacementType, FootnoteRenderParams,
     HtmlSubstitutionRenderer, IconRenderParams, ImageRenderParams, IndexTermRenderParams,
-    InlineSubstitutionRenderer, LinkRenderParams, LinkRenderType, MenuRenderParams, QuoteScope,
-    QuoteType, SpecialCharacter, XrefRenderParams,
+    InlineSubstitutionRenderer, LinkRenderParams, MenuRenderParams, QuoteScope, QuoteType,
+    SpecialCharacter, XrefRenderParams,
 };
 
 mod parser;

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -578,6 +578,16 @@ impl Parser {
     /// [`built_in_attrs`](super::built_in_attrs)).
     pub(crate) const DEFAULT_MAX_BLOCK_NESTING: usize = 32;
 
+    /// Creates a new [`Parser`] with the default configuration.
+    ///
+    /// This is equivalent to [`Parser::default()`](Self::default) and is
+    /// provided for discoverability. Configure the parser by chaining the
+    /// `with_*` builder methods, then call [`parse()`](Self::parse).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Parse a UTF-8 string as an AsciiDoc document.
     ///
     /// The [`Document`] data structure returned by this call has a '`static`
@@ -625,6 +635,7 @@ impl Parser {
     ///
     /// [`warnings()`]: Document::warnings
     /// [`attribute_value()`]: Self::attribute_value
+    #[must_use]
     pub fn parse(&mut self, source: &str) -> Document<'static> {
         let mut document = self.parse_deferred(source);
 
@@ -652,6 +663,7 @@ impl Parser {
     ///
     /// [`parse()`]: Self::parse
     /// [`catalog()`]: Document::catalog
+    #[must_use]
     pub fn parse_deferred(&mut self, source: &str) -> Document<'static> {
         // Restore the configured attribute baseline so a `Parser` reused across
         // documents does not carry one document's header/body assignments into
@@ -1412,6 +1424,7 @@ impl Parser {
     /// [intrinsic attribute]: https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes-ref/#intrinsic-attributes
     ///
     /// [`with_intrinsic_attribute_bool()`]: Self::with_intrinsic_attribute_bool
+    #[must_use]
     pub fn with_intrinsic_attribute<N: AsRef<str>, V: AsRef<str>>(
         mut self,
         name: N,
@@ -1461,6 +1474,7 @@ impl Parser {
     /// [intrinsic attribute]: https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes-ref/#intrinsic-attributes
     ///
     /// [`with_intrinsic_attribute()`]: Self::with_intrinsic_attribute
+    #[must_use]
     pub fn with_intrinsic_attribute_silent<N: AsRef<str>, V: AsRef<str>>(
         mut self,
         name: N,
@@ -1863,6 +1877,7 @@ impl Parser {
     /// [intrinsic attribute]: https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes-ref/#intrinsic-attributes
     ///
     /// [`with_intrinsic_attribute()`]: Self::with_intrinsic_attribute
+    #[must_use]
     pub fn with_intrinsic_attribute_bool<N: AsRef<str>>(
         mut self,
         name: N,
@@ -1912,6 +1927,7 @@ impl Parser {
     ///
     /// [`with_intrinsic_attribute_bool()`]: Self::with_intrinsic_attribute_bool
     /// [`with_intrinsic_attribute_silent()`]: Self::with_intrinsic_attribute_silent
+    #[must_use]
     pub fn with_intrinsic_attribute_bool_silent<N: AsRef<str>>(
         mut self,
         name: N,
@@ -1962,6 +1978,7 @@ impl Parser {
     /// `:docdate:`) still wins over the computed default.
     ///
     /// [`with_input_mtime`]: Self::with_input_mtime
+    #[must_use]
     pub fn with_reference_time(mut self, reference_time: ReferenceTime) -> Self {
         self.reference_time = Some(reference_time);
         self
@@ -1980,6 +1997,7 @@ impl Parser {
     /// `:docdate:`) still wins over the computed default.
     ///
     /// [`with_reference_time`]: Self::with_reference_time
+    #[must_use]
     pub fn with_input_mtime(mut self, input_mtime: ReferenceTime) -> Self {
         self.input_mtime = Some(input_mtime);
         self
@@ -2047,6 +2065,7 @@ impl Parser {
     /// provided is suitable for HTML5 rendering. If you are targeting a
     /// different back-end rendering, you will need to provide your own
     /// implementation and set it using this call before parsing.
+    #[must_use]
     pub fn with_inline_substitution_renderer<ISR: InlineSubstitutionRenderer + 'static>(
         mut self,
         renderer: ISR,
@@ -2065,6 +2084,7 @@ impl Parser {
     ///
     /// [`parse()`]: Self::parse
     /// [`IncludeFileHandler::resolve_target()`]: crate::parser::IncludeFileHandler::resolve_target
+    #[must_use]
     pub fn with_primary_file_name<S: AsRef<str>>(mut self, name: S) -> Self {
         self.primary_file_name = Some(name.as_ref().to_owned());
         self
@@ -2077,6 +2097,7 @@ impl Parser {
     /// include directives will be ignored.
     ///
     /// [`IncludeFileHandler`]: crate::parser::IncludeFileHandler
+    #[must_use]
     pub fn with_include_file_handler<IFH: IncludeFileHandler + 'static>(
         mut self,
         handler: IFH,
@@ -2096,6 +2117,7 @@ impl Parser {
     /// [`DocinfoFileHandler`]: crate::parser::DocinfoFileHandler
     /// [docinfo files]: https://docs.asciidoctor.org/asciidoc/latest/docinfo/
     /// [`Document::docinfo`]: crate::Document::docinfo
+    #[must_use]
     pub fn with_docinfo_file_handler<DFH: DocinfoFileHandler + 'static>(
         mut self,
         handler: DFH,
@@ -2112,6 +2134,7 @@ impl Parser {
     /// images fall back to rendering their alt text.
     ///
     /// [`SvgFileHandler`]: crate::parser::SvgFileHandler
+    #[must_use]
     pub fn with_svg_file_handler<SFH: SvgFileHandler + 'static>(mut self, handler: SFH) -> Self {
         self.svg_file_handler = Some(Rc::new(handler));
         self
@@ -2127,6 +2150,7 @@ impl Parser {
     /// `data-uri` were not set.
     ///
     /// [`ImageFileHandler`]: crate::parser::ImageFileHandler
+    #[must_use]
     pub fn with_image_file_handler<IFH: ImageFileHandler + 'static>(
         mut self,
         handler: IFH,
@@ -2142,6 +2166,7 @@ impl Parser {
     /// catalog and can be retrieved afterward via
     /// [`Catalog::images`](crate::document::Catalog::images). The default is
     /// disabled, in which case no image references are recorded.
+    #[must_use]
     pub fn with_catalog_assets(mut self, catalog_assets: bool) -> Self {
         self.catalog_assets = catalog_assets;
         self
@@ -2154,6 +2179,7 @@ impl Parser {
     /// such as rendering an interactive SVG image as an `<object>` element.
     ///
     /// [`SafeMode`]: crate::SafeMode
+    #[must_use]
     pub fn with_safe_mode(mut self, safe: SafeMode) -> Self {
         self.safe = safe;
         self.apply_safe_mode_attributes();
@@ -2836,6 +2862,14 @@ mod tests {
         assert_eq!(p.attribute_value("foo"), InterpretedValue::Unset);
     }
 
+    #[test]
+    fn new_matches_default() {
+        // `Parser::new()` is a discoverability alias for `Parser::default()`.
+        let p = Parser::new();
+        assert_eq!(p.attribute_value("foo"), InterpretedValue::Unset);
+        assert_eq!(p.safe_mode(), Parser::default().safe_mode());
+    }
+
     mod attribute_state_between_parses {
         use crate::tests::prelude::*;
 
@@ -2845,7 +2879,7 @@ mod tests {
 
             // The first document defines `foo`; it is inspectable on the parser
             // once that parse returns.
-            parser.parse(":foo: bar\n\nText.\n");
+            let _ = parser.parse(":foo: bar\n\nText.\n");
             assert_eq!(
                 parser.attribute_value("foo"),
                 InterpretedValue::Value("bar")
@@ -2853,7 +2887,7 @@ mod tests {
 
             // A second document that never defines `foo` must not observe the
             // first document's assignment.
-            parser.parse("Text.\n");
+            let _ = parser.parse("Text.\n");
             assert_eq!(parser.attribute_value("foo"), InterpretedValue::Unset);
         }
 
@@ -2863,13 +2897,13 @@ mod tests {
 
             // A body (not header) assignment leaks the same way a header one
             // would if the baseline were not restored.
-            parser.parse("First.\n\n:mode: fast\n\nSecond.\n");
+            let _ = parser.parse("First.\n\n:mode: fast\n\nSecond.\n");
             assert_eq!(
                 parser.attribute_value("mode"),
                 InterpretedValue::Value("fast")
             );
 
-            parser.parse("Text.\n");
+            let _ = parser.parse("Text.\n");
             assert_eq!(parser.attribute_value("mode"), InterpretedValue::Unset);
         }
 
@@ -2882,7 +2916,7 @@ mod tests {
             );
 
             // The first document overrides the API-configured value in its body.
-            parser.parse(":site: dev\n\nText.\n");
+            let _ = parser.parse(":site: dev\n\nText.\n");
             assert_eq!(
                 parser.attribute_value("site"),
                 InterpretedValue::Value("dev")
@@ -2890,7 +2924,7 @@ mod tests {
 
             // The next parse begins from the configured baseline, not the
             // previous document's override.
-            parser.parse("Text.\n");
+            let _ = parser.parse("Text.\n");
             assert_eq!(
                 parser.attribute_value("site"),
                 InterpretedValue::Value("prod")
@@ -2901,14 +2935,14 @@ mod tests {
         fn reconfiguring_between_parses_updates_baseline() {
             let mut parser = Parser::default();
 
-            parser.parse("Text.\n");
+            let _ = parser.parse("Text.\n");
             assert_eq!(parser.attribute_value("env"), InterpretedValue::Unset);
 
             // A builder call between parses re-establishes the baseline for every
             // subsequent parse.
             parser = parser.with_intrinsic_attribute("env", "ci", ModificationContext::Anywhere);
 
-            parser.parse("Text.\n");
+            let _ = parser.parse("Text.\n");
             assert_eq!(parser.attribute_value("env"), InterpretedValue::Value("ci"));
         }
 
@@ -3617,7 +3651,7 @@ mod tests {
             }
         }
 
-        fn render_quoted_substitition(
+        fn render_quoted_substitution(
             &self,
             _type_: QuoteType,
             _scope: QuoteScope,
@@ -3795,7 +3829,7 @@ mod tests {
 
         fn parse_header(entries: &str) -> Parser {
             let mut parser = Parser::default();
-            parser.parse(&format!("= Title\n{entries}\n\nbody"));
+            let _ = parser.parse(&format!("= Title\n{entries}\n\nbody"));
             parser
         }
 
@@ -3852,7 +3886,7 @@ mod tests {
             // A body attribute entry links the partner just as a header entry
             // does.
             let mut parser = Parser::default();
-            parser.parse("= Title\n\nintro\n\n:notitle:\n\nmore");
+            let _ = parser.parse("= Title\n\nintro\n\n:notitle:\n\nmore");
             assert_eq!(parser.attribute_value("notitle"), InterpretedValue::Set);
             assert!(!parser.has_attribute("showtitle"));
         }

--- a/parser/src/parser/reference_resolver.rs
+++ b/parser/src/parser/reference_resolver.rs
@@ -277,6 +277,26 @@ pub struct ResolutionContext<'a> {
     pub derived: Option<&'a DerivedReference>,
 }
 
+impl<'a> ResolutionContext<'a> {
+    /// Constructs a [`ResolutionContext`] from its parts.
+    ///
+    /// The crate itself builds these values internally; this constructor exists
+    /// so a downstream [`ReferenceResolver`] implementation can build its own
+    /// contexts in unit tests despite the type being `#[non_exhaustive]`.
+    #[must_use]
+    pub fn new(
+        target: &'a str,
+        provided_text: Option<&'a str>,
+        derived: Option<&'a DerivedReference>,
+    ) -> Self {
+        Self {
+            target,
+            provided_text,
+            derived,
+        }
+    }
+}
+
 /// Resolves cross-reference targets to their destinations.
 ///
 /// Implementations map a [`ResolutionContext`] to a [`ResolvedReference`], or
@@ -361,6 +381,22 @@ mod tests {
 
         assert_eq!(resolved.href, "#later");
         assert_eq!(resolved.text.as_deref(), Some("The Later Section"));
+    }
+
+    #[test]
+    fn new_builds_a_resolvable_context() {
+        // The `new` constructor is the seam a downstream `ReferenceResolver`
+        // uses to build its own contexts, since the type is `#[non_exhaustive]`.
+        let catalog = catalog_with("later", Some("The Later Section"), RefType::Section);
+        let resolver = CatalogResolver::new(&catalog);
+
+        let context = ResolutionContext::new("later", None, None);
+        assert_eq!(context.target, "later");
+        assert_eq!(context.provided_text, None);
+        assert!(context.derived.is_none());
+
+        let resolved = resolver.resolve(&context).unwrap();
+        assert_eq!(resolved.href, "#later");
     }
 
     #[test]

--- a/parser/src/tests/asciidoc_lang/attributes/attribute_entry_substitutions.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/attribute_entry_substitutions.rs
@@ -26,7 +26,7 @@ That means that any inline formatting in an attribute value isn't interpreted be
     );
 
     let mut parser = Parser::default();
-    parser.parse(":special_chars: <tag_this>\n:y: yes\n:answer: {y}\n:format: *bold*");
+    let _ = parser.parse(":special_chars: <tag_this>\n:y: yes\n:answer: {y}\n:format: *bold*");
 
     assert_eq!(
         parser
@@ -82,7 +82,7 @@ This might be useful if you're referencing the attribute in a place that depends
         );
 
         let mut parser = Parser::default();
-        parser.parse(":cols: pass:[.>2,.>4]");
+        let _ = parser.parse(":cols: pass:[.>2,.>4]");
 
         assert_eq!(
             parser.attribute_value("cols").as_maybe_str().unwrap(),

--- a/parser/src/tests/asciidoc_lang/attributes/boolean_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/boolean_attributes.rs
@@ -36,7 +36,7 @@ The attribute is now set and its behavior will be applied to the document.
     );
 
     let mut parser = Parser::default();
-    parser.parse(":name-of-a-boolean-attribute:");
+    let _ = parser.parse(":name-of-a-boolean-attribute:");
 
     assert_eq!(
         parser.attribute_value("name-of-a-boolean-attribute"),
@@ -63,7 +63,7 @@ When `sectanchors` is set, it xref:sections:title-links.adoc#anchor[activates an
     );
 
     let mut parser = Parser::default();
-    parser.parse("= Document Title\n:sectanchors:");
+    let _ = parser.parse("= Document Title\n:sectanchors:");
 
     assert_eq!(parser.attribute_value("sectanchors"), InterpretedValue::Set);
 }

--- a/parser/src/tests/asciidoc_lang/attributes/built_in_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/built_in_attributes.rs
@@ -42,7 +42,7 @@ In the example above, the default value of `auto` will be assigned to `toc` sinc
     );
 
     let mut parser = Parser::default();
-    parser.parse("= Title of Document\n:toc:");
+    let _ = parser.parse("= Title of Document\n:toc:");
 
     assert_eq!(
         parser.attribute_value("toc").as_maybe_str().unwrap(),
@@ -76,7 +76,7 @@ The value assigned to an attribute in the document header replaces the default v
     );
 
     let mut parser = Parser::default();
-    parser.parse("= Title of My Document\n:doctype: book");
+    let _ = parser.parse("= Title of My Document\n:doctype: book");
 
     assert_eq!(
         parser.attribute_value("doctype").as_maybe_str().unwrap(),
@@ -111,7 +111,7 @@ This explicit user-defined value replaces the default value (assuming the attrib
     );
 
     let mut parser = Parser::default();
-    parser.parse("= My Document\n:imagesdir: ./images\n:iconsdir: ./icons\n:stylesdir: ./styles\n:scriptsdir: ./js");
+    let _ = parser.parse("= My Document\n:imagesdir: ./images\n:iconsdir: ./icons\n:stylesdir: ./styles\n:scriptsdir: ./js");
 
     assert_eq!(
         parser.attribute_value("imagesdir").as_maybe_str().unwrap(),

--- a/parser/src/tests/asciidoc_lang/attributes/custom_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/custom_attributes.rs
@@ -182,7 +182,7 @@ A best practice is to only use lowercase letters in the name and avoid starting 
     #[test]
     fn may_contain_uppercase() {
         let mut parser = Parser::default();
-        parser.parse(":URL: /foo/bar");
+        let _ = parser.parse(":URL: /foo/bar");
 
         assert_eq!(parser.attribute_value("URL"), InterpretedValue::Unset);
 

--- a/parser/src/tests/asciidoc_lang/attributes/document_attributes_ref.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/document_attributes_ref.rs
@@ -1347,7 +1347,7 @@ fn relfilesuffix_tracks_outfilesuffix() {
     // Changing `outfilesuffix` (here, to a DocBook-style suffix) moves
     // `relfilesuffix` with it, rather than leaving it pinned at `.html`.
     let mut parser = Parser::default();
-    parser.parse("= Title\n:outfilesuffix: .xml\n");
+    let _ = parser.parse("= Title\n:outfilesuffix: .xml\n");
     assert_eq!(
         parser.attribute_value("outfilesuffix").as_maybe_str(),
         Some(".xml")
@@ -1359,7 +1359,7 @@ fn relfilesuffix_tracks_outfilesuffix() {
 
     // An explicit `relfilesuffix` wins and no longer tracks `outfilesuffix`.
     let mut parser = Parser::default();
-    parser.parse("= Title\n:outfilesuffix: .xml\n:relfilesuffix: .adoc\n");
+    let _ = parser.parse("= Title\n:outfilesuffix: .xml\n:relfilesuffix: .adoc\n");
     assert_eq!(
         parser.attribute_value("relfilesuffix").as_maybe_str(),
         Some(".adoc")
@@ -1385,7 +1385,7 @@ fn relfilesuffix_tracks_outfilesuffix() {
 #[test]
 fn relfilesuffix_tracks_outfilesuffix_counter_overlay() {
     let mut parser = Parser::default();
-    parser.parse("= Title\n\nSuffix is {counter:outfilesuffix}.\n");
+    let _ = parser.parse("= Title\n\nSuffix is {counter:outfilesuffix}.\n");
 
     // Resolving the counter overlays `outfilesuffix`: the counter increments its
     // last character, so `.html` becomes `.htmm`. An unset `relfilesuffix` must

--- a/parser/src/tests/asciidoc_lang/attributes/unset_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/unset_attributes.rs
@@ -47,7 +47,7 @@ Don't add a value to the entry.
             .with_intrinsic_attribute("name2", "name2", ModificationContext::Anywhere)
             .with_intrinsic_attribute("name3", "name3", ModificationContext::Anywhere);
 
-        parser.parse("= Title\n:!name1:\n:name2!:");
+        let _ = parser.parse("= Title\n:!name1:\n:name2!:");
 
         assert_eq!(parser.attribute_value("name1"), InterpretedValue::Unset);
 
@@ -83,7 +83,7 @@ When `sectids` is unset, the AsciiDoc processor will not generate IDs from secti
 
         let mut parser = Parser::default();
 
-        parser.parse("= Document Title\n:!sectids:");
+        let _ = parser.parse("= Document Title\n:!sectids:");
 
         assert_eq!(parser.attribute_value("sectids"), InterpretedValue::Unset);
     }
@@ -108,7 +108,7 @@ This is an attribute that is set and assigned a default value of `Example` autom
 
         let mut parser = Parser::default();
 
-        parser.parse("= Title\n:!example-caption:");
+        let _ = parser.parse("= Title\n:!example-caption:");
 
         assert_eq!(
             parser.attribute_value("example-caption"),

--- a/parser/src/tests/asciidoctor_rb/parser_test.rs
+++ b/parser/src/tests/asciidoctor_rb/parser_test.rs
@@ -343,7 +343,7 @@ fn store_accessible_attribute_on_document_with_value() {
     // `:foo:` entry.
     let mut parser =
         Parser::default().with_intrinsic_attribute("foo", "baz", ModificationContext::Anywhere);
-    parser.parse(":foo: bar");
+    let _ = parser.parse(":foo: bar");
     assert_eq!(
         parser.attribute_value("foo"),
         InterpretedValue::Value("bar")
@@ -377,7 +377,7 @@ fn store_accessible_attribute_on_document_with_value_that_contains_attribute_ref
     let mut parser = Parser::default()
         .with_intrinsic_attribute("foo", "baz", ModificationContext::Anywhere)
         .with_intrinsic_attribute("release", "ultramega", ModificationContext::Anywhere);
-    parser.parse(":foo: {release}");
+    let _ = parser.parse(":foo: {release}");
     assert_eq!(
         parser.attribute_value("foo"),
         InterpretedValue::Value("ultramega")
@@ -442,7 +442,7 @@ fn store_accessible_attribute_on_document_with_negated_value() {
     for input in [":foo!:", ":!foo:"] {
         let mut parser =
             Parser::default().with_intrinsic_attribute("foo", "baz", ModificationContext::Anywhere);
-        parser.parse(input);
+        let _ = parser.parse(input);
         assert_eq!(parser.attribute_value("foo"), InterpretedValue::Unset);
     }
 }
@@ -1143,7 +1143,7 @@ fn parse_name_with_more_than_3_parts_in_author_attribute() {
     // trailing parts in `lastname`, and repeated interior whitespace is
     // condensed (issue #758).
     let mut parser = Parser::default();
-    parser.parse(":author: Leroy  Harold  Scherer,  Jr.");
+    let _ = parser.parse(":author: Leroy  Harold  Scherer,  Jr.");
 
     assert_eq!(
         parser.attribute_value("author"),
@@ -1183,7 +1183,7 @@ fn use_explicit_authorinitials_if_set_after_implicit_author_line() {
     // This crate recognizes an author line only when a document title is
     // present, so the input is given a synthetic title.
     let mut parser = Parser::default();
-    parser.parse("= Document Title\nJean-Claude Van Damme\n:authorinitials: JCVD");
+    let _ = parser.parse("= Document Title\nJean-Claude Van Damme\n:authorinitials: JCVD");
     assert_eq!(
         parser.attribute_value("authorinitials"),
         InterpretedValue::Value("JCVD")
@@ -1208,7 +1208,7 @@ fn use_explicit_authorinitials_if_set_after_author_attribute() {
     );
 
     let mut parser = Parser::default();
-    parser.parse("= Document Title\n:author: Jean-Claude Van Damme\n:authorinitials: JCVD");
+    let _ = parser.parse("= Document Title\n:author: Jean-Claude Van Damme\n:authorinitials: JCVD");
     assert_eq!(
         parser.attribute_value("authorinitials"),
         InterpretedValue::Value("JCVD")
@@ -1324,7 +1324,7 @@ fn allows_authors_to_be_overridden_using_explicit_author_attributes() {
     // `author` rather than `author_1`, and does not derive `authorcount` /
     // `authors`.)
     let mut parser = Parser::default();
-    parser.parse(
+    let _ = parser.parse(
         "= Document Title\nKismet Chameleon; Johnny Bravo; Lazarus het_Draeke\n:author_2: Danger Mouse",
     );
     assert_eq!(
@@ -1684,7 +1684,7 @@ fn skip_line_comments_before_author() {
     // Line comments preceding the author line are skipped (synthetic title
     // added so the author line is recognized).
     let mut parser = Parser::default();
-    parser.parse("= Document Title\n// Asciidoctor\n// release artist\nRyan Waldron");
+    let _ = parser.parse("= Document Title\n// Asciidoctor\n// release artist\nRyan Waldron");
     assert_eq!(
         parser.attribute_value("author"),
         InterpretedValue::Value("Ryan Waldron")
@@ -1730,7 +1730,7 @@ fn skip_block_comment_before_author() {
     // A `////` block comment preceding the author line is skipped in its
     // entirety (synthetic title added so the author line is recognized).
     let mut parser = Parser::default();
-    parser.parse("= Document Title\n////\nAsciidoctor\nrelease artist\n////\nRyan Waldron");
+    let _ = parser.parse("= Document Title\n////\nAsciidoctor\nrelease artist\n////\nRyan Waldron");
     assert_eq!(
         parser.attribute_value("author"),
         InterpretedValue::Value("Ryan Waldron")
@@ -1817,7 +1817,7 @@ fn break_header_at_line_with_three_forward_slashes() {
     // A `///` line breaks the header; the author and revision number before it
     // are captured (synthetic title added).
     let mut parser = Parser::default();
-    parser.parse("= Document Title\nJoe Cool\nv1.0\n///\nstuff");
+    let _ = parser.parse("= Document Title\nJoe Cool\nv1.0\n///\nstuff");
     assert_eq!(
         parser.attribute_value("author"),
         InterpretedValue::Value("Joe Cool")


### PR DESCRIPTION
Closes #897.

Settles several pre-1.0 public-API commitments flagged in the adversarial review. Each is a stable-API commitment that would become a breaking change to fix after the 1.0 freeze, so they are settled now.

## Changes

**1. Method-name typo**
- Rename the misspelled trait method `InlineSubstitutionRenderer::render_quoted_substitition` → `render_quoted_substitution` (and all call sites / the HTML impl).

**2. Provisional render params**
- Remove the single-variant `LinkRenderType` enum (marked `// TEMPORARY`) and the `LinkRenderParams::type_` field it backed. The field carried no information, so per the issue discussion it is dropped from the public surface rather than frozen; a future link-type distinction can be re-introduced deliberately.
- Change `LinkRenderParams::window` from `Option<&'static str>` to `Option<&'a str>`, matching `XrefRenderParams::window` and removing the odd `'static` bound from a per-render value. The only value ever passed is the `"_blank"` literal, so this is a pure type-signature change.

**3. Extensibility / testability**
- Add `#[must_use]` to `Parser::parse`, `Parser::parse_deferred`, and every `with_*` builder.
- Add `ResolutionContext::new(...)`, a public constructor so a downstream `ReferenceResolver` implementation can build contexts in its own unit tests despite the type being `#[non_exhaustive]`.
- Add `Parser::new()` as a discoverability alias for `Parser::default()`.

### Out of scope
- The `PathResolver`-as-trait item is explicitly deferred to its own issue and is not touched here.
- `Parser::builder()` was considered but omitted (the `with_*` chain from `Parser::new()`/`default()` already serves as the builder entry point).

## Breaking changes
- `render_quoted_substitition` → `render_quoted_substitution` (trait method — every implementor must update).
- `LinkRenderType` and `LinkRenderParams::type_` removed.
- `LinkRenderParams::window` type changed to `Option<&'a str>`.

## Testing
- `cargo test --workspace`: 4408 passed, 0 failed (adds 2 tests: `Parser::new` parity and `ResolutionContext::new`).
- `cargo clippy --workspace --all-targets`: clean.
- `cargo +nightly fmt --all -- --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)