### PR TITLE
feat: Expose an AsciiDoc table cell's own footnotes

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -10,7 +10,7 @@ use crate::{
         metadata::BlockMetadata, parse_utils::parse_blocks_until,
     },
     content::{Content, SubstitutionGroup},
-    document::{InterpretedValue, TocConfig, TocMode},
+    document::{Footnote, InterpretedValue, TocConfig, TocMode},
     parser::{
         AttributeValue, InlineSubstitutionRenderer, ModificationContext, ReferenceResolver,
         ReferenceWarnings, ResolvedAttributes, SourceLine, built_in_attr, built_in_attrs_iter,
@@ -1873,7 +1873,7 @@ fn process_content<'src>(
                 // (file, line), and so a table nested within cannot mis-map its
                 // spans against the document source map.
                 parser.push_owned_cell_source_map(cell_source_map);
-                let (title, inline, toc, blocks, attributes) =
+                let (title, inline, toc, blocks, attributes, footnotes) =
                     parse_asciidoc_cell_body(Span::new(source), parser, &mut owned_warnings);
 
                 let owned_root = Span::new(source);
@@ -1900,6 +1900,7 @@ fn process_content<'src>(
                     toc,
                     blocks,
                     attributes,
+                    footnotes,
                 }
             });
 
@@ -1923,15 +1924,16 @@ fn process_content<'src>(
 
             AsciiDocCell::Owned(Arc::new(owned))
         } else {
-            let (title, inline, toc, blocks, attributes) =
+            let (title, inline, toc, blocks, attributes, footnotes) =
                 parse_asciidoc_cell_body(trimmed, parser, warnings);
-            AsciiDocCell::Borrowed(BorrowedCell {
+            AsciiDocCell::Borrowed(Box::new(BorrowedCell {
                 title,
                 inline,
                 toc,
                 blocks,
                 attributes,
-            })
+                footnotes,
+            }))
         };
 
         parser.locked_attribute_names = saved_locks;
@@ -1956,8 +1958,8 @@ fn process_content<'src>(
 
 /// Parses the body of an AsciiDoc table cell – a nested, standalone AsciiDoc
 /// document – returning its (shown) title, whether its doctype is `inline`, its
-/// table-of-contents configuration, its blocks, and a snapshot of the cell's
-/// resolved attribute state.
+/// table-of-contents configuration, its blocks, a snapshot of the cell's
+/// resolved attribute state, and the footnotes defined within the cell.
 ///
 /// A leading level-0 title line (`= Title`) is the nested document's title
 /// rather than a section, so it is split off and rendered here (a level-0
@@ -1981,6 +1983,7 @@ fn parse_asciidoc_cell_body<'src>(
     TocConfig,
     Vec<Block<'src>>,
     ResolvedAttributes,
+    Vec<Footnote>,
 ) {
     let first_line = content.take_line();
     let (title_source, body) = if first_line.item.data().starts_with("= ") {
@@ -1995,9 +1998,10 @@ fn parse_asciidoc_cell_body<'src>(
     // A nested document keeps its own footnote registry: footnotes defined
     // inside this cell must not be shared with (or numbered into the list of)
     // the enclosing document. We swap in a fresh, empty footnote list for the
-    // duration of the cell parse and restore the parent's afterward, discarding
-    // the cell's footnotes (see issue #544). The `footnote-number` counter is a
-    // document-wide attribute and is deliberately *not* reset, so footnote
+    // duration of the cell parse and restore the parent's afterward (see issue
+    // #544). The cell's own footnotes are retained and returned so a renderer
+    // can emit the cell-local `#footnotes` block. The `footnote-number` counter
+    // is a document-wide attribute and is deliberately *not* reset, so footnote
     // numbering continues across the cell as Asciidoctor does.
     let saved_footnotes = parser.take_footnotes();
 
@@ -2026,6 +2030,10 @@ fn parse_asciidoc_cell_body<'src>(
     warnings.append(&mut maw.warnings);
 
     parser.pending_block_title = saved_pending_block_title;
+
+    // Take the cell's own footnotes (leaving the registry empty) before
+    // restoring the parent's, so they can be returned for the cell to expose.
+    let footnotes = parser.take_footnotes();
     parser.restore_footnotes(saved_footnotes);
 
     let inline = matches!(
@@ -2063,7 +2071,7 @@ fn parse_asciidoc_cell_body<'src>(
     // attribute state the caller restores to the parent's on return anyway).
     attributes.materialize_toc_attributes(toc.mode);
 
-    (title, inline, toc, maw.item.item, attributes)
+    (title, inline, toc, maw.item.item, attributes, footnotes)
 }
 
 /// Returns `true` when the cell content holds an `include::` preprocessor
@@ -2357,7 +2365,10 @@ pub enum TableCellContent<'src> {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum AsciiDocCell<'src> {
     /// Parsed in place from the parent document's source.
-    Borrowed(BorrowedCell<'src>),
+    ///
+    /// Boxed to keep the two variants' sizes close (the [`Owned`](Self::Owned)
+    /// variant is a single [`Arc`]).
+    Borrowed(Box<BorrowedCell<'src>>),
 
     /// Parsed from an owned, include-expanded source the cell carries.
     Owned(Arc<OwnedCell>),
@@ -2431,6 +2442,22 @@ impl<'src> AsciiDocCell<'src> {
         }
     }
 
+    /// Returns the footnotes defined within the cell, in document order.
+    ///
+    /// An AsciiDoc (`a`) cell is a nested, standalone document that keeps its
+    /// own footnote registry, isolated from the enclosing document (see issue
+    /// #544). These are the footnotes the cell defined, letting a renderer emit
+    /// the cell-local `#footnotes` block the way Asciidoctor renders the cell's
+    /// nested document. It mirrors
+    /// [`Catalog::footnotes`](crate::document::Catalog::footnotes), which
+    /// exposes the top-level document's own footnotes.
+    pub fn footnotes(&self) -> &[Footnote] {
+        match self {
+            Self::Borrowed(cell) => &cell.footnotes,
+            Self::Owned(cell) => &cell.borrow_dependent().footnotes,
+        }
+    }
+
     /// Returns `true` because an AsciiDoc table cell is always a nested,
     /// standalone document.
     ///
@@ -2481,9 +2508,9 @@ impl<'src> AsciiDocCell<'src> {
         }
     }
 
-    /// Resolves any deferred cross-references in the cell's blocks. `source` is
-    /// the enclosing cell's span, used to anchor warnings raised from an
-    /// [owned](Self::Owned) cell's private source.
+    /// Resolves any deferred cross-references in the cell's blocks and
+    /// footnotes. `source` is the enclosing cell's span, used to anchor
+    /// warnings raised from an [owned](Self::Owned) cell's private source.
     fn resolve_references(
         &mut self,
         resolver: &dyn ReferenceResolver,
@@ -2496,6 +2523,13 @@ impl<'src> AsciiDocCell<'src> {
                 for block in &mut cell.blocks {
                     block.resolve_references(resolver, renderer, warnings);
                 }
+
+                // A cell footnote records no document location (it is defined in
+                // an owned sub-source), so resolution falls back to `source`,
+                // the cell's span, for any unresolved-reference warning.
+                for footnote in &mut cell.footnotes {
+                    footnote.resolve_references(resolver, renderer, warnings, source);
+                }
             }
 
             // The owned store is shared behind an `Arc`, but references are
@@ -2503,14 +2537,29 @@ impl<'src> AsciiDocCell<'src> {
             // owner, so `get_mut` succeeds.
             Self::Owned(cell) => {
                 if let Some(cell) = Arc::get_mut(cell) {
-                    cell.with_dependent_mut(|_, dependent| {
-                        // These blocks borrow the cell's own owned source, so
-                        // their warnings are collected separately and then
-                        // re-anchored to the cell's span in the document.
+                    cell.with_dependent_mut(|owned_source, dependent| {
+                        // These blocks (and footnotes) borrow the cell's own
+                        // owned source, so their warnings are collected
+                        // separately and then re-anchored to the cell's span in
+                        // the document.
                         let mut owned_warnings = ReferenceWarnings::default();
 
                         for block in &mut dependent.blocks {
                             block.resolve_references(resolver, renderer, &mut owned_warnings);
+                        }
+
+                        // A cell footnote records no document location, so its
+                        // resolution falls back to the owned source span for any
+                        // warning; those warnings are re-homed to the cell's span
+                        // in the document below regardless.
+                        let owned_root = Span::new(owned_source);
+                        for footnote in &mut dependent.footnotes {
+                            footnote.resolve_references(
+                                resolver,
+                                renderer,
+                                &mut owned_warnings,
+                                owned_root,
+                            );
                         }
 
                         owned_warnings.rehome_into(warnings, source);
@@ -2530,6 +2579,7 @@ pub struct BorrowedCell<'src> {
     toc: TocConfig,
     blocks: Vec<Block<'src>>,
     attributes: ResolvedAttributes,
+    footnotes: Vec<Footnote>,
 }
 
 self_cell! {
@@ -2553,6 +2603,7 @@ struct OwnedCellInner<'src> {
     toc: TocConfig,
     blocks: Vec<Block<'src>>,
     attributes: ResolvedAttributes,
+    footnotes: Vec<Footnote>,
 }
 
 /// Parse the value of the `cols` attribute into a list of columns, mirroring
@@ -3282,6 +3333,7 @@ mod tests {
                 toc: TocConfig::disabled(),
                 blocks: vec![],
                 attributes: ResolvedAttributes::default(),
+                footnotes: vec![],
             }
         })));
 

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -3255,6 +3255,8 @@ mod tests {
     };
     use crate::{
         Span,
+        content::FootnoteDeferred,
+        document::Footnote,
         parser::{
             HtmlSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext,
             ResolvedReference, SourceLine,
@@ -3324,6 +3326,11 @@ mod tests {
     /// panicking. Production code resolves while the cell is its sole
     /// owner, so this defensive branch is exercised here by deliberately
     /// holding a second reference.
+    ///
+    /// The cell's footnotes are resolved in the *same* guarded branch as its
+    /// blocks, so they share this behavior exactly: a shared owned cell leaves
+    /// both its blocks and its footnotes untouched – they never diverge (one
+    /// re-resolved while the other stays stale).
     #[test]
     fn resolve_references_skips_shared_owned_cell() {
         let mut cell = AsciiDocCell::Owned(Arc::new(OwnedCell::new(String::new(), |_source| {
@@ -3333,7 +3340,21 @@ mod tests {
                 toc: TocConfig::disabled(),
                 blocks: vec![],
                 attributes: ResolvedAttributes::default(),
-                footnotes: vec![],
+
+                // A footnote that still carries deferred cross-reference state:
+                // resolving it would rebuild `text` from the template
+                // (`RESOLVED`), so the sentinel `text` below changes if – and
+                // only if – the shared cell is mistakenly resolved.
+                footnotes: vec![Footnote {
+                    index: "1".to_string(),
+                    id: None,
+                    text: "UNRESOLVED".to_string(),
+                    deferred: Some(Box::new(FootnoteDeferred::new(
+                        "RESOLVED".to_string(),
+                        vec![],
+                    ))),
+                    location: None,
+                }],
             }
         })));
 
@@ -3354,6 +3375,11 @@ mod tests {
         assert!(warnings.host.is_empty());
         assert!(warnings.doc.is_empty());
         assert_eq!(cell, shared);
+
+        // The footnote was left untouched too: its text keeps the
+        // pre-resolution sentinel rather than the rebuilt `RESOLVED` value.
+        let footnote_texts: Vec<&str> = cell.footnotes().iter().map(|f| f.text.as_str()).collect();
+        assert_eq!(footnote_texts, ["UNRESOLVED"]);
     }
 
     mod unresolved_directive_in_asciidoc_cell {

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -1998,10 +1998,10 @@ fn parse_asciidoc_cell_body<'src>(
     // A nested document keeps its own footnote registry: footnotes defined
     // inside this cell must not be shared with (or numbered into the list of)
     // the enclosing document. We swap in a fresh, empty footnote list for the
-    // duration of the cell parse and restore the parent's afterward (see issue
-    // #544). The cell's own footnotes are retained and returned so a renderer
-    // can emit the cell-local `#footnotes` block. The `footnote-number` counter
-    // is a document-wide attribute and is deliberately *not* reset, so footnote
+    // duration of the cell parse and restore the parent's afterward. The cell's
+    // own footnotes are retained and returned so a renderer can emit the
+    // cell-local `#footnotes` block. The `footnote-number` counter is a
+    // document-wide attribute and is deliberately *not* reset, so footnote
     // numbering continues across the cell as Asciidoctor does.
     let saved_footnotes = parser.take_footnotes();
 
@@ -2445,10 +2445,10 @@ impl<'src> AsciiDocCell<'src> {
     /// Returns the footnotes defined within the cell, in document order.
     ///
     /// An AsciiDoc (`a`) cell is a nested, standalone document that keeps its
-    /// own footnote registry, isolated from the enclosing document (see issue
-    /// #544). These are the footnotes the cell defined, letting a renderer emit
-    /// the cell-local `#footnotes` block the way Asciidoctor renders the cell's
-    /// nested document. It mirrors
+    /// own footnote registry, isolated from the enclosing document. These are
+    /// the footnotes the cell defined, letting a renderer emit the cell-local
+    /// `#footnotes` block the way Asciidoctor renders the cell's nested
+    /// document. It mirrors
     /// [`Catalog::footnotes`](crate::document::Catalog::footnotes), which
     /// exposes the top-level document's own footnotes.
     pub fn footnotes(&self) -> &[Footnote] {

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -773,9 +773,8 @@ fn include_expanded_asciidoc_cell_exposes_inherited_attributes_for_introspection
 #[test]
 fn asciidoc_cell_exposes_its_own_footnotes() {
     // An AsciiDoc cell keeps its own footnote registry, isolated from the
-    // enclosing document (see issue #544). Its footnotes are retained and
-    // exposed via `footnotes()`, so a renderer can emit the cell-local
-    // `#footnotes` block.
+    // enclosing document. Its footnotes are retained and exposed via
+    // `footnotes()`, so a renderer can emit the cell-local `#footnotes` block.
     let doc =
         Parser::default().parse("|===\na|AsciiDoc footnote:[A lightweight markup language.]\n|===");
 
@@ -799,7 +798,7 @@ fn asciidoc_cell_exposes_its_own_footnotes() {
     assert_eq!(footnotes[0].text, "A lightweight markup language.");
 
     // It is *not* shared with the enclosing document: the main document's
-    // footnote registry stays empty (see issue #544).
+    // footnote registry stays empty.
     assert!(doc.catalog().footnotes().is_empty());
 }
 

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -770,6 +770,104 @@ fn include_expanded_asciidoc_cell_exposes_inherited_attributes_for_introspection
     assert!(!cell.has_attribute("no-such-attr"));
 }
 
+#[test]
+fn asciidoc_cell_exposes_its_own_footnotes() {
+    // An AsciiDoc cell keeps its own footnote registry, isolated from the
+    // enclosing document (see issue #544). Its footnotes are retained and
+    // exposed via `footnotes()`, so a renderer can emit the cell-local
+    // `#footnotes` block.
+    let doc =
+        Parser::default().parse("|===\na|AsciiDoc footnote:[A lightweight markup language.]\n|===");
+
+    let table = doc
+        .child_blocks()
+        .find_map(|block| match block {
+            Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .unwrap();
+
+    let TableCellContent::AsciiDoc(cell) = table.body_rows()[0].cells()[0].content() else {
+        panic!("expected AsciiDoc cell content");
+    };
+
+    // The footnote defined inside the cell is retained on the cell.
+    let footnotes = cell.footnotes();
+    assert_eq!(footnotes.len(), 1);
+    assert_eq!(footnotes[0].index, "1");
+    assert_eq!(footnotes[0].id, None);
+    assert_eq!(footnotes[0].text, "A lightweight markup language.");
+
+    // It is *not* shared with the enclosing document: the main document's
+    // footnote registry stays empty (see issue #544).
+    assert!(doc.catalog().footnotes().is_empty());
+}
+
+#[test]
+fn include_expanded_asciidoc_cell_exposes_its_own_footnotes() {
+    // A cell whose first line is an `include::` directive is parsed from an
+    // owned, include-expanded source (the `AsciiDocCell::Owned` variant). Its
+    // footnotes reach through the owned store the same way, exercising the
+    // owned-store branch of `footnotes()`.
+    use crate::{SafeMode, tests::fixtures::inline_file_handler::InlineFileHandler};
+
+    let handler = InlineFileHandler::from_pairs([(
+        "fixtures/cell.adoc",
+        "AsciiDoc footnote:[A lightweight markup language.]",
+    )]);
+
+    let doc = Parser::default()
+        .with_safe_mode(SafeMode::Server)
+        .with_include_file_handler(handler)
+        .parse("|===\na|include::fixtures/cell.adoc[]\n|===");
+
+    let table = doc
+        .child_blocks()
+        .find_map(|block| match block {
+            Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .unwrap();
+
+    let TableCellContent::AsciiDoc(cell) = table.body_rows()[0].cells()[0].content() else {
+        panic!("expected AsciiDoc cell content");
+    };
+
+    let footnotes = cell.footnotes();
+    assert_eq!(footnotes.len(), 1);
+    assert_eq!(footnotes[0].text, "A lightweight markup language.");
+
+    assert!(doc.catalog().footnotes().is_empty());
+}
+
+#[test]
+fn asciidoc_cell_footnote_resolves_cross_reference() {
+    // A cross-reference inside a cell footnote is resolved during the document's
+    // reference-resolution pass, against the shared catalog. The resolved link
+    // is reflected in the exposed footnote text.
+    let doc = Parser::default()
+        .parse("[[target]]Anchored text.\n\n|===\na|Cell footnote:[See <<target>>.]\n|===");
+
+    let table = doc
+        .child_blocks()
+        .find_map(|block| match block {
+            Block::Table(table) => Some(table),
+            _ => None,
+        })
+        .unwrap();
+
+    let TableCellContent::AsciiDoc(cell) = table.body_rows()[0].cells()[0].content() else {
+        panic!("expected AsciiDoc cell content");
+    };
+
+    let footnotes = cell.footnotes();
+    assert_eq!(footnotes.len(), 1);
+    assert_eq!(
+        footnotes[0].text,
+        r##"See <a href="#target">[target]</a>."##
+    );
+}
+
 /// Collect the rendered text of every block in an AsciiDoc cell.
 fn asciidoc_cell_text(table: &TableBlock<'_>, row: usize, col: usize) -> String {
     match table.body_rows()[row].cells()[col].content() {

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -656,7 +656,7 @@ fn render_template(
 /// (see [`Footnote::resolve_references`]).
 ///
 /// [`Footnote::resolve_references`]: crate::document::Footnote::resolve_references
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, Hash, PartialEq)]
 pub(crate) struct FootnoteDeferred {
     /// The footnote text with opaque placeholder tokens marking where each
     /// cross-reference will be spliced in.

--- a/parser/src/document/catalog.rs
+++ b/parser/src/document/catalog.rs
@@ -335,7 +335,7 @@ impl Catalog {
 /// be referenced from multiple locations by assigning it an ID at the first
 /// occurrence and repeating that ID (with empty text) afterward; only the
 /// defining occurrence produces a `Footnote` entry.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, Hash, PartialEq)]
 pub struct Footnote {
     /// The footnote's number, assigned in document order via the
     /// `footnote-number` counter. Normally a consecutive integer (`1`, `2`, …),

--- a/parser/src/tests/asciidoctor_rb/tables_test.rs
+++ b/parser/src/tests/asciidoctor_rb/tables_test.rs
@@ -3868,6 +3868,28 @@ mod psv {
             doc.catalog().footnotes().is_empty(),
             "cell footnote leaked into the main document's registry"
         );
+
+        // The cell instead retains and exposes its own footnote, so a renderer
+        // can emit the cell-local `#footnotes` block (`#_footnotedef_1` in the
+        // Ruby assertion above).
+        let table = doc
+            .child_blocks()
+            .find_map(|block| match block {
+                crate::blocks::Block::Table(table) => Some(table),
+                _ => None,
+            })
+            .expect("expected a table block");
+
+        let crate::blocks::TableCellContent::AsciiDoc(cell) =
+            table.body_rows()[0].cells()[0].content()
+        else {
+            panic!("expected an AsciiDoc cell");
+        };
+
+        let footnotes = cell.footnotes();
+        assert_eq!(footnotes.len(), 1);
+        assert_eq!(footnotes[0].index, "1");
+        assert_eq!(footnotes[0].text, "A lightweight markup language.");
     }
 
     // Out of scope: DocBook backend. ("callout numbers should be globally unique,


### PR DESCRIPTION
## Summary

An AsciiDoc (`a`) table cell is a nested document with its own footnote registry, correctly isolated from the main document (#544). But that per-cell footnote list was **discarded** after the cell parsed, so a downstream renderer had no data to build the cell-local `#footnotes` block that Asciidoctor emits.

This PR retains each AsciiDoc cell's own footnotes and exposes them via a new accessor, mirroring `Catalog::footnotes()`.

## Changes

- **`AsciiDocCell::footnotes() -> &[Footnote]`** – new public accessor returning the footnotes defined within the cell, in document order. Works for both the borrowed and owned (include-expanded) cell variants.
- **Retention** – `parse_asciidoc_cell_body` now takes the cell's own footnote list (leaving the registry empty) before restoring the parent's, instead of dropping it. The parent document's registry stays untouched, so the #544 isolation guarantee is preserved.
- **Cross-reference resolution** – cross-references inside a cell footnote are now resolved during the document's reference-resolution pass (against the shared catalog), so the exposed footnote text reflects resolved links rather than the unresolved fallback.
- **`Footnote` / `FootnoteDeferred`** now derive `Hash` (needed so the footnote list can live in the hashable cell structs).
- The `AsciiDocCell::Borrowed` variant is boxed to keep the enum's two variants close in size (satisfies `clippy::large_enum_variant` after the new field).

## Tests

- `asciidoc_cell_exposes_its_own_footnotes` – borrowed cell exposes its footnote; main document registry stays empty.
- `include_expanded_asciidoc_cell_exposes_its_own_footnotes` – exercises the owned-store branch.
- `asciidoc_cell_footnote_resolves_cross_reference` – a `<<target>>` inside a cell footnote resolves to a link in the exposed text.
- Extended the existing Ruby-mirrored `footnotes_should_not_be_shared_between_an_asciidoc_table_cell_and_the_main_document` test to assert the cell now exposes the footnote the Ruby `#_footnotedef_1` assertion depends on.

## Downstream context

`asciidoc-html5` has the document-level footnotes feature implemented (asciidoc-rs/asciidoc-html5#162); the AsciiDoc-table-cell case was the only remaining gap, tracked `non_normative!` there pending this parser capability.

Closes #975

🤖 Generated with [Claude Code](https://claude.com/claude-code)