### PR TITLE
fix: Populate combined `authors` and `author_1` attributes from the implicit author line

### DIFF
--- a/parser/src/document/author.rs
+++ b/parser/src/document/author.rs
@@ -260,6 +260,70 @@ impl Author {
     }
 }
 
+/// Populates the derived author document attributes from a resolved author
+/// list, mirroring Asciidoctor's `process_authors`.
+///
+/// The first author sets the unsuffixed keys (`author`, `firstname`,
+/// `authorinitials`, …); each subsequent author sets its `_N` companions. Once
+/// a second author appears, the first author is also mirrored onto its `_1`
+/// companions. The `authors` attribute is rewritten to the comma-joined list of
+/// resolved author names.
+///
+/// This intentionally does **not** honor `authorinitials_from_entry`: the
+/// derived `authorinitials` always overwrites an explicit `:authorinitials:`
+/// entry for the `authors` and `author_N` forms. Only a single `:author:` entry
+/// (handled inline in [`Header::parse`](crate::document::Header)) preserves an
+/// explicit override, exactly as Asciidoctor does – its `authorinitials`
+/// deletion guard lives only in the `author` branch of `process_authors`, not
+/// the `authors`/indexed branches.
+pub(crate) fn set_author_metadata(parser: &mut Parser, authors: &[Author]) {
+    for (idx, author) in authors.iter().enumerate() {
+        set_author_keys(parser, author, if idx == 0 { None } else { Some(idx + 1) });
+
+        // The `_1` companions are only assigned once a second author is seen.
+        if idx == 1
+            && let Some(first) = authors.first()
+        {
+            set_author_keys(parser, first, Some(1));
+        }
+    }
+
+    let joined = authors
+        .iter()
+        .map(Author::name)
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    parser.set_attribute_by_value_from_header("authors", joined);
+}
+
+/// Sets the author attributes for a single author, either as the unsuffixed
+/// keys (`index` is `None`) or the `_N` companions (`index` is `Some(n)`).
+fn set_author_keys(parser: &mut Parser, author: &Author, index: Option<usize>) {
+    let key = |name: &str| match index {
+        None => name.to_string(),
+        Some(n) => format!("{name}_{n}"),
+    };
+
+    parser.set_attribute_by_value_from_header(key("author"), author.name());
+
+    parser.set_attribute_by_value_from_header(key("firstname"), author.firstname());
+
+    if let Some(middlename) = author.middlename() {
+        parser.set_attribute_by_value_from_header(key("middlename"), middlename);
+    }
+
+    if let Some(lastname) = author.lastname() {
+        parser.set_attribute_by_value_from_header(key("lastname"), lastname);
+    }
+
+    parser.set_attribute_by_value_from_header(key("authorinitials"), author.initials());
+
+    if let Some(email) = author.email() {
+        parser.set_attribute_by_value_from_header(key("email"), email);
+    }
+}
+
 fn first_char_or_empty_string(s: &str) -> String {
     s.chars().next().map_or(String::new(), |c| c.to_string())
 }

--- a/parser/src/document/author_line.rs
+++ b/parser/src/document/author_line.rs
@@ -27,21 +27,36 @@ impl<'src> AuthorLine<'src> {
             .collect();
 
         for (index, author) in authors.iter().enumerate() {
-            set_nth_attribute(parser, "author", index, author.name());
-            set_nth_attribute(parser, "authorinitials", index, author.initials());
-            set_nth_attribute(parser, "firstname", index, author.firstname());
+            let suffix = if index == 0 {
+                String::new()
+            } else {
+                format!("_{count}", count = index + 1)
+            };
 
-            if let Some(middlename) = author.middlename() {
-                set_nth_attribute(parser, "middlename", index, middlename);
-            }
+            set_author_attributes(parser, author, &suffix);
+        }
 
-            if let Some(lastname) = author.lastname() {
-                set_nth_attribute(parser, "lastname", index, lastname);
-            }
+        // When the implicit author line names more than one author, Asciidoctor
+        // also exposes the first author's attributes under explicit
+        // `_1`-suffixed names (`author_1`, `firstname_1`, ...) in addition to
+        // the unsuffixed forms set above. For a single author only the
+        // unsuffixed names are set.
+        if let Some(first) = authors.first()
+            && authors.len() > 1
+        {
+            set_author_attributes(parser, first, "_1");
+        }
 
-            if let Some(email) = author.email() {
-                set_nth_attribute(parser, "email", index, email);
-            }
+        // Asciidoctor exposes the combined, comma-joined `authors` attribute
+        // whenever the implicit author line names at least one author.
+        if !authors.is_empty() {
+            let combined = authors
+                .iter()
+                .map(Author::name)
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            parser.set_attribute_by_value_from_header("authors", combined);
         }
 
         Self { authors, source }
@@ -114,14 +129,28 @@ fn split_authors(data: &str) -> Vec<&str> {
     authors
 }
 
-fn set_nth_attribute<V: AsRef<str>>(parser: &mut Parser, name: &str, index: usize, value: V) {
-    let name = if index == 0 {
-        name.to_string()
-    } else {
-        format!("{name}_{count}", count = index + 1)
-    };
+/// Set the built-in author attributes for a single author, appending `suffix`
+/// (e.g. `""` for the first author or `"_2"` for the second) to each attribute
+/// name. Optional parts (middle name, last name, email) are set only when the
+/// author supplies them.
+fn set_author_attributes(parser: &mut Parser, author: &Author, suffix: &str) {
+    parser.set_attribute_by_value_from_header(format!("author{suffix}"), author.name());
 
-    parser.set_attribute_by_value_from_header(name, value);
+    parser.set_attribute_by_value_from_header(format!("authorinitials{suffix}"), author.initials());
+
+    parser.set_attribute_by_value_from_header(format!("firstname{suffix}"), author.firstname());
+
+    if let Some(middlename) = author.middlename() {
+        parser.set_attribute_by_value_from_header(format!("middlename{suffix}"), middlename);
+    }
+
+    if let Some(lastname) = author.lastname() {
+        parser.set_attribute_by_value_from_header(format!("lastname{suffix}"), lastname);
+    }
+
+    if let Some(email) = author.email() {
+        parser.set_attribute_by_value_from_header(format!("email{suffix}"), email);
+    }
 }
 
 impl<'src> HasSpan<'src> for AuthorLine<'src> {
@@ -874,6 +903,29 @@ mod tests {
             InterpretedValue::Value("jane@example.com")
         );
 
+        // First author, also exposed under explicit `_1`-suffixed names because
+        // more than one author is present.
+        assert_eq!(
+            parser.attribute_value("author_1"),
+            InterpretedValue::Value("Jane Smith")
+        );
+        assert_eq!(
+            parser.attribute_value("firstname_1"),
+            InterpretedValue::Value("Jane")
+        );
+        assert_eq!(
+            parser.attribute_value("lastname_1"),
+            InterpretedValue::Value("Smith")
+        );
+        assert_eq!(
+            parser.attribute_value("authorinitials_1"),
+            InterpretedValue::Value("JS")
+        );
+        assert_eq!(
+            parser.attribute_value("email_1"),
+            InterpretedValue::Value("jane@example.com")
+        );
+
         // Second author
         assert_eq!(
             parser.attribute_value("author_2"),
@@ -896,13 +948,48 @@ mod tests {
             InterpretedValue::Value("john@example.com")
         );
 
-        // Verify middlename attributes are unset for both authors.
+        // Verify middlename attributes are unset for all authors.
         assert_eq!(
             parser.attribute_value("middlename"),
             InterpretedValue::Unset
         );
         assert_eq!(
+            parser.attribute_value("middlename_1"),
+            InterpretedValue::Unset
+        );
+        assert_eq!(
             parser.attribute_value("middlename_2"),
+            InterpretedValue::Unset
+        );
+
+        // The combined, comma-joined `authors` attribute lists every author.
+        assert_eq!(
+            parser.attribute_value("authors"),
+            InterpretedValue::Value("Jane Smith, John Doe")
+        );
+    }
+
+    #[test]
+    fn single_author_sets_combined_authors_but_no_indexed_names() {
+        let mut parser = Parser::default();
+        let _doc = parser.parse("= Document Title\nKismet R. Lee <kismet@asciidoctor.org>");
+
+        // For a single author, the combined `authors` attribute equals the
+        // primary `author` attribute ...
+        assert_eq!(
+            parser.attribute_value("authors"),
+            InterpretedValue::Value("Kismet R. Lee")
+        );
+
+        // ... and no `_1`-suffixed names are derived (those appear only when
+        // more than one author is present).
+        assert_eq!(parser.attribute_value("author_1"), InterpretedValue::Unset);
+        assert_eq!(
+            parser.attribute_value("firstname_1"),
+            InterpretedValue::Unset
+        );
+        assert_eq!(
+            parser.attribute_value("lastname_1"),
             InterpretedValue::Unset
         );
     }

--- a/parser/src/document/author_line.rs
+++ b/parser/src/document/author_line.rs
@@ -2,7 +2,11 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
-use crate::{HasSpan, Parser, Span, document::Author, internal::opaque_iter::opaque_slice_iter};
+use crate::{
+    HasSpan, Parser, Span,
+    document::{Author, set_author_metadata},
+    internal::opaque_iter::opaque_slice_iter,
+};
 
 opaque_slice_iter! {
     /// An iterator over the [`Author`]s in an [`AuthorLine`], returned by
@@ -26,37 +30,15 @@ impl<'src> AuthorLine<'src> {
             .filter_map(|raw_author| Author::parse(raw_author, parser, false))
             .collect();
 
-        for (index, author) in authors.iter().enumerate() {
-            let suffix = if index == 0 {
-                String::new()
-            } else {
-                format!("_{count}", count = index + 1)
-            };
-
-            set_author_attributes(parser, author, &suffix);
-        }
-
-        // When the implicit author line names more than one author, Asciidoctor
-        // also exposes the first author's attributes under explicit
-        // `_1`-suffixed names (`author_1`, `firstname_1`, ...) in addition to
-        // the unsuffixed forms set above. For a single author only the
-        // unsuffixed names are set.
-        if let Some(first) = authors.first()
-            && authors.len() > 1
-        {
-            set_author_attributes(parser, first, "_1");
-        }
-
-        // Asciidoctor exposes the combined, comma-joined `authors` attribute
-        // whenever the implicit author line names at least one author.
+        // Populate the derived author document attributes from the implicit
+        // author line – the unsuffixed first-author keys (`author`,
+        // `firstname`, ...), the `author_N` companions, the `_1` companions
+        // (mirrored once a second author appears), and the combined,
+        // comma-joined `authors` attribute – exactly as Asciidoctor's
+        // `process_authors` does. Setting them here, during header parsing,
+        // keeps `{author}`, `{authors}`, etc. available to later header lines.
         if !authors.is_empty() {
-            let combined = authors
-                .iter()
-                .map(Author::name)
-                .collect::<Vec<_>>()
-                .join(", ");
-
-            parser.set_attribute_by_value_from_header("authors", combined);
+            set_author_metadata(parser, &authors);
         }
 
         Self { authors, source }
@@ -127,30 +109,6 @@ fn split_authors(data: &str) -> Vec<&str> {
 
     authors.push(&data[start..]);
     authors
-}
-
-/// Set the built-in author attributes for a single author, appending `suffix`
-/// (e.g. `""` for the first author or `"_2"` for the second) to each attribute
-/// name. Optional parts (middle name, last name, email) are set only when the
-/// author supplies them.
-fn set_author_attributes(parser: &mut Parser, author: &Author, suffix: &str) {
-    parser.set_attribute_by_value_from_header(format!("author{suffix}"), author.name());
-
-    parser.set_attribute_by_value_from_header(format!("authorinitials{suffix}"), author.initials());
-
-    parser.set_attribute_by_value_from_header(format!("firstname{suffix}"), author.firstname());
-
-    if let Some(middlename) = author.middlename() {
-        parser.set_attribute_by_value_from_header(format!("middlename{suffix}"), middlename);
-    }
-
-    if let Some(lastname) = author.lastname() {
-        parser.set_attribute_by_value_from_header(format!("lastname{suffix}"), lastname);
-    }
-
-    if let Some(email) = author.email() {
-        parser.set_attribute_by_value_from_header(format!("email{suffix}"), email);
-    }
 }
 
 impl<'src> HasSpan<'src> for AuthorLine<'src> {

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -4,7 +4,7 @@ use crate::{
     content::{Content, SubstitutionGroup, substitute_attributes_in_reftext},
     document::{
         Attribute, Author, AuthorLine, InterpretedValue, RefType, RevisionLine,
-        matches_author_pattern,
+        matches_author_pattern, set_author_metadata,
     },
     internal::{debug::DebugSliceReference, opaque_iter::opaque_slice_iter},
     span::MatchedItem,
@@ -1028,69 +1028,6 @@ fn split_author_entries(value: &str) -> Vec<&str> {
 
     entries.push(&value[start..]);
     entries
-}
-
-/// Populates the derived author document attributes from a resolved author
-/// list, mirroring Asciidoctor's `process_authors`.
-///
-/// The first author sets the unsuffixed keys (`author`, `firstname`,
-/// `authorinitials`, …); each subsequent author sets its `_N` companions. Once
-/// a second author appears, the first author is also mirrored onto its `_1`
-/// companions. The `authors` attribute is rewritten to the comma-joined list of
-/// resolved author names.
-///
-/// This intentionally does **not** honor `authorinitials_from_entry`: the
-/// derived `authorinitials` always overwrites an explicit `:authorinitials:`
-/// entry for the `authors` and `author_N` forms. Only a single `:author:` entry
-/// (handled inline in [`Header::parse`]) preserves an explicit override,
-/// exactly as Asciidoctor does – its `authorinitials` deletion guard lives only
-/// in the `author` branch of `process_authors`, not the `authors`/indexed
-/// branches.
-fn set_author_metadata(parser: &mut Parser, authors: &[Author]) {
-    for (idx, author) in authors.iter().enumerate() {
-        set_author_keys(parser, author, if idx == 0 { None } else { Some(idx + 1) });
-
-        // The `_1` companions are only assigned once a second author is seen.
-        if idx == 1
-            && let Some(first) = authors.first()
-        {
-            set_author_keys(parser, first, Some(1));
-        }
-    }
-
-    let joined = authors
-        .iter()
-        .map(Author::name)
-        .collect::<Vec<_>>()
-        .join(", ");
-
-    parser.set_attribute_by_value_from_header("authors", joined);
-}
-
-/// Sets the author attributes for a single author, either as the unsuffixed
-/// keys (`index` is `None`) or the `_N` companions (`index` is `Some(n)`).
-fn set_author_keys(parser: &mut Parser, author: &Author, index: Option<usize>) {
-    let key = |name: &str| match index {
-        None => name.to_string(),
-        Some(n) => format!("{name}_{n}"),
-    };
-
-    parser.set_attribute_by_value_from_header(key("author"), author.name());
-    parser.set_attribute_by_value_from_header(key("firstname"), author.firstname());
-
-    if let Some(middlename) = author.middlename() {
-        parser.set_attribute_by_value_from_header(key("middlename"), middlename);
-    }
-
-    if let Some(lastname) = author.lastname() {
-        parser.set_attribute_by_value_from_header(key("lastname"), lastname);
-    }
-
-    parser.set_attribute_by_value_from_header(key("authorinitials"), author.initials());
-
-    if let Some(email) = author.email() {
-        parser.set_attribute_by_value_from_header(key("email"), email);
-    }
 }
 
 fn apply_header_subs(source: &str, parser: &Parser) -> String {

--- a/parser/src/document/mod.rs
+++ b/parser/src/document/mod.rs
@@ -5,7 +5,7 @@ pub use attribute::{Attribute, InterpretedValue};
 
 mod author;
 pub use author::Author;
-pub(crate) use author::matches_author_pattern;
+pub(crate) use author::{matches_author_pattern, set_author_metadata};
 
 mod author_line;
 pub use author_line::{AuthorLine, Authors};

--- a/parser/src/tests/asciidoctor_rb/parser_test.rs
+++ b/parser/src/tests/asciidoctor_rb/parser_test.rs
@@ -63,11 +63,13 @@
 //!   [`AuthorLine::parse`](crate::document::AuthorLine), asserting on the
 //!   parsed [`Author`](crate::document::Author) list (name / firstname /
 //!   middlename / lastname / email / initials). This crate derives the combined
-//!   `authors` (comma-joined) attribute and, when more than one author is
-//!   present, the first author's `_1`-suffixed names (`author_1`, ...) as well
-//!   as the unsuffixed forms; it does not derive Ruby's `authorcount` document
-//!   attribute, so assertions on that are dropped. The Ruby `metadata.size`
-//!   (hash cardinality) has no crate analog and is likewise not asserted.
+//!   `authors` (comma-joined) attribute, the `authorcount` count, and – when
+//!   more than one author is present – the first author's `_1`-suffixed names
+//!   (`author_1`, ...) as well as the unsuffixed forms. The one divergence is
+//!   that an author-less document leaves `authorcount` unset rather than
+//!   materializing Ruby's default of `0`, so that case is left
+//!   `non_normative!`. The Ruby `metadata.size` (hash cardinality) has no crate
+//!   analog and is likewise not asserted.
 //! * **`parse_header_metadata`** revision parsing — driven through a full
 //!   [`Parser::parse`] over the header (title, author line, revision line) and
 //!   asserting on `doc.header().revision_line()`'s `revnumber()` / `revdate()`
@@ -160,17 +162,6 @@ fn parse_authors(line: &str) -> Vec<ParsedAuthor> {
             initials: a.initials(),
         })
         .collect()
-}
-
-/// Parse an implicit author line through [`AuthorLine::parse`] and return the
-/// [`Parser`] so the caller can assert on the document attributes it derives:
-/// the combined, comma-joined `authors` attribute and – when more than one
-/// author is present – the first author's `_1`-suffixed names (`author_1`,
-/// `firstname_1`, ...) alongside the `author_2`, `author_3`, ... family.
-fn parse_authors_deriving_attributes(line: &str) -> Parser {
-    let mut parser = Parser::default();
-    let _author_line = crate::document::AuthorLine::parse(crate::Span::new(line), &mut parser);
-    parser
 }
 
 /// Define a document attribute entry whose raw (as-written) name is `raw_name`
@@ -1077,9 +1068,7 @@ fn parse_multiple_authors() {
 "#
     );
 
-    // This crate does not derive the `authorcount` attribute, so that
-    // assertion is dropped. The combined `authors` attribute and the `author_1`
-    // / `author_2` family match Asciidoctor exactly.
+    // The parsed author list carries the per-author name parts ...
     let a =
         parse_authors("Doc Writer <doc.writer@asciidoc.org>; John Smith <john.smith@asciidoc.org>");
     assert_eq!(a.len(), 2);
@@ -1088,10 +1077,18 @@ fn parse_multiple_authors() {
     assert_eq!(a[1].name, "John Smith");
     assert_eq!(a[1].email.as_deref(), Some("john.smith@asciidoc.org"));
 
-    let parser = parse_authors_deriving_attributes(
-        "Doc Writer <doc.writer@asciidoc.org>; John Smith <john.smith@asciidoc.org>",
+    // ... and the derived document attributes match Asciidoctor exactly. A
+    // synthetic document title is prepended because this crate only recognizes
+    // an author line when a title is present.
+    let mut parser = Parser::default();
+    let _doc = parser.parse(
+        "= Document Title\nDoc Writer <doc.writer@asciidoc.org>; John Smith <john.smith@asciidoc.org>",
     );
 
+    assert_eq!(
+        parser.attribute_value("authorcount"),
+        InterpretedValue::Value("2")
+    );
     assert_eq!(
         parser.attribute_value("authors"),
         InterpretedValue::Value("Doc Writer, John Smith")
@@ -1152,11 +1149,17 @@ fn skips_blank_author_entries_in_implicit_author_line() {
     assert_eq!(a[1].name, "John Smith");
     assert_eq!(a[1].email.as_deref(), Some("john.smith@asciidoc.org"));
 
-    // The two surviving authors are numbered `author_1` / `author_2`, matching
-    // Asciidoctor. This crate does not derive `authorcount`.
-    let parser =
-        parse_authors_deriving_attributes("Doc Writer; ; John Smith <john.smith@asciidoc.org>;");
+    // The two surviving authors are counted and numbered `author_1` /
+    // `author_2`, matching Asciidoctor. A synthetic document title is prepended
+    // because this crate only recognizes an author line when a title is present.
+    let mut parser = Parser::default();
+    let _doc =
+        parser.parse("= Document Title\nDoc Writer; ; John Smith <john.smith@asciidoc.org>;");
 
+    assert_eq!(
+        parser.attribute_value("authorcount"),
+        InterpretedValue::Value("2")
+    );
     assert_eq!(
         parser.attribute_value("author_1"),
         InterpretedValue::Value("Doc Writer")
@@ -1284,12 +1287,8 @@ fn use_implicit_authors_if_value_of_authors_attribute_matches_computed_value() {
     // The `:authors:` entry value matches the computed (comma-joined) value of
     // the implicit author line, so the implicit list is retained unchanged. A
     // synthetic document title is prepended because this crate only recognizes
-    // an author line when a title is present.
-    //
-    // This crate names the first author from an implicit line `author` (not
-    // `author_1`) and, because the retain path leaves the implicit list
-    // untouched, does not derive an `author_1` companion here; the first
-    // author is asserted through the unsuffixed `author` attribute instead.
+    // an author line when a title is present. The implicit line exposes the
+    // first author both unsuffixed (`author`) and as `author_1`.
     let mut parser = Parser::default();
     let doc = parser
         .parse("= Document Title\nDoc Writer; Junior Writer\n:authors: Doc Writer, Junior Writer");
@@ -1305,6 +1304,10 @@ fn use_implicit_authors_if_value_of_authors_attribute_matches_computed_value() {
     );
     assert_eq!(
         parser.attribute_value("author"),
+        InterpretedValue::Value("Doc Writer")
+    );
+    assert_eq!(
+        parser.attribute_value("author_1"),
         InterpretedValue::Value("Doc Writer")
     );
     assert_eq!(
@@ -1414,17 +1417,23 @@ fn does_not_drop_name_joiner_when_using_multiple_authors() {
     );
 
     // The `het_Draeke` name-joiner underscore becomes a space (`het Draeke`)
-    // rather than being dropped. This crate does not derive `authorcount`, but
-    // the combined `authors` attribute and the indexed author names match
-    // Asciidoctor exactly.
+    // rather than being dropped. The combined `authors` attribute, the indexed
+    // author names, and `authorcount` all match Asciidoctor exactly.
     let a = parse_authors("Kismet Chameleon; Lazarus het_Draeke");
     assert_eq!(a.len(), 2);
     assert_eq!(a[0].name, "Kismet Chameleon");
     assert_eq!(a[1].name, "Lazarus het Draeke");
     assert_eq!(a[1].lastname.as_deref(), Some("het Draeke"));
 
-    let parser = parse_authors_deriving_attributes("Kismet Chameleon; Lazarus het_Draeke");
+    // A synthetic document title is prepended because this crate only
+    // recognizes an author line when a title is present.
+    let mut parser = Parser::default();
+    let _doc = parser.parse("= Document Title\nKismet Chameleon; Lazarus het_Draeke");
 
+    assert_eq!(
+        parser.attribute_value("authorcount"),
+        InterpretedValue::Value("2")
+    );
     assert_eq!(
         parser.attribute_value("authors"),
         InterpretedValue::Value("Kismet Chameleon, Lazarus het Draeke")

--- a/parser/src/tests/asciidoctor_rb/parser_test.rs
+++ b/parser/src/tests/asciidoctor_rb/parser_test.rs
@@ -62,10 +62,11 @@
 //! * **`parse_header_metadata`** author parsing — driven through
 //!   [`AuthorLine::parse`](crate::document::AuthorLine), asserting on the
 //!   parsed [`Author`](crate::document::Author) list (name / firstname /
-//!   middlename / lastname / email / initials). This crate does not derive
-//!   Ruby's `authors` (comma-joined) or `authorcount` document attributes, and
-//!   numbers the first author's attributes unsuffixed (`author`, not
-//!   `author_1`), so assertions on those are dropped. The Ruby `metadata.size`
+//!   middlename / lastname / email / initials). This crate derives the combined
+//!   `authors` (comma-joined) attribute and, when more than one author is
+//!   present, the first author's `_1`-suffixed names (`author_1`, ...) as well
+//!   as the unsuffixed forms; it does not derive Ruby's `authorcount` document
+//!   attribute, so assertions on that are dropped. The Ruby `metadata.size`
 //!   (hash cardinality) has no crate analog and is likewise not asserted.
 //! * **`parse_header_metadata`** revision parsing — driven through a full
 //!   [`Parser::parse`] over the header (title, author line, revision line) and
@@ -159,6 +160,17 @@ fn parse_authors(line: &str) -> Vec<ParsedAuthor> {
             initials: a.initials(),
         })
         .collect()
+}
+
+/// Parse an implicit author line through [`AuthorLine::parse`] and return the
+/// [`Parser`] so the caller can assert on the document attributes it derives:
+/// the combined, comma-joined `authors` attribute and – when more than one
+/// author is present – the first author's `_1`-suffixed names (`author_1`,
+/// `firstname_1`, ...) alongside the `author_2`, `author_3`, ... family.
+fn parse_authors_deriving_attributes(line: &str) -> Parser {
+    let mut parser = Parser::default();
+    let _author_line = crate::document::AuthorLine::parse(crate::Span::new(line), &mut parser);
+    parser
 }
 
 /// Define a document attribute entry whose raw (as-written) name is `raw_name`
@@ -1065,9 +1077,9 @@ fn parse_multiple_authors() {
 "#
     );
 
-    // This crate does not derive the `authors` (comma-joined) or `authorcount`
-    // attributes and numbers the first author unsuffixed, so we assert on the
-    // parsed author list directly.
+    // This crate does not derive the `authorcount` attribute, so that
+    // assertion is dropped. The combined `authors` attribute and the `author_1`
+    // / `author_2` family match Asciidoctor exactly.
     let a =
         parse_authors("Doc Writer <doc.writer@asciidoc.org>; John Smith <john.smith@asciidoc.org>");
     assert_eq!(a.len(), 2);
@@ -1075,6 +1087,27 @@ fn parse_multiple_authors() {
     assert_eq!(a[0].email.as_deref(), Some("doc.writer@asciidoc.org"));
     assert_eq!(a[1].name, "John Smith");
     assert_eq!(a[1].email.as_deref(), Some("john.smith@asciidoc.org"));
+
+    let parser = parse_authors_deriving_attributes(
+        "Doc Writer <doc.writer@asciidoc.org>; John Smith <john.smith@asciidoc.org>",
+    );
+
+    assert_eq!(
+        parser.attribute_value("authors"),
+        InterpretedValue::Value("Doc Writer, John Smith")
+    );
+    assert_eq!(
+        parser.attribute_value("author"),
+        InterpretedValue::Value("Doc Writer")
+    );
+    assert_eq!(
+        parser.attribute_value("author_1"),
+        InterpretedValue::Value("Doc Writer")
+    );
+    assert_eq!(
+        parser.attribute_value("author_2"),
+        InterpretedValue::Value("John Smith")
+    );
 }
 
 #[test]
@@ -1118,6 +1151,20 @@ fn skips_blank_author_entries_in_implicit_author_line() {
     assert_eq!(a[0].name, "Doc Writer");
     assert_eq!(a[1].name, "John Smith");
     assert_eq!(a[1].email.as_deref(), Some("john.smith@asciidoc.org"));
+
+    // The two surviving authors are numbered `author_1` / `author_2`, matching
+    // Asciidoctor. This crate does not derive `authorcount`.
+    let parser =
+        parse_authors_deriving_attributes("Doc Writer; ; John Smith <john.smith@asciidoc.org>;");
+
+    assert_eq!(
+        parser.attribute_value("author_1"),
+        InterpretedValue::Value("Doc Writer")
+    );
+    assert_eq!(
+        parser.attribute_value("author_2"),
+        InterpretedValue::Value("John Smith")
+    );
 }
 
 #[test]
@@ -1289,12 +1336,33 @@ fn does_not_drop_name_joiner_when_using_multiple_authors() {
     );
 
     // The `het_Draeke` name-joiner underscore becomes a space (`het Draeke`)
-    // rather than being dropped.
+    // rather than being dropped. This crate does not derive `authorcount`, but
+    // the combined `authors` attribute and the indexed author names match
+    // Asciidoctor exactly.
     let a = parse_authors("Kismet Chameleon; Lazarus het_Draeke");
     assert_eq!(a.len(), 2);
     assert_eq!(a[0].name, "Kismet Chameleon");
     assert_eq!(a[1].name, "Lazarus het Draeke");
     assert_eq!(a[1].lastname.as_deref(), Some("het Draeke"));
+
+    let parser = parse_authors_deriving_attributes("Kismet Chameleon; Lazarus het_Draeke");
+
+    assert_eq!(
+        parser.attribute_value("authors"),
+        InterpretedValue::Value("Kismet Chameleon, Lazarus het Draeke")
+    );
+    assert_eq!(
+        parser.attribute_value("author_1"),
+        InterpretedValue::Value("Kismet Chameleon")
+    );
+    assert_eq!(
+        parser.attribute_value("author_2"),
+        InterpretedValue::Value("Lazarus het Draeke")
+    );
+    assert_eq!(
+        parser.attribute_value("lastname_2"),
+        InterpretedValue::Value("het Draeke")
+    );
 }
 
 #[test]
@@ -1320,15 +1388,22 @@ fn allows_authors_to_be_overridden_using_explicit_author_attributes() {
     );
 
     // The `:author_2:` entry overrides the second author computed from the
-    // implicit author line. (This crate names the first author unsuffixed
-    // `author` rather than `author_1`, and does not derive `authorcount` /
-    // `authors`.)
+    // implicit author line. The first author is now exposed both unsuffixed
+    // (`author`) and as `author_1`. This crate does not derive
+    // `authorcount`, and – unlike Asciidoctor – it does not re-derive the
+    // combined `authors` attribute after the explicit override, so `authors`
+    // still reflects the implicit line (`... Johnny Bravo ...`, not `... Danger
+    // Mouse ...`).
     let mut parser = Parser::default();
     let _ = parser.parse(
         "= Document Title\nKismet Chameleon; Johnny Bravo; Lazarus het_Draeke\n:author_2: Danger Mouse",
     );
     assert_eq!(
         parser.attribute_value("author"),
+        InterpretedValue::Value("Kismet Chameleon")
+    );
+    assert_eq!(
+        parser.attribute_value("author_1"),
         InterpretedValue::Value("Kismet Chameleon")
     );
     assert_eq!(

--- a/parser/src/tests/asciidoctor_rb/parser_test.rs
+++ b/parser/src/tests/asciidoctor_rb/parser_test.rs
@@ -63,13 +63,12 @@
 //!   [`AuthorLine::parse`](crate::document::AuthorLine), asserting on the
 //!   parsed [`Author`](crate::document::Author) list (name / firstname /
 //!   middlename / lastname / email / initials). This crate derives the combined
-//!   `authors` (comma-joined) attribute, the `authorcount` count, and – when
-//!   more than one author is present – the first author's `_1`-suffixed names
-//!   (`author_1`, ...) as well as the unsuffixed forms. The one divergence is
-//!   that an author-less document leaves `authorcount` unset rather than
-//!   materializing Ruby's default of `0`, so that case is left
-//!   `non_normative!`. The Ruby `metadata.size` (hash cardinality) has no crate
-//!   analog and is likewise not asserted.
+//!   `authors` (comma-joined) attribute, the `authorcount` count (including `0`
+//!   for an author-less document, via the built-in default), and – when more
+//!   than one author is present – the first author's `_1`-suffixed names
+//!   (`author_1`, ...) as well as the unsuffixed forms. The Ruby
+//!   `metadata.size` (hash cardinality) has no crate analog and is not
+//!   asserted.
 //! * **`parse_header_metadata`** revision parsing — driven through a full
 //!   [`Parser::parse`] over the header (title, author line, revision line) and
 //!   asserting on `doc.header().revision_line()`'s `revnumber()` / `revdate()`
@@ -1379,9 +1378,10 @@ fn replace_implicit_authors_if_value_of_authors_attribute_does_not_match_compute
     );
 }
 
-// This crate does not derive an `authorcount` document attribute.
-non_normative!(
-    r#"
+#[test]
+fn sets_authorcount_to_0_if_document_has_no_authors() {
+    verifies!(
+        r#"
   test 'sets authorcount to 0 if document has no authors' do
     input = ''
     doc = empty_document
@@ -1390,6 +1390,34 @@ non_normative!(
     assert_equal 0, metadata['authorcount']
   end
 
+"#
+    );
+
+    // A document with no authors reports `authorcount` as `0`, matching
+    // Asciidoctor. The count resolves through the built-in `authorcount`
+    // default (see `built_in_attrs`); the header parser materializes an
+    // explicit value only for a non-zero count.
+    let doc = Parser::default().parse("");
+
+    assert_eq!(
+        doc.attribute_value("authorcount"),
+        InterpretedValue::Value("0")
+    );
+
+    // The same holds for a document that has a header but no author line.
+    let doc = Parser::default().parse("= Document Title\n\nBody.");
+
+    assert_eq!(
+        doc.attribute_value("authorcount"),
+        InterpretedValue::Value("0")
+    );
+}
+
+// This crate does not surface Asciidoctor's header-metadata hash, so there is
+// no analog for asserting its cardinality when `parse_header_metadata` is
+// invoked without a document.
+non_normative!(
+    r#"
   test 'returns empty hash if document has no authors and invoked without document' do
     metadata, _ = parse_header_metadata ''
     assert_empty metadata


### PR DESCRIPTION
## Summary

Fixes #1005.

For an **implicit author line** with more than one author, Asciidoctor exposes both a combined `authors` attribute (comma-joined) and a full `author_1` family for the first author. `asciidoc-parser` set neither: the combined `authors` attribute stayed unset, and the first author was reachable only as `author` (with `author_2`, `author_3`, … for the rest — but no `author_1`).

This makes the implicit author line match Asciidoctor's `process_authors`:

- **`authors`** (comma-joined author names) is derived whenever the implicit author line names at least one author. For a single author it equals `author`.
- When the line names **more than one author**, the first author's attributes are additionally mirrored under explicit `_1`-suffixed names (`author_1`, `authorinitials_1`, `firstname_1`, and `middlename_1` / `lastname_1` / `email_1` when present), alongside the existing unsuffixed forms. For a single author, only the unsuffixed names are set (matching Asciidoctor).

### Example

| attribute   | before      | after                        |
|-------------|-------------|------------------------------|
| `authors`   | *(unset)*   | `Doc Writer, John Smith`     |
| `author`    | `Doc Writer`| `Doc Writer`                 |
| `author_1`  | *(unset)*   | `Doc Writer`                 |
| `author_2`  | `John Smith`| `John Smith`                 |

## Relationship to #1006 / #1003 (now merged)

#1006 fixed the sibling issue #1003 (`:authors:`-entry reconciliation) and landed `set_author_metadata` / `set_author_keys` in `header.rs` — the same list→attributes derivation this PR needs for the implicit line. After merging `main`, this branch **consolidates** rather than duplicating:

- `set_author_metadata` / `set_author_keys` moved into `document/author.rs` (next to `Author`) as `pub(crate)`.
- Both `AuthorLine::parse` (eagerly, so `{author}` / `{authors}` stay available to later header lines) and `resolve_authors` now call the one shared helper. The old `set_nth_attribute` is gone.

## Out of scope

- `authorcount` is already derived on `main` (the earlier "does not derive authorcount" test notes were stale and are corrected here). The one remaining divergence — an author-less document leaves `authorcount` unset instead of materializing Ruby's default of `0` — stays `non_normative!`.
- The combined `authors` attribute is **not** re-derived after an explicit `:author_N:` (indexed, singular) override — it reflects the implicit line. `:authors:` (plural) reconciliation is handled by #1006. This pre-existing divergence is documented inline.

## Testing

- Unit tests in `author_line.rs` cover the multi-author `_1` family, the combined `authors` value, and confirm a single author gets `authors` but no `_1` names.
- The ported `parser_test.rs` cases now drive a full `Parser::parse` and assert `authorcount` / `authors` / `author_1` / `author_2`, matching the Ruby originals. #1006's "matching value" test now also asserts `author_1` (previously unavailable).
- `cargo test -p asciidoc-parser`, `cargo clippy --all-targets`, and `cargo +nightly fmt --all -- --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)