### PR TITLE
fix: Honor API-supplied `hardbreaks` document attribute for line breaks

### DIFF
--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1435,7 +1435,7 @@ impl Parser {
         value: V,
         modification_context: ModificationContext,
     ) -> Self {
-        let name = name.as_ref().to_lowercase();
+        let name = alias_attr_name(name.as_ref().to_lowercase());
         let value = InterpretedValue::Value(value.as_ref().to_string());
         let attribute_value = AttributeValue {
             allowable_value: AllowableValue::Any,
@@ -1485,7 +1485,7 @@ impl Parser {
         value: V,
         modification_context: ModificationContext,
     ) -> Self {
-        let name = name.as_ref().to_lowercase();
+        let name = alias_attr_name(name.as_ref().to_lowercase());
         let value = InterpretedValue::Value(value.as_ref().to_string());
         let attribute_value = AttributeValue {
             allowable_value: AllowableValue::Any,
@@ -1888,7 +1888,7 @@ impl Parser {
         value: bool,
         modification_context: ModificationContext,
     ) -> Self {
-        let name = name.as_ref().to_lowercase();
+        let name = alias_attr_name(name.as_ref().to_lowercase());
         let value = if value {
             InterpretedValue::Set
         } else {
@@ -1938,7 +1938,7 @@ impl Parser {
         value: bool,
         modification_context: ModificationContext,
     ) -> Self {
-        let name = name.as_ref().to_lowercase();
+        let name = alias_attr_name(name.as_ref().to_lowercase());
         let value = if value {
             InterpretedValue::Set
         } else {
@@ -2860,10 +2860,22 @@ fn remap_attr_name<N: AsRef<str>>(raw_attr_name: N) -> String {
         .to_lowercase();
 
     // Some attribute names have aliases. Remap to the primary name.
-    //
-    // `numbered` is a legacy alias for `sectnums`, so setting `numbered` sets
-    // `sectnums` (and `numbered!` unsets it). Mirrors Asciidoctor's
-    // `Parser.store_attribute`, which renames the attribute before storing it.
+    alias_attr_name(attr_name)
+}
+
+/// Remaps an attribute name that is a legacy alias to its primary name,
+/// returning any other name unchanged.
+///
+/// `numbered` is a legacy alias for `sectnums`, and `hardbreaks` for
+/// `hardbreaks-option`, so setting `numbered` sets `sectnums` (and `numbered!`
+/// unsets it), and setting `hardbreaks` sets `hardbreaks-option`. Mirrors both
+/// Asciidoctor's `Parser.store_attribute` (which renames a header/body
+/// attribute entry before storing it) and its `Document#initialize` (which
+/// renames the same two API-supplied attribute overrides: `attr_overrides`
+/// `sectnums`/`hardbreaks-option` reassignment). Applying it on both paths is
+/// what lets `-a hardbreaks` supplied through the API enable hard line breaks,
+/// exactly as `:hardbreaks:` in the header does.
+fn alias_attr_name(attr_name: String) -> String {
     match attr_name.as_str() {
         "hardbreaks" => "hardbreaks-option".to_string(),
         "numbered" => "sectnums".to_string(),
@@ -3083,6 +3095,15 @@ mod tests {
         }
 
         #[test]
+        fn remaps_legacy_aliases() {
+            // `hardbreaks` and `numbered` are legacy aliases remapped to their
+            // primary names, matching Asciidoctor's `Parser.store_attribute`.
+            assert_eq!(remap_attr_name("hardbreaks"), "hardbreaks-option");
+            assert_eq!(remap_attr_name("Hardbreaks"), "hardbreaks-option");
+            assert_eq!(remap_attr_name("numbered"), "sectnums");
+        }
+
+        #[test]
         fn preserves_unicode_word_characters() {
             // Unicode letters and digits are word characters, so they survive
             // sanitization; the `{café}` / `{سمن}` references then resolve.
@@ -3246,6 +3267,30 @@ mod tests {
         assert!(p.is_attribute_set("foo"));
         assert!(!p.is_attribute_set("foo2"));
         assert!(!p.is_attribute_set("xyz"));
+    }
+
+    #[test]
+    fn with_intrinsic_attribute_remaps_legacy_aliases() {
+        // An API-supplied `hardbreaks` (Asciidoctor's `-a hardbreaks`) is a
+        // legacy alias remapped to `hardbreaks-option`, exactly as the same
+        // attribute written as a header entry (`:hardbreaks:`) is. Without the
+        // remap the API form is stored verbatim as `hardbreaks` and the
+        // paragraph's post-replacement check (which consults
+        // `hardbreaks-option`) never sees it.
+        let mut p = Parser::default().with_intrinsic_attribute(
+            "hardbreaks",
+            "",
+            ModificationContext::Anywhere,
+        );
+
+        assert!(p.is_attribute_set("hardbreaks-option"));
+
+        // The end-to-end effect: each unwrapped line gains a hard line break.
+        let doc = p.parse("First line\nSecond line");
+        assert_eq!(
+            rendered_paragraphs(&doc),
+            vec!["First line<br>\nSecond line"]
+        );
     }
 
     // Under `SafeMode::Server` or greater, `docdir` reads as empty and

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -11596,11 +11596,17 @@ mod post_replacements {
 "#
         );
 
-        let mut p = Parser::default();
-        let maw = crate::blocks::Block::parse(
-            crate::Span::new("[%hardbreaks]\nFirst line\nSecond line"),
-            &mut p,
+        // The `hardbreaks` attribute is supplied through the API (as
+        // Asciidoctor's `attributes: { 'hardbreaks' => '' }`), not via a
+        // `[%hardbreaks]` block option: a document-level `hardbreaks` set
+        // through the API must enable per-line hard breaks.
+        let mut p = Parser::default().with_intrinsic_attribute(
+            "hardbreaks",
+            "",
+            ModificationContext::Anywhere,
         );
+
+        let maw = crate::blocks::Block::parse(crate::Span::new("First line\nSecond line"), &mut p);
 
         let block = maw.item.unwrap().item;
 
@@ -11610,14 +11616,14 @@ mod post_replacements {
                 content: Content {
                     original: Span {
                         data: "First line\nSecond line",
-                        line: 2,
+                        line: 1,
                         col: 1,
-                        offset: 14,
+                        offset: 0,
                     },
                     rendered: "First line<br>\nSecond line",
                 },
                 source: Span {
-                    data: "[%hardbreaks]\nFirst line\nSecond line",
+                    data: "First line\nSecond line",
                     line: 1,
                     col: 1,
                     offset: 0,
@@ -11629,20 +11635,7 @@ mod post_replacements {
                 number: None,
                 anchor: None,
                 anchor_reftext: None,
-                attrlist: Some(Attrlist {
-                    attributes: &[ElementAttribute {
-                        name: None,
-                        shorthand_items: &["%hardbreaks"],
-                        value: "%hardbreaks"
-                    },],
-                    anchor: None,
-                    source: Span {
-                        data: "%hardbreaks",
-                        line: 1,
-                        col: 2,
-                        offset: 1,
-                    },
-                },),
+                attrlist: None,
             },)
         );
     }
@@ -11660,11 +11653,16 @@ mod post_replacements {
 "#
         );
 
-        let mut p = Parser::default();
-        let maw = crate::blocks::Block::parse(
-            crate::Span::new("[%hardbreaks]\nFirst line +\nSecond line"),
-            &mut p,
+        // See the note on the API-supplied `hardbreaks` attribute in
+        // `line_break_inserted_after_line_wrap_with_hardbreaks_enabled`.
+        let mut p = Parser::default().with_intrinsic_attribute(
+            "hardbreaks",
+            "",
+            ModificationContext::Anywhere,
         );
+
+        let maw =
+            crate::blocks::Block::parse(crate::Span::new("First line +\nSecond line"), &mut p);
 
         let block = maw.item.unwrap().item;
 
@@ -11674,14 +11672,14 @@ mod post_replacements {
                 content: Content {
                     original: Span {
                         data: "First line +\nSecond line",
-                        line: 2,
+                        line: 1,
                         col: 1,
-                        offset: 14,
+                        offset: 0,
                     },
                     rendered: "First line<br>\nSecond line",
                 },
                 source: Span {
-                    data: "[%hardbreaks]\nFirst line +\nSecond line",
+                    data: "First line +\nSecond line",
                     line: 1,
                     col: 1,
                     offset: 0,
@@ -11693,20 +11691,7 @@ mod post_replacements {
                 number: None,
                 anchor: None,
                 anchor_reftext: None,
-                attrlist: Some(Attrlist {
-                    attributes: &[ElementAttribute {
-                        name: None,
-                        shorthand_items: &["%hardbreaks"],
-                        value: "%hardbreaks"
-                    },],
-                    anchor: None,
-                    source: Span {
-                        data: "%hardbreaks",
-                        line: 1,
-                        col: 2,
-                        offset: 1,
-                    },
-                },),
+                attrlist: None,
             },)
         );
     }
@@ -11723,9 +11708,15 @@ mod post_replacements {
 "#
         );
 
-        let mut p = Parser::default();
-        let maw =
-            crate::blocks::Block::parse(crate::Span::new("[%hardbreaks]\nFirst line"), &mut p);
+        // See the note on the API-supplied `hardbreaks` attribute in
+        // `line_break_inserted_after_line_wrap_with_hardbreaks_enabled`.
+        let mut p = Parser::default().with_intrinsic_attribute(
+            "hardbreaks",
+            "",
+            ModificationContext::Anywhere,
+        );
+
+        let maw = crate::blocks::Block::parse(crate::Span::new("First line"), &mut p);
 
         let block = maw.item.unwrap().item;
 
@@ -11735,14 +11726,14 @@ mod post_replacements {
                 content: Content {
                     original: Span {
                         data: "First line",
-                        line: 2,
+                        line: 1,
                         col: 1,
-                        offset: 14,
+                        offset: 0,
                     },
                     rendered: "First line",
                 },
                 source: Span {
-                    data: "[%hardbreaks]\nFirst line",
+                    data: "First line",
                     line: 1,
                     col: 1,
                     offset: 0,
@@ -11754,20 +11745,7 @@ mod post_replacements {
                 number: None,
                 anchor: None,
                 anchor_reftext: None,
-                attrlist: Some(Attrlist {
-                    attributes: &[ElementAttribute {
-                        name: None,
-                        shorthand_items: &["%hardbreaks"],
-                        value: "%hardbreaks"
-                    },],
-                    anchor: None,
-                    source: Span {
-                        data: "%hardbreaks",
-                        line: 1,
-                        col: 2,
-                        offset: 1,
-                    },
-                },),
+                attrlist: None,
             },)
         );
     }


### PR DESCRIPTION
## Summary

Fixes #974. When the `hardbreaks` document attribute is supplied **via the API / CLI** (Asciidoctor's `-a hardbreaks` / `attributes: { 'hardbreaks' => '' }`), paragraphs now get a `<br>` inserted at each unwrapped line — matching Asciidoctor, and matching what this crate already did for the header entry (`:hardbreaks:`) and the `[%hardbreaks]` block option.

## Root cause

Asciidoctor renames the legacy `hardbreaks` alias to `hardbreaks-option` on **both** attribute paths:

- the header/body path — `Parser.store_attribute`
- the API-override path — `Document#initialize` (`attr_overrides['hardbreaks-option'] = attr_overrides.delete 'hardbreaks'`)

This crate only applied the rename on the header/body path, in `remap_attr_name`. The API path (`with_intrinsic_attribute` and its `_silent` / `_bool` / `_bool_silent` variants) stored the name verbatim as `hardbreaks`. The paragraph's post-replacement check consults `hardbreaks-option`, so the API-supplied value was never honored.

## Fix

- Extract the alias remap (`hardbreaks` → `hardbreaks-option`, `numbered` → `sectnums`) into a shared `alias_attr_name` helper.
- Apply it on the API path in all four `with_intrinsic_attribute*` setters, so the API form is stored under the same key the header form uses.

## Tests

- The three ported `substitutions_test` hardbreaks cases (`line_break_inserted_after_line_wrap…`, `line_break_character_stripped…`, `line_break_not_inserted_for_single_line…`) now **faithfully** exercise the API attribute the way upstream does, instead of sidestepping the case via `[%hardbreaks]`.
- Added unit coverage: `alias_attr_name` remapping and an end-to-end `with_intrinsic_attribute_remaps_legacy_aliases` test.

Full lib suite passes; `cargo clippy` and `cargo +nightly fmt --check` are clean.

Downstream: unblocks `asciidoc-rs/asciidoc-html5`'s port of this test, currently marked `non_normative!` pending this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)