### PR TITLE
fix: Unlock an API-enabled `numbered` so a body toggle still applies

### DIFF
--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -108,6 +108,13 @@ impl<'src> Document<'src> {
             let iconsdir_set_in_header = header.attributes().any(|a| a.name().data() == "iconsdir");
             parser.apply_iconsdir_default(iconsdir_set_in_header);
 
+            // Unfreeze any "flexible" attribute (`sectnums`) that was supplied
+            // *set* through the API, now that the header is parsed, so the body
+            // may still toggle it. An API-supplied *unset* stays locked. This
+            // mirrors the timing of Asciidoctor's `finalize_header` (see
+            // `Parser::unlock_flexible_attributes`).
+            parser.unlock_flexible_attributes();
+
             let mut maw_blocks = parse_blocks_until(after_header, |_, _| false, parser);
 
             if !maw_blocks.warnings.is_empty() {

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2593,6 +2593,46 @@ impl Parser {
         Arc::make_mut(&mut self.attribute_values).insert(attr_name, attribute_value);
     }
 
+    /// Unlocks each *flexible* document attribute ([`FLEXIBLE_ATTRIBUTES`],
+    /// currently just `sectnums`) that was supplied *set* through the API, so a
+    /// later document-body assignment may still toggle it.
+    ///
+    /// Mirrors the flexible-attribute unfreeze at the end of Asciidoctor's
+    /// `save_attributes` (run by `finalize_header`, after the header is parsed
+    /// and before the body): an API attribute override whose value is *truthy*
+    /// is dropped from the locked overrides, while one whose value is an
+    /// [unset] (from `numbered!` / `sectnums!`) is kept locked. That asymmetry
+    /// is exactly what lets an API-*enabled* `numbered` still be toggled off by
+    /// a body `:numbered!:`, while an API-*disabled* `numbered!` stays
+    /// permanently unnumbered even across a later `:numbered:`.
+    ///
+    /// Called once, for the top-level document only – Asciidoctor guards the
+    /// unfreeze with `unless @parent_document`, and an AsciiDoc table cell
+    /// never reaches this path. This must *not* recapture the attribute
+    /// baseline: the unlock is a per-parse effect, so a `Parser` reused across
+    /// documents re-derives it from the still-locked API override each time.
+    ///
+    /// [unset]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unset-attributes/
+    pub(crate) fn unlock_flexible_attributes(&mut self) {
+        for name in FLEXIBLE_ATTRIBUTES {
+            // Only an API-set (`ApiOnly`, i.e. locked) override with a value
+            // that is not an explicit unset is unfrozen; everything else is
+            // left exactly as it stands.
+            if let Some(existing) = self.attribute_values.get(name)
+                && existing.modification_context == ModificationContext::ApiOnly
+                && existing.value != InterpretedValue::Unset
+            {
+                let unlocked = AttributeValue {
+                    modification_context: ModificationContext::Anywhere,
+                    silent_when_locked: false,
+                    ..existing.clone()
+                };
+
+                Arc::make_mut(&mut self.attribute_values).insert(name.to_string(), unlocked);
+            }
+        }
+    }
+
     /// Assign the next section number for a given level.
     pub(crate) fn assign_section_number(&mut self, level: usize) -> SectionNumber {
         match self.topmost_section_type {
@@ -2862,6 +2902,16 @@ fn remap_attr_name<N: AsRef<str>>(raw_attr_name: N) -> String {
     // Some attribute names have aliases. Remap to the primary name.
     alias_attr_name(attr_name)
 }
+
+/// Document attributes that are *flexible*: an API-supplied *set* value is
+/// unlocked once the header is parsed so the document body may still toggle it,
+/// while an API-supplied [unset] stays locked (see
+/// [`unlock_flexible_attributes`](Parser::unlock_flexible_attributes)). Mirrors
+/// Asciidoctor's `FLEXIBLE_ATTRIBUTES` constant, currently just `sectnums` (the
+/// primary name of the `numbered` alias).
+///
+/// [unset]: https://docs.asciidoctor.org/asciidoc/latest/attributes/unset-attributes/
+const FLEXIBLE_ATTRIBUTES: [&str; 1] = ["sectnums"];
 
 /// Remaps an attribute name that is a legacy alias to its primary name,
 /// returning any other name unchanged.
@@ -3291,6 +3341,53 @@ mod tests {
             rendered_paragraphs(&doc),
             vec!["First line<br>\nSecond line"]
         );
+    }
+
+    #[test]
+    fn api_set_flexible_attribute_is_unlocked_after_the_header() {
+        // An API-*set* `sectnums` (here via the `numbered` alias) is a flexible
+        // attribute: it seeds numbering on, but is unlocked once the header is
+        // parsed so a body `:sectnums!:` still takes effect. Modeled as the
+        // html5 converter applies it: an `ApiOnly` override on `numbered`.
+        let mut p = Parser::default().with_intrinsic_attribute(
+            "numbered",
+            "",
+            ModificationContext::ApiOnly,
+        );
+
+        // Before any parse the alias is stored, locked, under `sectnums`.
+        assert!(p.is_attribute_set("sectnums"));
+
+        // A body `:sectnums!:` turns numbering back off for the sections that
+        // follow it: the unlock let the assignment through.
+        let doc = p.parse("= Title\n\n== On\n\n:sectnums!:\n\n== Off");
+        let nums: Vec<Option<String>> = crate::tests::prelude::all_sections(&doc)
+            .iter()
+            .map(|s| s.section_number().map(|n| n.to_string()))
+            .collect();
+
+        assert_eq!(nums, vec![Some("1".to_string()), None]);
+    }
+
+    #[test]
+    fn api_unset_flexible_attribute_stays_locked() {
+        // An API-*unset* `sectnums` (here via `numbered!`, i.e. the alias set to
+        // `false`) stays locked: a body `:sectnums:` cannot re-enable numbering.
+        let mut p = Parser::default().with_intrinsic_attribute_bool(
+            "numbered",
+            false,
+            ModificationContext::ApiOnly,
+        );
+
+        assert!(!p.is_attribute_set("sectnums"));
+
+        let doc = p.parse("= Title\n\n:sectnums:\n\n== Still Off");
+        let nums: Vec<Option<String>> = crate::tests::prelude::all_sections(&doc)
+            .iter()
+            .map(|s| s.section_number().map(|n| n.to_string()))
+            .collect();
+
+        assert_eq!(nums, vec![None]);
     }
 
     // Under `SafeMode::Server` or greater, `docdir` reads as empty and

--- a/parser/src/tests/asciidoctor_rb/sections_test.rs
+++ b/parser/src/tests/asciidoctor_rb/sections_test.rs
@@ -3676,13 +3676,10 @@ mod section_numbering {
         );
     }
 
-    // NOTE: These two tests additionally exercise Asciidoctor's API attribute
-    // soft-set / hard-lock semantics (`attributes: { 'numbered' => '' }` vs
-    // `{ 'numbered!' => '' }`) — beyond the `numbered` document alias — which
-    // this crate models via `with_intrinsic_attribute` on the raw name, so they
-    // are left out of scope here.
-    non_normative!(
-        r##"
+    #[test]
+    fn section_numbers_can_be_toggled_even_if_numbered_attribute_is_enabled_via_the_api() {
+        verifies!(
+            r##"
     test 'section numbers can be toggled even if numbered attribute is enable via the API' do
       input = <<~'EOS'
       = Document Title
@@ -3717,6 +3714,45 @@ mod section_numbering {
       assert_xpath '//h2[@id="_section_three"][text()="3. Section Three"]', output, 1
     end
 
+"##
+        );
+
+        // An API-*enabled* `numbered` (`attributes: { 'numbered' => '' }`,
+        // modeled here as an `ApiOnly` `with_intrinsic_attribute` on the raw
+        // `numbered` alias) seeds `sectnums` *set*, but a flexible attribute set
+        // through the API is unlocked once the header is parsed – so the body's
+        // `:numbered!:` / `:numbered:` toggles still take effect. The colophon
+        // sections are unnumbered and numbering restarts at `1` after
+        // `:numbered:`.
+        let doc = Parser::default()
+            .with_intrinsic_attribute("numbered", "", ModificationContext::ApiOnly)
+            .parse(
+                "= Document Title\n\n:numbered!:\n\n== Colophon Section\n\n== Another Colophon Section\n\n== Final Colophon Section\n\n:numbered:\n\n== Section One\n\n=== Section One Subsection\n\n== Section Two\n\n== Section Three\n",
+            );
+
+        let nums: Vec<(&str, Option<String>)> = all_sections(&doc)
+            .iter()
+            .map(|s| (s.section_title(), s.section_number().map(|n| n.to_string())))
+            .collect();
+
+        assert_eq!(
+            nums,
+            vec![
+                ("Colophon Section", None),
+                ("Another Colophon Section", None),
+                ("Final Colophon Section", None),
+                ("Section One", Some("1".to_string())),
+                ("Section One Subsection", Some("1.1".to_string())),
+                ("Section Two", Some("2".to_string())),
+                ("Section Three", Some("3".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn section_numbers_cannot_be_toggled_even_if_numbered_attribute_is_disabled_via_the_api() {
+        verifies!(
+            r##"
     test 'section numbers cannot be toggled even if numbered attribute is disabled via the API' do
       input = <<~'EOS'
       = Document Title
@@ -3752,7 +3788,37 @@ mod section_numbering {
     end
 
 "##
-    );
+        );
+
+        // An API-*disabled* `numbered!` (`attributes: { 'numbered!' => '' }`,
+        // modeled here as an `ApiOnly` `with_intrinsic_attribute_bool` `false`
+        // on the raw `numbered` alias) seeds `sectnums` *unset*. An unset
+        // flexible attribute stays locked – so the body's `:numbered:` cannot
+        // re-enable numbering and every section is unnumbered.
+        let doc = Parser::default()
+            .with_intrinsic_attribute_bool("numbered", false, ModificationContext::ApiOnly)
+            .parse(
+                "= Document Title\n\n:numbered!:\n\n== Colophon Section\n\n== Another Colophon Section\n\n== Final Colophon Section\n\n:numbered:\n\n== Section One\n\n=== Section One Subsection\n\n== Section Two\n\n== Section Three\n",
+            );
+
+        let nums: Vec<(&str, Option<String>)> = all_sections(&doc)
+            .iter()
+            .map(|s| (s.section_title(), s.section_number().map(|n| n.to_string())))
+            .collect();
+
+        assert_eq!(
+            nums,
+            vec![
+                ("Colophon Section", None),
+                ("Another Colophon Section", None),
+                ("Final Colophon Section", None),
+                ("Section One", None),
+                ("Section One Subsection", None),
+                ("Section Two", None),
+                ("Section Three", None),
+            ]
+        );
+    }
 
     #[test]
     fn section_numbers_should_not_increment_until_numbered_attribute_is_turned_back_on() {


### PR DESCRIPTION
## Summary

Fixes #989. As of 0.27.3, supplying `numbered` as an API/intrinsic attribute (`ModificationContext::ApiOnly`, as the html5 converter applies `attributes: { 'numbered' => '' }`) remapped to a **locked** `sectnums`, and a locked `sectnums` could not be unset by a body `:numbered!:` — so every section rendered numbered and the mid-document toggle was silently ignored.

## Cause

The 0.27.3 legacy-alias remap (`numbered` → `sectnums`) was correctly extended to the API-intrinsic path, but a side effect was that an API-set `numbered` stored a *locked* `sectnums`. Asciidoctor keeps `sectnums` toggleable in this case because it is a **flexible attribute**.

## What Asciidoctor actually does

`FLEXIBLE_ATTRIBUTES = ['sectnums']`. At the end of `save_attributes` (run by `finalize_header`, after the header is parsed and before the body, top-level document only), an API override whose value is **truthy** is dropped from the locked overrides, while one whose value is an **unset** is kept locked. Verified directly against Asciidoctor 2.0.26:

| API attribute | `attribute_locked?('sectnums')` | body toggle |
| --- | --- | --- |
| `{ 'numbered'  => '' }` (enabled)  | `false` | **works** — colophon unnumbered, restart at 1 |
| `{ 'numbered!' => '' }` (disabled) | `true`  | ignored — every section unnumbered |

## Fix

Add `Parser::unlock_flexible_attributes`, called from `Document::parse` right after the header is parsed (top-level only, matching Asciidoctor's `unless @parent_document` guard). An `ApiOnly` `sectnums` whose value is not an explicit unset is downgraded to `Anywhere`, so the body may reassign it; an API-supplied unset stays locked. The unlock is a per-parse effect and never recaptures the attribute baseline, so a `Parser` reused across documents re-derives it each time from the still-locked API override.

## Tests

- Promoted the two ported Asciidoctor parity tests (`section numbers can/cannot be toggled ... via the API`) from `non_normative!` to verified tests, checking numbering on the AST.
- Added focused parser unit tests for both directions of the flexible-attribute lock.

Full suite: `cargo test -p asciidoc-parser` → 4497 passed; `cargo +nightly fmt --all -- --check` and `cargo clippy` clean.

Once this lands, the corresponding parity test in asciidoc-rs/asciidoc-html5#216 can be promoted back to verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)