### PR TITLE
fix: Match breaking-change commits (feat!:) in release_commits regex

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -36,7 +36,7 @@ commit_parsers = [
 dependencies_update = true
 pr_labels = ["release"]
 release_always = false
-release_commits = "^(feat|fix|update|doc)[(:]"
+release_commits = "^(feat|fix|update|doc)!?[(:]"
 
 [[package]]
 changelog_path = "./CHANGELOG.md"


### PR DESCRIPTION
## Problem

After #999 (`feat!: Distinguish an unreadable include file from a missing one`), release-plz failed to open a release PR, reporting *"no commit matches the release commit regex."*

The workspace `release_commits` regex in `release-plz.toml` was:

```
^(feat|fix|update|doc)[(:]
```

This requires the commit type to be immediately followed by `(` or `:`. A scopeless breaking-change commit like `feat!:` places a `!` between `feat` and `:`, so it never matched.

## Fix

Add an optional `!` before the `(`/`:`:

```
^(feat|fix|update|doc)!?[(:]
```

All Conventional Commit forms now match:

| Commit | Before | After |
|---|---|---|
| `feat: …` | ✅ | ✅ |
| `feat(scope): …` | ✅ | ✅ |
| `feat(scope)!: …` | ✅ (matches at `(`) | ✅ |
| `feat!: …` | ❌ | ✅ |

Only the scopeless breaking form (`feat!:`, `fix!:`, etc.) was affected.

## Note

Once merged, the next qualifying commit will trigger a release PR that sweeps in #999 as well. This `fix:` commit itself qualifies, so merging it should be enough to get release-plz moving again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)