### PR TITLE
chore: Drop stale allow(clippy::large_enum_variant) on Block (close #947)

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -28,7 +28,6 @@ use crate::{
 /// This enum represents all of the block types that are understood directly by
 /// this parser and also implements the [`IsBlock`] trait.
 #[derive(Clone, Eq, Hash, PartialEq)]
-#[allow(clippy::large_enum_variant)] // TODO: Reduce variant size or box the large variant (#947).
 #[non_exhaustive]
 pub enum Block<'src> {
     /// A block that’s treated as contiguous lines of paragraph text (and


### PR DESCRIPTION
Part of the #939 TEMPORARY-marker audit; closes #947.

## What

Removes the `#[allow(clippy::large_enum_variant)]` from the `Block` enum in `parser/src/blocks/block.rs`.

## Why it's now dead

The enum's variants have converged in size as the parser evolved. Measured inner-type sizes:

| variant | bytes |  | variant | bytes |
|---|---|---|---|---|
| Section | 568 | | Admonition | 480 |
| Media | 536 | | Table | 480 |
| RawDelimited | 520 | | Simple | 472 |
| Quote | 512 | | CompoundDelimited | 424 |
| ListItem | 408 | | List | 368 |
| Break | 304 | | DocumentAttribute | 144 |
| Preamble | 64 | | | |

`large_enum_variant` fires when the largest variant exceeds the second-largest by clippy's default 200-byte threshold. Here the gap is `Section` − `Media` = **32 bytes**, so the lint no longer triggers. The `#[allow]` was carried forward unexamined since the workspace reorg (#173) and #950 only swapped its marker text; it suppressed nothing and would have masked a future genuine regression.

## Why not box

Every variant sits in the 300–568 byte range with no single outlier to box. Shrinking `Block` meaningfully would require boxing nearly all variants, adding allocations and pointer-chasing on the hot parse path — the same tradeoff already documented against on `BlockParseOutcome` ("boxing it would just trade the size for an allocation").

## Verification

- `cargo clippy --all-features --all-targets -- -Dwarnings` (the CI invocation) — clean, no `large_enum_variant`.
- `cargo test -p asciidoc-parser` — 4436 passed.
- `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)