### PR TITLE
fix: Parse the `toc::[]` block macro as a `toc`-context block

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -4,7 +4,7 @@ use crate::{
     blocks::{
         AdmonitionBlock, Break, CompoundDelimitedBlock, ContentModel, IsBlock, ListBlock, ListItem,
         ListItemMarker, MediaBlock, Preamble, QuoteBlock, RawDelimitedBlock, SectionBlock,
-        SimpleBlock, TableBlock, media::TargetResolution, metadata::BlockMetadata,
+        SimpleBlock, TableBlock, TocBlock, media::TargetResolution, metadata::BlockMetadata,
         starts_with_admonition_label,
     },
     content::{Content, SubstitutionGroup, substitute_attributes_in_reftext},
@@ -78,6 +78,10 @@ pub enum Block<'src> {
     /// A thematic or page break.
     Break(Break<'src>),
 
+    /// The `toc::[]` block macro, marking where a table of contents should be
+    /// rendered under `toc-placement: macro`.
+    Toc(TocBlock<'src>),
+
     /// When an attribute is defined in the document body using an attribute
     /// entry, that’s simply referred to as a document attribute.
     DocumentAttribute(Attribute<'src>),
@@ -106,6 +110,7 @@ impl<'src> std::fmt::Debug for Block<'src> {
             Block::Table(block) => f.debug_tuple("Block::Table").field(block).finish(),
             Block::Preamble(block) => f.debug_tuple("Block::Preamble").field(block).finish(),
             Block::Break(break_) => f.debug_tuple("Block::Break").field(break_).finish(),
+            Block::Toc(block) => f.debug_tuple("Block::Toc").field(block).finish(),
 
             Block::DocumentAttribute(block) => f
                 .debug_tuple("Block::DocumentAttribute")
@@ -551,6 +556,41 @@ impl<'src> Block<'src> {
                 // automatically error out on a parse failure.
             }
 
+            if line.item.starts_with("toc::") {
+                let mut toc_block_maw = TocBlock::parse(&metadata, parser);
+
+                if let Some(toc_block) = toc_block_maw.item {
+                    // Only propagate warnings from TOC block parsing if we think
+                    // this *is* a TOC block. Otherwise, there would likely be too
+                    // many false positives.
+                    if !toc_block_maw.warnings.is_empty() {
+                        warnings.append(&mut toc_block_maw.warnings);
+                    }
+
+                    let block = Self::Toc(toc_block.item);
+
+                    Self::register_block_id(
+                        block.id(),
+                        Self::block_reftext(&block, anchor_reftext.as_deref()).as_deref(),
+                        Self::block_signifier(&block, parser),
+                        block.span(),
+                        parser,
+                        &mut warnings,
+                    );
+
+                    return MatchAndWarnings {
+                        item: BlockParseOutcome::Parsed(MatchedItem {
+                            item: block,
+                            after: toc_block.after,
+                        }),
+                        warnings,
+                    };
+                }
+
+                // This might be some other kind of block, so we don't
+                // automatically error out on a parse failure.
+            }
+
             if (line.item.starts_with('=') || line.item.starts_with('#'))
                 && let Some(mi_section_block) =
                     SectionBlock::parse(&metadata, parser, &mut warnings)
@@ -865,6 +905,7 @@ impl<'src> Block<'src> {
             Self::Quote(b) => b.title_content_mut(),
             Self::Table(b) => b.title_content_mut(),
             Self::Break(b) => b.title_content_mut(),
+            Self::Toc(b) => b.title_content_mut(),
             _ => None,
         }
     }
@@ -885,6 +926,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::Table(b) => b.content_model(),
             Self::Preamble(b) => b.content_model(),
             Self::Break(b) => b.content_model(),
+            Self::Toc(b) => b.content_model(),
             Self::DocumentAttribute(b) => b.content_model(),
         }
     }
@@ -903,6 +945,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::Table(b) => b.declared_style(),
             Self::Preamble(b) => b.declared_style(),
             Self::Break(b) => b.declared_style(),
+            Self::Toc(b) => b.declared_style(),
             Self::DocumentAttribute(b) => b.declared_style(),
         }
     }
@@ -921,6 +964,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::Table(b) => b.rendered_content(),
             Self::Preamble(b) => b.rendered_content(),
             Self::Break(b) => b.rendered_content(),
+            Self::Toc(b) => b.rendered_content(),
             Self::DocumentAttribute(b) => b.rendered_content(),
         }
     }
@@ -939,6 +983,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::Table(b) => b.raw_context(),
             Self::Preamble(b) => b.raw_context(),
             Self::Break(b) => b.raw_context(),
+            Self::Toc(b) => b.raw_context(),
             Self::DocumentAttribute(b) => b.raw_context(),
         }
     }
@@ -957,6 +1002,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::Table(b) => b.child_blocks_mut(),
             Self::Preamble(b) => b.child_blocks_mut(),
             Self::Break(b) => b.child_blocks_mut(),
+            Self::Toc(b) => b.child_blocks_mut(),
             Self::DocumentAttribute(b) => b.child_blocks_mut(),
         }
     }
@@ -975,6 +1021,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::Table(b) => b.content_mut(),
             Self::Preamble(b) => b.content_mut(),
             Self::Break(b) => b.content_mut(),
+            Self::Toc(b) => b.content_mut(),
             Self::DocumentAttribute(b) => b.content_mut(),
         }
     }
@@ -993,6 +1040,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::Table(b) => b.title_source(),
             Self::Preamble(b) => b.title_source(),
             Self::Break(b) => b.title_source(),
+            Self::Toc(b) => b.title_source(),
             Self::DocumentAttribute(b) => b.title_source(),
         }
     }
@@ -1011,6 +1059,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::Table(b) => b.title(),
             Self::Preamble(b) => b.title(),
             Self::Break(b) => b.title(),
+            Self::Toc(b) => b.title(),
             Self::DocumentAttribute(b) => b.title(),
         }
     }
@@ -1029,6 +1078,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::Table(b) => b.caption(),
             Self::Preamble(b) => b.caption(),
             Self::Break(b) => b.caption(),
+            Self::Toc(b) => b.caption(),
             Self::DocumentAttribute(b) => b.caption(),
         }
     }
@@ -1047,15 +1097,19 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::Table(b) => b.number(),
             Self::Preamble(b) => b.number(),
             Self::Break(b) => b.number(),
+            Self::Toc(b) => b.number(),
             Self::DocumentAttribute(b) => b.number(),
         }
     }
 
     fn id(&'src self) -> Option<&'src str> {
-        // Two variants override the trait default:
+        // Three variants override the trait default:
         //
         // * A `MediaBlock` additionally recognizes a named `id=` _inside_ its macro
         //   attribute list (e.g. `image::sunset.jpg[id=sunset-img]`).
+        //
+        // * A `TocBlock` likewise recognizes a named `id=` _inside_ its macro attribute
+        //   list (e.g. `toc::[id=contents]`).
         //
         // * A `SectionBlock` falls back to its auto-generated (`_slug`) ID when no
         //   explicit ID was supplied, so `block.id()` yields the same ID the section is
@@ -1068,6 +1122,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
         match self {
             Self::Media(b) => b.id(),
             Self::Section(b) => b.id(),
+            Self::Toc(b) => b.id(),
             _ => self
                 .anchor()
                 .map(|a| a.data())
@@ -1089,6 +1144,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::Table(b) => b.anchor(),
             Self::Preamble(b) => b.anchor(),
             Self::Break(b) => b.anchor(),
+            Self::Toc(b) => b.anchor(),
             Self::DocumentAttribute(b) => b.anchor(),
         }
     }
@@ -1107,6 +1163,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::Table(b) => b.anchor_reftext(),
             Self::Preamble(b) => b.anchor_reftext(),
             Self::Break(b) => b.anchor_reftext(),
+            Self::Toc(b) => b.anchor_reftext(),
             Self::DocumentAttribute(b) => b.anchor_reftext(),
         }
     }
@@ -1125,6 +1182,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::Table(b) => b.attrlist(),
             Self::Preamble(b) => b.attrlist(),
             Self::Break(b) => b.attrlist(),
+            Self::Toc(b) => b.attrlist(),
             Self::DocumentAttribute(b) => b.attrlist(),
         }
     }
@@ -1143,6 +1201,7 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::Table(b) => b.substitution_group(),
             Self::Preamble(b) => b.substitution_group(),
             Self::Break(b) => b.substitution_group(),
+            Self::Toc(b) => b.substitution_group(),
             Self::DocumentAttribute(b) => b.substitution_group(),
         }
     }
@@ -1163,6 +1222,7 @@ impl<'src> HasSpan<'src> for Block<'src> {
             Self::Table(b) => b.span(),
             Self::Preamble(b) => b.span(),
             Self::Break(b) => b.span(),
+            Self::Toc(b) => b.span(),
             Self::DocumentAttribute(b) => b.span(),
         }
     }

--- a/parser/src/blocks/find.rs
+++ b/parser/src/blocks/find.rs
@@ -537,6 +537,7 @@ fn children_of<'a>(block: &'a Block<'a>, traverse_documents: bool) -> ChildBlock
         | Block::Media(_)
         | Block::RawDelimited(_)
         | Block::Break(_)
+        | Block::Toc(_)
         | Block::DocumentAttribute(_) => ChildBlocksInner::Empty,
     }
 }

--- a/parser/src/blocks/mod.rs
+++ b/parser/src/blocks/mod.rs
@@ -86,5 +86,8 @@ pub use table::{
     TableCellContent, TableColumn, TableRow, VerticalAlignment,
 };
 
+mod toc;
+pub use toc::TocBlock;
+
 #[cfg(test)]
 mod tests;

--- a/parser/src/blocks/tests/mod.rs
+++ b/parser/src/blocks/tests/mod.rs
@@ -13,6 +13,7 @@ mod raw_delimited;
 mod section;
 mod simple;
 mod table;
+mod toc;
 
 mod content_model {
     use crate::blocks::ContentModel;
@@ -105,6 +106,17 @@ mod impl_debug {
         let debug_output = format!("{:?}", mi.item);
         assert!(debug_output.starts_with("Block::Break"));
     }
+
+    #[test]
+    fn toc() {
+        let mut parser = Parser::default();
+        let mi = Block::parse(Span::new("toc::[]"), &mut parser)
+            .unwrap_if_no_warnings()
+            .unwrap();
+
+        let debug_output = format!("{:?}", mi.item);
+        assert!(debug_output.starts_with("Block::Toc"));
+    }
 }
 
 mod as_list_item {
@@ -166,6 +178,7 @@ mod caption_and_number {
             "[quote]\n____\nq\n____", // Quote
             "* item",                 // List
             "'''",                    // Break
+            "toc::[]",                // Toc
             ":author: Jane",          // DocumentAttribute
         ];
 

--- a/parser/src/blocks/tests/toc.rs
+++ b/parser/src/blocks/tests/toc.rs
@@ -1,0 +1,96 @@
+use std::ops::Deref;
+
+use crate::{blocks::ContentModel, tests::prelude::*};
+
+#[test]
+fn simplest_toc_macro() {
+    let mut parser = Parser::default();
+
+    let mi = crate::blocks::Block::parse(crate::Span::new("toc::[]"), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    assert_eq!(
+        mi.item,
+        Block::Toc(TocBlock {
+            macro_attrlist: Attrlist {
+                attributes: &[],
+                anchor: None,
+                source: Span {
+                    data: "",
+                    line: 1,
+                    col: 7,
+                    offset: 6,
+                }
+            },
+            source: Span {
+                data: "toc::[]",
+                line: 1,
+                col: 1,
+                offset: 0,
+            },
+            title_source: None,
+            title: None,
+            anchor: None,
+            anchor_reftext: None,
+            attrlist: None,
+        })
+    );
+
+    assert_eq!(
+        mi.item.span(),
+        Span {
+            data: "toc::[]",
+            line: 1,
+            col: 1,
+            offset: 0,
+        }
+    );
+
+    assert_eq!(mi.item.content_model(), ContentModel::Empty);
+    assert_eq!(mi.item.raw_context().deref(), "toc");
+    assert_eq!(mi.item.resolved_context().deref(), "toc");
+}
+
+#[test]
+fn not_a_toc_macro_becomes_paragraph() {
+    // `toc::foo[]` carries a target, which the `toc` block macro does not take,
+    // so it is not recognized as a TOC block and falls through to a paragraph.
+    let mut parser = Parser::default();
+
+    let mi = crate::blocks::Block::parse(crate::Span::new("toc::foo[]"), &mut parser)
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+    assert_eq!(mi.item.raw_context().deref(), "paragraph");
+}
+
+#[test]
+fn parses_in_preamble() {
+    // `toc::[]` on its own line parses to a block whose resolved context is
+    // `toc`, rather than a paragraph containing the literal text `toc::[]`.
+    let doc = Parser::default()
+        .parse("= Article\n:toc: macro\n\npre\n\ntoc::[]\n\n== Section One\n\nbody\n");
+
+    let toc_contexts: Vec<String> = doc
+        .descendant_blocks()
+        .map(|b| b.resolved_context().as_ref().to_string())
+        .filter(|c| c == "toc")
+        .collect();
+
+    assert_eq!(toc_contexts, vec!["toc".to_string()]);
+}
+
+#[test]
+fn block_title_overrides_toc_title() {
+    // A block title above the macro is surfaced through `title()` so a backend
+    // can use it to override `toc-title`.
+    let doc = Parser::default().parse("= Article\n:toc: macro\n\n.Contents\ntoc::[]\n");
+
+    let toc = doc
+        .descendant_blocks()
+        .find(|b| b.resolved_context().as_ref() == "toc")
+        .unwrap();
+
+    assert_eq!(toc.title(), Some("Contents"));
+}

--- a/parser/src/blocks/tests/toc.rs
+++ b/parser/src/blocks/tests/toc.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::{blocks::ContentModel, tests::prelude::*};
+use crate::{blocks::ContentModel, tests::prelude::*, warnings::MatchAndWarnings};
 
 #[test]
 fn simplest_toc_macro() {
@@ -50,6 +50,21 @@ fn simplest_toc_macro() {
     assert_eq!(mi.item.content_model(), ContentModel::Empty);
     assert_eq!(mi.item.raw_context().deref(), "toc");
     assert_eq!(mi.item.resolved_context().deref(), "toc");
+
+    // Exercise the remaining `Block::Toc` accessor delegations.
+    assert!(mi.item.rendered_content().is_none());
+    assert!(mi.item.declared_style().is_none());
+    assert!(mi.item.title_source().is_none());
+    assert!(mi.item.title().is_none());
+    assert!(mi.item.caption().is_none());
+    assert!(mi.item.number().is_none());
+    assert!(mi.item.id().is_none());
+    assert!(mi.item.roles().is_empty());
+    assert!(mi.item.options().is_empty());
+    assert!(mi.item.anchor().is_none());
+    assert!(mi.item.anchor_reftext().is_none());
+    assert!(mi.item.attrlist().is_none());
+    assert_eq!(mi.item.substitution_group(), SubstitutionGroup::Normal);
 }
 
 #[test]
@@ -63,6 +78,33 @@ fn not_a_toc_macro_becomes_paragraph() {
         .unwrap();
 
     assert_eq!(mi.item.raw_context().deref(), "paragraph");
+}
+
+#[test]
+fn macro_attrlist_warning_is_surfaced() {
+    // A warning raised while parsing the macro's attribute list (here, an empty
+    // attribute value from the doubled comma) is propagated even though the TOC
+    // block still parses.
+    let mut parser = Parser::default();
+
+    let MatchAndWarnings { item: mi, warnings } =
+        crate::blocks::Block::parse(crate::Span::new("toc::[blah,,blap]"), &mut parser);
+
+    let mi = mi.unwrap();
+    assert_eq!(mi.item.raw_context().deref(), "toc");
+
+    assert_eq!(
+        warnings,
+        vec![Warning {
+            source: Span {
+                data: "blah,,blap",
+                line: 1,
+                col: 7,
+                offset: 6,
+            },
+            warning: WarningType::EmptyAttributeValue,
+        }]
+    );
 }
 
 #[test]

--- a/parser/src/blocks/toc.rs
+++ b/parser/src/blocks/toc.rs
@@ -86,16 +86,7 @@ impl<'src> TocBlock<'src> {
         // followed immediately by the attribute list. Anything else (e.g.
         // `toc::foo[]`) is not a TOC block macro, so quietly decline and let it
         // fall through to a paragraph.
-        let target = colons.after.take_while(|c| c != '[');
-
-        if !target.item.is_empty() {
-            return MatchAndWarnings {
-                item: None,
-                warnings: vec![],
-            };
-        }
-
-        let Some(open_brace) = target.after.take_prefix("[") else {
+        let Some(open_brace) = colons.after.take_prefix("[") else {
             return MatchAndWarnings {
                 item: None,
                 warnings: vec![],
@@ -233,6 +224,30 @@ mod tests {
         let mut parser = Parser::default();
         assert!(
             crate::blocks::TocBlock::parse(&BlockMetadata::new("image::foo.png[]"), &mut parser)
+                .unwrap_if_no_warnings()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn err_macro_name_not_word_char() {
+        // A macro name must begin with a word character; a leading `#` is
+        // rejected before any name is captured (see `take_block_macro_name`).
+        let mut parser = Parser::default();
+        assert!(
+            crate::blocks::TocBlock::parse(&BlockMetadata::new("#toc::[]"), &mut parser)
+                .unwrap_if_no_warnings()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn err_macro_name_not_exactly_toc() {
+        // A name that merely starts with `toc` (e.g. `tocx`) is a different
+        // macro and is not recognized as a TOC block.
+        let mut parser = Parser::default();
+        assert!(
+            crate::blocks::TocBlock::parse(&BlockMetadata::new("tocx::[]"), &mut parser)
                 .unwrap_if_no_warnings()
                 .is_none()
         );

--- a/parser/src/blocks/toc.rs
+++ b/parser/src/blocks/toc.rs
@@ -1,0 +1,356 @@
+use crate::{
+    HasSpan, Parser, Span,
+    attributes::{Attrlist, AttrlistContext},
+    blocks::{ChildBlocks, ContentModel, IsBlock, metadata::BlockMetadata},
+    content::Content,
+    span::MatchedItem,
+    strings::CowStr,
+    warnings::MatchAndWarnings,
+};
+
+/// A TOC block represents the `toc::[]` block macro, which marks the position
+/// where a table of contents should be rendered when `toc-placement` is set to
+/// `macro`.
+///
+/// The macro carries no target; its optional attribute list can override the
+/// per-macro settings Asciidoctor honors on the generated TOC (`id`, `levels`,
+/// and `role`), while a block title above the macro overrides `toc-title`.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct TocBlock<'src> {
+    macro_attrlist: Attrlist<'src>,
+    source: Span<'src>,
+    title_source: Option<Span<'src>>,
+    title: Option<Content<'src>>,
+    anchor: Option<Span<'src>>,
+    anchor_reftext: Option<Span<'src>>,
+    attrlist: Option<Attrlist<'src>>,
+}
+
+impl<'src> TocBlock<'src> {
+    /// Returns a document-order iterator over this block's direct child blocks.
+    ///
+    /// A TOC block never has child blocks, so this iterator is always empty.
+    /// See [`FindBlocks`](crate::blocks::FindBlocks) to search from a
+    /// [`Block`](crate::blocks::Block) or [`Document`](crate::Document).
+    pub fn child_blocks(&'src self) -> ChildBlocks<'src> {
+        ChildBlocks::empty()
+    }
+
+    /// Returns the block's title as a mutable [`Content`], if the block has
+    /// one.
+    ///
+    /// This narrow seam exists for the document-order title resolution pass
+    /// (see `document::title_refs`), which installs the re-rendered title
+    /// after resolving any cross-references embedded in it. All other access
+    /// goes through the read-only [`IsBlock::title`] accessor.
+    pub(crate) fn title_content_mut(&mut self) -> Option<&mut Content<'src>> {
+        self.title.as_mut()
+    }
+
+    pub(crate) fn parse(
+        metadata: &BlockMetadata<'src>,
+        parser: &mut Parser,
+    ) -> MatchAndWarnings<'src, Option<MatchedItem<'src, Self>>> {
+        let line = metadata.block_start.take_normalized_line();
+
+        // Line must end with `]`; otherwise, it's not a block macro.
+        if !line.item.ends_with(']') {
+            return MatchAndWarnings {
+                item: None,
+                warnings: vec![],
+            };
+        }
+
+        let Some(name) = line.item.take_block_macro_name() else {
+            return MatchAndWarnings {
+                item: None,
+                warnings: vec![],
+            };
+        };
+
+        if name.item.data() != "toc" {
+            return MatchAndWarnings {
+                item: None,
+                warnings: vec![],
+            };
+        }
+
+        let Some(colons) = name.after.take_prefix("::") else {
+            return MatchAndWarnings {
+                item: None,
+                warnings: vec![],
+            };
+        };
+
+        // The `toc` block macro takes no target: the double colon must be
+        // followed immediately by the attribute list. Anything else (e.g.
+        // `toc::foo[]`) is not a TOC block macro, so quietly decline and let it
+        // fall through to a paragraph.
+        let target = colons.after.take_while(|c| c != '[');
+
+        if !target.item.is_empty() {
+            return MatchAndWarnings {
+                item: None,
+                warnings: vec![],
+            };
+        }
+
+        let Some(open_brace) = target.after.take_prefix("[") else {
+            return MatchAndWarnings {
+                item: None,
+                warnings: vec![],
+            };
+        };
+
+        let attrlist = open_brace.after.slice(0..open_brace.after.len() - 1);
+
+        // Note that we already checked that this line ends with a close brace.
+
+        let macro_attrlist = Attrlist::parse(attrlist, parser, AttrlistContext::Inline);
+
+        let source: Span = metadata.source.trim_remainder(line.after);
+        let source = source.slice(0..source.trim().len());
+
+        MatchAndWarnings {
+            item: Some(MatchedItem {
+                item: Self {
+                    macro_attrlist: macro_attrlist.item.item,
+                    source,
+                    title_source: metadata.title_source,
+                    title: metadata.title.clone(),
+                    anchor: metadata.anchor,
+                    anchor_reftext: metadata.anchor_reftext,
+                    attrlist: metadata.attrlist.clone(),
+                },
+
+                after: line.after.discard_empty_lines(),
+            }),
+            warnings: macro_attrlist.warnings,
+        }
+    }
+
+    /// Return the macro's attribute list.
+    ///
+    /// **IMPORTANT:** This is the list of attributes _within_ the macro block
+    /// definition itself (e.g. `toc::[levels=2]`), which Asciidoctor uses to
+    /// override the per-macro TOC settings (`id`, `levels`, and `role`).
+    ///
+    /// See also [`attrlist()`] for attributes that can be defined before the
+    /// macro invocation.
+    ///
+    /// [`attrlist()`]: Self::attrlist()
+    pub fn macro_attrlist(&'src self) -> &'src Attrlist<'src> {
+        &self.macro_attrlist
+    }
+}
+
+impl<'src> IsBlock<'src> for TocBlock<'src> {
+    fn content_model(&self) -> ContentModel {
+        ContentModel::Empty
+    }
+
+    fn raw_context(&self) -> CowStr<'src> {
+        "toc".into()
+    }
+
+    fn title_source(&'src self) -> Option<Span<'src>> {
+        self.title_source
+    }
+
+    fn title(&self) -> Option<&str> {
+        self.title.as_ref().map(Content::rendered_str)
+    }
+
+    fn id(&'src self) -> Option<&'src str> {
+        // In addition to a block anchor (`[[id]]`/`[#id]`) or the block
+        // attribute list above the macro, a TOC block may carry its ID as a
+        // named `id=` attribute _inside_ the macro attribute list (e.g.
+        // `toc::[id=contents]`), which the trait default does not consider.
+        // Fall back to that last, so the block-level forms win.
+        self.anchor()
+            .map(|a| a.data())
+            .or_else(|| self.attrlist().and_then(|attrlist| attrlist.id()))
+            .or_else(|| self.macro_attrlist.id())
+    }
+
+    fn anchor(&'src self) -> Option<Span<'src>> {
+        self.anchor
+    }
+
+    fn anchor_reftext(&'src self) -> Option<Span<'src>> {
+        self.anchor_reftext
+    }
+
+    fn attrlist(&'src self) -> Option<&'src Attrlist<'src>> {
+        self.attrlist.as_ref()
+    }
+}
+
+impl<'src> HasSpan<'src> for TocBlock<'src> {
+    fn span(&self) -> Span<'src> {
+        self.source
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use std::ops::Deref;
+
+    use crate::{
+        blocks::{ContentModel, metadata::BlockMetadata},
+        tests::prelude::*,
+    };
+
+    #[test]
+    fn impl_clone() {
+        // Silly test to mark the #[derive(...)] line as covered.
+        let mut parser = Parser::default();
+
+        let b1 = crate::blocks::TocBlock::parse(&BlockMetadata::new("toc::[]"), &mut parser)
+            .unwrap_if_no_warnings()
+            .unwrap()
+            .item;
+
+        let b2 = b1.clone();
+        assert_eq!(b1, b2);
+    }
+
+    #[test]
+    fn err_empty_source() {
+        let mut parser = Parser::default();
+        assert!(
+            crate::blocks::TocBlock::parse(&BlockMetadata::new(""), &mut parser)
+                .unwrap_if_no_warnings()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn err_not_toc_macro() {
+        // A different macro name is not a TOC block.
+        let mut parser = Parser::default();
+        assert!(
+            crate::blocks::TocBlock::parse(&BlockMetadata::new("image::foo.png[]"), &mut parser)
+                .unwrap_if_no_warnings()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn err_not_closed() {
+        let mut parser = Parser::default();
+        assert!(
+            crate::blocks::TocBlock::parse(&BlockMetadata::new("toc::["), &mut parser)
+                .unwrap_if_no_warnings()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn err_missing_double_colon() {
+        // A single colon is an inline macro form, not a block macro.
+        let mut parser = Parser::default();
+        assert!(
+            crate::blocks::TocBlock::parse(&BlockMetadata::new("toc:[]"), &mut parser)
+                .unwrap_if_no_warnings()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn err_has_target() {
+        // The `toc` block macro takes no target.
+        let mut parser = Parser::default();
+        assert!(
+            crate::blocks::TocBlock::parse(&BlockMetadata::new("toc::foo[]"), &mut parser)
+                .unwrap_if_no_warnings()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn simplest_toc_macro() {
+        let mut parser = Parser::default();
+
+        let mi = crate::blocks::TocBlock::parse(&BlockMetadata::new("toc::[]"), &mut parser)
+            .unwrap_if_no_warnings()
+            .unwrap();
+
+        assert_eq!(
+            mi.item,
+            TocBlock {
+                macro_attrlist: Attrlist {
+                    attributes: &[],
+                    anchor: None,
+                    source: Span {
+                        data: "",
+                        line: 1,
+                        col: 7,
+                        offset: 6,
+                    }
+                },
+                source: Span {
+                    data: "toc::[]",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                title_source: None,
+                title: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: None,
+            }
+        );
+
+        assert_eq!(
+            mi.after,
+            Span {
+                data: "",
+                line: 1,
+                col: 8,
+                offset: 7
+            }
+        );
+
+        assert_eq!(mi.item.content_model(), ContentModel::Empty);
+        assert_eq!(mi.item.raw_context().deref(), "toc");
+        assert_eq!(mi.item.resolved_context().deref(), "toc");
+        assert!(mi.item.child_blocks().next().is_none());
+        assert!(mi.item.title_source().is_none());
+        assert!(mi.item.title().is_none());
+        assert!(mi.item.anchor().is_none());
+        assert!(mi.item.anchor_reftext().is_none());
+        assert!(mi.item.attrlist().is_none());
+        assert_eq!(mi.item.substitution_group(), SubstitutionGroup::Normal);
+    }
+
+    #[test]
+    fn macro_attrlist_overrides() {
+        // The macro attribute list carries the per-macro TOC overrides.
+        let mut parser = Parser::default();
+
+        let mi = crate::blocks::TocBlock::parse(
+            &BlockMetadata::new("toc::[id=contents,levels=2,role=toc2]"),
+            &mut parser,
+        )
+        .unwrap_if_no_warnings()
+        .unwrap();
+
+        let macro_attrlist = mi.item.macro_attrlist();
+        assert_eq!(macro_attrlist.id().unwrap(), "contents");
+        assert_eq!(
+            macro_attrlist.named_attribute("levels").unwrap().value(),
+            "2"
+        );
+        assert_eq!(
+            macro_attrlist.named_attribute("role").unwrap().value(),
+            "toc2"
+        );
+
+        // The macro `id=` is surfaced through the block's `id()`.
+        assert_eq!(mi.item.id().unwrap(), "contents");
+    }
+}

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -115,16 +115,9 @@ fn scoped_toc(
     TocScopeGuard { key, prev }
 }
 
-/// A regular expression matching a `toc::[]` block macro line (with any
-/// attributes between the brackets).
-static TOC_MACRO: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^toc::\[.*\]$").unwrap());
-
-/// Returns `true` if `block` is a `toc::[]` block macro (which the parser
-/// represents as a plain paragraph, since `toc` is not a media macro).
+/// Returns `true` if `block` is a `toc::[]` block macro.
 fn is_toc_macro(block: &Block) -> bool {
-    matches!(block, Block::Simple(simple)
-        if simple.declared_style().is_none()
-            && TOC_MACRO.is_match(simple.content().original().data().trim()))
+    matches!(block, Block::Toc(_))
 }
 
 /// Renders a `toc::[]` block macro: the table of contents for the active
@@ -813,6 +806,7 @@ impl ToVirtualDom for Block<'_> {
             Block::Table(table) => table_to_node(table),
             Block::Preamble(preamble) => preamble_to_node(preamble),
             Block::Break(break_) => break_to_node(break_),
+            Block::Toc(_) => toc_to_node(self),
             Block::DocumentAttribute(_) => {
                 // Document attributes don't render in HTML.
                 VirtualNode::new("comment")
@@ -2696,6 +2690,14 @@ fn break_to_node<'a>(break_: &'a Break<'a>) -> VirtualNode {
         "page_break" => VirtualNode::new("div").with_class("page-break"),
         _ => VirtualNode::new("hr"),
     }
+}
+
+fn toc_to_node<'a>(toc: &'a Block<'a>) -> VirtualNode {
+    // A `toc::[]` macro renders the table of contents when a `toc: macro` scope
+    // is active, and nothing otherwise (matching Asciidoctor). This arm is the
+    // fallback for a block reached directly rather than through
+    // `add_block_with_title`, which intercepts the macro earlier.
+    toc_macro_node(toc).unwrap_or_else(|| VirtualNode::new("comment"))
 }
 
 #[cfg(test)]

--- a/parser/src/tests/fixtures/blocks/block.rs
+++ b/parser/src/tests/fixtures/blocks/block.rs
@@ -1,7 +1,7 @@
 use crate::tests::fixtures::{
     blocks::{
         AdmonitionBlock, Break, CompoundDelimitedBlock, ListBlock, ListItem, MediaBlock, Preamble,
-        QuoteBlock, RawDelimitedBlock, SectionBlock, SimpleBlock, TableBlock,
+        QuoteBlock, RawDelimitedBlock, SectionBlock, SimpleBlock, TableBlock, TocBlock,
     },
     document::Attribute,
 };
@@ -20,6 +20,7 @@ pub(crate) enum Block {
     Table(TableBlock),
     Preamble(Preamble),
     Break(Break),
+    Toc(TocBlock),
     DocumentAttribute(Attribute),
 }
 
@@ -98,6 +99,11 @@ fn fixture_eq_observed(fixture: &Block, observed: &crate::blocks::Block) -> bool
 
         Block::Break(break_fixture) => match observed {
             crate::blocks::Block::Break(break_observed) => break_fixture == break_observed,
+            _ => false,
+        },
+
+        Block::Toc(toc_fixture) => match observed {
+            crate::blocks::Block::Toc(toc_observed) => toc_fixture == toc_observed,
             _ => false,
         },
 

--- a/parser/src/tests/fixtures/blocks/mod.rs
+++ b/parser/src/tests/fixtures/blocks/mod.rs
@@ -42,3 +42,6 @@ pub(crate) use simple::SimpleBlock;
 
 mod table;
 pub(crate) use table::{TableBlock, TableCell, TableCellContent, TableColumn, TableRow};
+
+mod toc;
+pub(crate) use toc::TocBlock;

--- a/parser/src/tests/fixtures/blocks/toc.rs
+++ b/parser/src/tests/fixtures/blocks/toc.rs
@@ -1,0 +1,107 @@
+use std::fmt;
+
+use crate::{
+    HasSpan,
+    blocks::IsBlock,
+    tests::fixtures::{Span, attributes::Attrlist},
+};
+
+#[derive(Eq, PartialEq)]
+pub(crate) struct TocBlock {
+    pub macro_attrlist: Attrlist,
+    pub source: Span,
+    pub title_source: Option<Span>,
+    pub title: Option<&'static str>,
+    pub anchor: Option<Span>,
+    pub anchor_reftext: Option<Span>,
+    pub attrlist: Option<Attrlist>,
+}
+
+impl fmt::Debug for TocBlock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TocBlock")
+            .field("macro_attrlist", &self.macro_attrlist)
+            .field("source", &self.source)
+            .field("title_source", &self.title_source)
+            .field("title", &self.title)
+            .field("anchor", &self.anchor)
+            .field("anchor_reftext", &self.anchor_reftext)
+            .field("attrlist", &self.attrlist)
+            .finish()
+    }
+}
+
+impl<'src> PartialEq<crate::blocks::TocBlock<'src>> for TocBlock {
+    fn eq(&self, other: &crate::blocks::TocBlock<'src>) -> bool {
+        fixture_eq_observed(self, other)
+    }
+}
+
+impl PartialEq<TocBlock> for crate::blocks::TocBlock<'_> {
+    fn eq(&self, other: &TocBlock) -> bool {
+        fixture_eq_observed(other, self)
+    }
+}
+
+fn fixture_eq_observed(fixture: &TocBlock, observed: &crate::blocks::TocBlock) -> bool {
+    if fixture.macro_attrlist != *observed.macro_attrlist() {
+        return false;
+    }
+
+    if fixture.title_source.is_some() != observed.title_source().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_title_source) = fixture.title_source
+        && let Some(ref observed_title_source) = observed.title_source()
+        && fixture_title_source != observed_title_source
+    {
+        return false;
+    }
+
+    if fixture.title.is_some() != observed.title().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_title) = fixture.title
+        && let Some(ref observed_title) = observed.title()
+        && fixture_title != observed_title
+    {
+        return false;
+    }
+
+    if fixture.anchor.is_some() != observed.anchor().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_anchor) = fixture.anchor
+        && let Some(ref observed_anchor) = observed.anchor()
+        && fixture_anchor != observed_anchor
+    {
+        return false;
+    }
+
+    if fixture.anchor_reftext.is_some() != observed.anchor_reftext().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_anchor_reftext) = fixture.anchor_reftext
+        && let Some(ref observed_anchor_reftext) = observed.anchor_reftext()
+        && fixture_anchor_reftext != observed_anchor_reftext
+    {
+        return false;
+    }
+
+    if fixture.attrlist.is_some() != observed.attrlist().is_some() {
+        return false;
+    }
+
+    if let Some(ref fixture_attrlist) = fixture.attrlist
+        && let Some(ref observed_attrlist) = observed.attrlist()
+        && &fixture_attrlist != observed_attrlist
+    {
+        return false;
+    }
+
+    fixture.source == observed.span()
+}


### PR DESCRIPTION
## Summary

The `toc::[]` block macro previously parsed as an ordinary paragraph whose content was the literal text `toc::[]`, so a backend had no way to detect the macro and render a table of contents at that position.

This PR adds a `TocBlock` type and a `Block::Toc` variant that parses the `toc::[]` block macro to a block whose `resolved_context()` is `toc` (`Context::Toc`).

## What changed

- **New `TocBlock`** (`parser/src/blocks/toc.rs`): parses a `toc::[]` block macro line. It takes no target (`toc::foo[]` is declined and falls through to a paragraph), and it carries the macro's attribute list.
- **`Block::Toc` variant** wired through the `Block` enum, the `IsBlock`/`HasSpan`/`Debug` delegations, `FindBlocks`, and the block-title resolution pass.
- **Dispatch** in `Block::parse_internal` recognizes a `toc::` line, alongside the existing `image::`/`video::`/`audio::` handling.
- **Backend overrides exposed:**
  - `macro_attrlist()` surfaces the per-macro overrides Asciidoctor honors on the generated TOC (`id`, `levels`, `role`); see `convert_toc` in `lib/asciidoctor/converter/html5.rb`.
  - `id()` additionally recognizes a named `id=` inside the macro attribute list (e.g. `toc::[id=contents]`), mirroring `MediaBlock`.
  - a block title above the macro is surfaced through `title()` so a backend can override `toc-title`.
- The test virtual-DOM builder now keys the `macro`-placement TOC off `Block::Toc` instead of a paragraph regex, so the pre-existing `toc` rendering tests exercise the real block.

## Motivation

Downstream, `asciidoc-html5` has wired up TOC rendering for the `auto` / `left` / `right` / `preamble` placements (asciidoc-rs/asciidoc-html5#86) but could not implement the `macro` placement, because `toc::[]` parsed as a paragraph. Surfacing the block here unblocks that last placement.

## Testing

- New unit tests in `blocks/toc.rs` and block-level tests in `blocks/tests/toc.rs` (empty macro, target rejection, macro-attrlist overrides, preamble placement, block-title override).
- Full suite green: `cargo test` (4473 passed), `cargo clippy --all-targets`, `cargo +nightly fmt --all -- --check`.

Closes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)