### PR TITLE
fix!: Make PathResolver a trait with a with_path_resolver builder (close #898)

### DIFF
--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use parser::DeferredWarning;
 pub use parser::Parser;
 
 mod path_resolver;
-pub use path_resolver::PathResolver;
+pub use path_resolver::{DefaultPathResolver, PathResolver};
 
 mod safe_mode;
 pub use safe_mode::SafeMode;

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -13,7 +13,7 @@ use crate::{
     blocks::{SectionNumber, SectionType},
     document::{Attribute, Catalog, InterpretedValue, RefType},
     parser::{
-        AllowableValue, AttributeValue, DatetimeContext, DocinfoFileHandler,
+        AllowableValue, AttributeValue, DatetimeContext, DefaultPathResolver, DocinfoFileHandler,
         HtmlSubstitutionRenderer, ImageFileHandler, IncludeFileHandler, InlineSubstitutionRenderer,
         ModificationContext, PathResolver, ReferenceTime, ResolvedAttributes, SafeMode, SourceLine,
         SourceMap, SvgFileHandler,
@@ -85,7 +85,11 @@ pub struct Parser {
 
     /// Specifies how to generate clean and secure paths relative to the parsing
     /// context.
-    pub path_resolver: PathResolver,
+    ///
+    /// Defaults to [`DefaultPathResolver`]; a host can substitute custom
+    /// path/URL rewriting via
+    /// [`with_path_resolver`](Self::with_path_resolver).
+    pub(crate) path_resolver: Rc<dyn PathResolver>,
 
     /// Handler for resolving include:: directives.
     pub(crate) include_file_handler: Option<Rc<dyn IncludeFileHandler>>,
@@ -533,7 +537,7 @@ impl Default for Parser {
             default_attribute_values: built_in_default_values(),
             renderer: Rc::new(HtmlSubstitutionRenderer {}),
             primary_file_name: None,
-            path_resolver: PathResolver::default(),
+            path_resolver: Rc::new(DefaultPathResolver::default()),
             include_file_handler: None,
             docinfo_file_handler: None,
             svg_file_handler: None,
@@ -2159,6 +2163,23 @@ impl Parser {
         self
     }
 
+    /// Sets the [`PathResolver`] for this parser.
+    ///
+    /// The path resolver turns an asset target (an image `src`, a stylesheet
+    /// href, and so on) into the clean, resolved path that appears in the
+    /// rendered output. The default is [`DefaultPathResolver`], which mirrors
+    /// Ruby Asciidoctor. A host that needs custom path or URL rewriting – a
+    /// virtual filesystem, a content root, URL slugs – can supply its own
+    /// implementation here.
+    ///
+    /// [`PathResolver`]: crate::parser::PathResolver
+    /// [`DefaultPathResolver`]: crate::parser::DefaultPathResolver
+    #[must_use]
+    pub fn with_path_resolver<PR: PathResolver + 'static>(mut self, path_resolver: PR) -> Self {
+        self.path_resolver = Rc::new(path_resolver);
+        self
+    }
+
     /// Enables or disables cataloging of referenced image assets.
     ///
     /// When enabled (Asciidoctor's `catalog_assets` API option), each image
@@ -3779,6 +3800,38 @@ mod tests {
         };
 
         assert_eq!(simple_block.content().rendered(), "test.[FOOTNOTE:missing]");
+    }
+
+    /// A custom [`PathResolver`](crate::parser::PathResolver) that rewrites
+    /// every asset target under a fixed content root, ignoring the start path.
+    /// Stands in for a host (Antora/Zola-style) that maps targets through a
+    /// virtual filesystem or URL scheme.
+    #[derive(Debug)]
+    struct CdnPathResolver;
+
+    impl crate::parser::PathResolver for CdnPathResolver {
+        fn web_path(&self, target: &str, _start: Option<&str>) -> String {
+            format!("https://cdn.example.com/{target}")
+        }
+    }
+
+    #[test]
+    fn with_path_resolver() {
+        let mut parser = Parser::default().with_path_resolver(CdnPathResolver);
+
+        // An inline image's `src` is resolved through the path resolver, so the
+        // custom resolver should rewrite it under the content root.
+        let doc = parser.parse("image:tiger.png[tiger]");
+
+        let block = doc.nested_blocks().next().unwrap();
+        let Block::Simple(simple_block) = block else {
+            panic!("Expected simple block, got: {block:?}");
+        };
+
+        assert_eq!(
+            simple_block.content().rendered(),
+            r#"<span class="image"><img src="https://cdn.example.com/tiger.png" alt="tiger"></span>"#
+        );
     }
 
     mod resolve_show_title {

--- a/parser/src/parser/path_resolver.rs
+++ b/parser/src/parser/path_resolver.rs
@@ -1,10 +1,49 @@
-use std::sync::LazyLock;
+use std::{fmt::Debug, sync::LazyLock};
 
 use regex::Regex;
 
 /// A `PathResolver` handles all operations for resolving, cleaning, and joining
-/// paths. This struct includes operations for handling both web paths (request
-/// URIs) and system paths.
+/// paths, covering both web paths (request URIs) and system paths.
+///
+/// The crate calls [`web_path`](Self::web_path) to turn an asset target (an
+/// image `src`, a stylesheet href, and so on) – optionally relative to a start
+/// path – into the clean, resolved path that appears in the rendered output.
+/// Clean paths are void of duplicate parent and current directory references in
+/// the path name.
+///
+/// This is one of the crate's extensibility seams, alongside
+/// [`IncludeFileHandler`], [`ImageFileHandler`], [`SvgFileHandler`],
+/// [`DocinfoFileHandler`], [`ReferenceResolver`], and
+/// [`InlineSubstitutionRenderer`]. A host that needs custom path or URL
+/// rewriting – a virtual filesystem, a content root, URL slugs (as an
+/// Antora- or Zola-style site generator might) – can supply its own
+/// implementation via [`Parser::with_path_resolver`]. The default
+/// implementation, [`DefaultPathResolver`], mirrors Ruby Asciidoctor's
+/// `PathResolver`.
+///
+/// [`IncludeFileHandler`]: crate::parser::IncludeFileHandler
+/// [`ImageFileHandler`]: crate::parser::ImageFileHandler
+/// [`SvgFileHandler`]: crate::parser::SvgFileHandler
+/// [`DocinfoFileHandler`]: crate::parser::DocinfoFileHandler
+/// [`ReferenceResolver`]: crate::parser::ReferenceResolver
+/// [`InlineSubstitutionRenderer`]: crate::parser::InlineSubstitutionRenderer
+/// [`Parser::with_path_resolver`]: crate::Parser::with_path_resolver
+pub trait PathResolver: Debug {
+    /// Resolve a web path from the target and start paths.
+    ///
+    /// The main function of this operation is to resolve any parent references
+    /// and remove any self references.
+    ///
+    /// The target is assumed to be a path, not a qualified URI. That check
+    /// should happen before this method is invoked.
+    ///
+    /// Returns a path that joins the target path with the start path with any
+    /// parent references resolved and self references removed.
+    fn web_path(&self, target: &str, start: Option<&str>) -> String;
+}
+
+/// The default [`PathResolver`] implementation, mirroring the Ruby Asciidoctor
+/// `PathResolver` class.
 ///
 /// The main emphasis of the struct is on creating clean and secure paths. Clean
 /// paths are void of duplicate parent and current directory references in the
@@ -21,7 +60,7 @@ use regex::Regex;
 /// Posix and Windows paths independent of the operating system on which it
 /// runs. This makes the class both deterministic and easier to test.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PathResolver {
+pub struct DefaultPathResolver {
     /// File separator to use for path operations. (Defaults to
     /// platform-appropriate separator.)
     pub file_separator: char,
@@ -36,7 +75,7 @@ pub struct PathResolver {
     // caller-supplied base over an implicit working directory.
 }
 
-impl Default for PathResolver {
+impl Default for DefaultPathResolver {
     fn default() -> Self {
         Self {
             file_separator: std::path::MAIN_SEPARATOR,
@@ -44,27 +83,8 @@ impl Default for PathResolver {
     }
 }
 
-impl PathResolver {
-    /// Normalize path by converting any backslashes to forward slashes.
-    pub fn posixify(&self, path: &str) -> String {
-        if self.file_separator == '\\' && path.contains('\\') {
-            path.replace('\\', "/")
-        } else {
-            path.to_string()
-        }
-    }
-
-    /// Resolve a web path from the target and start paths.
-    ///
-    /// The main function of this operation is to resolve any parent references
-    /// and remove any self references.
-    ///
-    /// The target is assumed to be a path, not a qualified URI. That check
-    /// should happen before this method is invoked.
-    ///
-    /// Returns a path that joins the target path with the start path with any
-    /// parent references resolved and self references removed.
-    pub fn web_path(&self, target: &str, start: Option<&str>) -> String {
+impl PathResolver for DefaultPathResolver {
+    fn web_path(&self, target: &str, start: Option<&str>) -> String {
         let mut target = self.posixify(target);
         let start = start.map(|start| self.posixify(start));
 
@@ -119,6 +139,17 @@ impl PathResolver {
             "{uri_prefix}{resolved_path}",
             uri_prefix = uri_prefix.unwrap_or_default()
         )
+    }
+}
+
+impl DefaultPathResolver {
+    /// Normalize path by converting any backslashes to forward slashes.
+    pub fn posixify(&self, path: &str) -> String {
+        if self.file_separator == '\\' && path.contains('\\') {
+            path.replace('\\', "/")
+        } else {
+            path.to_string()
+        }
     }
 
     /// Partition the path into path segments and remove self references (`.`)
@@ -302,14 +333,14 @@ pub(crate) struct WebPath(pub(crate) bool);
 mod tests {
     #![allow(clippy::unwrap_used)]
 
-    use crate::parser::PathResolver;
+    use crate::parser::DefaultPathResolver;
 
     mod posixify {
-        use crate::parser::PathResolver;
+        use crate::parser::DefaultPathResolver;
 
         #[test]
         fn replaces_backslashes_if_windowsish() {
-            let pr = PathResolver {
+            let pr = DefaultPathResolver {
                 file_separator: '\\',
             };
 
@@ -318,7 +349,7 @@ mod tests {
 
         #[test]
         fn doesnt_replace_backslashes_if_posixish() {
-            let pr = PathResolver {
+            let pr = DefaultPathResolver {
                 file_separator: '/',
             };
 
@@ -327,7 +358,7 @@ mod tests {
 
         #[test]
         fn doesnt_replace_backslashes_if_none_exist() {
-            let pr = PathResolver {
+            let pr = DefaultPathResolver {
                 file_separator: '\\',
             };
 
@@ -336,11 +367,11 @@ mod tests {
     }
 
     mod web_path {
-        use crate::parser::PathResolver;
+        use crate::parser::{DefaultPathResolver, PathResolver};
 
         #[test]
         fn test_cases_from_asciidoctor_rb() {
-            let pr = PathResolver::default();
+            let pr = DefaultPathResolver::default();
 
             assert_eq!(pr.web_path("images", None), "images");
             assert_eq!(pr.web_path("./images", None), "./images");
@@ -513,7 +544,7 @@ mod tests {
             // to `/`. This guards the trailing-empty-segment stripping in
             // `partition_path` against regressing to a one-shot pop (which would
             // leave `//`, `///`, etc.).
-            let pr = PathResolver::default();
+            let pr = DefaultPathResolver::default();
 
             assert_eq!(pr.web_path("/", None), "/");
             assert_eq!(pr.web_path("//", None), "/");
@@ -525,7 +556,7 @@ mod tests {
 
     #[test]
     fn is_web_root() {
-        let pr = PathResolver::default();
+        let pr = DefaultPathResolver::default();
         assert!(pr.is_web_root("/blah"));
         assert!(!pr.is_web_root(""));
         assert!(!pr.is_web_root("./blah"));
@@ -533,7 +564,7 @@ mod tests {
 
     mod partition_path {
         use super::super::WebPath;
-        use crate::parser::PathResolver;
+        use crate::parser::DefaultPathResolver;
 
         fn seg(items: &[&str]) -> Vec<String> {
             items.iter().map(|s| (*s).to_owned()).collect()
@@ -541,7 +572,7 @@ mod tests {
 
         #[test]
         fn relative_system_path() {
-            let pr = PathResolver::default();
+            let pr = DefaultPathResolver::default();
             assert_eq!(
                 pr.partition_path("sample/path", WebPath(false)),
                 (seg(&["sample", "path"]), None)
@@ -550,7 +581,7 @@ mod tests {
 
         #[test]
         fn dot_slash_system_path() {
-            let pr = PathResolver::default();
+            let pr = DefaultPathResolver::default();
             assert_eq!(
                 pr.partition_path("./sample/path", WebPath(false)),
                 (seg(&["sample", "path"]), Some("./".to_owned()))
@@ -559,7 +590,7 @@ mod tests {
 
         #[test]
         fn self_references_are_removed() {
-            let pr = PathResolver::default();
+            let pr = DefaultPathResolver::default();
             assert_eq!(
                 pr.partition_path("sample/./path", WebPath(false)),
                 (seg(&["sample", "path"]), None)
@@ -568,7 +599,7 @@ mod tests {
 
         #[test]
         fn absolute_system_path() {
-            let pr = PathResolver::default();
+            let pr = DefaultPathResolver::default();
             assert_eq!(
                 pr.partition_path("/sample/path", WebPath(false)),
                 (seg(&["sample", "path"]), Some("/".to_owned()))
@@ -577,7 +608,7 @@ mod tests {
 
         #[test]
         fn unc_path() {
-            let pr = PathResolver::default();
+            let pr = DefaultPathResolver::default();
             assert_eq!(
                 pr.partition_path("//server/share/path", WebPath(false)),
                 (seg(&["server", "share", "path"]), Some("//".to_owned()))
@@ -586,7 +617,7 @@ mod tests {
 
         #[test]
         fn uri_classloader_rooted() {
-            let pr = PathResolver::default();
+            let pr = DefaultPathResolver::default();
             assert_eq!(
                 pr.partition_path("uri:classloader:/sample/path", WebPath(false)),
                 (
@@ -598,7 +629,7 @@ mod tests {
 
         #[test]
         fn uri_classloader_relative() {
-            let pr = PathResolver::default();
+            let pr = DefaultPathResolver::default();
             assert_eq!(
                 pr.partition_path("uri:classloader:sample/path", WebPath(false)),
                 (
@@ -610,7 +641,7 @@ mod tests {
 
         #[test]
         fn windows_drive_letter() {
-            let pr = PathResolver {
+            let pr = DefaultPathResolver {
                 file_separator: '\\',
             };
 
@@ -622,7 +653,7 @@ mod tests {
 
         #[test]
         fn windows_drive_letter_forward_slashes() {
-            let pr = PathResolver {
+            let pr = DefaultPathResolver {
                 file_separator: '\\',
             };
 
@@ -637,7 +668,7 @@ mod tests {
             // Without a Windows-style separator, a drive-letter prefix is not
             // treated as a root. (Constructed explicitly rather than via
             // `default()`, whose separator is platform-dependent.)
-            let pr = PathResolver {
+            let pr = DefaultPathResolver {
                 file_separator: '/',
             };
 

--- a/parser/src/tests/asciidoctor_rb/paths_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paths_test.rs
@@ -59,7 +59,10 @@
 //! [`PathResolver`](crate::parser::PathResolver)). The whole context is
 //! therefore `non_normative!`.
 
-use crate::{parser::PathResolver, tests::sdd::*};
+use crate::{
+    parser::{DefaultPathResolver, PathResolver},
+    tests::sdd::*,
+};
 
 track_file!("ref/asciidoctor/test/paths_test.rb");
 
@@ -90,7 +93,7 @@ fn target_with_absolute_path() {
 "#
     );
 
-    let resolver = PathResolver::default();
+    let resolver = DefaultPathResolver::default();
 
     assert_eq!(resolver.web_path("/images", None), "/images");
     assert_eq!(resolver.web_path("/images", Some("")), "/images");
@@ -110,7 +113,7 @@ fn target_with_relative_path() {
 "#
     );
 
-    let resolver = PathResolver::default();
+    let resolver = DefaultPathResolver::default();
 
     assert_eq!(resolver.web_path("images", None), "images");
     assert_eq!(resolver.web_path("images", Some("")), "images");
@@ -130,7 +133,7 @@ fn target_with_hidden_relative_path() {
 "#
     );
 
-    let resolver = PathResolver::default();
+    let resolver = DefaultPathResolver::default();
 
     assert_eq!(resolver.web_path(".images", None), ".images");
     assert_eq!(resolver.web_path(".images", Some("")), ".images");
@@ -150,7 +153,7 @@ fn target_with_path_relative_to_current_directory() {
 "#
     );
 
-    let resolver = PathResolver::default();
+    let resolver = DefaultPathResolver::default();
 
     assert_eq!(resolver.web_path("./images", None), "./images");
     assert_eq!(resolver.web_path("./images", Some("")), "./images");
@@ -170,7 +173,7 @@ fn target_with_absolute_path_ignores_start_path() {
 "#
     );
 
-    let resolver = PathResolver::default();
+    let resolver = DefaultPathResolver::default();
 
     assert_eq!(resolver.web_path("/images", Some("foo")), "/images");
     assert_eq!(resolver.web_path("/images", Some("/foo")), "/images");
@@ -193,7 +196,7 @@ fn target_with_relative_path_appended_to_start_path() {
 "#
     );
 
-    let resolver = PathResolver::default();
+    let resolver = DefaultPathResolver::default();
 
     assert_eq!(resolver.web_path("images", Some("assets")), "assets/images");
     assert_eq!(
@@ -224,7 +227,7 @@ fn target_with_path_relative_to_current_directory_appended_to_start_path() {
 "#
     );
 
-    let resolver = PathResolver::default();
+    let resolver = DefaultPathResolver::default();
 
     assert_eq!(
         resolver.web_path("./images", Some("assets")),
@@ -251,7 +254,7 @@ fn target_with_relative_path_appended_to_url_start_path() {
 "#
     );
 
-    let resolver = PathResolver::default();
+    let resolver = DefaultPathResolver::default();
 
     assert_eq!(
         resolver.web_path("images", Some("http://www.example.com/assets")),
@@ -287,7 +290,7 @@ fn normalize_target() {
 "#
     );
 
-    let resolver = PathResolver::default();
+    let resolver = DefaultPathResolver::default();
 
     assert_eq!(resolver.web_path("../images/../images", None), "../images");
 }
@@ -304,7 +307,7 @@ fn append_target_to_start_path_and_normalize() {
 "#
     );
 
-    let resolver = PathResolver::default();
+    let resolver = DefaultPathResolver::default();
 
     assert_eq!(
         resolver.web_path("../images/../images", Some("../images")),
@@ -325,7 +328,7 @@ fn normalize_parent_directory_that_follows_root() {
 "#
     );
 
-    let resolver = PathResolver::default();
+    let resolver = DefaultPathResolver::default();
 
     assert_eq!(resolver.web_path("/../tiger.png", None), "/tiger.png");
     assert_eq!(resolver.web_path("/../../tiger.png", None), "/tiger.png");
@@ -343,7 +346,7 @@ fn uses_start_when_target_is_empty() {
 "#
     );
 
-    let resolver = PathResolver::default();
+    let resolver = DefaultPathResolver::default();
 
     assert_eq!(
         resolver.web_path("", Some("assets/images")),
@@ -374,7 +377,7 @@ fn posixifies_windows_paths() {
 "#
     );
 
-    let resolver = PathResolver {
+    let resolver = DefaultPathResolver {
         file_separator: '\\',
     };
 
@@ -398,7 +401,7 @@ fn url_encode_spaces_in_path() {
 "#
     );
 
-    let resolver = PathResolver::default();
+    let resolver = DefaultPathResolver::default();
 
     assert_eq!(
         resolver.web_path("lots of images", Some("assets and stuff")),


### PR DESCRIPTION
Closes #898.

## Problem

`PathResolver` was the one extensibility seam in the crate that couldn't be swapped. It was a concrete struct exposed as a `pub` by-value field on `Parser` (`pub path_resolver: PathResolver`). Only `file_separator` was tunable; the resolution logic was private, and the `pub` field also permitted direct live mutation — a wider API commitment than the `with_*` builder pattern used for every other configurable field.

Every other seam in the crate is an `Rc<dyn Trait>` (`IncludeFileHandler`, `ImageFileHandler`, `SvgFileHandler`, `DocinfoFileHandler`, `ReferenceResolver`, `InlineSubstitutionRenderer`). An Antora/Zola-style host that needs custom path/URL rewriting (virtual filesystems, content roots, URL slugs) had no way to override resolution behavior.

## Change

- **`PathResolver` is now a trait** carrying the single `web_path(target, start)` method the crate actually calls, matching the other handler seams (`Debug` supertrait, `Rc<dyn …>`).
- **The former struct is now `DefaultPathResolver`**, the default implementation (unchanged behavior; mirrors Ruby Asciidoctor). Its inherent helpers (`posixify`, `is_web_root`, etc.) are retained.
- **`Parser::path_resolver`** is now `pub(crate) Rc<dyn PathResolver>` instead of a `pub` field.
- **New `Parser::with_path_resolver(...)` builder** to configure it, consistent with `with_image_file_handler`, `with_svg_file_handler`, and the rest.

## Breaking changes

- `PathResolver` is a trait rather than a struct. Code constructing `PathResolver::default()` / `PathResolver { file_separator }` should use `DefaultPathResolver`.
- `Parser::path_resolver` is no longer a public field. Configure it via `with_path_resolver(...)`.

These fit the pre-1.0 public-API polish already underway (cf. #897/#929).

## Tests

- Existing `PathResolver`/`web_path` unit tests and the Asciidoctor `paths_test.rb` port were retargeted to `DefaultPathResolver` and pass unchanged (behavior is identical).
- Added a `with_path_resolver` test: a custom resolver rewrites an inline image's `src` under a content root, verifying the seam end-to-end through the render pipeline.
- `cargo test`, `cargo clippy --all-targets`, and `cargo +nightly fmt --all -- --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)