### PR TITLE
fix: Report `floating_title` context for discrete headings

### DIFF
--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -505,7 +505,16 @@ impl<'src> IsBlock<'src> for SectionBlock<'src> {
     // circular), which per-content resolution cannot see.
 
     fn raw_context(&self) -> CowStr<'src> {
-        "section".into()
+        // A discrete (floating) heading is modeled by Asciidoctor as a block
+        // with the `floating_title` context rather than a section, so a
+        // consumer that switches on block context can tell it apart from an
+        // ordinary section – for instance, to exclude it from the table of
+        // contents or to pick a converter method.
+        if self.section_type == SectionType::Discrete {
+            "floating_title".into()
+        } else {
+            "section".into()
+        }
     }
 
     fn child_blocks_mut(&mut self) -> &mut [Block<'src>] {
@@ -3887,7 +3896,8 @@ mod tests {
             .unwrap();
 
             assert_eq!(mi.item.content_model(), ContentModel::Compound);
-            assert_eq!(mi.item.raw_context().deref(), "section");
+            assert_eq!(mi.item.raw_context().deref(), "floating_title");
+            assert_eq!(mi.item.resolved_context().deref(), "floating_title");
             assert_eq!(mi.item.level(), 1);
             assert_eq!(mi.item.section_title(), "Discrete Heading");
             assert_eq!(mi.item.section_type(), SectionType::Discrete);

--- a/parser/src/blocks/tests/section.rs
+++ b/parser/src/blocks/tests/section.rs
@@ -513,6 +513,37 @@ fn discrete_heading_keeps_its_title() {
 }
 
 #[test]
+fn discrete_heading_reports_floating_title_context() {
+    // A discrete (floating) heading reports the `floating_title` context so a
+    // consumer switching on block context can distinguish it from an ordinary
+    // section, which reports `section`. Both the `float` and `discrete` styles
+    // produce a discrete heading.
+    for style in ["float", "discrete"] {
+        let doc = Parser::default().parse(&format!(
+            "[{style}]\n=== Independent Heading!\n\nnot in section"
+        ));
+
+        let Some(crate::blocks::Block::Section(heading)) = doc.child_blocks().next() else {
+            panic!("expected discrete heading");
+        };
+
+        assert_eq!(heading.raw_context().deref(), "floating_title");
+        assert_eq!(heading.resolved_context().deref(), "floating_title");
+        assert_eq!(heading.section_type(), SectionType::Discrete);
+    }
+
+    // An ordinary section still reports the `section` context.
+    let doc = Parser::default().parse("== Real Section\n\nin section");
+
+    let Some(crate::blocks::Block::Section(section)) = doc.child_blocks().next() else {
+        panic!("expected section");
+    };
+
+    assert_eq!(section.raw_context().deref(), "section");
+    assert_eq!(section.resolved_context().deref(), "section");
+}
+
+#[test]
 fn carried_title_does_not_escape_a_table_cell() {
     // A titled empty section at the end of an AsciiDoc table cell leaves a
     // block title pending. The cell is a nested standalone document, so that


### PR DESCRIPTION
Closes #966.

## Problem

A discrete (floating) heading — a `[float]` or `[discrete]` styled title — was exposed with the block context `"section"`, indistinguishable from an ordinary section by context alone. Asciidoctor (the parity oracle) models a discrete heading as a block whose `context` is `:floating_title`, not a `Section`. Consumers that switch on block context rely on this distinction — e.g. to exclude discrete headings from the table of contents, or to pick a converter method.

Before this change, the two were distinguishable only via the separate `section_type()` accessor, not through the block-context vocabulary.

## Fix

`SectionBlock::raw_context()` now returns `"floating_title"` when `section_type == SectionType::Discrete`, and `"section"` otherwise. `resolved_context()` follows automatically, since neither the `float` nor `discrete` declared style is a built-in context (so it falls through to `raw_context()`).

`floating_title` was already part of the `BuiltInContext` vocabulary (`BuiltInContext::FloatingTitle`), so no new context needed to be introduced.

## Tests

- Updated `blocks::section::tests::discrete_headings::basic_case` to assert the corrected `raw_context()`/`resolved_context()`.
- Added `discrete_heading_reports_floating_title_context`, covering both the `float` and `discrete` styles and confirming an ordinary section still reports `section`.

Full `asciidoc-parser` suite passes; `cargo +nightly fmt --all -- --check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)