### PR TITLE
fix: Keep block metadata attached when a comment sits directly above it

### DIFF
--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -337,7 +337,7 @@ fn skip_comments_before_section(source: Span<'_>, level_offset: i32) -> Option<S
 /// `.`, provided that period is not followed by a space, tab, or a further `.`.
 /// So `.Title` yields `Title` and `..gitignore` yields `.gitignore`, while a
 /// leading `. ` (dot then space) or `..` alone is not a title.
-fn block_title_text(line: Span<'_>) -> Option<Span<'_>> {
+pub(crate) fn block_title_text(line: Span<'_>) -> Option<Span<'_>> {
     if !line.starts_with('.') {
         return None;
     }

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -3,7 +3,9 @@ use crate::{
     attributes::Attrlist,
     blocks::{
         ChildBlocks, CompoundDelimitedBlock, ContentModel, IsBlock, ListItemMarker,
-        RawDelimitedBlock, TableBlock, caption::assign_block_caption, metadata::BlockMetadata,
+        RawDelimitedBlock, TableBlock,
+        caption::assign_block_caption,
+        metadata::{BlockMetadata, block_title_text},
     },
     content::{Content, SubstitutionGroup},
     span::MatchedItem,
@@ -411,21 +413,26 @@ fn parse_lines<'src>(
         }
 
         // A leading line comment sitting directly above a line that begins a new
-        // block – block metadata (`[...]`, including an anchor `[[...]]`) or a
-        // block delimiter (a delimited block or a table) – must not absorb that
-        // line as paragraph content. Terminate the comment-only block here so
-        // the following line gets a fresh dispatch and can attach as metadata to
-        // (or open) the block it decorates. Without this, the first such line
-        // after the comment is swallowed as paragraph text. This is scoped to
-        // the case where only comment lines have been consumed so far
-        // (`filtered_lines` still empty); once real content has accumulated, the
-        // general stop conditions below take over. Like the section-heading case
-        // above, it applies at the top level and in paragraph style only.
+        // block – block metadata (a `.Title`, or a `[...]` attribute list or
+        // `[[...]]` anchor) or a block delimiter (a delimited block or a table)
+        // – must not absorb that line as paragraph content. Terminate the
+        // comment-only block here so the following line gets a fresh dispatch
+        // and can attach as metadata to (or open) the block it decorates.
+        // Without this, the first such line after the comment is swallowed as
+        // paragraph text. This is scoped to the case where only comment lines
+        // have been consumed so far (`filtered_lines` still empty); once real
+        // content has accumulated, the general stop conditions below take over.
+        // Like the section-heading case above, it applies at the top level and
+        // in paragraph style only. The `[...]` test mirrors the general
+        // attribute-line stop below (it treats any bracketed line as a block
+        // boundary, valid metadata or not), so a comment directly above such a
+        // line is split the same way `text` directly above it already is.
         if !stop_for_list_items
             && skipped_comment_line
             && filtered_lines.is_empty()
             && style == SimpleBlockStyle::Paragraph
-            && ((line.starts_with('[') && line.ends_with(']'))
+            && (block_title_text(line).is_some()
+                || (line.starts_with('[') && line.ends_with(']'))
                 || RawDelimitedBlock::is_valid_delimiter(&line)
                 || CompoundDelimitedBlock::is_valid_delimiter(&line)
                 || TableBlock::is_table_delimiter(&line))

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -3,7 +3,7 @@ use crate::{
     attributes::Attrlist,
     blocks::{
         ChildBlocks, CompoundDelimitedBlock, ContentModel, IsBlock, ListItemMarker,
-        RawDelimitedBlock, caption::assign_block_caption, metadata::BlockMetadata,
+        RawDelimitedBlock, TableBlock, caption::assign_block_caption, metadata::BlockMetadata,
     },
     content::{Content, SubstitutionGroup},
     span::MatchedItem,
@@ -406,6 +406,29 @@ fn parse_lines<'src>(
             && skipped_comment_line
             && style == SimpleBlockStyle::Paragraph
             && is_section_header(line.data(), parser.level_offset())
+        {
+            break;
+        }
+
+        // A leading line comment sitting directly above a line that begins a new
+        // block – block metadata (`[...]`, including an anchor `[[...]]`) or a
+        // block delimiter (a delimited block or a table) – must not absorb that
+        // line as paragraph content. Terminate the comment-only block here so
+        // the following line gets a fresh dispatch and can attach as metadata to
+        // (or open) the block it decorates. Without this, the first such line
+        // after the comment is swallowed as paragraph text. This is scoped to
+        // the case where only comment lines have been consumed so far
+        // (`filtered_lines` still empty); once real content has accumulated, the
+        // general stop conditions below take over. Like the section-heading case
+        // above, it applies at the top level and in paragraph style only.
+        if !stop_for_list_items
+            && skipped_comment_line
+            && filtered_lines.is_empty()
+            && style == SimpleBlockStyle::Paragraph
+            && ((line.starts_with('[') && line.ends_with(']'))
+                || RawDelimitedBlock::is_valid_delimiter(&line)
+                || CompoundDelimitedBlock::is_valid_delimiter(&line)
+                || TableBlock::is_table_delimiter(&line))
         {
             break;
         }

--- a/parser/src/blocks/tests/simple.rs
+++ b/parser/src/blocks/tests/simple.rs
@@ -1356,3 +1356,94 @@ fn comment_then_hashes_without_space_does_not_terminate_paragraph() {
         }
     );
 }
+
+/// A single-line comment (`//`) placed directly above a block-metadata line –
+/// an attribute list, an anchor, etc., with no blank line between them – must
+/// not detach that metadata from the block it decorates. Regression tests for
+/// the case where the first metadata line after the comment was surfaced as
+/// paragraph text.
+mod comment_directly_above_metadata {
+    use crate::tests::prelude::*;
+
+    #[test]
+    fn attrlist_before_listing() {
+        let doc = Parser::default().parse("= T\n\n// note\n[,ruby]\n----\nputs 1\n----\n");
+        let blocks = top_blocks(&doc);
+
+        // The comment is retained as its own (empty) paragraph block.
+        assert_eq!(blocks[0].raw_context().as_ref(), "paragraph");
+        assert_eq!(blocks[0].span().data(), "// note");
+
+        // The `[,ruby]` metadata attaches to the following listing rather than
+        // being consumed as paragraph text.
+        assert_eq!(blocks[1].raw_context().as_ref(), "listing");
+        assert_eq!(
+            blocks[1]
+                .attrlist()
+                .and_then(|a| a.nth_attribute(2))
+                .map(|a| a.value()),
+            Some("ruby")
+        );
+        assert_eq!(doc.warnings().count(), 0);
+    }
+
+    #[test]
+    fn stem_style_before_passthrough() {
+        let doc = Parser::default().parse("= T\n:stem:\n\n// note\n[stem]\n++++\nx = y^2\n++++\n");
+        let blocks = top_blocks(&doc);
+
+        assert_eq!(blocks[0].raw_context().as_ref(), "paragraph");
+        assert_eq!(blocks[0].span().data(), "// note");
+
+        // The `[stem]` style attaches to the following delimited block.
+        assert_eq!(blocks[1].declared_style(), Some("stem"));
+        assert_eq!(doc.warnings().count(), 0);
+    }
+
+    #[test]
+    fn anchor_and_attrlist_both_attach() {
+        // Both the anchor directly under the comment and the attribute list
+        // after it attach to the listing.
+        let doc = Parser::default().parse("= T\n\n// note\n[[an]]\n[,ruby]\n----\nputs 1\n----\n");
+        let blocks = top_blocks(&doc);
+
+        assert_eq!(blocks[0].raw_context().as_ref(), "paragraph");
+        assert_eq!(blocks[0].span().data(), "// note");
+
+        assert_eq!(blocks[1].raw_context().as_ref(), "listing");
+        assert_eq!(blocks[1].id(), Some("an"));
+        assert_eq!(
+            blocks[1]
+                .attrlist()
+                .and_then(|a| a.nth_attribute(2))
+                .map(|a| a.value()),
+            Some("ruby")
+        );
+    }
+
+    #[test]
+    fn bare_table_delimiter_after_comment() {
+        // A comment directly above a bare table delimiter opens the table rather
+        // than swallowing the whole table as paragraph text.
+        let doc = Parser::default().parse("= T\n\n// note\n|===\n|a |b\n|===\n");
+        let blocks = top_blocks(&doc);
+
+        assert_eq!(blocks[0].raw_context().as_ref(), "paragraph");
+        assert_eq!(blocks[0].span().data(), "// note");
+
+        assert_eq!(blocks[1].raw_context().as_ref(), "table");
+    }
+
+    #[test]
+    fn plain_text_after_comment_still_merges() {
+        // A comment directly above ordinary paragraph text is still absorbed
+        // into that single paragraph (the metadata-adjacency stop must not
+        // fire for non-metadata content).
+        let doc = Parser::default().parse("// note\nHello world\n");
+        let blocks = top_blocks(&doc);
+
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].raw_context().as_ref(), "paragraph");
+        assert_eq!(blocks[0].rendered_content(), Some("Hello world"));
+    }
+}

--- a/parser/src/blocks/tests/simple.rs
+++ b/parser/src/blocks/tests/simple.rs
@@ -1422,6 +1422,52 @@ mod comment_directly_above_metadata {
     }
 
     #[test]
+    fn title_before_listing() {
+        // A `.Title` line directly under the comment attaches as the following
+        // block's title rather than being surfaced as paragraph text.
+        let doc = Parser::default().parse("= T\n\n// note\n.Title\n----\nputs 1\n----\n");
+        let blocks = top_blocks(&doc);
+
+        assert_eq!(blocks[0].raw_context().as_ref(), "paragraph");
+        assert_eq!(blocks[0].span().data(), "// note");
+
+        assert_eq!(blocks[1].raw_context().as_ref(), "listing");
+        assert_eq!(blocks[1].title(), Some("Title"));
+    }
+
+    #[test]
+    fn title_before_paragraph() {
+        // The title also attaches when the decorated block is itself a
+        // paragraph.
+        let doc = Parser::default().parse("= T\n\nfirst\n\n// note\n.Title\ntext\n");
+        let blocks = top_blocks(&doc);
+
+        // blocks[0] is `first`; blocks[1] is the retained comment.
+        assert_eq!(blocks[2].raw_context().as_ref(), "paragraph");
+        assert_eq!(blocks[2].title(), Some("Title"));
+        assert_eq!(blocks[2].rendered_content(), Some("text"));
+    }
+
+    #[test]
+    fn bracketed_line_after_comment_is_a_block_boundary() {
+        // A bracketed line that is not valid block metadata (a leading space is
+        // rejected by attribute-line parsing) is still treated as a block
+        // boundary, exactly as it is when it directly follows ordinary
+        // paragraph text. The comment is retained as its own block and the
+        // bracketed line renders as its own paragraph – the same rendered
+        // output the pre-existing merged form produced, just as a distinct
+        // block.
+        let doc = Parser::default().parse("= T\n\nfirst\n\n// note\n[ foo]\n");
+        let blocks = top_blocks(&doc);
+
+        assert_eq!(blocks[1].raw_context().as_ref(), "paragraph");
+        assert_eq!(blocks[1].span().data(), "// note");
+
+        assert_eq!(blocks[2].raw_context().as_ref(), "paragraph");
+        assert_eq!(blocks[2].rendered_content(), Some("[ foo]"));
+    }
+
+    #[test]
     fn bare_table_delimiter_after_comment() {
         // A comment directly above a bare table delimiter opens the table rather
         // than swallowing the whole table as paragraph text.


### PR DESCRIPTION
## Summary

Fixes #995. A single-line comment (`//`) placed **directly above** a block-metadata line — an attribute list (`[…]`), an anchor (`[[…]]`), etc., with no blank line between — detached that metadata from the block it should apply to. The parser surfaced the metadata line as ordinary paragraph text, and the following block lost its intended style/anchor. Asciidoctor 2.0.26 attaches the metadata correctly for the same input.

## Root cause

In `SimpleBlock`'s line scanner (`parse_lines` in `parser/src/blocks/simple.rs`), a leading `//` comment line is skipped without being added to `filtered_lines`. The paragraph stop conditions are gated on `!filtered_lines.is_empty()`, so with only a comment consumed so far they did not run — and the first block-starting line after the comment (`[,ruby]`, `[stem]`, `[[anchor]]`, a delimiter, …) was absorbed as paragraph text. This also explains the "only the first metadata line after the comment is lost" characterization: once that line lands in `filtered_lines`, the next metadata line is stopped normally.

## Fix

Terminate the comment-only paragraph when the next line begins a new block — block metadata (`[...]`), a delimited block, or a table — while only comment lines have been consumed. The comment is still retained as its own block (this crate deliberately does not discard comments); the following line then dispatches fresh and its metadata attaches to the block it decorates. Scoped to the top level and paragraph style, mirroring the pre-existing comment-then-section-heading stop right above it.

## Tests

New regression tests in `parser/src/blocks/tests/simple.rs` (`comment_directly_above_metadata`):

- `[,ruby]` attaches to the following listing (language `ruby` captured).
- `[stem]` style attaches to the following passthrough block.
- Anchor `[[an]]` **and** `[,ruby]` both attach across the comment.
- A bare table delimiter (`|===`) opens the table instead of being swallowed.
- A comment above ordinary paragraph text still merges into one paragraph (guard against over-terminating).

Full suite passes (`cargo test`), `cargo +nightly fmt --all -- --check` and `cargo clippy --all-targets` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)