### PR TITLE
fix: Reconcile an explicit `:authors:` entry against the implicit author line

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -891,6 +891,17 @@ fn resolve_authors(
             if authors_value != computed
                 && let Some(authors) = authors_from_authors_attribute(&authors_value, parser)
             {
+                // `set_author_metadata` overwrites the derived attributes for
+                // the replacement authors but does not clear ones the implicit
+                // list set that the replacement does not (a shorter list leaves
+                // a stale trailing `author_N`; a replacement author lacking a
+                // middle name / email leaves the implicit `middlename` /
+                // `email`). This mirrors Asciidoctor's `doc_attrs.update
+                // author_metadata` – a merge that overwrites present keys and
+                // never deletes absent ones – so `{author_3}` and friends can
+                // outlive an `authorcount` that reflects the shorter list. The
+                // divergence is Asciidoctor's; see the shrinking-replacement
+                // regression test in this module.
                 set_author_metadata(parser, &authors);
                 return authors;
             }
@@ -2042,6 +2053,71 @@ mod tests {
 
         assert_eq!(doc.attribute_value("author"), InterpretedValue::Unset);
         assert!(doc.authors().is_empty());
+    }
+
+    #[test]
+    fn authors_entry_replacing_a_longer_implicit_list_leaves_stale_attributes() {
+        // When a differing `:authors:` entry replaces a *longer* implicit author
+        // line, the reconciliation re-derives only the replacement authors'
+        // attributes. Attributes the implicit line set that the replacement does
+        // not are left in place: a trailing `author_N` (and its name parts)
+        // beyond the shorter list, and the base `email` / `middlename` when the
+        // replacement's first author omits them.
+        //
+        // This is not a gap in the port – it is exactly Asciidoctor's behavior.
+        // Its `parse_header_metadata` reconciles with `doc_attrs.update
+        // author_metadata`, a merge that overwrites the keys the replacement
+        // supplies and never deletes the ones it omits, so `{author_3}` (and the
+        // stale `email` / `middlename`) survive alongside an `authorcount` that
+        // reflects the shorter list. Verified byte-for-byte against Asciidoctor
+        // 2.0.26; there is no upstream test for this shrinking case, so this one
+        // pins the parity to guard against a future "cleanup" that would clear
+        // the stale keys and diverge.
+        let mut parser = Parser::default();
+        let doc = parser.parse(
+            "= T\nKismet R. Lee <kismet@example.com>; Junior Writer; Third Author\n:authors: Stuart Rackham; Dan Allen\n",
+        );
+
+        // The typed author list and `authorcount` reflect the two-author
+        // replacement.
+        let authors = doc.header().authors();
+        assert_eq!(authors.len(), 2);
+        assert_eq!(authors.first().unwrap().name(), "Stuart Rackham");
+        assert_eq!(authors.get(1).unwrap().name(), "Dan Allen");
+        assert_eq!(
+            parser.attribute_value("authorcount"),
+            InterpretedValue::Value("2")
+        );
+
+        // The replacement authors' attributes are re-derived.
+        assert_eq!(
+            parser.attribute_value("authors"),
+            InterpretedValue::Value("Stuart Rackham, Dan Allen")
+        );
+        assert_eq!(
+            parser.attribute_value("author_1"),
+            InterpretedValue::Value("Stuart Rackham")
+        );
+        assert_eq!(
+            parser.attribute_value("author_2"),
+            InterpretedValue::Value("Dan Allen")
+        );
+
+        // Stale attributes from the longer/richer implicit list survive, exactly
+        // as they do in Asciidoctor: the third author, the first implicit
+        // author's email, and its middle name.
+        assert_eq!(
+            parser.attribute_value("author_3"),
+            InterpretedValue::Value("Third Author")
+        );
+        assert_eq!(
+            parser.attribute_value("email"),
+            InterpretedValue::Value("kismet@example.com")
+        );
+        assert_eq!(
+            parser.attribute_value("middlename"),
+            InterpretedValue::Value("R.")
+        );
     }
 
     #[test]

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -834,10 +834,13 @@ fn partition_title(title: &str, parser: &Parser) -> (String, Option<String>) {
 
 /// Resolves the document's author list.
 ///
-/// When an [`AuthorLine`] is present it is authoritative (and has already
-/// populated the `author_N` attributes). Otherwise the list is reconstructed
-/// from document attributes, mirroring Asciidoctor's `parse_header_metadata`
-/// reconciliation in precedence order: a directly-assigned `author` attribute
+/// When an [`AuthorLine`] is present it is normally authoritative (and has
+/// already populated the `author_N` attributes), except that an explicit
+/// `:authors:` entry whose value differs from the computed implicit value
+/// replaces the implicit list. Otherwise the list is
+/// reconstructed from document attributes, mirroring Asciidoctor's
+/// `parse_header_metadata` reconciliation in precedence order: a
+/// directly-assigned `author` attribute
 /// stands in for a single author; failing that a semicolon-separated `authors`
 /// attribute is split into individual authors; and failing that a contiguous
 /// run of indexed `author_N` attributes (`author_1`, `author_2`, …) each
@@ -865,7 +868,35 @@ fn resolve_authors(
     parser: &mut Parser,
 ) -> Vec<Author> {
     if let Some(author_line) = author_line {
-        return author_line.authors().cloned().collect();
+        let implicit_authors: Vec<Author> = author_line.authors().cloned().collect();
+
+        // Reconcile an explicit `:authors:` entry against the implicit author
+        // line, mirroring Asciidoctor's `parse_header_metadata`. When the
+        // entry's value differs from the computed (comma-joined) value of the
+        // implicit list, the entry *replaces* that list – re-splitting on `;`,
+        // updating `authorcount`, and repopulating the derived `author_N` (and
+        // per-author name-part) attributes. A value that matches the computed
+        // value leaves the implicit list untouched.
+        //
+        // Only the multi-author `:authors:` path is reconciled here; the single
+        // `:author:` and indexed `:author_N:` entry paths keep their existing
+        // inline handling.
+        if let Some(authors_value) = attribute_string(parser, "authors") {
+            let computed = implicit_authors
+                .iter()
+                .map(Author::name)
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            if authors_value != computed
+                && let Some(authors) = authors_from_authors_attribute(&authors_value, parser)
+            {
+                set_author_metadata(parser, &authors);
+                return authors;
+            }
+        }
+
+        return implicit_authors;
     }
 
     if !header_has_attributes {
@@ -886,18 +917,11 @@ fn resolve_authors(
 
     // A semicolon-separated `authors` attribute entry contributes one author
     // per entry (Asciidoctor's `process_authors` with `multiple` set).
-    if let Some(authors_value) = attribute_string(parser, "authors") {
-        let authors = collect_indexed_authors(
-            split_author_entries(&authors_value)
-                .into_iter()
-                .filter_map(|entry| Author::parse(entry, parser, true)),
-            parser,
-        );
-
-        if !authors.is_empty() {
-            set_author_metadata(parser, &authors);
-            return authors;
-        }
+    if let Some(authors_value) = attribute_string(parser, "authors")
+        && let Some(authors) = authors_from_authors_attribute(&authors_value, parser)
+    {
+        set_author_metadata(parser, &authors);
+        return authors;
     }
 
     // Otherwise, walk the indexed `author_N` attributes until one is missing.
@@ -921,6 +945,26 @@ fn resolve_authors(
     }
 
     authors
+}
+
+/// Builds the author list described by an `authors` attribute value, splitting
+/// it into individual authors (Asciidoctor's `process_authors` with `multiple`
+/// set) and attaching each author's companion `email_N`. Returns `None` when
+/// the value yields no authors (so the caller can fall through to its next
+/// resolution step).
+fn authors_from_authors_attribute(value: &str, parser: &Parser) -> Option<Vec<Author>> {
+    let authors = collect_indexed_authors(
+        split_author_entries(value)
+            .into_iter()
+            .filter_map(|entry| Author::parse(entry, parser, true)),
+        parser,
+    );
+
+    if authors.is_empty() {
+        None
+    } else {
+        Some(authors)
+    }
 }
 
 /// Reads the string value of a document attribute, or `None` when it is unset

--- a/parser/src/tests/asciidoctor_rb/parser_test.rs
+++ b/parser/src/tests/asciidoctor_rb/parser_test.rs
@@ -1215,12 +1215,10 @@ fn use_explicit_authorinitials_if_set_after_author_attribute() {
     );
 }
 
-// Incompatibility: this crate does not implement Asciidoctor's reconciliation
-// of an explicit `:authors:` entry against the computed value; it simply stores
-// the `:authors:` entry verbatim and never re-derives `author_1`/`authorcount`
-// from it.
-non_normative!(
-    r#"
+#[test]
+fn use_implicit_authors_if_value_of_authors_attribute_matches_computed_value() {
+    verifies!(
+        r#"
   test 'use implicit authors if value of authors attribute matches computed value' do
     input = <<~'EOS'
     Doc Writer; Junior Writer
@@ -1233,6 +1231,45 @@ non_normative!(
     assert_equal 'Junior Writer', doc.attributes['author_2']
   end
 
+"#
+    );
+
+    // The `:authors:` entry value matches the computed (comma-joined) value of
+    // the implicit author line, so the implicit list is retained unchanged. A
+    // synthetic document title is prepended because this crate only recognizes
+    // an author line when a title is present.
+    //
+    // This crate names the first author from an implicit line `author` (not
+    // `author_1`) and, because the retain path leaves the implicit list
+    // untouched, does not derive an `author_1` companion here; the first
+    // author is asserted through the unsuffixed `author` attribute instead.
+    let mut parser = Parser::default();
+    let doc = parser
+        .parse("= Document Title\nDoc Writer; Junior Writer\n:authors: Doc Writer, Junior Writer");
+
+    let authors = doc.header().authors();
+    assert_eq!(authors.len(), 2);
+    assert_eq!(authors[0].name(), "Doc Writer");
+    assert_eq!(authors[1].name(), "Junior Writer");
+
+    assert_eq!(
+        parser.attribute_value("authors"),
+        InterpretedValue::Value("Doc Writer, Junior Writer")
+    );
+    assert_eq!(
+        parser.attribute_value("author"),
+        InterpretedValue::Value("Doc Writer")
+    );
+    assert_eq!(
+        parser.attribute_value("author_2"),
+        InterpretedValue::Value("Junior Writer")
+    );
+}
+
+#[test]
+fn replace_implicit_authors_if_value_of_authors_attribute_does_not_match_computed_value() {
+    verifies!(
+        r#"
   test 'replace implicit authors if value of authors attribute does not match computed value' do
     input = <<~'EOS'
     Doc Writer; Junior Writer
@@ -1249,7 +1286,48 @@ non_normative!(
   end
 
 "#
-);
+    );
+
+    // The `:authors:` entry value differs from the computed value of the
+    // implicit author line, so it replaces the implicit list: re-split on `;`
+    // into three authors, with `authorcount`, the joined `authors`, and the
+    // per-author `author_N` attributes all re-derived from the entry. A
+    // synthetic document title is prepended because this crate only recognizes
+    // an author line when a title is present. (This crate does not surface the
+    // header-metadata hash, so `metadata['authorcount']` is not modeled
+    // separately.)
+    let mut parser = Parser::default();
+    let doc = parser.parse(
+        "= Document Title\nDoc Writer; Junior Writer\n:authors: Stuart Rackham; Dan Allen; Sarah White",
+    );
+
+    let authors = doc.header().authors();
+    assert_eq!(authors.len(), 3);
+    assert_eq!(authors[0].name(), "Stuart Rackham");
+    assert_eq!(authors[1].name(), "Dan Allen");
+    assert_eq!(authors[2].name(), "Sarah White");
+
+    assert_eq!(
+        parser.attribute_value("authorcount"),
+        InterpretedValue::Value("3")
+    );
+    assert_eq!(
+        parser.attribute_value("authors"),
+        InterpretedValue::Value("Stuart Rackham, Dan Allen, Sarah White")
+    );
+    assert_eq!(
+        parser.attribute_value("author_1"),
+        InterpretedValue::Value("Stuart Rackham")
+    );
+    assert_eq!(
+        parser.attribute_value("author_2"),
+        InterpretedValue::Value("Dan Allen")
+    );
+    assert_eq!(
+        parser.attribute_value("author_3"),
+        InterpretedValue::Value("Sarah White")
+    );
+}
 
 // This crate does not derive an `authorcount` document attribute.
 non_normative!(


### PR DESCRIPTION
## Summary

Fixes the divergence described in #1003: when an explicit `:authors:` attribute entry follows an **implicit author line** and its value does not match the computed value, Asciidoctor *replaces* the implicit author list. The parser previously kept the implicit list untouched and stored only the raw `:authors:` string.

For the reproduction:

```rust
Parser::new().parse("= T\nDoc Writer; Junior Writer\n:authors: Stuart Rackham; Dan Allen; Sarah White\n");
```

the parser now resolves `authors()` to `[Stuart Rackham, Dan Allen, Sarah White]` and re-derives `authorcount` = `3`, `authors` = `Stuart Rackham, Dan Allen, Sarah White`, and `author_1`/`author_2`/`author_3`, matching Asciidoctor 2.0.26.

## What changed

- `resolve_authors` (in `parser/src/document/header.rs`) now reconciles an explicit `:authors:` entry against the implicit author line, mirroring Asciidoctor's `parse_header_metadata`. When the entry value differs from the computed comma-joined value it replaces the list (re-splitting on `;`) and repopulates the derived author attributes; a matching value leaves the implicit list in place.
- Only the multi-author `:authors:` path is reconciled for the implicit-line-present case; the single `:author:` and indexed `:author_N:` entry paths keep their existing inline handling.
- Factored a small `authors_from_authors_attribute` helper shared with the pre-existing (no author line) `authors` resolution branch.

## Tests

The two upstream `parser_test.rb` cases that were previously ported as `non_normative!` — *use implicit authors if value of authors attribute matches computed value* and *replace implicit authors if value of authors attribute does not match computed value* — are now real, passing tests.

Full parser test suite (`cargo test -p asciidoc-parser --lib`) passes; `cargo +nightly fmt --all -- --check` and `cargo clippy` are clean.

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)