### PR TITLE
fix: Fall back to link macro for remote include under non-secure safe mode

### DIFF
--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -612,20 +612,33 @@ impl<'p> PreprocessorState<'p> {
 
                 let attrlist = parse_attrlist(&caps, self.parser);
 
-                // A URI target is only honored when the URI read permission has
+                // A URI target is only fetched when the URI read permission has
                 // been granted (`allow-uri-read`). This is disabled by default,
-                // so a URI include that is not permitted is treated as an
-                // unresolved directive. (At `SafeMode::Secure` and above the
-                // include was already converted to a link above; `allow-uri-read`
-                // is meaningful only below that level.) See `include-uri.adoc`.
+                // so a URI include that is not permitted is not fetched; instead
+                // the directive is converted to a `link:` macro to its target –
+                // the same rewrite applied at `SafeMode::Secure` above – and no
+                // warning is recorded (matching Asciidoctor). See
+                // `include-uri.adoc`.
                 if is_uri(&target) && !self.parser.is_attribute_set("allow-uri-read") {
-                    self.emit_unresolved_directive(
-                        line.data(),
-                        WarningType::IncludeFileNotFound(target),
+                    self.record_origin(
                         file_name,
                         source_line_number,
+                        Fidelity::Synthetic(Transform::SecureLinkRewrite),
                         &mut has_reported_file,
                     );
+
+                    // A target containing a space would break the link macro,
+                    // so it is wrapped in a `pass:c[…]` macro (matching
+                    // Asciidoctor).
+                    let replacement = if target.contains(' ') {
+                        format!("link:pass:c[{target}][role=include]")
+                    } else {
+                        format!("link:{target}[role=include]")
+                    };
+                    self.output_line_number += 1;
+                    self.output.push_str(&replacement);
+                    self.output.push('\n');
+
                     continue;
                 }
 
@@ -4018,9 +4031,10 @@ mod tests {
     }
 
     #[test]
-    fn uri_include_disabled_without_allow_uri_read() {
-        // A URI target is not resolved unless `allow-uri-read` is set; it is
-        // reported as an unresolved directive.
+    fn uri_include_falls_back_to_link_without_allow_uri_read() {
+        // A URI target is not fetched unless `allow-uri-read` is set; below
+        // secure safe mode it falls back to a `link:` macro (the same rewrite
+        // applied at `SafeMode::Secure`), with no warning.
         let source = "include::https://example.org/frag.adoc[]";
         let handler =
             InlineFileHandler::from_pairs([("https://example.org/frag.adoc", "SHOULD NOT APPEAR")]);
@@ -4031,11 +4045,26 @@ mod tests {
 
         let (output, _source_map, warnings, _includes) = preprocess(source, &parser);
 
+        assert_eq!(output, "link:https://example.org/frag.adoc[role=include]\n");
+        assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+    }
+
+    #[test]
+    fn uri_include_with_space_falls_back_to_passthrough_link() {
+        // A remote target containing a space is wrapped in `pass:c[…]` so the
+        // link macro parses correctly (matching Asciidoctor).
+        let source = "include::https://example.org/no such file.adoc[]";
+        let parser = Parser::default()
+            .with_safe_mode(SafeMode::Server)
+            .with_primary_file_name("main.adoc");
+
+        let (output, _source_map, warnings, _includes) = preprocess(source, &parser);
+
         assert_eq!(
             output,
-            "Unresolved directive in main.adoc - include::https://example.org/frag.adoc[]\n"
+            "link:pass:c[https://example.org/no such file.adoc][role=include]\n"
         );
-        assert_eq!(warnings.len(), 1);
+        assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
     }
 
     #[test]

--- a/parser/src/parser/source_map.rs
+++ b/parser/src/parser/source_map.rs
@@ -123,7 +123,9 @@ pub enum Transform {
     /// A synthetic `:leveloffset:` attribute entry wrapping an include.
     LevelOffsetWrapper,
 
-    /// A secure-mode rewrite of an `include::` directive into a `link:` macro.
+    /// A rewrite of an `include::` directive into a `link:` macro: applied to
+    /// every target at `SafeMode::Secure` and above, and to a remote (URI)
+    /// target below secure when `allow-uri-read` is unset.
     SecureLinkRewrite,
 
     /// A synthetic "Unresolved directive" line replacing an include that could

--- a/parser/src/tests/asciidoc_lang/directives/include_uri.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include_uri.rs
@@ -68,13 +68,20 @@ To allow content to be read from a URI, you must enable the URI read permission 
 "#
     );
 
-    // Without `allow-uri-read`, a URI target is not resolved even in server
-    // mode; it becomes an unresolved directive and the handler is not consulted.
+    // Without `allow-uri-read`, a URI target is not fetched even in server
+    // mode; the handler is not consulted. Rather than report an unresolved
+    // directive, the directive falls back to a `link:` macro to the target
+    // (matching Asciidoctor at safe mode `SERVER` or below), so its content is
+    // never read.
     let paras = uri_include(SafeMode::Server, false, "SHOULD NOT APPEAR");
     assert_eq!(paras.len(), 1);
     assert!(
-        paras[0].starts_with("Unresolved directive in main.adoc - include::"),
-        "was: {paras:?}"
+        !paras[0].contains("SHOULD NOT APPEAR"),
+        "URI content was fetched: {paras:?}"
+    );
+    assert!(
+        paras[0].contains(&format!("href=\"{URI}\"")) && paras[0].contains("include"),
+        "expected a link fallback, was: {paras:?}"
     );
 }
 

--- a/parser/src/tests/asciidoc_lang/directives/include_uri.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include_uri.rs
@@ -149,3 +149,27 @@ To enable the built-in cache, you must:
 When these two conditions are satisfied, Asciidoctor caches content read from a URI according the to {url-http}[HTTP caching recommendations^].
 "#
 );
+
+// A remote target containing a space is wrapped in `pass:c[…]` by the
+// preprocessor fallback (see `reader_test.rs`); this confirms that wrapper is
+// extracted correctly downstream, so the rendered link carries the full URI as
+// its `href` (spaces and all) rather than leaving `pass:c` as the destination.
+#[test]
+fn space_in_remote_target_renders_full_uri() {
+    const SPACE_URI: &str = "https://example.org/no such file.adoc";
+
+    let mut parser = Parser::default()
+        .with_safe_mode(SafeMode::Safe)
+        .with_primary_file_name("main.adoc");
+
+    let source = format!("include::{SPACE_URI}[]");
+    let doc = parser.parse(&source);
+    let paras = rendered_paragraphs(&doc);
+
+    assert_eq!(
+        paras,
+        vec![format!(
+            "<a href=\"{SPACE_URI}\" class=\"bare include\">{SPACE_URI}</a>"
+        )]
+    );
+}

--- a/parser/src/tests/asciidoctor_rb/reader_test.rs
+++ b/parser/src/tests/asciidoctor_rb/reader_test.rs
@@ -1185,7 +1185,11 @@ fn should_escape_spaces_in_target_when_generating_link_from_include_directive() 
     );
 }
 
-// A remote (URI) target is link-replaced the same way at secure safe mode.
+// A remote (URI) target below secure safe mode is not fetched when
+// `allow-uri-read` is unset; it falls back to the same `link:` rewrite applied
+// at secure mode, with an empty logger. A `SafeMode::Safe` parser is used (not
+// `Parser::default()`, which is secure) so the below-secure fallback branch —
+// not the secure-mode rewrite — is exercised.
 #[test]
 fn should_replace_include_directive_with_link_macro_if_safe_mode_allows_it_but_allow_uri_read_is_not_set()
  {
@@ -1204,13 +1208,18 @@ fn should_replace_include_directive_with_link_macro_if_safe_mode_allows_it_but_a
 "#
     );
 
-    assert_eq!(
-        reader_read(
-            &Parser::default(),
-            "include::https://example.org/dist/info.adoc[]"
-        ),
-        "link:https://example.org/dist/info.adoc[role=include]"
+    let parser = Parser::default().with_safe_mode(SafeMode::Safe);
+
+    let (output, _source_map, warnings, _includes) = crate::parser::preprocessor::preprocess(
+        "include::https://example.org/dist/info.adoc[]",
+        &parser,
     );
+
+    assert_eq!(
+        output,
+        "link:https://example.org/dist/info.adoc[role=include]\n"
+    );
+    assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
 }
 
 non_normative!(
@@ -1225,6 +1234,9 @@ non_normative!(
 "#
 );
 
+// A remote target containing a space, below secure safe mode, is wrapped in
+// `pass:c[…]` by the same fallback. As above, a `SafeMode::Safe` parser is used
+// so the below-secure branch is exercised.
 #[test]
 fn should_escape_spaces_in_target_when_generating_link_from_remote_include_directive() {
     verifies!(
@@ -1241,7 +1253,7 @@ fn should_escape_spaces_in_target_when_generating_link_from_remote_include_direc
 
     assert_eq!(
         reader_read(
-            &Parser::default(),
+            &Parser::default().with_safe_mode(SafeMode::Safe),
             "include::https://example.org/no such file.adoc[]"
         ),
         "link:pass:c[https://example.org/no such file.adoc][role=include]"


### PR DESCRIPTION
## Summary

Fixes #981.

Under a **non-secure** safe mode (`unsafe`/`safe`/`server`), a remote (URI) `include::` target whose `allow-uri-read` attribute is **unset** now falls back to a `link:…[role=include]` macro – the same rewrite the parser already applies at `SafeMode::Secure` – and emits **no warning**. Previously the preprocessor treated the URI as an unresolvable file: it emitted the "Unresolved directive" placeholder and recorded a `WarningType::IncludeFileNotFound`.

This is the **no-fetch** path: it requires no network read (distinct from the `allow-uri-read` remote-fetch feature); it only asks that a remote target be *linked* rather than reported unresolved. When `allow-uri-read` *is* set, the include-file handler is still consulted as before.

## Changes

- `parser/src/parser/preprocessor.rs`: the below-secure URI-without-`allow-uri-read` branch now produces the `link:…[role=include]` replacement (with the `pass:c[…]` wrapper when the target contains a space) and records no warning, instead of emitting an unresolved directive.
- `parser/src/parser/source_map.rs`: broadened the `Transform::SecureLinkRewrite` doc comment, since this rewrite now also applies to a below-secure remote target.
- Tests:
  - Updated the two Asciidoctor `reader_test.rs` port cases to drive through a `SafeMode::Safe` parser (they previously used the secure default, so they exercised the secure-mode branch rather than the fixed one). The first now also asserts an empty warning set.
  - Updated `include_uri.rs` (`not_enabled_by_default`) and the in-file preprocessor tests to assert the link fallback, and added a space-escaping case.

## Verification

- `cargo test -p asciidoc-parser` – all pass.
- `cargo +nightly fmt --all -- --check` – clean.

## Downstream

Unblocks asciidoc-rs/asciidoc-html5#136, where these cases are tracked `non_normative!` pending this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)