### PR TITLE
fix: Tokenize a run of `+` around a passthrough like Asciidoctor

### DIFF
--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -368,23 +368,26 @@ static INLINE_PASS: LazyLock<Regex> = LazyLock::new(|| {
     #[allow(clippy::unwrap_used)]
     Regex::new(
         r#"(?xs)
-            \b{start-half}              # Must not follow a word
-
             (?:
                                         # Option 1: [... x-] followed by `xxx`
+                \b{start-half}              # Must not follow a word
                 \[(x-|[^\[\]]+\ x-)\]       # Group 1: [attrlist] with x- suffix
                 \`(\S(?:.*?\S)??)\`         # Group 2: `...` content
-            
+
             |                           # --OR--
                                         # Option 2: [...] followed by +xxx+
+                \b{start-half}              # Must not follow a word
                 \[([^\[\]]+)\]              # Group 3: [attrlist]
                 (\\{0,2})                   # Group 4: optional escapes
                 \+(\S(?:.*?\S)??)\+         # Group 5: +...+ content (surrounded by non-space)
 
             |                           # --OR--
                                         # Option 3: +xxx+ without attrlist
-                (\\)?                       # Group 6: optional escape
-                \+(\S(?:.*?\S)??)\+         # Group 7: +...+ content (surrounded by non-space)
+                (?:^|([^\w;:\\]))           # Group 6: consume a preceding char, so a run
+                                        # of `+` tokenizes like Asciidoctor's `gsub`
+                                        # (which consumes one char before each match)
+                (\\)?                       # Group 7: optional escape
+                \+(\S(?:.*?\S)??)\+         # Group 8: +...+ content (surrounded by non-space)
 
             )
 
@@ -407,7 +410,11 @@ impl Replacer for InlinePassReplacer<'_> {
             // the quoted text is still subject to inline pass replacement.
             let replacer = InlinePassReplacer(self.0);
 
-            let (first, rem) = &caps[0].split_at(1);
+            // Split off the first character (a char boundary, since Option 3
+            // may consume a multi-byte preceding character) and retry on the
+            // remainder.
+            let first_len = caps[0].chars().next().map_or(0, char::len_utf8);
+            let (first, rem) = &caps[0].split_at(first_len);
             dest.push_str(first);
 
             let new_result = INLINE_PASS.replace_all(rem, replacer);
@@ -416,7 +423,14 @@ impl Replacer for InlinePassReplacer<'_> {
             return;
         }
 
-        let escapes = caps.get(4).or_else(|| caps.get(6));
+        // Option 3 consumes one preceding character (mirroring Asciidoctor's
+        // `InlinePassRx`, whose leading group absorbs the character before the
+        // passthrough). Re-emit it verbatim ahead of whatever this match
+        // produces. Options 1 and 2 never capture it, so this is a no-op there.
+        let preceding = caps.get(6).map_or("", |m| m.as_str());
+        dest.push_str(preceding);
+
+        let escapes = caps.get(4).or_else(|| caps.get(7));
         let escape_count = escapes.map_or(0, |m| m.len());
 
         let format_mark = if caps.get(2).is_some() { '`' } else { '+' };
@@ -432,7 +446,7 @@ impl Replacer for InlinePassReplacer<'_> {
             }
         });
 
-        let quoted_text = caps.get(2).or_else(|| caps.get(5)).or_else(|| caps.get(7));
+        let quoted_text = caps.get(2).or_else(|| caps.get(5)).or_else(|| caps.get(8));
         let quoted_text = quoted_text.map_or("", |m| m.as_str());
 
         if let Some(orig_attrlist_body) = orig_attrlist_body {

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -8957,11 +8957,10 @@ mod passthroughs {
     fn should_not_crash_if_role_on_passthrough_is_enclosed_in_quotes_2() {
         // As in the first case, the quoted role is preserved, so the rendered
         // output includes `<span class="'role'">` (the only thing the upstream
-        // Ruby test asserts). The exact tail after the span (`+This+` here vs.
-        // Asciidoctor's `++This++`) still differs because the two
-        // implementations tokenize the surrounding run of `+` characters
-        // differently – a separate passthrough-extraction nuance (tracked in
-        // issue #979), not the role handling exercised by this robustness test.
+        // Ruby test asserts). The tail after the span (`++This++`) now matches
+        // Asciidoctor exactly: the surrounding run of `+` characters tokenizes
+        // into the same passthrough spans because `INLINE_PASS` consumes one
+        // character before each match, mirroring Asciidoctor's `InlinePassRx`.
         let mut p = Parser::default();
         let maw = crate::blocks::Block::parse(
             crate::Span::new("['role']\\+++++++++This++++++++++++"),
@@ -8980,7 +8979,7 @@ mod passthroughs {
                         col: 1,
                         offset: 0,
                     },
-                    rendered: "<span class=\"'role'\">+</span>+This+",
+                    rendered: "<span class=\"'role'\">+</span>++This++",
                 },
                 source: Span {
                     data: "['role']\\+++++++++This++++++++++++",


### PR DESCRIPTION
## Summary

Fixes #979 — inline passthrough extraction now partitions a run of `+` characters into the same passthrough spans as Asciidoctor.

Asciidoctor's `InlinePassRx` consumes **one character before** each inline passthrough it matches (its leading group `(?:^|[^\w;:\\])…` absorbs the preceding character and re-emits it). Because Ruby's `gsub` resumes scanning after each match, that consumed character shifts where the opening `+` lands inside a long run of `+`, which determines how the run is split into passthrough placeholders.

The Rust port used a zero-width `\b{start-half}` boundary instead, so it opened a passthrough one `+` earlier and tokenized the run differently. For the robustness input `['role']\+++++++++This++++++++++++` this produced a `+This+` tail where Asciidoctor produces `++This++`:

| Input | before | after (this PR) | Asciidoctor 2.0.26 |
|-------|--------|-----------------|--------------------|
| `['role']\++This++++++++++++` | `<span class="'role'">+This</span>+` | *(unchanged)* | `<span class="'role'">+This</span>+` |
| `['role']\+++++++++This++++++++++++` | `<span class="'role'">+</span>`**`+This+`** | `<span class="'role'">+</span>`**`++This++`** | `<span class="'role'">+</span>`**`++This++`** |

## Change

- `INLINE_PASS` Option 3 (`+…+` without an attrlist) now consumes a preceding character — start-of-string or one non-word, non-`;:\` character — and the replacer re-emits it verbatim ahead of the match. Options 1 and 2 keep their zero-width `\b{start-half}` boundary, so `[attrlist]`-prefixed passthroughs are unaffected.
- The prohibited-prefix retry now splits on a UTF-8 char boundary, since the newly-consumed preceding character may be multi-byte.

## Testing

- The ported robustness test `should_not_crash_if_role_on_passthrough_is_enclosed_in_quotes_2` now asserts the Asciidoctor-matching `++This++` tail (the divergence note it carried is removed).
- Full suite: `cargo test -p asciidoc-parser` — 4493 passed, 0 failed. No other test changed behavior.
- `cargo +nightly fmt --all -- --check` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)