### PR TITLE
fix: Recognize `[[id]]` block anchor above the document title

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -1,7 +1,7 @@
 use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
-    content::{Content, SubstitutionGroup},
+    content::{Content, SubstitutionGroup, substitute_attributes_in_reftext},
     document::{
         Attribute, Author, AuthorLine, InterpretedValue, RevisionLine, matches_author_pattern,
     },
@@ -225,6 +225,13 @@ impl<'src> Header<'src> {
                 id = Some(anchor_id);
 
                 if let Some(reftext) = anchor_reftext {
+                    // Resolve attribute references in the reftext now, while the
+                    // attributes in effect at the anchor are still current –
+                    // mirroring the block parser and the `[reftext=…]` attribute
+                    // form, whose values are expanded as the attribute list is
+                    // parsed. Without this, `[[id,See {label}]]` would store the
+                    // literal `{label}`.
+                    let reftext = substitute_attributes_in_reftext(reftext, parser);
                     parser.set_attribute_by_value_from_header("reftext", reftext);
                 }
 
@@ -765,15 +772,20 @@ fn parse_document_metadata_attrlist<'src>(
 }
 
 /// Parse a `[[id]]` or `[[id,reftext]]` block anchor line appearing directly
-/// above the document title, returning the (owned) id and optional reftext.
+/// above the document title, returning the (owned) id and the raw reftext span.
 ///
 /// Mirrors the block-anchor handling in [`crate::blocks::metadata`]: the id may
 /// be followed by a comma and a reftext, and the id must be a valid XML name.
+/// The reftext is returned as a raw [`Span`] (not yet attribute-substituted);
+/// the caller resolves its attribute references with
+/// [`substitute_attributes_in_reftext`], exactly as the block parser does,
+/// while the attributes in effect at the anchor are still current.
+///
 /// Returns `None` when `line` is not a well-formed anchor with a valid id (an
 /// empty `[[]]`, a `[[,reftext]]` with no id, or a non-XML-name id), so the
 /// caller leaves the line for the block parser (which reports any warning on
 /// its own path) rather than folding it as document metadata.
-fn parse_document_block_anchor(line: Span<'_>) -> Option<(String, Option<String>)> {
+fn parse_document_block_anchor(line: Span<'_>) -> Option<(String, Option<Span<'_>>)> {
     if !(line.starts_with("[[") && line.ends_with("]]")) {
         return None;
     }
@@ -799,7 +811,7 @@ fn parse_document_block_anchor(line: Span<'_>) -> Option<(String, Option<String>
         return None;
     }
 
-    Some((id.data().to_string(), reftext.map(|r| r.data().to_string())))
+    Some((id.data().to_string(), reftext))
 }
 
 /// Partition a document title into its main title and optional subtitle.
@@ -2208,6 +2220,23 @@ mod tests {
         assert_eq!(
             doc.attribute_value("reftext"),
             InterpretedValue::Value("Manual")
+        );
+    }
+
+    #[test]
+    fn block_anchor_reftext_resolves_attribute_references() {
+        // Attribute references in a `[[id,reftext]]` reftext are expanded
+        // against the attributes in effect at the anchor, just like the block
+        // parser and the `[reftext="…"]` attribute form – so the stored
+        // `reftext` holds the resolved text, not the literal `{label}`.
+        let doc = Parser::default()
+            .parse(":label: The Manual\n[[manual,See {label}]]\n= Reference Manual\n\npreamble");
+        let header = doc.header();
+
+        assert_eq!(header.id(), Some("manual"));
+        assert_eq!(
+            doc.attribute_value("reftext"),
+            InterpretedValue::Value("See The Manual")
         );
     }
 

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -206,6 +206,30 @@ impl<'src> Header<'src> {
                 attributes.push(attr.item);
                 source = attr.after;
             } else if title.is_none()
+                && line.starts_with("[[")
+                && line.ends_with("]]")
+                && document_title_follows_block_metadata(line_mi.after)
+                && let Some((anchor_id, anchor_reftext)) = parse_document_block_anchor(line)
+            {
+                // A `[[id]]` (or `[[id,reftext]]`) block anchor directly above
+                // the document title assigns the id – and optional reftext – to
+                // the *document*, mirroring Asciidoctor's
+                // `parse_block_metadata_line`. It is intercepted only when a
+                // document title eventually follows (possibly after further
+                // stacked metadata lines), just like the block-attribute form
+                // above; otherwise it is a body-level block anchor and is left
+                // for the block parser.
+                //
+                // Like the `[#id]` shorthand, a later id wins: this anchor
+                // overrides any id set by an earlier stacked metadata line.
+                id = Some(anchor_id);
+
+                if let Some(reftext) = anchor_reftext {
+                    parser.set_attribute_by_value_from_header("reftext", reftext);
+                }
+
+                source = line_mi.after;
+            } else if title.is_none()
                 && line.starts_with('[')
                 && line.ends_with(']')
                 && document_title_follows_block_metadata(line_mi.after)
@@ -494,8 +518,9 @@ impl<'src> Header<'src> {
     /// Return the document's ID, if one was assigned.
     ///
     /// A document ID is set with a block attribute line directly above the
-    /// document title, using either the shorthand (`[#id]`) or longhand
-    /// (`[id=id]`) syntax. Returns `None` when no such ID was given.
+    /// document title, using the shorthand (`[#id]`), longhand (`[id=id]`), or
+    /// block-anchor (`[[id]]`, optionally `[[id,reftext]]`) syntax. Returns
+    /// `None` when no such ID was given.
     pub fn id(&self) -> Option<&str> {
         self.id.as_deref()
     }
@@ -603,20 +628,21 @@ fn document_title_marker(line: Span<'_>) -> Option<char> {
 }
 
 /// Reports whether a document title marker eventually follows the source at
-/// `after`, allowing any number of stacked block attribute lines in between.
+/// `after`, allowing any number of stacked block metadata lines in between.
 ///
-/// Starting immediately below the block attribute line under consideration,
-/// consecutive lines that are themselves document-metadata block attribute
-/// lines (see [`is_document_metadata_line`]) are skipped, and the first line
-/// that is not is tested for a document title marker. This generalizes the
+/// Starting immediately below the block metadata line under consideration,
+/// consecutive lines that are themselves foldable document metadata – a block
+/// attribute line (see [`is_document_metadata_line`]) or a `[[id]]` block
+/// anchor (see [`is_document_block_anchor_line`]) – are skipped, and the first
+/// line that is not is tested for a document title marker. This generalizes the
 /// original single-line lookahead so that stacked metadata lines above the
 /// title are all folded, mirroring Asciidoctor's `parse_block_metadata_lines`.
 ///
-/// A line that starts with `[` and ends with `]` but is *not* a valid
-/// document-metadata line (e.g. a `[[anchor]]` block anchor or a leading-space
-/// form) stops the scan without matching, so the run of foldable lines is only
-/// ever a contiguous prefix of well-formed metadata lines terminated by the
-/// title.
+/// A line that starts with `[` and ends with `]` but is *not* a foldable
+/// metadata line (e.g. an empty `[]`, a leading-space form, or a `[[anchor]]`
+/// whose id is not a valid XML name) stops the scan without matching, so the
+/// run of foldable lines is only ever a contiguous prefix of well-formed
+/// metadata lines terminated by the title.
 fn document_title_follows_block_metadata(after: Span<'_>) -> bool {
     let mut next = after;
 
@@ -628,7 +654,7 @@ fn document_title_follows_block_metadata(after: Span<'_>) -> bool {
             return true;
         }
 
-        if !is_document_metadata_line(line) {
+        if !is_document_metadata_line(line) && !is_document_block_anchor_line(line) {
             return false;
         }
 
@@ -638,17 +664,17 @@ fn document_title_follows_block_metadata(after: Span<'_>) -> bool {
     false
 }
 
-/// Reports whether `line` is a block attribute line that this crate folds into
-/// document metadata when it appears above the document title.
+/// Reports whether `line` is a single-bracket block attribute line (e.g.
+/// `[#id]`, `[role=…]`, `[separator=::]`) that this crate folds into document
+/// metadata when it appears above the document title.
 ///
 /// This captures the purely syntactic acceptance rules shared by the lookahead
 /// ([`document_title_follows_block_metadata`]) and the folding step
 /// ([`parse_document_metadata_attrlist`]): the line must be bracket-delimited
 /// and its contents must not be empty, must not begin with whitespace, and must
-/// not be a `[[anchor]]` block anchor. The legacy double-bracket anchor above
-/// the document title is left unsupported (it terminates the header, as
-/// before); the single-bracket `[#id]` shorthand is the supported way to set a
-/// document ID.
+/// not be a `[[anchor]]` block anchor. The double-bracket anchor form is folded
+/// separately (see [`is_document_block_anchor_line`] /
+/// [`parse_document_block_anchor`]) so that it can carry a reftext.
 fn is_document_metadata_line(line: Span<'_>) -> bool {
     if !(line.starts_with('[') && line.ends_with(']')) {
         return false;
@@ -660,6 +686,20 @@ fn is_document_metadata_line(line: Span<'_>) -> bool {
         || inner.starts_with(' ')
         || inner.starts_with('\t')
         || (inner.starts_with('[') && inner.ends_with(']')))
+}
+
+/// Reports whether `line` is a `[[id]]` (or `[[id,reftext]]`) block anchor that
+/// this crate folds into document metadata when it appears above the document
+/// title.
+///
+/// This is the block-anchor counterpart to [`is_document_metadata_line`], used
+/// by the lookahead ([`document_title_follows_block_metadata`]) to skip stacked
+/// anchor lines. It agrees with the folding step
+/// ([`parse_document_block_anchor`]) – a line is foldable only when that parse
+/// would succeed – so an anchor with an empty or non-XML-name id stops the scan
+/// rather than being skipped.
+fn is_document_block_anchor_line(line: Span<'_>) -> bool {
+    parse_document_block_anchor(line).is_some()
 }
 
 /// Document metadata folded from a block attribute line appearing directly
@@ -722,6 +762,44 @@ fn parse_document_metadata_attrlist<'src>(
     };
 
     Some((metadata, warnings))
+}
+
+/// Parse a `[[id]]` or `[[id,reftext]]` block anchor line appearing directly
+/// above the document title, returning the (owned) id and optional reftext.
+///
+/// Mirrors the block-anchor handling in [`crate::blocks::metadata`]: the id may
+/// be followed by a comma and a reftext, and the id must be a valid XML name.
+/// Returns `None` when `line` is not a well-formed anchor with a valid id (an
+/// empty `[[]]`, a `[[,reftext]]` with no id, or a non-XML-name id), so the
+/// caller leaves the line for the block parser (which reports any warning on
+/// its own path) rather than folding it as document metadata.
+fn parse_document_block_anchor(line: Span<'_>) -> Option<(String, Option<String>)> {
+    if !(line.starts_with("[[") && line.ends_with("]]")) {
+        return None;
+    }
+
+    // Drop the enclosing double brackets.
+    let inner = line.slice(2..line.len() - 2);
+    if inner.is_empty() {
+        return None;
+    }
+
+    // An optional `,reftext` follows the id (`[[id,reftext]]`); a trailing comma
+    // with no reftext (`[[id,]]`) is not split off, so the id then includes the
+    // comma and fails the XML-name check below, matching the block parser.
+    let (id, reftext) = match inner.position(|c| c == ',') {
+        Some(comma) if comma < inner.len() - 1 => (
+            inner.slice(0..comma),
+            Some(inner.slice(comma + 1..inner.len())),
+        ),
+        _ => (inner, None),
+    };
+
+    if !id.is_xml_name() {
+        return None;
+    }
+
+    Some((id.data().to_string(), reftext.map(|r| r.data().to_string())))
 }
 
 /// Partition a document title into its main title and optional subtitle.
@@ -2091,6 +2169,60 @@ mod tests {
     }
 
     #[test]
+    fn block_anchor_id_above_title() {
+        // A `[[id]]` block anchor above the title assigns the document ID and
+        // still recovers the title, matching Asciidoctor and the `[#id]`
+        // shorthand.
+        let doc = Parser::default().parse("[[idname]]\n= Document Title\n\ncontent\n");
+        let header = doc.header();
+
+        assert_eq!(header.title(), Some("Document Title"));
+        assert_eq!(header.id(), Some("idname"));
+        assert_eq!(doc.id(), Some("idname"));
+        assert_eq!(rendered_paragraphs(&doc), vec!["content"]);
+
+        // The header continues past the anchor: an attribute entry below the
+        // title is still applied.
+        let doc = Parser::default()
+            .parse("[[reference]]\n= Reference Manual\n:css-signature: refguide\n\npreamble");
+        let header = doc.header();
+
+        assert_eq!(header.title(), Some("Reference Manual"));
+        assert_eq!(header.id(), Some("reference"));
+        assert_eq!(
+            doc.attribute_value("css-signature"),
+            InterpretedValue::Value("refguide")
+        );
+    }
+
+    #[test]
+    fn block_anchor_reftext_above_title() {
+        // The `[[id,reftext]]` form assigns both the document ID and, folded
+        // like a `[reftext="…"]` block attribute, the `reftext` document
+        // attribute.
+        let doc = Parser::default().parse("[[manual,Manual]]\n= Reference Manual\n\npreamble");
+        let header = doc.header();
+
+        assert_eq!(header.title(), Some("Reference Manual"));
+        assert_eq!(header.id(), Some("manual"));
+        assert_eq!(
+            doc.attribute_value("reftext"),
+            InterpretedValue::Value("Manual")
+        );
+    }
+
+    #[test]
+    fn empty_block_anchor_above_title_is_not_folded() {
+        // An empty `[[]]` anchor is not a valid document anchor, so it is not
+        // folded: the header terminates and no title is recognized.
+        let doc = Parser::default().parse("[[]]\n= Document Title");
+        let header = doc.header();
+
+        assert_eq!(header.title(), None);
+        assert_eq!(header.id(), None);
+    }
+
+    #[test]
     fn stacked_block_attributes_above_title() {
         // Multiple block attribute lines may stack above the document title;
         // each folds into the document's metadata and the title is still
@@ -2141,16 +2273,16 @@ mod tests {
     }
 
     #[test]
-    fn stacked_block_attributes_stop_at_a_block_anchor() {
-        // A `[[anchor]]` line breaks the run of foldable metadata lines: the
-        // scan stops there without seeing the title, so nothing above it is
-        // folded and the header terminates (matching the single-line anchor
-        // rejection).
+    fn stacked_block_anchor_folds_and_overrides_id() {
+        // A `[[anchor]]` line stacks with other foldable metadata above the
+        // document title. It is folded as document metadata and, like the block
+        // parser, a later id wins: the anchor's id overrides the id set by the
+        // preceding `[#docid]` shorthand.
         let doc = Parser::default().parse("[#docid]\n[[anchor]]\n= Some Title");
         let header = doc.header();
 
-        assert_eq!(header.title(), None);
-        assert_eq!(header.id(), None);
+        assert_eq!(header.title(), Some("Some Title"));
+        assert_eq!(header.id(), Some("anchor"));
     }
 
     #[test]
@@ -2158,8 +2290,10 @@ mod tests {
         // A block attribute line above the title is only parsed as document
         // metadata once a title is confirmed to follow it (via
         // `document_title_follows_block_metadata`, which scans structurally and
-        // never parses an attribute list). Here the `[[anchor]]` breaks the run
-        // before any title, so the lookahead fails and the `[reftext=…]` line's
+        // never parses an attribute list). Here the `[[not a name]]` line is not
+        // foldable metadata – it is neither a block attribute list nor a valid
+        // `[[id]]` anchor (the id is not an XML name) – so it breaks the run
+        // before any title, the lookahead fails, and the `[reftext=…]` line's
         // attribute list is never parsed during header parsing – its embedded
         // `{counter:item}` must not fire at header time.
         //
@@ -2168,10 +2302,13 @@ mod tests {
         // reference renders 2 – not 3, which is what a leaked header-time
         // evaluation would produce.
         let doc = Parser::default()
-            .parse("[reftext=\"See {counter:item}\"]\n[[anchor]]\n= Title\n\n{counter:item}");
+            .parse("[reftext=\"See {counter:item}\"]\n[[not a name]]\n= Title\n\n{counter:item}");
 
         assert_eq!(doc.header().title(), None);
-        assert_eq!(rendered_paragraphs(&doc), vec!["= Title", "2"]);
+        assert_eq!(
+            rendered_paragraphs(&doc),
+            vec!["[[not a name]]\n= Title", "2"]
+        );
     }
 
     #[test]
@@ -2229,20 +2366,27 @@ mod tests {
     fn bracketed_line_that_is_not_a_separator_attribute_list() {
         // A `[...]` line above the title that isn't a well-formed block
         // attribute list carrying `separator` is not consumed as a separator. A
-        // block anchor (`[[...]]`) and a leading-space form are both rejected,
-        // so the line terminates the header exactly as any other unrecognized
-        // line would.
-        let doc = Parser::default().parse("[[anchor]]\n= Some Title: Subtitle");
-        let header = doc.header();
-
-        assert_eq!(header.title(), None);
-        assert_eq!(header.subtitle(), None);
-
+        // leading-space form is rejected, so the line terminates the header
+        // exactly as any other unrecognized line would.
         let doc = Parser::default().parse("[ separator=::]\n= Main Title:: Subtitle");
         let header = doc.header();
 
         assert_eq!(header.title(), None);
         assert_eq!(header.subtitle(), None);
+    }
+
+    #[test]
+    fn block_anchor_above_title_sets_id_and_recovers_title() {
+        // A `[[id]]` block anchor directly above the document title assigns the
+        // document id and still recovers the title (including a subtitle),
+        // matching the `[#id]` shorthand.
+        let doc = Parser::default().parse("[[anchor]]\n= Some Title: Subtitle");
+        let header = doc.header();
+
+        assert_eq!(header.title(), Some("Some Title: Subtitle"));
+        assert_eq!(header.subtitle(), Some("Subtitle"));
+        assert_eq!(header.id(), Some("anchor"));
+        assert_eq!(doc.id(), Some("anchor"));
     }
 
     #[test]

--- a/parser/src/tests/asciidoctor_rb/sections_test.rs
+++ b/parser/src/tests/asciidoctor_rb/sections_test.rs
@@ -1305,10 +1305,13 @@ mod levels {
 
         // NOTE: A document-level ID (`[[idname]]`/`[#idname]` above the document
         // title, or a block ID above it) sets the `id` on the standalone
-        // `<body>` and registers the document in the catalog. This crate does
-        // not model a document-level ID / body element / document self-entry, so
-        // the remaining Level-0 tests — which assert `body#id`, `doc.id`, and
-        // document catalog registration — are out of scope.
+        // `<body>` and registers the document in the catalog. This crate models
+        // the document-level ID itself — exposed through `Header::id` /
+        // `Document::id`, and exercised directly in the `header` unit tests for
+        // both the shorthand and `[[id]]` anchor forms — but does not
+        // model the standalone `<body>` element or the document self-entry in
+        // the catalog. The remaining Level-0 tests below assert `body#id` and
+        // catalog registration, so they stay out of scope.
         non_normative!(
             r##"
       test 'should assign id on document title to body' do


### PR DESCRIPTION
## Summary

Fixes #968: a bracketed block anchor (`[[id]]`) on the line directly above the document title was not recognized as document-title metadata. Header detection failed entirely — `Header::title()` and `Header::id()` both returned `None`, and the `= Document Title` line was parsed as ordinary paragraph text. Only the `[#id]` shorthand worked.

## What changed

`parser/src/document/header.rs` now folds a `[[id]]` anchor above the title the same way it already folds a `[#id]` / `[role=…]` block-attribute line:

- A new `parse_document_block_anchor` extracts the id and optional reftext from a `[[id]]` / `[[id,reftext]]` line, validating the id as an XML name (mirroring the block-parser anchor handling in `blocks/metadata.rs`).
- The header parse loop gains a branch that assigns the id to the document and folds `[[id,reftext]]`'s reftext into the `reftext` document attribute.
- The stacked-metadata lookahead (`document_title_follows_block_metadata`) now treats a valid `[[id]]` anchor as a foldable metadata line, so anchors stack with block-attribute lines above the title; a later id wins, matching Asciidoctor's `parse_block_metadata_line`.

## Behavior

```rust
parser.parse("[[idname]]\n= Document Title\n\ncontent\n");
// header.id()    == Some("idname")
// header.title() == Some("Document Title")

parser.parse("[[manual,Manual]]\n= Reference Manual\n\npreamble");
// header.id()                    == Some("manual")
// doc.attribute_value("reftext") == "Manual"
```

An empty `[[]]` or a non-XML-name id (e.g. `[[not a name]]`) is not folded and still terminates the header, so it is left for the block parser.

## Tests

- Added `block_anchor_id_above_title`, `block_anchor_reftext_above_title`, `empty_block_anchor_above_title_is_not_folded`, `block_anchor_above_title_sets_id_and_recovers_title`, and repurposed the stacked-anchor test to assert the new fold/override behavior.
- Updated three existing header tests that had deliberately encoded the old rejection behavior.
- Updated the `non_normative!` NOTE in `sections_test.rs`: the document-level id is now modeled (`Header::id` / `Document::id`); only `body#id` rendering and catalog registration remain out of scope for this crate.

`cargo +nightly fmt --all -- --check`, `cargo clippy`, and the full test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)