### PR TITLE
chore: Remove consumed 'while building' scaffolding allows (#949)

### DIFF
--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -462,7 +462,6 @@ pub struct VirtualNode {
     pub children: Vec<VirtualNode>,
 }
 
-#[allow(dead_code)] // TODO: Remove once these helpers are used (#949).
 impl VirtualNode {
     /// Creates a new virtual node with the specified tag.
     pub fn new(tag: impl Into<String>) -> Self {

--- a/parser/src/tests/fixtures/blocks/list_item_marker.rs
+++ b/parser/src/tests/fixtures/blocks/list_item_marker.rs
@@ -6,18 +6,13 @@ use crate::tests::fixtures::{content::Content, span::Span};
 pub(crate) enum ListItemMarker {
     Hyphen(Span),
     Asterisks(Span),
-    #[allow(unused)] // TODO: Remove once this variant is used (#949).
-    Bullet(Span),
     Dots(Span),
-    #[allow(unused)] // TODO: Remove once this variant is used (#949).
-    AlphaListCapital(Span),
     AlphaListLower(Span),
     RomanNumeralLower(Span),
     RomanNumeralUpper(Span),
     ArabicNumeral(Span),
     Callout(Span),
 
-    #[allow(unused)] // TODO: Remove once this variant is used (#949).
     DefinedTerm {
         term: Content,
         marker: Span,
@@ -30,13 +25,7 @@ impl fmt::Debug for ListItemMarker {
         match self {
             Self::Hyphen(x) => f.debug_tuple("ListItemMarker::Hyphen").field(x).finish(),
             Self::Asterisks(x) => f.debug_tuple("ListItemMarker::Asterisks").field(x).finish(),
-            Self::Bullet(x) => f.debug_tuple("ListItemMarker::Bullet").field(x).finish(),
             Self::Dots(x) => f.debug_tuple("ListItemMarker::Dots").field(x).finish(),
-
-            Self::AlphaListCapital(x) => f
-                .debug_tuple("ListItemMarker::AlphaListCapital")
-                .field(x)
-                .finish(),
 
             Self::AlphaListLower(x) => f
                 .debug_tuple("ListItemMarker::AlphaListLower")
@@ -103,20 +92,8 @@ fn fixture_eq_observed(
             _ => false,
         },
 
-        ListItemMarker::Bullet(fixture_span) => match observed {
-            crate::blocks::ListItemMarker::Bullet(observed_span) => fixture_span == observed_span,
-            _ => false,
-        },
-
         ListItemMarker::Dots(fixture_span) => match observed {
             crate::blocks::ListItemMarker::Dots(observed_span) => fixture_span == observed_span,
-            _ => false,
-        },
-
-        ListItemMarker::AlphaListCapital(fixture_span) => match observed {
-            crate::blocks::ListItemMarker::AlphaListCapital(observed_span) => {
-                fixture_span == observed_span
-            }
             _ => false,
         },
 


### PR DESCRIPTION
Part of the #939 TEMPORARY-marker audit. Removes the `#[allow(...)]` attributes that were guarding test scaffolding "while building" now that the underlying items are (mostly) consumed.

## Changes

- **`assert_dom/virtual_dom.rs`** — the `VirtualNode` builder helpers (`new`, `with_class`, `with_html_content`, `with_children`, etc.) are now used throughout the DOM assertion machinery. The blanket `#[allow(dead_code)]` on the `impl VirtualNode` block is removed; the compiler confirms every method is live.
- **`fixtures/blocks/list_item_marker.rs`**:
  - `DefinedTerm` fixture variant is now exercised by the description/qanda list tests → its `#[allow(unused)]` is removed.
  - `Bullet` and `AlphaListCapital` fixture variants are still constructed nowhere. Per the audit's guidance ("remove the item, if it stays unused"), they are removed along with their `Debug` and `fixture_eq_observed` arms, rather than left behind an allow. They can be reintroduced when a test first needs to assert against those markers.

## Verification

- `cargo check --tests -p asciidoc-parser` clean under `#[deny(warnings)]` (this is what surfaced that `Bullet`/`AlphaListCapital` were the only genuinely-unused items).
- `cargo test -p asciidoc-parser` — 4436 passed, 0 failed.
- `cargo +nightly fmt --all -- --check` clean.

Closes #949.

🤖 Generated with [Claude Code](https://claude.com/claude-code)