### PR TITLE
chore(deps): Bump criterion to 0.8.2 and codspeed-criterion-compat to 5.0.1

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -21,8 +21,8 @@ self_cell = "1.2.0"
 thiserror = "2.0.1"
 
 [dev-dependencies]
-codspeed-criterion-compat = "5.0.0"
-criterion = "0.8.0"
+codspeed-criterion-compat = "5.0.1"
+criterion = "0.8.2"
 pretty_assertions_sorted = "1.2.3"
 
 [[bench]]


### PR DESCRIPTION
Patch-level updates to the benchmark-harness dev-dependencies:

- `criterion` `0.8.0` → `0.8.2`
- `codspeed-criterion-compat` `5.0.0` → `5.0.1`

Both are within the existing caret ranges, so normal resolution already picked these patches; this raises the declared **floors** so the `-Z direct-minimal-versions` CI job also tracks the current patch releases.

Verified locally:
- `cargo check --benches` compiles against the bumped versions
- `cargo +nightly -Z direct-minimal-versions generate-lockfile` resolves cleanly

Split out from the serde PR (#937) per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)