### PR TITLE
chore: Replace TEMPORARY markers with issue-linked TODOs

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -28,7 +28,7 @@ use crate::{
 /// This enum represents all of the block types that are understood directly by
 /// this parser and also implements the [`IsBlock`] trait.
 #[derive(Clone, Eq, Hash, PartialEq)]
-#[allow(clippy::large_enum_variant)] // TEMPORARY: review later
+#[allow(clippy::large_enum_variant)] // TODO: Reduce variant size or box the large variant (#947).
 #[non_exhaustive]
 pub enum Block<'src> {
     /// A block that’s treated as contiguous lines of paragraph text (and

--- a/parser/src/blocks/list.rs
+++ b/parser/src/blocks/list.rs
@@ -104,7 +104,8 @@ impl<'src> ListBlock<'src> {
                 }
             }
 
-            // TEMPORARY: Ignore block metadata for list items.
+            // TODO: Attach real block metadata to list items instead of
+            // ignoring it (#946).
             let list_item_metadata = BlockMetadata {
                 title_source: None,
                 title: None,

--- a/parser/src/document/mod.rs
+++ b/parser/src/document/mod.rs
@@ -11,7 +11,7 @@ mod author_line;
 pub use author_line::{AuthorLine, Authors};
 
 mod catalog;
-#[allow(unused)] // TEMPORARY while building
+#[allow(unused)] // TODO: Remove once `DuplicateIdError` is consumed (#949).
 pub(crate) use catalog::DuplicateIdError;
 pub use catalog::{Catalog, Footnote, ImageReference, RefEntry, RefType};
 

--- a/parser/src/span/primitives.rs
+++ b/parser/src/span/primitives.rs
@@ -13,6 +13,9 @@ impl<'src> Span<'src> {
     ///
     /// Please use more specific functions, such as `take_attr_name` or
     /// `take_user_attr_name`, when possible.
+    ///
+    /// TODO: Define identifier semantics from the AsciiDoc spec, or migrate the
+    /// remaining callers to the specific helpers and remove this (#948).
     pub(crate) fn take_ident(self) -> Option<MatchedItem<'src, Self>> {
         let mut chars = self.data.char_indices();
 

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -462,7 +462,7 @@ pub struct VirtualNode {
     pub children: Vec<VirtualNode>,
 }
 
-#[allow(dead_code)] // TEMPORARY while building
+#[allow(dead_code)] // TODO: Remove once these helpers are used (#949).
 impl VirtualNode {
     /// Creates a new virtual node with the specified tag.
     pub fn new(tag: impl Into<String>) -> Self {

--- a/parser/src/tests/fixtures/blocks/list_item_marker.rs
+++ b/parser/src/tests/fixtures/blocks/list_item_marker.rs
@@ -6,10 +6,10 @@ use crate::tests::fixtures::{content::Content, span::Span};
 pub(crate) enum ListItemMarker {
     Hyphen(Span),
     Asterisks(Span),
-    #[allow(unused)] // TEMPORARY while building
+    #[allow(unused)] // TODO: Remove once this variant is used (#949).
     Bullet(Span),
     Dots(Span),
-    #[allow(unused)] // TEMPORARY while building
+    #[allow(unused)] // TODO: Remove once this variant is used (#949).
     AlphaListCapital(Span),
     AlphaListLower(Span),
     RomanNumeralLower(Span),
@@ -17,7 +17,7 @@ pub(crate) enum ListItemMarker {
     ArabicNumeral(Span),
     Callout(Span),
 
-    #[allow(unused)] // TEMPORARY while building
+    #[allow(unused)] // TODO: Remove once this variant is used (#949).
     DefinedTerm {
         term: Content,
         marker: Span,


### PR DESCRIPTION
Audits the code base for `TEMPORARY` / "while building" markers (excluding anything vendored in `ref` and tests that quote `ref` content) and converts the genuine ones into TODO comments that link to tracking issues. Closes #939.

## Markers converted

| Location | New TODO | Issue |
|---|---|---|
| `parser/src/blocks/list.rs` | Attach real block metadata to list items instead of ignoring it | #946 |
| `parser/src/blocks/block.rs` | Reduce variant size or box the large variant | #947 |
| `parser/src/span/primitives.rs` | Define identifier semantics from the spec, or migrate callers and remove `take_ident` | #948 |
| `parser/src/document/mod.rs` | Remove once `DuplicateIdError` is consumed | #949 |
| `parser/src/tests/fixtures/blocks/list_item_marker.rs` (×3) | Remove once each variant is used | #949 |
| `parser/src/tests/assert_dom/virtual_dom.rs` | Remove once these helpers are used | #949 |

## Deliberately not touched

- Domain concepts named "placeholder" (xref / passthrough / footnote machinery) — permanent architecture, not stopgaps.
- The "temporary parser" in `section.rs` — a legitimately short-lived look-ahead parser, not incomplete code.
- `FIXME` / "for now" text inside `asciidoctor_rb/` and `asciidoc_lang/` — those quote upstream Asciidoctor Ruby / AsciiDoc language sources.

## Verification

- `cargo +nightly fmt --all -- --check` — clean.
- `cargo build -p asciidoc-parser` — compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)