### PR TITLE
fix: Repair stale nested_blocks() call left by concurrent PR landing

### DIFF
--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -3823,7 +3823,7 @@ mod tests {
         // custom resolver should rewrite it under the content root.
         let doc = parser.parse("image:tiger.png[tiger]");
 
-        let block = doc.nested_blocks().next().unwrap();
+        let block = doc.child_blocks().next().unwrap();
         let Block::Simple(simple_block) = block else {
             panic!("Expected simple block, got: {block:?}");
         };


### PR DESCRIPTION
## Problem

`origin/main` currently does not compile. PRs #930 (`child_blocks` API, close #894) and #934 (PathResolver trait, close #898) landed concurrently without a rebase, leaving the `with_path_resolver` test in `parser/src/parser/parser.rs` calling the removed `Document::nested_blocks()`. There is no `nested_blocks` method anywhere in the crate anymore.

Repro on `main`:

```
cargo test -p asciidoc-parser --lib
# E0599: no method named `nested_blocks` found for struct Document
```

## Fix

Point the single stale call site at `child_blocks()`, matching the sibling call sites already migrated by #930.

## Verification

- `cargo test -p asciidoc-parser` — 4426 passed, 0 failed (plus doctests green)
- `cargo +nightly fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)