### PR TITLE
fix: Drop an all-comment paragraph instead of emitting an empty block

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -131,10 +131,12 @@ pub(crate) enum BlockParseOutcome<'src> {
     /// A block was parsed.
     Parsed(MatchedItem<'src, Block<'src>>),
 
-    /// The input was recognized as a block macro but dropped at parse time
-    /// because its target referenced a missing attribute under
-    /// `attribute-missing=drop-line`. The contained span is where parsing
-    /// should resume (the dropped block's `after`).
+    /// The input was recognized as a block but deliberately discarded at parse
+    /// time, contributing no block to the tree. This covers a block macro whose
+    /// target referenced a missing attribute under
+    /// `attribute-missing=drop-line` as well as an all-comment paragraph
+    /// (issue #956). The contained span is where parsing should resume (the
+    /// dropped block's `after`).
     Dropped(Span<'src>),
 
     /// No block matched. This happens only for empty or all-blank input.
@@ -646,6 +648,23 @@ impl<'src> Block<'src> {
                 }
             }
         };
+
+        // A paragraph that is nothing but line comments (e.g. a lone `// ...`
+        // line offset by blank lines) carries no content. Asciidoctor discards
+        // such a block entirely rather than emitting an empty paragraph, so drop
+        // it here rather than surface a spurious empty block (issue #956). Only a
+        // bare, unstyled paragraph is dropped: a title, anchor, or attribute list
+        // (including `[comment]`) keeps the block, and `Dropped` advances parsing
+        // past the comment so the collection loop does not spin.
+        if let Some(ref mi) = simple_block_mi
+            && metadata.is_empty()
+            && mi.item.is_line_comment_only()
+        {
+            return MatchAndWarnings {
+                item: BlockParseOutcome::Dropped(mi.after),
+                warnings,
+            };
+        }
 
         let mut result = MatchAndWarnings {
             item: match simple_block_mi {

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -275,6 +275,39 @@ impl<'src> SimpleBlock<'src> {
     pub fn style(&self) -> SimpleBlockStyle {
         self.style
     }
+
+    /// Reports whether this block is nothing but AsciiDoc line comments (`//`,
+    /// but not a `///`+ delimiter), i.e. an all-comment paragraph that carries
+    /// no content.
+    ///
+    /// Asciidoctor discards such a paragraph entirely rather than emitting an
+    /// empty block, so the block dispatch drops it (issue #956). Only an
+    /// unstyled paragraph qualifies: a `[comment]`, literal, listing, or source
+    /// block retains its `//` lines as content, so its content is non-empty and
+    /// this returns `false`.
+    pub(crate) fn is_line_comment_only(&self) -> bool {
+        if self.style != SimpleBlockStyle::Paragraph || !self.content.is_empty() {
+            return false;
+        }
+
+        // Every non-empty line of the block's source must be a line comment.
+        // The same `//` / `///` test used to strip comment lines in
+        // `parse_lines` is applied here so the two stay in lockstep.
+        let mut next = self.source;
+        let mut saw_line = false;
+
+        while let Some(line_mi) = next.take_non_empty_line() {
+            let line = line_mi.item;
+            if !line.starts_with("//") || line.starts_with("///") {
+                return false;
+            }
+
+            saw_line = true;
+            next = line_mi.after;
+        }
+
+        saw_line
+    }
 }
 
 /// Parse the content-bearing lines for this block.

--- a/parser/src/blocks/tests/simple.rs
+++ b/parser/src/blocks/tests/simple.rs
@@ -1356,3 +1356,44 @@ fn comment_then_hashes_without_space_does_not_terminate_paragraph() {
         }
     );
 }
+
+// A paragraph consisting solely of line comments carries no content, so it is
+// discarded rather than emitted as an empty block (issue #956). These tests pin
+// that a lone `// ...` line drops entirely at the block and document levels.
+
+#[test]
+fn lone_line_comment_is_dropped() {
+    // A bare comment paragraph parses to no block: `Block::parse` flattens the
+    // dropped outcome to `None`, and no `MissingBlockAfterTitleOrAttributeList`
+    // warning fires because there is no metadata attached.
+    let mut parser = Parser::default();
+
+    let maw = crate::blocks::Block::parse(crate::Span::new("// line comment\n"), &mut parser);
+
+    assert!(maw.item.is_none());
+    assert!(maw.warnings.is_empty());
+}
+
+#[test]
+fn line_comment_between_paragraphs_yields_two_blocks() {
+    // The repro from issue #956: a lone line comment offset by blank lines
+    // between two paragraphs must not surface as a spurious empty paragraph.
+    let doc = Parser::default().parse("first paragraph\n\n// line comment\n\nsecond paragraph\n");
+
+    let blocks: Vec<_> = doc.child_blocks().collect();
+    assert_eq!(blocks.len(), 2);
+
+    assert_eq!(
+        rendered_paragraphs(&doc),
+        &["first paragraph", "second paragraph"]
+    );
+}
+
+#[test]
+fn multi_line_all_comment_paragraph_is_dropped() {
+    // Every line of the paragraph is a comment, so the whole block is dropped
+    // and the surrounding paragraphs remain adjacent.
+    let doc = Parser::default().parse("before\n\n// one\n// two\n\nafter\n");
+
+    assert_eq!(rendered_paragraphs(&doc), &["before", "after"]);
+}

--- a/parser/src/tests/asciidoc_lang/lists/separating.rs
+++ b/parser/src/tests/asciidoc_lang/lists/separating.rs
@@ -163,31 +163,6 @@ This technique works for separating any type of list.
                     anchor_reftext: None,
                     attrlist: None,
                 },),
-                Block::Simple(SimpleBlock {
-                    content: Content {
-                        original: Span {
-                            data: "//-",
-                            line: 4,
-                            col: 1,
-                            offset: 20,
-                        },
-                        rendered: "",
-                    },
-                    source: Span {
-                        data: "//-",
-                        line: 4,
-                        col: 1,
-                        offset: 20,
-                    },
-                    style: SimpleBlockStyle::Paragraph,
-                    title_source: None,
-                    title: None,
-                    caption: None,
-                    number: None,
-                    anchor: None,
-                    anchor_reftext: None,
-                    attrlist: None,
-                },),
                 Block::List(ListBlock {
                     type_: ListType::Unordered,
                     items: &[

--- a/parser/src/tests/asciidoc_lang/lists/unordered.rs
+++ b/parser/src/tests/asciidoc_lang/lists/unordered.rs
@@ -772,31 +772,6 @@ See xref:separating.adoc[] for more details.
                         anchor_reftext: None,
                         attrlist: None,
                     },),
-                    Block::Simple(SimpleBlock {
-                        content: Content {
-                            original: Span {
-                                data: "//-",
-                                line: 4,
-                                col: 1,
-                                offset: 20,
-                            },
-                            rendered: "",
-                        },
-                        source: Span {
-                            data: "//-",
-                            line: 4,
-                            col: 1,
-                            offset: 20,
-                        },
-                        style: SimpleBlockStyle::Paragraph,
-                        title_source: None,
-                        title: None,
-                        caption: None,
-                        number: None,
-                        anchor: None,
-                        anchor_reftext: None,
-                        attrlist: None,
-                    },),
                     Block::List(ListBlock {
                         type_: ListType::Unordered,
                         items: &[

--- a/parser/src/tests/asciidoc_lang/root/comments.rs
+++ b/parser/src/tests/asciidoc_lang/root/comments.rs
@@ -122,12 +122,12 @@ Line comments can be used strategically to separate blocks that otherwise have a
     );
 
     // A lone `//` between two lists forces them apart into two separate lists.
+    // The comment itself is dropped, so the only blocks are the two lists (no
+    // spurious empty paragraph sits between them – issue #956).
     let doc = Parser::default().parse("* first list\n\n//\n\n* second list");
-    let lists = doc
-        .child_blocks()
-        .filter(|b| matches!(b, Block::List(_)))
-        .count();
-    assert_eq!(lists, 2);
+    let blocks: Vec<_> = doc.child_blocks().collect();
+    assert_eq!(blocks.len(), 2);
+    assert!(blocks.iter().all(|b| matches!(b, Block::List(_))));
 
     non_normative!(
         r#"
@@ -143,9 +143,9 @@ Line comments can be used strategically to separate blocks that otherwise have a
 "#
     );
 
-    // DEVIATION: the comment line is retained as an empty-rendered paragraph
-    // rather than dropped, but it still serves as the block boundary described
-    // here.
+    // The single line comment serves as a block boundary between the two lists
+    // and is then dropped from the parsed document, matching the spec text below
+    // (verified by the block count above – issue #956).
     non_normative!(
         r#"
 In this case, the single line comment effectively acts as an empty paragraph that's dropped from the parsed document.

--- a/parser/src/tests/asciidoctor_rb/blocks_test.rs
+++ b/parser/src/tests/asciidoctor_rb/blocks_test.rs
@@ -241,14 +241,6 @@ mod comments {
 "#
     );
 
-    // NOTE: divergence from Asciidoctor. Asciidoctor drops a line comment
-    // entirely, leaving two paragraphs; this crate currently emits an empty
-    // paragraph where the blank-line-delimited `// line comment` sits, so
-    // `//p` counts 3 rather than 2. The comment text itself is removed. Kept
-    // `#[ignore]`d with the Ruby-intended assertions until the empty paragraph
-    // is suppressed.
-    // TODO: suppress the empty paragraph left by a standalone line comment.
-    #[ignore]
     #[test]
     fn line_comment_between_paragraphs_offset_by_blank_lines() {
         verifies!(


### PR DESCRIPTION
## Summary

Fixes #956. A standalone `//` line comment surrounded by blank lines produced a spurious empty `paragraph` block, so a lone comment between two paragraphs surfaced as three blocks (the middle one empty) instead of two.

The root cause is in `SimpleBlock::parse_lines`: it strips the `//` comment line, but the block's `source` span still spans the comment text, so it built a `SimpleBlock` with empty content rather than declining. Downstream (asciidoc-html5#117) rendered `<div class="paragraph"><p></p></div>`.

## Fix

- Added `SimpleBlock::is_line_comment_only`, which reports an unstyled paragraph whose every source line is an AsciiDoc line comment (`//`, not `///`+) and whose content is therefore empty.
- The block dispatch (`Block::parse_internal`) now recognizes such a block and returns `BlockParseOutcome::Dropped`, advancing past the comment without contributing a block — the same mechanism already used for `attribute-missing=drop-line`. Returning `None` was not viable because the block-collection loop treats `NoMatch` as unreachable and would spin.

Only the **contentless** all-comment paragraph is dropped. Comments are still retained everywhere they carry content:
- a `////` comment block (context `comment`),
- a `[comment]`-styled paragraph,
- a `//` line inside a verbatim/literal/listing/source block,
- a `//` line mid-paragraph (stripped, surrounding text preserved).

The `//`-separates-two-lists idiom is unchanged: the comment still acts as a block boundary; it simply no longer leaves an empty paragraph between the lists.

## Tests

- New regression tests in `blocks/tests/simple.rs` (block-level drop, the issue's document-level repro, and a multi-line all-comment paragraph).
- Un-ignored `asciidoctor_rb::blocks_test::line_comment_between_paragraphs_offset_by_blank_lines`, the ported Asciidoctor test this issue tracks (`//p` count is now 2), and removed its stale divergence note.
- Updated the two `separating`/`unordered` list-separation fixtures and the `root/comments` spec test to drop the (now-absent) empty paragraph; the documented two-separate-lists outcome is preserved and strengthened.

`cargo test`, `cargo +nightly fmt --all -- --check`, and `cargo clippy --all-targets` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)