### PR TITLE
feat!: Distinguish an unreadable include file from a missing one

### DIFF
--- a/parser/src/parser/include_file_handler.rs
+++ b/parser/src/parser/include_file_handler.rs
@@ -22,9 +22,23 @@ pub trait IncludeFileHandler: Debug {
     /// - `parser`: An implementation may read document attribute values from
     ///   the [`Parser`] state.
     ///
-    /// Return the content of the include file (wrapped in [`IncludeContent`])
-    /// if found. If no file is found, return `None` and an appropriate warning
-    /// message will be generated.
+    /// Return the outcome as an [`IncludeResolution`]:
+    ///
+    /// - [`IncludeResolution::Found`] carries the content of the include file
+    ///   (wrapped in [`IncludeContent`]).
+    /// - [`IncludeResolution::NotFound`] signals that no such file exists; the
+    ///   parser records a [`WarningType::IncludeFileNotFound`] warning.
+    /// - [`IncludeResolution::NotReadable`] signals that the file exists but
+    ///   could not be read (for example a permission or other IO error); the
+    ///   parser records a [`WarningType::IncludeFileNotReadable`] warning.
+    ///
+    /// The rendered replacement (`Unresolved directive …`) is identical for the
+    /// two failure reasons; only the warning differs, mirroring Asciidoctor's
+    /// separate `include file not found` and `include file not readable`
+    /// messages.
+    ///
+    /// [`WarningType::IncludeFileNotFound`]: crate::warnings::WarningType::IncludeFileNotFound
+    /// [`WarningType::IncludeFileNotReadable`]: crate::warnings::WarningType::IncludeFileNotReadable
     ///
     /// # Options
     /// With the exception of `encoding` (see below), the implementation should
@@ -49,14 +63,51 @@ pub trait IncludeFileHandler: Debug {
     /// include-encoding warning in that case.
     ///
     /// If the implementation finds a file that is not encoded in UTF-8 and is
-    /// incapable of transcoding it, it should return `None`.
+    /// incapable of transcoding it, it should return
+    /// [`IncludeResolution::NotFound`].
     fn resolve_target<'src>(
         &self,
         source: Option<&str>,
         target: &str,
         attrlist: &Attrlist<'src>,
         parser: &Parser,
-    ) -> Option<IncludeContent>;
+    ) -> IncludeResolution;
+}
+
+/// The outcome of an [`IncludeFileHandler::resolve_target`] call: either the
+/// resolved content, or the reason resolution failed.
+///
+/// The two failure reasons map to distinct warnings – mirroring Asciidoctor,
+/// which distinguishes a missing include file (`include file not found`) from
+/// one that is present but unreadable (`include file not readable`).
+///
+/// This enum is `non_exhaustive`: future resolution reasons may be recognized
+/// as the parser grows, so a host matching on it needs a catch-all arm. New
+/// variants can still be returned by an [`IncludeFileHandler`] implementation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum IncludeResolution {
+    /// The include file was resolved; its content is carried here.
+    Found(IncludeContent),
+
+    /// No file could be found for the directive's target. The parser records a
+    /// [`WarningType::IncludeFileNotFound`] warning.
+    ///
+    /// [`WarningType::IncludeFileNotFound`]: crate::warnings::WarningType::IncludeFileNotFound
+    NotFound,
+
+    /// A file was found for the directive's target but could not be read (for
+    /// example a permission or other IO error). The parser records a
+    /// [`WarningType::IncludeFileNotReadable`] warning.
+    ///
+    /// [`WarningType::IncludeFileNotReadable`]: crate::warnings::WarningType::IncludeFileNotReadable
+    NotReadable,
+}
+
+impl From<IncludeContent> for IncludeResolution {
+    fn from(content: IncludeContent) -> Self {
+        IncludeResolution::Found(content)
+    }
 }
 
 /// The content returned by an [`IncludeFileHandler`] for an `include::`

--- a/parser/src/parser/include_file_handler.rs
+++ b/parser/src/parser/include_file_handler.rs
@@ -182,7 +182,14 @@ impl From<&str> for IncludeContent {
 
 #[cfg(test)]
 mod tests {
-    use super::IncludeContent;
+    use super::{IncludeContent, IncludeResolution};
+
+    #[test]
+    fn resolution_from_include_content_is_found() {
+        let content = IncludeContent::new("Content.");
+        let resolution: IncludeResolution = content.clone().into();
+        assert_eq!(resolution, IncludeResolution::Found(content));
+    }
 
     #[test]
     fn new_does_not_mark_encoding_handled() {

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -15,7 +15,7 @@ mod image_file_handler;
 pub use image_file_handler::ImageFileHandler;
 
 mod include_file_handler;
-pub use include_file_handler::{IncludeContent, IncludeFileHandler};
+pub use include_file_handler::{IncludeContent, IncludeFileHandler, IncludeResolution};
 
 mod inline_substitution_renderer;
 pub use inline_substitution_renderer::{

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -7,7 +7,10 @@ use crate::{
     attributes::{Attrlist, AttrlistContext},
     content::AttributeMissing,
     document::{Attribute, InterpretedValue},
-    parser::{DeferredWarning, Fidelity, SourceLine, SourceMap, Transform, attribute_lookup_name},
+    parser::{
+        DeferredWarning, Fidelity, IncludeResolution, SourceLine, SourceMap, Transform,
+        attribute_lookup_name,
+    },
     span::MatchedItem,
     warnings::{Warning, WarningType},
 };
@@ -642,11 +645,26 @@ impl<'p> PreprocessorState<'p> {
                     continue;
                 }
 
-                if let Some(include_content) =
-                    self.parser.include_file_handler.as_ref().and_then(|ifh| {
+                // Ask the handler to resolve the target. With no handler
+                // configured, the target is treated as not found. The failure
+                // reason (`NotFound` vs `NotReadable`) selects the warning
+                // recorded below, mirroring Asciidoctor's distinct `include file
+                // not found` and `include file not readable` messages.
+                let resolution = self
+                    .parser
+                    .include_file_handler
+                    .as_ref()
+                    .map_or(IncludeResolution::NotFound, |ifh| {
                         ifh.resolve_target(file_name, &target, &attrlist, self.parser)
-                    })
-                {
+                    });
+
+                let (include_content, not_readable) = match resolution {
+                    IncludeResolution::Found(content) => (Some(content), false),
+                    IncludeResolution::NotReadable => (None, true),
+                    _ => (None, false),
+                };
+
+                if let Some(include_content) = include_content {
                     // Apply `lines`/`tag(s)` selection and `indent` normalization
                     // to the raw included content before it is merged, matching
                     // Asciidoctor. Any nested include/conditional directives in an
@@ -848,10 +866,18 @@ impl<'p> PreprocessorState<'p> {
                     has_reported_file = false;
                 } else {
                     // The target could not be resolved. Replace the directive with
-                    // an "Unresolved directive" message and record a warning.
+                    // an "Unresolved directive" message and record a warning. A
+                    // file that exists but can't be read is reported distinctly
+                    // from a missing one, matching Asciidoctor.
+                    let warning = if not_readable {
+                        WarningType::IncludeFileNotReadable(target)
+                    } else {
+                        WarningType::IncludeFileNotFound(target)
+                    };
+
                     self.emit_unresolved_directive(
                         line.data(),
-                        WarningType::IncludeFileNotFound(target),
+                        warning,
                         file_name,
                         source_line_number,
                         &mut has_reported_file,
@@ -2402,7 +2428,10 @@ mod tests {
     use crate::{
         SafeMode,
         attributes::Attrlist,
-        parser::{IncludeContent, IncludeFileHandler, SourceLine, preprocessor::preprocess},
+        parser::{
+            IncludeContent, IncludeFileHandler, IncludeResolution, SourceLine,
+            preprocessor::preprocess,
+        },
         tests::{fixtures::inline_file_handler::InlineFileHandler, prelude::*},
     };
 
@@ -4147,10 +4176,10 @@ mod tests {
                 _target: &str,
                 _attrlist: &Attrlist<'src>,
                 _parser: &Parser,
-            ) -> Option<IncludeContent> {
+            ) -> IncludeResolution {
                 // Pretend the bytes on disk were `iso-8859-1` and we decoded
                 // them; the returned content is valid UTF-8.
-                Some(IncludeContent::transcoded("Résumé."))
+                IncludeResolution::Found(IncludeContent::transcoded("Résumé."))
             }
         }
 

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -658,10 +658,15 @@ impl<'p> PreprocessorState<'p> {
                         ifh.resolve_target(file_name, &target, &attrlist, self.parser)
                     });
 
+                // Matched exhaustively (no catch-all) on purpose: although
+                // `IncludeResolution` is `non_exhaustive` for downstream crates,
+                // within this crate a new reason must be handled here
+                // deliberately – likely with its own warning – rather than
+                // silently collapsing into "not found".
                 let (include_content, not_readable) = match resolution {
                     IncludeResolution::Found(content) => (Some(content), false),
                     IncludeResolution::NotReadable => (None, true),
-                    _ => (None, false),
+                    IncludeResolution::NotFound => (None, false),
                 };
 
                 if let Some(include_content) = include_content {

--- a/parser/src/tests/asciidoctor_rb/reader_test.rs
+++ b/parser/src/tests/asciidoctor_rb/reader_test.rs
@@ -73,7 +73,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use crate::{
     attributes::Attrlist,
-    parser::{IncludeContent, IncludeFileHandler},
+    parser::{IncludeContent, IncludeFileHandler, IncludeResolution},
     tests::prelude::{inline_file_handler::InlineFileHandler, *},
 };
 
@@ -93,21 +93,34 @@ type RecordedInclude = (Option<String>, String, Option<String>);
 /// naming the including file as `source`, and forwarding the `encoding`
 /// attribute — before delegating. This handler lets a test assert exactly what
 /// the parser hands off.
+/// What a [`RecordingIncludeFileHandler`] returns from `resolve_target`.
+#[derive(Clone, Copy, Debug)]
+enum MockResolution {
+    /// A resolved file whose content is returned via
+    /// [`IncludeContent::transcoded`] when the flag is set, otherwise
+    /// [`IncludeContent::new`].
+    Found(&'static str, bool),
+
+    /// A target for which no file could be found.
+    NotFound,
+
+    /// A target whose file exists but could not be read.
+    NotReadable,
+}
+
 #[derive(Clone, Debug)]
 struct RecordingIncludeFileHandler {
     calls: Rc<RefCell<Vec<RecordedInclude>>>,
-    /// What the handler returns from `resolve_target`: `Some((content,
-    /// transcoded))` for a resolved file (returned via
-    /// [`IncludeContent::transcoded`] when `transcoded` is set, otherwise
-    /// [`IncludeContent::new`]), or `None` for a file that could not be found.
-    result: Option<(&'static str, bool)>,
+
+    /// What the handler returns from `resolve_target`.
+    result: MockResolution,
 }
 
 impl RecordingIncludeFileHandler {
     fn new(content: &'static str) -> Self {
         Self {
             calls: Rc::new(RefCell::new(Vec::new())),
-            result: Some((content, false)),
+            result: MockResolution::Found(content, false),
         }
     }
 
@@ -116,16 +129,27 @@ impl RecordingIncludeFileHandler {
     /// file and reencoded it per the `encoding` attribute.
     fn transcoding(content: &'static str) -> Self {
         Self {
-            result: Some((content, true)),
+            result: MockResolution::Found(content, true),
             ..Self::new(content)
         }
     }
 
     /// A handler that records the call but reports the file as not found
-    /// (returns `None`), as a real handler would for a missing target.
+    /// (returns [`IncludeResolution::NotFound`]), as a real handler would for a
+    /// missing target.
     fn missing() -> Self {
         Self {
-            result: None,
+            result: MockResolution::NotFound,
+            ..Self::new("")
+        }
+    }
+
+    /// A handler that records the call but reports the file as present yet
+    /// unreadable (returns [`IncludeResolution::NotReadable`]), as a real
+    /// handler would for a file it could not read (e.g. a permission error).
+    fn unreadable() -> Self {
+        Self {
+            result: MockResolution::NotReadable,
             ..Self::new("")
         }
     }
@@ -145,20 +169,28 @@ impl IncludeFileHandler for RecordingIncludeFileHandler {
         target: &str,
         attrlist: &Attrlist<'src>,
         _parser: &Parser,
-    ) -> Option<IncludeContent> {
+    ) -> IncludeResolution {
         let encoding = attrlist
             .named_attribute("encoding")
             .map(|a| a.value().to_string());
         self.calls
             .borrow_mut()
             .push((source.map(str::to_owned), target.to_owned(), encoding));
-        self.result.map(|(content, transcoded)| {
-            if transcoded {
-                IncludeContent::transcoded(content)
-            } else {
-                IncludeContent::new(content)
+        match self.result {
+            MockResolution::Found(content, transcoded) => {
+                let content = if transcoded {
+                    IncludeContent::transcoded(content)
+                } else {
+                    IncludeContent::new(content)
+                };
+
+                IncludeResolution::Found(content)
             }
-        })
+
+            MockResolution::NotFound => IncludeResolution::NotFound,
+
+            MockResolution::NotReadable => IncludeResolution::NotReadable,
+        }
     }
 }
 
@@ -1814,11 +1846,12 @@ fn should_replace_include_directive_that_references_missing_file_with_message() 
     );
 }
 
-// This crate delegates file access to the handler, which signals both a
-// missing and an unreadable file the same way (by returning `None`), so an
-// unreadable target is reported with the same `IncludeFileNotFound` warning
-// as a missing one — it does not distinguish Asciidoctor's separate "include
-// file not readable" message.
+// This crate delegates file access to the handler, which distinguishes a
+// missing file ([`IncludeResolution::NotFound`]) from one that exists but can't
+// be read ([`IncludeResolution::NotReadable`]). An unreadable target is
+// therefore reported with an `IncludeFileNotReadable` warning – matching
+// Asciidoctor's separate "include file not readable" message – while the
+// rendered "Unresolved directive" replacement is identical to the missing case.
 #[test]
 fn should_replace_include_directive_that_references_unreadable_file_with_message() {
     verifies!(
@@ -1850,7 +1883,7 @@ fn should_replace_include_directive_that_references_unreadable_file_with_message
 "#
     );
 
-    let handler = RecordingIncludeFileHandler::missing();
+    let handler = RecordingIncludeFileHandler::unreadable();
     let probe = handler.clone();
     let parser = Parser::default()
         .with_safe_mode(SafeMode::Server)
@@ -1870,7 +1903,7 @@ fn should_replace_include_directive_that_references_unreadable_file_with_message
     assert_eq!(warnings.len(), 1);
     assert_eq!(
         warnings[0].warning,
-        WarningType::IncludeFileNotFound("fixtures/chapter-a.adoc".to_owned())
+        WarningType::IncludeFileNotReadable("fixtures/chapter-a.adoc".to_owned())
     );
 }
 

--- a/parser/src/tests/asciidoctor_rb/reader_test.rs
+++ b/parser/src/tests/asciidoctor_rb/reader_test.rs
@@ -1907,6 +1907,31 @@ fn should_replace_include_directive_that_references_unreadable_file_with_message
     );
 }
 
+// `opts=optional` suppresses the unresolved-directive replacement and the
+// warning for an *unreadable* target just as it does for a missing one: the
+// directive is dropped silently, leaving only the trailing content. There is no
+// dedicated Asciidoctor test for the optional + unreadable combination; this
+// guards the crate's intentional behavior against regression (twin of
+// `should_skip_include_directive_that_references_missing_file_if_optional_option_is_set`).
+#[test]
+fn should_skip_include_directive_that_references_unreadable_file_if_optional_option_is_set() {
+    let handler = RecordingIncludeFileHandler::unreadable();
+    let probe = handler.clone();
+    let parser = Parser::default()
+        .with_safe_mode(SafeMode::Server)
+        .with_include_file_handler(handler);
+    let (output, _source_map, warnings, _includes) = crate::parser::preprocessor::preprocess(
+        "include::fixtures/chapter-a.adoc[opts=optional]\n\ntrailing content",
+        &parser,
+    );
+    assert_eq!(output, "\ntrailing content\n");
+    assert_eq!(
+        probe.calls(),
+        vec![(None, "fixtures/chapter-a.adoc".to_owned(), None)]
+    );
+    assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+}
+
 non_normative!(
     r#"
 

--- a/parser/src/tests/fixtures/inline_file_handler.rs
+++ b/parser/src/tests/fixtures/inline_file_handler.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::{
     attributes::Attrlist,
-    parser::{IncludeContent, IncludeFileHandler},
+    parser::{IncludeContent, IncludeFileHandler, IncludeResolution},
     tests::prelude::*,
 };
 
@@ -22,7 +22,9 @@ impl IncludeFileHandler for InlineFileHandler {
         target: &str,
         _attrlist: &Attrlist<'src>,
         _parser: &Parser,
-    ) -> Option<IncludeContent> {
-        self.0.get(target).map(|v| IncludeContent::new(*v))
+    ) -> IncludeResolution {
+        self.0.get(target).map_or(IncludeResolution::NotFound, |v| {
+            IncludeResolution::Found(IncludeContent::new(*v))
+        })
     }
 }

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -231,6 +231,14 @@ pub enum WarningType {
     #[error("include file not found: {0}")]
     IncludeFileNotFound(String),
 
+    /// An `include::` directive named a file that exists but the configured
+    /// include file handler could not read (for example a permission or other
+    /// IO error). The field is the target as written. Asciidoctor distinguishes
+    /// this from [`IncludeFileNotFound`](Self::IncludeFileNotFound), logging
+    /// `include file not readable` rather than `include file not found`.
+    #[error("include file not readable: {0}")]
+    IncludeFileNotReadable(String),
+
     /// An include directive's target referenced a missing attribute while
     /// `attribute-missing` was set to `warn`, so the directive was dropped
     /// without being resolved. (Under `drop-line` the directive line is
@@ -486,6 +494,11 @@ impl std::fmt::Debug for WarningType {
 
             WarningType::IncludeFileNotFound(target) => f
                 .debug_tuple("WarningType::IncludeFileNotFound")
+                .field(target)
+                .finish(),
+
+            WarningType::IncludeFileNotReadable(target) => f
+                .debug_tuple("WarningType::IncludeFileNotReadable")
                 .field(target)
                 .finish(),
 
@@ -958,6 +971,16 @@ mod tests {
                 assert_eq!(
                     debug_output,
                     "WarningType::IncludeFileNotFound(\"content.adoc\")"
+                );
+            }
+
+            #[test]
+            fn include_file_not_readable() {
+                let warning = WarningType::IncludeFileNotReadable("content.adoc".to_string());
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(
+                    debug_output,
+                    "WarningType::IncludeFileNotReadable(\"content.adoc\")"
                 );
             }
 


### PR DESCRIPTION
Closes #998.

## Summary

When an `include::` directive names a file that **exists but cannot be read** (e.g. a permission error), the parser previously reported it identically to a **missing** file (`WarningType::IncludeFileNotFound`). Asciidoctor distinguishes the two, logging `include file not readable` where this parser logged `include file not found`.

This PR implements the issue's **preferred** approach: an explicit resolution-reason enum returned by the handler.

## Changes

- **New warning variant.** `WarningType::IncludeFileNotReadable(String)` (field = target as written), with the `thiserror` message `include file not readable: {0}`, mirroring `IncludeFileNotFound`.
- **New handler return type.** `IncludeFileHandler::resolve_target` now returns `IncludeResolution` instead of `Option<IncludeContent>`:
  ```rust
  #[non_exhaustive]
  pub enum IncludeResolution {
      Found(IncludeContent),
      NotFound,
      NotReadable,
  }
  ```
  A `From<IncludeContent>` conversion is provided for convenience. The enum is `#[non_exhaustive]`, leaving room for future reasons (notably non-UTF-8 content, which today is also silently unresolved).
- **Preprocessor mapping.** A `NotReadable` result maps to `IncludeFileNotReadable`; `NotFound` (and a missing handler) map to `IncludeFileNotFound`. The rendered `Unresolved directive in <src> - include::<t>[]` replacement is identical in both cases — only the warning differs, matching Asciidoctor. The `opts=optional` short-circuit still drops both silently.

## Tests

- The Asciidoctor port `should_replace_include_directive_that_references_unreadable_file_with_message` (`reader_test.rs`) is converted from a note about the previous limitation into a **verified** test asserting `IncludeFileNotReadable`, via a new `RecordingIncludeFileHandler::unreadable()` mock.
- Added a `WarningType::IncludeFileNotReadable` `Debug` test.
- Updated the three in-crate `IncludeFileHandler` implementations to the new return type.

## Breaking change

This is a breaking change to the public `IncludeFileHandler` trait. Downstream (`asciidoc-html5`, asciidoc-rs/asciidoc-html5#146) will bump the parser dependency and update `FsIncludeFileHandler` to distinguish `io::ErrorKind::NotFound` from other IO errors, returning `IncludeResolution::NotReadable` for the latter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)