### PR TITLE
fix: Preserve a quoted role on an inline passthrough span (#973)

### DIFF
--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -568,16 +568,13 @@ impl<'src> Attrlist<'src> {
             return None;
         }
 
-        // Asciidoctor considers only the first positional attribute, which is the
-        // source up to the first comma.
+        // Asciidoctor's `parse_quoted_text_attributes` considers only the first
+        // positional attribute – the source up to the first comma – and uses it
+        // verbatim (quote characters included) as the role. A quote-delimited
+        // first positional always leaves at least its opening quote here, so the
+        // slice is never empty.
         let raw = self.source.data();
-        let segment = raw.split(',').next().unwrap_or(raw).trim();
-
-        if segment.is_empty() {
-            None
-        } else {
-            Some(segment)
-        }
+        Some(raw.split_once(',').map_or(raw, |(first, _)| first).trim())
     }
 
     /// Returns any option attributes that were found.
@@ -2434,10 +2431,32 @@ mod tests {
             assert!(mi.item.block_style().is_none());
             assert_eq!(mi.item.quoted_text_fallback_role().unwrap(), "'role'");
 
+            // Only the first positional (the source up to the first comma) is
+            // considered, mirroring Asciidoctor's `parse_quoted_text_attributes`.
+            let mi = crate::attributes::Attrlist::parse(
+                crate::Span::new("'role',keep=dropped"),
+                &p,
+                AttrlistContext::Inline,
+            )
+            .unwrap_if_no_warnings();
+
+            assert_eq!(mi.item.quoted_text_fallback_role().unwrap(), "'role'");
+
             // An unquoted positional is handled by the normal block-style path,
             // so there is no fallback role to recover.
             let mi = crate::attributes::Attrlist::parse(
                 crate::Span::new("role"),
+                &p,
+                AttrlistContext::Inline,
+            )
+            .unwrap_if_no_warnings();
+
+            assert!(mi.item.quoted_text_fallback_role().is_none());
+
+            // A named-only or otherwise position-1-less attribute list has no
+            // first positional attribute, so there is nothing to recover.
+            let mi = crate::attributes::Attrlist::parse(
+                crate::Span::new("id=x"),
                 &p,
                 AttrlistContext::Inline,
             )

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -2445,6 +2445,19 @@ mod tests {
 
             assert_eq!(mi.item.quoted_text_fallback_role().unwrap(), "'role'");
 
+            // The comma boundary is applied to the raw source, matching
+            // Asciidoctor's `str.slice 0, (str.index ',')`, so a comma inside the
+            // quotes truncates the role there too rather than being kept as
+            // quoted content.
+            let mi = crate::attributes::Attrlist::parse(
+                crate::Span::new("'a,b'"),
+                &p,
+                AttrlistContext::Inline,
+            )
+            .unwrap_if_no_warnings();
+
+            assert_eq!(mi.item.quoted_text_fallback_role().unwrap(), "'a");
+
             // An unquoted positional is handled by the normal block-style path,
             // so there is no fallback role to recover.
             let mi = crate::attributes::Attrlist::parse(

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -570,9 +570,12 @@ impl<'src> Attrlist<'src> {
 
         // Asciidoctor's `parse_quoted_text_attributes` considers only the first
         // positional attribute – the source up to the first comma – and uses it
-        // verbatim (quote characters included) as the role. A quote-delimited
-        // first positional always leaves at least its opening quote here, so the
-        // slice is never empty.
+        // verbatim (quote characters included) as the role. The comma split is on
+        // the raw source, matching Asciidoctor's `str.slice 0, (str.index ',')`,
+        // so a comma *inside* the quotes truncates the role there too (e.g.
+        // `['a,b']` yields the role `'a`) rather than being treated as quoted
+        // content. A quote-delimited first positional always leaves at least its
+        // opening quote here, so the slice is never empty.
         let raw = self.source.data();
         Some(raw.split_once(',').map_or(raw, |(first, _)| first).trim())
     }

--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -548,6 +548,38 @@ impl<'src> Attrlist<'src> {
         roles
     }
 
+    /// Recovers the role from a quote-delimited first positional attribute (for
+    /// example `['role']`) in a quoted-text attribute list.
+    ///
+    /// This mirrors the `else` branch of Asciidoctor's
+    /// `parse_quoted_text_attributes`: when the first positional attribute is
+    /// not shorthand (it does not begin with `.` or `#`), Asciidoctor treats
+    /// the entire first positional – verbatim, quote characters included –
+    /// as the role. The shorthand parser used for the general attribute
+    /// list instead strips the surrounding quotes and records no role or
+    /// block style for such a value, so a quoted role would otherwise be
+    /// dropped.
+    ///
+    /// Returns the verbatim role only when the first positional attribute was
+    /// genuinely quote-delimited; otherwise the normal shorthand path already
+    /// produced the role, id, and block style, so this returns `None`.
+    pub(crate) fn quoted_text_fallback_role(&'src self) -> Option<&'src str> {
+        if !self.nth_attribute(1)?.value_is_quoted() {
+            return None;
+        }
+
+        // Asciidoctor considers only the first positional attribute, which is the
+        // source up to the first comma.
+        let raw = self.source.data();
+        let segment = raw.split(',').next().unwrap_or(raw).trim();
+
+        if segment.is_empty() {
+            None
+        } else {
+            Some(segment)
+        }
+    }
+
     /// Returns any option attributes that were found.
     ///
     /// The `options` attribute (often abbreviated as `opts`) is a versatile
@@ -2381,6 +2413,37 @@ mod tests {
                     offset: 17
                 }
             );
+        }
+
+        #[test]
+        fn quoted_first_positional_becomes_verbatim_role() {
+            let p = Parser::default();
+
+            // A quote-delimited first positional carries no shorthand role or
+            // block style, so `quoted_text_fallback_role` recovers it verbatim
+            // (quotes included), mirroring Asciidoctor's
+            // `parse_quoted_text_attributes`.
+            let mi = crate::attributes::Attrlist::parse(
+                crate::Span::new("'role'"),
+                &p,
+                AttrlistContext::Inline,
+            )
+            .unwrap_if_no_warnings();
+
+            assert!(mi.item.roles().is_empty());
+            assert!(mi.item.block_style().is_none());
+            assert_eq!(mi.item.quoted_text_fallback_role().unwrap(), "'role'");
+
+            // An unquoted positional is handled by the normal block-style path,
+            // so there is no fallback role to recover.
+            let mi = crate::attributes::Attrlist::parse(
+                crate::Span::new("role"),
+                &p,
+                AttrlistContext::Inline,
+            )
+            .unwrap_if_no_warnings();
+
+            assert!(mi.item.quoted_text_fallback_role().is_none());
         }
     }
 

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -615,6 +615,11 @@ impl Replacer for PassthroughRestoreReplacer<'_> {
         pass.subs.apply(&mut subbed_text, self.1, None);
 
         if let Some(type_) = pass.type_ {
+            // NOTE: The stored attrlist is parsed here without applying attribute
+            // reference substitution, so a reference embedded in a passthrough
+            // role (e.g. `['{myrole}']++x++`) is not resolved – unlike the inline
+            // quoted-text path, whose attrlist comes from the already-substituted
+            // buffer. Tracked in issue #987.
             let attrlist = pass.attrlist.as_ref().map(|attrlist_body| {
                 let span = Span::new(attrlist_body);
                 let maw = Attrlist::parse(span, self.1, AttrlistContext::Inline);

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -5,7 +5,7 @@ use regex::{Captures, Regex, Replacer};
 use crate::{
     Parser, Span,
     attributes::{Attrlist, AttrlistContext},
-    content::{Content, SubstitutionGroup},
+    content::{Content, SubstitutionGroup, substitution_step::substitute_attributes_in_text},
     parser::{QuoteScope, QuoteType},
     warnings::WarningType,
 };
@@ -615,12 +615,20 @@ impl Replacer for PassthroughRestoreReplacer<'_> {
         pass.subs.apply(&mut subbed_text, self.1, None);
 
         if let Some(type_) = pass.type_ {
-            // NOTE: The stored attrlist is parsed here without applying attribute
-            // reference substitution, so a reference embedded in a passthrough
-            // role (e.g. `['{myrole}']++x++`) is not resolved – unlike the inline
-            // quoted-text path, whose attrlist comes from the already-substituted
-            // buffer. Tracked in issue #987.
-            let attrlist = pass.attrlist.as_ref().map(|attrlist_body| {
+            // Resolve attribute references in the stored attrlist before parsing
+            // it. Inline passthroughs are extracted before the substitution
+            // pipeline runs, so – unlike the inline quoted-text path, whose
+            // attrlist is a slice of the already-substituted buffer – a reference
+            // embedded in a passthrough role (e.g. `['{myrole}']++x++`) would
+            // otherwise render verbatim. This mirrors Asciidoctor's
+            // `parse_quoted_text_attributes`, which runs `sub_attributes` on the
+            // attribute list.
+            let attrlist_body = pass
+                .attrlist
+                .as_ref()
+                .map(|attrlist_body| substitute_attributes_in_text(attrlist_body, self.1));
+
+            let attrlist = attrlist_body.as_ref().map(|attrlist_body| {
                 let span = Span::new(attrlist_body);
                 let maw = Attrlist::parse(span, self.1, AttrlistContext::Inline);
                 maw.item.item

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -1308,6 +1308,28 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
     }
 }
 
+/// Writes an HTML attribute value to `dest`, escaping the double-quote
+/// delimiter as `&quot;`.
+///
+/// A `"` left raw inside a `"…"`-delimited attribute value would terminate the
+/// value early and let following text be parsed as additional attributes –
+/// attribute injection. Role and id values can carry a literal `"` (for
+/// example a single-quoted positional role such as `['a"b']`, or a
+/// single-quoted `role='a"b'` named attribute), so escape it here. The `<`,
+/// `>`, and `&` characters are left as-is: the surrounding content pipeline
+/// already escapes them for the constrained/inline paths, and Asciidoctor
+/// deliberately leaves them unescaped for a passthrough attribute list, so
+/// re-escaping here would double-escape the former and diverge on the latter.
+fn push_attribute_value(dest: &mut String, value: &str) {
+    for ch in value.chars() {
+        if ch == '"' {
+            dest.push_str("&quot;");
+        } else {
+            dest.push(ch);
+        }
+    }
+}
+
 fn wrap_body_in_html_tag(
     _attrlist: Option<&Attrlist<'_>>,
     tag: &'static str,
@@ -1321,14 +1343,14 @@ fn wrap_body_in_html_tag(
 
     if let Some(id) = id.as_ref() {
         dest.push_str(" id=\"");
-        dest.push_str(id);
+        push_attribute_value(dest, id);
         dest.push('"');
     }
 
     if !roles.is_empty() {
         let roles = roles.join(" ");
         dest.push_str(" class=\"");
-        dest.push_str(&roles);
+        push_attribute_value(dest, &roles);
         dest.push('"');
     }
 

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -656,6 +656,19 @@ impl InlineSubstitutionRenderer for HtmlSubstitutionRenderer {
                 .map(|id| id.to_owned())
         }
 
+        // A quote-delimited first positional attribute (e.g. `['role']`) carries
+        // no shorthand role or block style, so the derivation above leaves it
+        // out. Asciidoctor treats such a value as a verbatim role – quotes
+        // included – so recover it here rather than dropping the role.
+        if roles.is_empty()
+            && id.is_none()
+            && let Some(role) = attrlist
+                .as_ref()
+                .and_then(|a| a.quoted_text_fallback_role())
+        {
+            roles.push(role);
+        }
+
         match type_ {
             QuoteType::Strong => {
                 wrap_body_in_html_tag(attrlist.as_ref(), "strong", id, roles, body, dest);

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -8960,8 +8960,8 @@ mod passthroughs {
         // Ruby test asserts). The exact tail after the span (`+This+` here vs.
         // Asciidoctor's `++This++`) still differs because the two
         // implementations tokenize the surrounding run of `+` characters
-        // differently – a separate passthrough-extraction nuance, not the role
-        // handling exercised by this robustness test.
+        // differently – a separate passthrough-extraction nuance (tracked in
+        // issue #979), not the role handling exercised by this robustness test.
         let mut p = Parser::default();
         let maw = crate::blocks::Block::parse(
             crate::Span::new("['role']\\+++++++++This++++++++++++"),

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -8914,6 +8914,9 @@ mod passthroughs {
 "#
         );
 
+        // The quote-delimited role (`['role']`) is preserved as a verbatim role
+        // on the passthrough span, so the rendered output includes
+        // `<span class="'role'">` – exactly matching Asciidoctor here.
         let mut p = Parser::default();
         let maw =
             crate::blocks::Block::parse(crate::Span::new("['role']\\++This++++++++++++"), &mut p);
@@ -8930,7 +8933,7 @@ mod passthroughs {
                         col: 1,
                         offset: 0,
                     },
-                    rendered: "+This+",
+                    rendered: "<span class=\"'role'\">+This</span>+",
                 },
                 source: Span {
                     data: "['role']\\++This++++++++++++",
@@ -8952,6 +8955,13 @@ mod passthroughs {
 
     #[test]
     fn should_not_crash_if_role_on_passthrough_is_enclosed_in_quotes_2() {
+        // As in the first case, the quoted role is preserved, so the rendered
+        // output includes `<span class="'role'">` (the only thing the upstream
+        // Ruby test asserts). The exact tail after the span (`+This+` here vs.
+        // Asciidoctor's `++This++`) still differs because the two
+        // implementations tokenize the surrounding run of `+` characters
+        // differently – a separate passthrough-extraction nuance, not the role
+        // handling exercised by this robustness test.
         let mut p = Parser::default();
         let maw = crate::blocks::Block::parse(
             crate::Span::new("['role']\\+++++++++This++++++++++++"),
@@ -8970,7 +8980,7 @@ mod passthroughs {
                         col: 1,
                         offset: 0,
                     },
-                    rendered: "++This+",
+                    rendered: "<span class=\"'role'\">+</span>+This+",
                 },
                 source: Span {
                     data: "['role']\\+++++++++This++++++++++++",

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -9001,6 +9001,42 @@ mod passthroughs {
     }
 
     #[test]
+    fn passthrough_role_resolves_attribute_reference() {
+        // An attribute reference embedded in a passthrough role is resolved
+        // before the role is applied, mirroring Asciidoctor's
+        // `parse_quoted_text_attributes` (which runs `sub_attributes` on the
+        // attribute list). This is a crate-specific regression test, not a port.
+        let render = |input: &str| {
+            let mut p = Parser::default().with_intrinsic_attribute(
+                "myrole",
+                "highlight",
+                ModificationContext::Anywhere,
+            );
+
+            let maw = crate::blocks::Block::parse(crate::Span::new(input), &mut p);
+
+            let crate::blocks::Block::Simple(block) = maw.item.unwrap().item else {
+                panic!("expected a simple block");
+            };
+
+            block.content().rendered().to_string()
+        };
+
+        // Unquoted role via the normal block-style path.
+        assert_eq!(
+            render("[{myrole}]++text++"),
+            r#"<span class="highlight">text</span>"#
+        );
+
+        // Quote-delimited role via the verbatim-role fallback (the case flagged
+        // in review): the reference resolves inside the retained quotes.
+        assert_eq!(
+            render("['{myrole}']++text++"),
+            r#"<span class="'highlight'">text</span>"#
+        );
+    }
+
+    #[test]
     fn should_allow_inline_double_plus_passthrough_to_be_escaped_using_backslash() {
         verifies!(
             r#"

--- a/parser/src/tests/security.rs
+++ b/parser/src/tests/security.rs
@@ -7,9 +7,10 @@
 //!
 //! Two properties are covered:
 //!
-//!   * every `href`/`target` and the icon `class`/`title`/`width`/`height`
-//!     attributes escape the `"` delimiter, so a stray quote cannot close the
-//!     attribute and inject further markup; and
+//!   * every `href`/`target`, the icon `class`/`title`/`width`/`height`
+//!     attributes, and the quoted-text `class` (role) attribute escape the `"`
+//!     delimiter, so a stray quote cannot close the attribute and inject
+//!     further markup; and
 //!   * the explicit `link:` macro rejects targets whose scheme could execute
 //!     script (`javascript:`, `data:`, `vbscript:`), rendering them as inert
 //!     source text rather than a live link.
@@ -122,6 +123,47 @@ fn xref_unresolved_target_does_not_double_escape_special_characters() {
     assert_eq!(
         render_paragraph("xref:foo<bar>[txt]"),
         r##"<a href="#foo&lt;bar&gt;">txt</a>"##
+    );
+}
+
+// ---- Quoted-text role (class) escaping -------------------------------------
+
+#[test]
+fn quoted_positional_role_class_escapes_quote_delimiter() {
+    // A single-quoted positional role is applied verbatim (quotes included) to
+    // the `class` attribute, so a `"` inside it must not close the attribute
+    // and inject an event handler.
+    assert_eq!(
+        render_paragraph(r#"['x" onmouseover="y']*bold*"#),
+        r#"<strong class="'x&quot; onmouseover=&quot;y'">bold</strong>"#
+    );
+}
+
+#[test]
+fn passthrough_quoted_positional_role_class_escapes_quote_delimiter() {
+    // Same guarantee on the inline-passthrough restore path.
+    assert_eq!(
+        render_paragraph(r#"['x" onmouseover="y']++text++"#),
+        r#"<span class="'x&quot; onmouseover=&quot;y'">text</span>"#
+    );
+}
+
+#[test]
+fn named_role_class_escapes_quote_delimiter() {
+    // A single-quoted `role=` value can also carry a literal `"`.
+    assert_eq!(
+        render_paragraph(r#"[role='a"b']*bold*"#),
+        r#"<strong class="a&quot;b">bold</strong>"#
+    );
+}
+
+#[test]
+fn quoted_positional_role_class_does_not_double_escape_special_characters() {
+    // `< > &` arrive already escaped for the constrained path; the added
+    // quote-escaping must leave them singly escaped.
+    assert_eq!(
+        render_paragraph("['a<b&c']*bold*"),
+        r#"<strong class="'a&lt;b&amp;c'">bold</strong>"#
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #973.

An inline passthrough whose role is enclosed in single quotes (`['role']…`) dropped the role and rendered no `<span>`, diverging from Asciidoctor, which keeps the quoted role verbatim (`<span class="'role'">…</span>`).

### Root cause

The general attribute-list parser (`AttrlistContext::Inline`) strips the surrounding quotes from a quote-delimited first positional attribute and records no shorthand role or block style for it, so the role was lost. Asciidoctor instead uses a dedicated `parse_quoted_text_attributes` whose `else` branch treats the entire first positional – quotes included – as the role.

This is a **shared** root cause: regular inline quoted text was affected too (`['role']#text#` previously rendered `text`, not `<span class="'role'">text</span>`).

### Fix

- New `Attrlist::quoted_text_fallback_role()` mirrors the `parse_quoted_text_attributes` `else` branch, returning the verbatim first positional (quotes included) **only** when it was genuinely quote-delimited.
- `render_quoted_substitution` (shared by the passthrough-restore path and the quotes substitution step) applies it as a fallback, but only when the standard derivation produced no role and no id — so existing shorthand (`.role`, `#id`), block-style (`[foo]`), and named-attribute cases are untouched.

### Result vs. Asciidoctor 2.0.26

| Input | Before | After (this PR) | Asciidoctor |
|-------|--------|-----------------|-------------|
| `['role']\++This++++++++++++` | `+This+` | `<span class="'role'">+This</span>+` | `<span class="'role'">+This</span>+` |
| `['role']\+++++++++This++++++++++++` | `++This+` | `<span class="'role'">+</span>+This+` | `<span class="'role'">+</span>++This++` |

The first input now matches Asciidoctor **exactly**. The second now emits the `<span class="'role'">` the upstream robustness test asserts (`assert_includes para.content, %(<span class="'role'">)`); its exact `+`-run **tail** (`+This+` vs `++This++`) still differs because the two implementations tokenize the surrounding run of `+` characters differently — a separate passthrough-extraction nuance, not the role handling this issue is about. That tail divergence is tracked separately in #979.

## Tests

- Updated this crate's ported `should_not_crash_if_role_on_passthrough_is_enclosed_in_quotes_1/_2` to assert the now-correct rendered `<span>`, with a comment explaining the residual tail difference on the second input.
- Added `Attrlist::quoted_text_fallback_role` unit coverage (quoted vs. unquoted first positional).
- Full workspace suite green (`cargo test`), `cargo clippy --all-targets --all-features` clean, `cargo +nightly fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
