### PR TITLE
fix: Enforce SourceMap append ordering with a debug assertion (close #903)

### DIFF
--- a/parser/src/parser/source_map.rs
+++ b/parser/src/parser/source_map.rs
@@ -397,6 +397,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic(expected = "SourceMap::append called out of order")]
     fn append_out_of_order_panics_in_debug() {
         let mut sm = SourceMap::default();

--- a/parser/src/parser/source_map.rs
+++ b/parser/src/parser/source_map.rs
@@ -146,8 +146,19 @@ impl SourceMap {
     ) {
         let file = self.intern(file);
 
-        // IMPORTANT: These _should_ be added in increasing order of
-        // `output_line`, but this is not enforced.
+        // Segments must be appended in non-decreasing `output_line` order:
+        // `resolve` binary-searches `segments` by `output_line`, which silently
+        // returns garbage on an unsorted slice. Lock that invariant here so an
+        // out-of-order call site fails loudly in debug builds rather than
+        // corrupting every downstream origin lookup.
+        debug_assert!(
+            self.segments
+                .last()
+                .is_none_or(|last| output_line >= last.output_line),
+            "SourceMap::append called out of order: output_line {output_line} follows {}",
+            self.segments.last().map_or(0, |last| last.output_line),
+        );
+
         self.segments.push(Segment {
             output_line,
             file,
@@ -383,6 +394,26 @@ mod tests {
         assert_eq!(after.file, Some("inc.adoc"));
         assert_eq!(after.line, 5);
         assert_eq!(after.col, Some(2));
+    }
+
+    #[test]
+    #[should_panic(expected = "SourceMap::append called out of order")]
+    fn append_out_of_order_panics_in_debug() {
+        let mut sm = SourceMap::default();
+        append(&mut sm, 10, None, 1);
+
+        // An earlier `output_line` than the last segment breaks the ordering
+        // that `resolve`'s binary search relies on, so it must fail loudly.
+        append(&mut sm, 5, None, 1);
+    }
+
+    #[test]
+    fn append_equal_output_line_is_allowed() {
+        let mut sm = SourceMap::default();
+        append(&mut sm, 1, None, 1);
+
+        // Equal `output_line` keeps the slice sorted, so it is permitted.
+        sm.append(1, None, 1, Fidelity::Verbatim);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`SourceMap::resolve` (formerly `original_file_and_line`) binary-searches the `segments` vector by `output_line`, which requires the entries to be sorted. But `append` only documented that entries _should_ arrive in increasing order – "this is not enforced". A binary search over an unsorted slice returns garbage, so any future out-of-order `append` call site would silently corrupt every downstream source-location lookup with no error. See #903.

## Fix

Add a `debug_assert!` in `append` locking the non-decreasing `output_line` invariant that the binary search relies on. An out-of-order call now fails loudly in debug builds instead of returning wrong line mappings; release builds are unaffected.

Equal `output_line` values are permitted (they keep the slice sorted); only a strictly-earlier line trips the assertion.

## Testing

- New `append_out_of_order_panics_in_debug` (`#[should_panic]`) and `append_equal_output_line_is_allowed` unit tests.
- Full parser suite passes (4410 tests), confirming the assertion never fires during real parsing – the invariant holds in practice today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)