### PR TITLE
fix: Resolve cross-references to the document title (issues #965, #968)

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -1,7 +1,7 @@
 use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
-    content::{Content, SubstitutionGroup},
+    content::{Content, SubstitutionGroup, substitute_attributes_in_reftext},
     document::{
         Attribute, Author, AuthorLine, InterpretedValue, RefType, RevisionLine,
         matches_author_pattern,
@@ -210,8 +210,7 @@ impl<'src> Header<'src> {
                 && line.starts_with('[')
                 && line.ends_with(']')
                 && document_title_follows_block_metadata(line_mi.after)
-                && let Some((metadata, metadata_warnings)) =
-                    parse_document_metadata_attrlist(line, parser)
+                && let Some((metadata, metadata_warnings)) = parse_document_metadata(line, parser)
             {
                 warnings.extend(metadata_warnings);
 
@@ -665,12 +664,10 @@ fn document_title_follows_block_metadata(after: Span<'_>) -> bool {
 ///
 /// This captures the purely syntactic acceptance rules shared by the lookahead
 /// ([`document_title_follows_block_metadata`]) and the folding step
-/// ([`parse_document_metadata_attrlist`]): the line must be bracket-delimited
-/// and its contents must not be empty, must not begin with whitespace, and must
-/// not be a `[[anchor]]` block anchor. The legacy double-bracket anchor above
-/// the document title is left unsupported (it terminates the header, as
-/// before); the single-bracket `[#id]` shorthand is the supported way to set a
-/// document ID.
+/// ([`parse_document_metadata`]): the line must be bracket-delimited and its
+/// contents must not be empty and must not begin with whitespace. Both a block
+/// attribute list (`[#id]`, `[reftext=…]`, …) and a `[[id]]` / `[[id,reftext]]`
+/// block anchor are accepted; an empty `[[]]` anchor is not.
 fn is_document_metadata_line(line: Span<'_>) -> bool {
     if !(line.starts_with('[') && line.ends_with(']')) {
         return false;
@@ -678,10 +675,18 @@ fn is_document_metadata_line(line: Span<'_>) -> bool {
 
     let inner = line.slice(1..line.len() - 1);
 
-    !(inner.is_empty()
-        || inner.starts_with(' ')
-        || inner.starts_with('\t')
-        || (inner.starts_with('[') && inner.ends_with(']')))
+    if inner.is_empty() || inner.starts_with(' ') || inner.starts_with('\t') {
+        return false;
+    }
+
+    // A `[[anchor]]` block anchor is document metadata when it names a non-empty
+    // anchor; the empty `[[]]` form is not (`inner` would be the two-character
+    // `[]`).
+    if inner.starts_with('[') && inner.ends_with(']') {
+        return inner.len() > 2;
+    }
+
+    true
 }
 
 /// Document metadata folded from a block attribute line appearing directly
@@ -697,31 +702,37 @@ struct DocumentMetadata {
     options: Vec<String>,
 }
 
-/// Parse a block attribute line (e.g. `[reftext="…"]`, `[#id]`, `[role=…]`,
-/// `[separator=::]`) appearing above the document title into
-/// [`DocumentMetadata`].
+/// Parse a metadata line appearing directly above the document title into
+/// [`DocumentMetadata`], dispatching on its form: a `[[id]]` / `[[id,reftext]]`
+/// block anchor, or a block attribute list (e.g. `[reftext="…"]`, `[#id]`,
+/// `[role=…]`, `[separator=::]`).
 ///
 /// The `line` is expected to begin with `[` and end with `]`. Returns the
-/// folded metadata together with any warnings raised while parsing the
-/// attribute list when the line is a well-formed block attribute list, and
-/// `None` otherwise (so the caller can fall through to its normal handling of
-/// the line, which then terminates the header). The warnings are only surfaced
-/// when the line is actually consumed as document metadata; otherwise the line
-/// is left for the block parser, which reports them on its own path.
-fn parse_document_metadata_attrlist<'src>(
+/// folded metadata together with any warnings raised while parsing when the
+/// line is a well-formed metadata line, and `None` otherwise (so the caller can
+/// fall through to its normal handling of the line, which then terminates the
+/// header). The warnings are only surfaced when the line is actually consumed
+/// as document metadata; otherwise the line is left for the block parser, which
+/// reports them on its own path.
+fn parse_document_metadata<'src>(
     line: Span<'src>,
     parser: &Parser,
 ) -> Option<(DocumentMetadata, Vec<Warning<'src>>)> {
-    // Reject forms that are not block attribute lists (a leading space or tab,
-    // an empty list, or a `[[anchor]]` block anchor); see
-    // [`is_document_metadata_line`] for the shared acceptance rules. The caller
-    // has already confirmed the enclosing square brackets are present.
+    // Reject forms that are not document metadata (a leading space or tab, an
+    // empty list, or an empty `[[]]` anchor); see [`is_document_metadata_line`]
+    // for the shared acceptance rules. The caller has already confirmed the
+    // enclosing square brackets are present.
     if !is_document_metadata_line(line) {
         return None;
     }
 
     // Drop the enclosing square brackets.
     let inner = line.slice(1..line.len() - 1);
+
+    // A `[[id]]` / `[[id,reftext]]` block anchor still has its inner brackets.
+    if inner.starts_with('[') && inner.ends_with(']') {
+        return parse_document_metadata_anchor(inner.slice(1..inner.len() - 1), parser);
+    }
 
     let MatchAndWarnings {
         item: MatchedItem {
@@ -744,6 +755,49 @@ fn parse_document_metadata_attrlist<'src>(
     };
 
     Some((metadata, warnings))
+}
+
+/// Fold a `[[id]]` / `[[id,reftext]]` block anchor above the document title
+/// into [`DocumentMetadata`]. `anchor` is the text *between* the inner brackets
+/// (`id` or `id,reftext`).
+///
+/// The anchor ID must be a valid XML name (as the block parser requires of any
+/// block anchor); otherwise `None` is returned so the line falls through and
+/// ends the header. Attribute references in the reftext are resolved against
+/// the attributes in effect at the anchor, mirroring the section/block anchor
+/// path (see [`substitute_attributes_in_reftext`]) rather than the doctitle's
+/// `SpecialCharacters`-plus-references header substitution.
+fn parse_document_metadata_anchor<'src>(
+    anchor: Span<'src>,
+    parser: &Parser,
+) -> Option<(DocumentMetadata, Vec<Warning<'src>>)> {
+    // Split an optional reftext off at the first comma (`id,reftext`). A comma
+    // in the final position leaves the whole span – trailing comma included – as
+    // the ID, which then fails XML-name validation, matching the block parser.
+    let (id, reftext) = match anchor.position(|c| c == ',') {
+        Some(comma) if comma < anchor.len() - 1 => (
+            anchor.slice(0..comma),
+            Some(substitute_attributes_in_reftext(
+                anchor.slice(comma + 1..anchor.len()),
+                parser,
+            )),
+        ),
+        _ => (anchor, None),
+    };
+
+    if !id.is_xml_name() {
+        return None;
+    }
+
+    let metadata = DocumentMetadata {
+        id: Some(id.data().to_string()),
+        separator: None,
+        reftext: reftext.map(|r| r.to_string()),
+        roles: vec![],
+        options: vec![],
+    };
+
+    Some((metadata, vec![]))
 }
 
 /// Partition a document title into its main title and optional subtitle.
@@ -2113,6 +2167,45 @@ mod tests {
     }
 
     #[test]
+    fn bracket_anchor_above_title() {
+        // A `[[id]]` block anchor above the title assigns the document ID and
+        // recovers the title, exactly as the `[#id]` shorthand does.
+        let doc = Parser::default().parse("[[idname]]\n= Document Title\n\ncontent");
+        let header = doc.header();
+
+        assert_eq!(header.title(), Some("Document Title"));
+        assert_eq!(header.id(), Some("idname"));
+        assert_eq!(doc.id(), Some("idname"));
+        assert_eq!(rendered_paragraphs(&doc), vec!["content"]);
+
+        // The `[[id,reftext]]` form additionally folds its reference text into
+        // the document's `reftext` attribute, resolving attribute references the
+        // way a section/block anchor reftext does.
+        let doc = Parser::default()
+            .parse(":product: Widgets\n[[guide,{product} Guide]]\n= User Guide\n\ncontent");
+        let header = doc.header();
+
+        assert_eq!(header.title(), Some("User Guide"));
+        assert_eq!(header.id(), Some("guide"));
+        assert_eq!(
+            doc.attribute_value("reftext"),
+            InterpretedValue::Value("Widgets Guide")
+        );
+    }
+
+    #[test]
+    fn bracket_anchor_above_title_requires_a_valid_name() {
+        // A `[[…]]` line whose anchor name is not a valid XML name is not folded
+        // as document metadata; the header terminates as it does for any other
+        // unrecognized line.
+        let doc = Parser::default().parse("[[bad name]]\n= Document Title\n\ncontent");
+        let header = doc.header();
+
+        assert_eq!(header.title(), None);
+        assert_eq!(header.id(), None);
+    }
+
+    #[test]
     fn stacked_block_attributes_above_title() {
         // Multiple block attribute lines may stack above the document title;
         // each folds into the document's metadata and the title is still
@@ -2163,16 +2256,16 @@ mod tests {
     }
 
     #[test]
-    fn stacked_block_attributes_stop_at_a_block_anchor() {
-        // A `[[anchor]]` line breaks the run of foldable metadata lines: the
-        // scan stops there without seeing the title, so nothing above it is
-        // folded and the header terminates (matching the single-line anchor
-        // rejection).
+    fn stacked_block_attributes_fold_a_block_anchor() {
+        // A `[[anchor]]` line is a foldable metadata line like the attribute
+        // lists around it, so a run mixing the two still folds and the title is
+        // recognized. The ID follows last-wins semantics across the run (the
+        // block anchor overrides the earlier `[#docid]`), matching Asciidoctor.
         let doc = Parser::default().parse("[#docid]\n[[anchor]]\n= Some Title");
         let header = doc.header();
 
-        assert_eq!(header.title(), None);
-        assert_eq!(header.id(), None);
+        assert_eq!(header.title(), Some("Some Title"));
+        assert_eq!(header.id(), Some("anchor"));
     }
 
     #[test]
@@ -2180,20 +2273,20 @@ mod tests {
         // A block attribute line above the title is only parsed as document
         // metadata once a title is confirmed to follow it (via
         // `document_title_follows_block_metadata`, which scans structurally and
-        // never parses an attribute list). Here the `[[anchor]]` breaks the run
-        // before any title, so the lookahead fails and the `[reftext=…]` line's
-        // attribute list is never parsed during header parsing – its embedded
-        // `{counter:item}` must not fire at header time.
+        // never parses an attribute list). Here no title follows, so the
+        // lookahead fails and the `[reftext=…]` line's attribute list is never
+        // parsed during header parsing – its embedded `{counter:item}` must not
+        // fire at header time.
         //
         // The `reftext` line advances the counter exactly once when the block
         // parser reaches it (yielding 1), so the following `{counter:item}`
         // reference renders 2 – not 3, which is what a leaked header-time
         // evaluation would produce.
-        let doc = Parser::default()
-            .parse("[reftext=\"See {counter:item}\"]\n[[anchor]]\n= Title\n\n{counter:item}");
+        let doc =
+            Parser::default().parse("[reftext=\"See {counter:item}\"]\nBody.\n\n{counter:item}");
 
         assert_eq!(doc.header().title(), None);
-        assert_eq!(rendered_paragraphs(&doc), vec!["= Title", "2"]);
+        assert_eq!(rendered_paragraphs(&doc), vec!["Body.", "2"]);
     }
 
     #[test]
@@ -2250,11 +2343,11 @@ mod tests {
     #[test]
     fn bracketed_line_that_is_not_a_separator_attribute_list() {
         // A `[...]` line above the title that isn't a well-formed block
-        // attribute list carrying `separator` is not consumed as a separator. A
-        // block anchor (`[[...]]`) and a leading-space form are both rejected,
+        // attribute list carrying `separator` is not consumed as a separator. An
+        // empty block anchor (`[[]]`) and a leading-space form are both rejected,
         // so the line terminates the header exactly as any other unrecognized
         // line would.
-        let doc = Parser::default().parse("[[anchor]]\n= Some Title: Subtitle");
+        let doc = Parser::default().parse("[[]]\n= Some Title: Subtitle");
         let header = doc.header();
 
         assert_eq!(header.title(), None);

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -3,7 +3,8 @@ use crate::{
     attributes::{Attrlist, AttrlistContext},
     content::{Content, SubstitutionGroup},
     document::{
-        Attribute, Author, AuthorLine, InterpretedValue, RevisionLine, matches_author_pattern,
+        Attribute, Author, AuthorLine, InterpretedValue, RefType, RevisionLine,
+        matches_author_pattern,
     },
     internal::{debug::DebugSliceReference, opaque_iter::opaque_slice_iter},
     span::MatchedItem,
@@ -391,6 +392,27 @@ impl<'src> Header<'src> {
             InterpretedValue::Set => Some(String::new()),
             InterpretedValue::Unset => title.clone(),
         };
+
+        // A document title carrying an explicit ID (`[#id]` above `= Title`)
+        // registers that ID in the catalog, mirroring Asciidoctor, which
+        // registers the document itself under its ID. Without this, a
+        // cross-reference to the document (`<<id>>`) finds no catalog entry and
+        // falls back to the bracketed `[id]` form instead of the title's
+        // reference text. The reference text follows the same precedence as a
+        // whole-document self-reference (see
+        // [`this_document_reference`](crate::content::this_document_reference)):
+        // an explicit `reftext` attribute, otherwise the document title. The
+        // header is parsed before the body, so this ID registers ahead of any
+        // body anchor; a later duplicate is ignored here and reported by the
+        // body parse.
+        if let Some(doc_id) = id.as_deref() {
+            let reftext = match parser.attribute_value("reftext") {
+                InterpretedValue::Value(reftext) if !reftext.is_empty() => Some(reftext),
+                _ => doctitle.clone().filter(|title| !title.is_empty()),
+            };
+
+            let _ = parser.register_ref(doc_id, reftext.as_deref(), RefType::Section);
+        }
 
         // Resolve the document's author list. The author line, when present, is
         // the source of truth; otherwise the list is derived from the `author`,

--- a/parser/src/tests/asciidoctor_rb/sections_test.rs
+++ b/parser/src/tests/asciidoctor_rb/sections_test.rs
@@ -1304,13 +1304,11 @@ mod levels {
         );
 
         // NOTE: A document-level ID above the document title sets the `id` on
-        // the standalone `<body>` and (in Asciidoctor) registers the document
-        // itself in the catalog. This crate models neither the `<body>` element
-        // nor a document `id` for the `[[idname]]` bracket form, so the tests
-        // that assert `body#id` or `doc.id` stay out of scope. It *does*
-        // register a document title carrying a shorthand ID (`[#id]`) in the
-        // catalog, so `should compute xreftext to document title` is verified as
-        // a real test below.
+        // the standalone `<body>`. This crate models embedded output, which has
+        // no `<body>` element, so the `body#id` assertions below are out of
+        // scope. The document `id` itself *is* recognized for both the `[[id]]`
+        // and `[#id]` forms (see the promoted tests further down that assert
+        // `doc.id` and the catalog registration through the crate's accessors).
         non_normative!(
             r##"
       test 'should assign id on document title to body' do
@@ -1346,6 +1344,19 @@ mod levels {
         assert_css 'body#idname-block', output, 1
       end
 
+"##
+        );
+
+        // The crate recognizes a document ID from a `[[id]]` block anchor above
+        // the document title, folding it into the header the same way the `[#id]`
+        // shorthand is. `doc.id` and any accompanying attribute entry are exposed
+        // through the header/document accessors; only the
+        // `assert_css 'body#reference'` (which needs a standalone `<body>`) is
+        // out of scope.
+        #[test]
+        fn block_id_above_document_title_sets_id_on_document() {
+            verifies!(
+                r##"
       test 'block id above document title sets id on document' do
         input = <<~'EOS'
         [[reference]]
@@ -1361,6 +1372,32 @@ mod levels {
         assert_css 'body#reference', output, 1
       end
 
+"##
+            );
+
+            use crate::document::InterpretedValue;
+
+            let doc = Parser::default()
+                .parse("[[reference]]\n= Reference Manual\n:css-signature: refguide\n\npreamble\n");
+
+            assert_eq!(doc.header().id(), Some("reference"));
+            assert_eq!(doc.header().title(), Some("Reference Manual"));
+            assert_eq!(
+                doc.attribute_value("css-signature"),
+                InterpretedValue::Value("refguide".to_string())
+            );
+        }
+
+        // A document title carrying an ID registers the document in the catalog
+        // under that ID, with its reference text (the `[[id,reftext]]` reftext
+        // here). This crate exposes the registration through
+        // [`Catalog::get_ref`](crate::document::Catalog::get_ref) rather than a
+        // `doc` self-entry, so the `catalog[:refs]['manual'] == doc` identity
+        // check becomes a lookup of the registered [`RefEntry`].
+        #[test]
+        fn should_register_document_in_catalog_if_id_is_set() {
+            verifies!(
+                r##"
       test 'should register document in catalog if id is set' do
         input = <<~'EOS'
         [[manual,Manual]]
@@ -1375,7 +1412,25 @@ mod levels {
       end
 
 "##
-        );
+            );
+
+            use crate::document::InterpretedValue;
+
+            let doc =
+                Parser::default().parse("[[manual,Manual]]\n= Reference Manual\n\npreamble\n");
+
+            assert_eq!(doc.header().id(), Some("manual"));
+            assert_eq!(
+                doc.attribute_value("reftext"),
+                InterpretedValue::Value("Manual".to_string())
+            );
+
+            let entry = doc
+                .catalog()
+                .get_ref("manual")
+                .expect("document registered in the catalog under its id");
+            assert_eq!(entry.reftext.as_deref(), Some("Manual"));
+        }
 
         // A cross-reference to a document title carrying an explicit shorthand
         // ID (`[#id]`) resolves to the title's reference text. The crate

--- a/parser/src/tests/asciidoctor_rb/sections_test.rs
+++ b/parser/src/tests/asciidoctor_rb/sections_test.rs
@@ -1303,12 +1303,14 @@ mod levels {
 "##
         );
 
-        // NOTE: A document-level ID (`[[idname]]`/`[#idname]` above the document
-        // title, or a block ID above it) sets the `id` on the standalone
-        // `<body>` and registers the document in the catalog. This crate does
-        // not model a document-level ID / body element / document self-entry, so
-        // the remaining Level-0 tests — which assert `body#id`, `doc.id`, and
-        // document catalog registration — are out of scope.
+        // NOTE: A document-level ID above the document title sets the `id` on
+        // the standalone `<body>` and (in Asciidoctor) registers the document
+        // itself in the catalog. This crate models neither the `<body>` element
+        // nor a document `id` for the `[[idname]]` bracket form, so the tests
+        // that assert `body#id` or `doc.id` stay out of scope. It *does*
+        // register a document title carrying a shorthand ID (`[#id]`) in the
+        // catalog, so `should compute xreftext to document title` is verified as
+        // a real test below.
         non_normative!(
             r##"
       test 'should assign id on document title to body' do
@@ -1372,6 +1374,20 @@ mod levels {
         assert_equal doc, doc.catalog[:refs]['manual']
       end
 
+"##
+        );
+
+        // A cross-reference to a document title carrying an explicit shorthand
+        // ID (`[#id]`) resolves to the title's reference text. The crate
+        // registers the document title in the catalog under its ID (as a
+        // [`Section`](crate::document::RefType::Section) whose reference text is
+        // the doctitle), so an `<<id>>` to it renders the title rather than the
+        // bracketed `[id]` fallback – matching a cross-reference to an ordinary
+        // section.
+        #[test]
+        fn should_compute_xreftext_to_document_title() {
+            verifies!(
+                r##"
       test 'should compute xreftext to document title' do
         input = <<~'EOS'
         [#manual]
@@ -1384,6 +1400,21 @@ mod levels {
         assert_xpath '//a[text()="Reference Manual"]', output, 1
       end
 
+"##
+            );
+
+            let doc = Parser::default().parse(
+                "[#manual]\n= Reference Manual\n:xrefstyle: full\n\nThis is the <<manual>>.\n",
+            );
+
+            assert_eq!(
+                rendered_paragraphs(&doc),
+                vec![r##"This is the <a href="#manual">Reference Manual</a>."##]
+            );
+        }
+
+        non_normative!(
+            r##"
       test 'should discard style, role and options shorthand attributes defined on document title' do
         input = <<~'EOS'
         [style#idname.rolename%optionname]

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -468,6 +468,34 @@ fn explicit_reftext_wins_for_document_title_reference() {
 }
 
 #[test]
+fn reference_to_document_title_with_bracket_anchor_resolves() {
+    // A document title whose ID comes from a `[[id]]` block anchor (rather than
+    // the `[#id]` shorthand) is registered the same way, so a cross-reference to
+    // it renders the title text.
+    let doc =
+        Parser::default().parse("[[manual]]\n= Reference Manual\n\nThis is the <<manual>>.\n");
+
+    assert_eq!(
+        first_paragraph(&doc),
+        "This is the <a href=\"#manual\">Reference Manual</a>."
+    );
+}
+
+#[test]
+fn reference_to_document_title_uses_bracket_anchor_reftext() {
+    // The reference text of a `[[id,reftext]]` block anchor on the document
+    // title is used as the cross-reference text, taking precedence over the
+    // title just as an explicit `reftext` attribute does.
+    let doc = Parser::default()
+        .parse("[[manual,The Manual]]\n= Reference Manual\n\nThis is the <<manual>>.\n");
+
+    assert_eq!(
+        first_paragraph(&doc),
+        "This is the <a href=\"#manual\">The Manual</a>."
+    );
+}
+
+#[test]
 fn host_resolver_can_override_a_derived_destination() {
     // The destination the parser derives for a target that names a document is
     // only a default: it is offered to the resolver (as

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -424,6 +424,50 @@ fn reference_to_this_document_by_name_resolves_within_it() {
 }
 
 #[test]
+fn reference_to_document_title_resolves_to_its_title() {
+    // A document title carrying an explicit ID is registered in the catalog
+    // under that ID (mirroring Asciidoctor, which registers the document itself
+    // under its ID). A cross-reference to it therefore renders the title's text
+    // rather than the bracketed `[id]` fallback – matching the behavior of a
+    // cross-reference to an ordinary section.
+    let doc = Parser::default()
+        .parse("[#manual]\n= Reference Manual\n:xrefstyle: full\n\nThis is the <<manual>>.\n");
+
+    assert_eq!(
+        first_paragraph(&doc),
+        "This is the <a href=\"#manual\">Reference Manual</a>."
+    );
+}
+
+#[test]
+fn natural_reference_to_document_title_resolves() {
+    // The document title's reference text (its title) also feeds the reverse
+    // lookup, so a natural cross-reference by that text resolves to the same
+    // destination.
+    let doc = Parser::default()
+        .parse("[#manual]\n= Reference Manual\n\nThis is the <<Reference Manual>>.\n");
+
+    assert_eq!(
+        first_paragraph(&doc),
+        "This is the <a href=\"#manual\">Reference Manual</a>."
+    );
+}
+
+#[test]
+fn explicit_reftext_wins_for_document_title_reference() {
+    // An explicit `reftext` attribute on the document takes precedence over the
+    // title as the cross-reference text, mirroring a whole-document
+    // self-reference.
+    let doc = Parser::default()
+        .parse("[#manual,reftext=The Manual]\n= Reference Manual\n\nThis is the <<manual>>.\n");
+
+    assert_eq!(
+        first_paragraph(&doc),
+        "This is the <a href=\"#manual\">The Manual</a>."
+    );
+}
+
+#[test]
 fn host_resolver_can_override_a_derived_destination() {
     // The destination the parser derives for a target that names a document is
     // only a default: it is offered to the resolver (as


### PR DESCRIPTION
Fixes two related gaps in how the **document title** participates in cross-referencing. The second builds on the first, so they ship together.

## #965 — Cross-reference to the document title is not resolved to its title text

An `<<id>>` to a document title carrying a shorthand ID (`[#id]`) rendered the raw id in brackets (`[manual]`) instead of the title's reference text, because the document title was never registered in the catalog under its id (unlike an ordinary section). `CatalogResolver` returned `None`, so the renderer fell back to `[id]`.

**Fix:** at the end of `Header::parse`, when the document title carries an explicit ID, register it in the catalog as a `Section` whose reference text follows the same precedence as a whole-document self-reference (`this_document_reference`): an explicit `reftext`, otherwise the doctitle.

```
[#manual]
= Reference Manual
:xrefstyle: full

This is the <<manual>>.
```
Before: `<p>This is the <a href="#manual">[manual]</a>.</p>`
After (matches Asciidoctor 2.0.26): `<p>This is the <a href="#manual">Reference Manual</a>.</p>`

## #968 — Bracketed block anchor `[[id]]` above the document title is not recognized

A `[[id]]` / `[[id,reftext]]` anchor directly above the title was not treated as document metadata at all: header detection failed, so `Header::id()` **and** `Header::title()` returned `None` and `= Title` was parsed as ordinary text. Only the `[#id]` shorthand worked.

**Fix:** fold the `[[id]]` / `[[id,reftext]]` block anchor above the title into the document's metadata alongside the attribute-list forms. The id is assigned to the document (last-wins across a stacked run), and a `[[id,reftext]]` reftext folds into the document `reftext` attribute (attribute references resolved as for a section/block anchor, via `substitute_attributes_in_reftext`). An invalid XML anchor name still falls through and ends the header; the empty `[[]]` form stays rejected.

Together, `<<id>>` to the document now resolves to its title (or reftext) for **both** the `[#id]` and `[[id]]`/`[[id,reftext]]` forms.

## Tests

- New integration tests in `tests/xref.rs`: `<<id>>` to the document title for `[#id]`, `[[id]]`, and `[[id,reftext]]`; natural reference by title text; and explicit-`reftext`/anchor-reftext precedence.
- New `Header::parse` unit tests for `[[id]]` / `[[id,reftext]]` recognition (id, title, reftext, invalid-name rejection); updated three existing header tests that asserted the old "unsupported" behavior (block anchors now fold, last-wins).
- Promoted three ported Asciidoctor tests in `asciidoctor_rb/sections_test.rs` from `non_normative!` to real `verifies!` tests: **should compute xreftext to document title**, **block id above document title sets id on document**, and **should register document in catalog if id is set**. The remaining `body#id` cases stay `non_normative!` (this crate models embedded output, with no standalone `<body>`).

`cargo test --workspace` (4459 pass), `cargo +nightly fmt --all -- --check`, and `cargo clippy --workspace --all-targets` are all clean.

Closes #965.
Closes #968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)