### PR TITLE
chore: Remove stale allow(unused) after dead-code coverage review

### DIFF
--- a/parser/src/document/mod.rs
+++ b/parser/src/document/mod.rs
@@ -11,7 +11,6 @@ mod author_line;
 pub use author_line::{AuthorLine, Authors};
 
 mod catalog;
-#[allow(unused)] // TEMPORARY while building
 pub(crate) use catalog::DuplicateIdError;
 pub use catalog::{Catalog, Footnote, ImageReference, RefEntry, RefType};
 


### PR DESCRIPTION
## Summary

Reviewed the latest code-coverage results to look for removable dead code (issue #935).

**Finding: there is no dead code to remove.** Line coverage is **98.79%**, and the compiler's own `dead_code` lint is completely clean. The genuinely-uncovered *product* lines are all intentionally-live guardrails, not dead code:

- Defensive fallback branches (e.g. `return None` after an exhaustive if/else, malformed-placeholder handling)
- Assertion messages and a `debug_assert!(false, …)` invariant guard
- A `panic!` that fails a test loudly, and `Debug` impl arms
- The inline-anchor path documented as coverage-blocked pending refactor #461

The large uncovered clusters flagged locally (in `section.rs`, `parser.rs`, `strings.rs`) live inside `#[cfg(test)]` modules that CI strips via `scouten/uncover-tests`, so they don't represent real coverage gaps.

## Change

The one actionable cleanup: removed a stale `#[allow(unused)] // TEMPORARY while building` on the `DuplicateIdError` re-export in `parser/src/document/mod.rs`. That re-export is now used (`crate::document::DuplicateIdError` in the parser), so the attribute suppressed nothing — verified that removing it produces no warning.

Closes #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)