### PR TITLE
feat: Expose the inline passthrough collection on a block's content

### DIFF
--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -5,6 +5,7 @@
 
 use crate::{
     Span,
+    content::Passthrough,
     parser::{
         InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext,
         XrefRenderParams,
@@ -69,6 +70,19 @@ pub struct Content<'src> {
     /// `None` for the overwhelming majority of content, which contains no
     /// cross-references.
     deferred: Option<Box<DeferredContent>>,
+
+    /// Inline passthroughs (`+++…+++`, `++…++`, `$$…$$`, `pass:[…]`, inline
+    /// STEM macros) extracted from this content during substitution, in the
+    /// order they were extracted.
+    ///
+    /// The substitution pipeline pulls each passthrough out before running the
+    /// other substitutions and splices it back in afterward; this retains the
+    /// collection so it is observable after the fact (see
+    /// [`passthroughs`](Self::passthroughs)), analogous to Asciidoctor's
+    /// internal `@passthroughs` array. Empty for the common case of content
+    /// with no passthroughs, and for content whose substitution group does not
+    /// extract them.
+    passthroughs: Vec<Passthrough>,
 }
 
 /// The deferred (cross-reference-bearing) portion of a [`Content`].
@@ -206,6 +220,7 @@ impl<'src> Content<'src> {
             rendered,
             source_lines: None,
             deferred: None,
+            passthroughs: Vec::new(),
         }
     }
 
@@ -233,6 +248,7 @@ impl<'src> Content<'src> {
             deferred: title
                 .deferred
                 .map(|(template, xrefs)| Box::new(DeferredContent { template, xrefs })),
+            passthroughs: Vec::new(),
         }
     }
 
@@ -269,6 +285,7 @@ impl<'src> Content<'src> {
             rendered,
             source_lines: Some(line_spans.into_boxed_slice()),
             deferred: None,
+            passthroughs: Vec::new(),
         }
     }
 
@@ -319,6 +336,33 @@ impl<'src> Content<'src> {
     /// Returns `true` if `self` contains no text.
     pub fn is_empty(&self) -> bool {
         self.rendered.as_ref().is_empty()
+    }
+
+    /// Returns the inline passthroughs extracted from this content during
+    /// substitution, in extraction order.
+    ///
+    /// An inline passthrough (`+++…+++`, `++…++`, `$$…$$`, `pass:[…]`, or an
+    /// inline STEM macro) is pulled out of the text before the other
+    /// substitutions run and spliced back in afterward. This exposes that
+    /// collection – each entry's stored [`text`](Passthrough::text) and
+    /// resolved [`subs`](Passthrough::subs) – for inspection, analogous to
+    /// Asciidoctor's internal `@passthroughs` array.
+    ///
+    /// The slice is empty when the content has no passthroughs, and when the
+    /// content's substitution group does not extract passthroughs at all (only
+    /// groups that include the
+    /// [macros](crate::content::SubstitutionStep::Macros) step, or the
+    /// header group, do).
+    pub fn passthroughs(&self) -> &[Passthrough] {
+        &self.passthroughs
+    }
+
+    /// Records the inline passthroughs extracted from this content during
+    /// substitution, so they remain observable via
+    /// [`passthroughs`](Self::passthroughs) after the restore pass has spliced
+    /// them back in.
+    pub(crate) fn set_passthroughs(&mut self, passthroughs: Vec<Passthrough>) {
+        self.passthroughs = passthroughs;
     }
 
     /// Removes the [`FOOTNOTE_MARKER_START`]/[`FOOTNOTE_MARKER_END`] sentinels
@@ -718,6 +762,7 @@ impl<'src> From<Span<'src>> for Content<'src> {
             rendered: CowStr::from(span.data()),
             source_lines: None,
             deferred: None,
+            passthroughs: Vec::new(),
         }
     }
 }

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -16,6 +16,7 @@ pub(crate) use macros::apply_macros_with_leading_anchor_registered;
 mod xref_target;
 
 pub(crate) mod passthroughs;
+pub use passthroughs::Passthrough;
 pub(crate) use passthroughs::Passthroughs;
 
 mod substitution_group;

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -10,14 +10,46 @@ use crate::{
     warnings::WarningType,
 };
 
-/// Saves the content of one passthrough (`+++` or similarly bracketed) passage
-/// for later re-expansion.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct Passthrough {
+/// Records one inline passthrough (`+++…+++`, `++…++`, `$$…$$`, `pass:[…]`, or
+/// an inline STEM macro) that the substitution pipeline extracted from a
+/// block's content before running the other substitutions, and restores
+/// afterward.
+///
+/// The collection of these for a block is observable via
+/// [`Content::passthroughs`](crate::content::Content::passthroughs), analogous
+/// to Asciidoctor's internal `@passthroughs` array. It exposes, for each
+/// entry, the stored (unescaped) source [`text`](Self::text) and the resolved
+/// [`subs`](Self::subs) that are applied to that text on restore.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Passthrough {
     pub(crate) text: String,
     pub(crate) subs: SubstitutionGroup,
     pub(crate) type_: Option<QuoteType>,
     pub(crate) attrlist: Option<String>,
+}
+
+impl Passthrough {
+    /// Returns the stored, unescaped source text of this passthrough – the text
+    /// that is substituted back in (after applying [`subs`](Self::subs)) when
+    /// the passthrough is restored.
+    ///
+    /// This mirrors the `:text` of an entry in Asciidoctor's `@passthroughs`
+    /// array.
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// Returns the resolved substitution group applied to this passthrough's
+    /// [`text`](Self::text) when it is restored, i.e. the ordered set of
+    /// substitution steps in effect for it.
+    ///
+    /// For example, `+++…+++` resolves to [`SubstitutionGroup::None`] (no
+    /// substitutions), while `++…++` and `$$…$$` resolve to
+    /// [`SubstitutionGroup::Verbatim`] (special characters). This mirrors the
+    /// resolved `:subs` of an entry in Asciidoctor's `@passthroughs` array.
+    pub fn subs(&self) -> &SubstitutionGroup {
+        &self.subs
+    }
 }
 
 /// Saves content of passthrough (`+++`-bracketed) passages for later
@@ -681,6 +713,7 @@ impl Replacer for PassthroughRestoreReplacer<'_> {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::panic)]
     #![allow(clippy::unwrap_used)]
 
     use crate::{
@@ -723,6 +756,54 @@ mod tests {
                 attrlist: None,
             },)
         );
+    }
+
+    #[test]
+    fn content_exposes_extracted_passthrough_collection() {
+        // The inline passthroughs extracted while substituting a block's
+        // content are retained on the `Content` and observable afterward via
+        // the public `passthroughs()` accessor, exposing each entry's stored
+        // (unescaped) text and its resolved substitution list. (Not a direct
+        // port of a Ruby test; it exercises the accessor surfaced for spec
+        // verification.)
+        let mut p = Parser::default();
+
+        let maw = crate::blocks::Block::parse(
+            crate::Span::new("some ++<code>{code}</code>++ and +++{raw}+++ text"),
+            &mut p,
+        );
+
+        let crate::blocks::Block::Simple(block) = maw.item.unwrap().item else {
+            panic!("expected a simple block");
+        };
+
+        let passthroughs = block.content().passthroughs();
+
+        assert_eq!(passthroughs.len(), 2);
+
+        // `++…++` stores the text verbatim and applies the special-characters
+        // substitution on restore.
+        assert_eq!(passthroughs[0].text(), "<code>{code}</code>");
+        assert_eq!(passthroughs[0].subs(), &SubstitutionGroup::Verbatim);
+
+        // `+++…+++` stores the text verbatim and applies no substitutions.
+        assert_eq!(passthroughs[1].text(), "{raw}");
+        assert_eq!(passthroughs[1].subs(), &SubstitutionGroup::None);
+    }
+
+    #[test]
+    fn content_without_passthroughs_exposes_an_empty_collection() {
+        // Plain content – and content whose substitution group never extracts
+        // passthroughs – exposes an empty collection rather than any sentinel.
+        let mut p = Parser::default();
+
+        let maw = crate::blocks::Block::parse(crate::Span::new("just plain prose"), &mut p);
+
+        let crate::blocks::Block::Simple(block) = maw.item.unwrap().item else {
+            panic!("expected a simple block");
+        };
+
+        assert!(block.content().passthroughs().is_empty());
     }
 
     #[test]

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -241,6 +241,10 @@ impl SubstitutionGroup {
 
         if let Some(passthroughs) = passthroughs {
             passthroughs.restore_to(content, parser);
+
+            // Retain the extracted passthroughs on the content so they remain
+            // observable after restore (see `Content::passthroughs`).
+            content.set_passthroughs(passthroughs.0);
         }
 
         // Capture any deferred cross-references as a placeholder template and
@@ -310,7 +314,15 @@ impl SubstitutionGroup {
         result
     }
 
-    fn steps(&self) -> &[SubstitutionStep] {
+    /// Returns the ordered list of substitution [steps](SubstitutionStep) this
+    /// group applies, in the order they run.
+    ///
+    /// This is the resolved, expanded form of the group: a named group (e.g.
+    /// [`Normal`](Self::Normal) or [`Verbatim`](Self::Verbatim)) expands to its
+    /// fixed step sequence, and a [`Custom`](Self::Custom) group returns its
+    /// own steps. Useful for inspecting the substitutions in effect for a
+    /// block or an extracted [`Passthrough`](crate::content::Passthrough).
+    pub fn steps(&self) -> &[SubstitutionStep] {
         match self {
             Self::Normal | Self::Title => NORMAL_STEPS,
 

--- a/parser/src/parser/inline_substitution_renderer.rs
+++ b/parser/src/parser/inline_substitution_renderer.rs
@@ -290,7 +290,7 @@ pub enum SpecialCharacter {
 /// Specifies which [quote type] is being rendered.
 ///
 /// [quote type]: https://docs.asciidoctor.org/asciidoc/latest/subs/quotes/
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum QuoteType {
     /// Strong (often bold) formatting.
     Strong,


### PR DESCRIPTION
## Summary

Closes #1002.

Surfaces the **inline passthrough collection** that the substitution pipeline builds while processing a block – analogous to how the document catalog already surfaces footnotes and images – so downstream consumers can assert, for each extracted passthrough, its stored (unescaped) **text** and the **resolved substitution list** applied to it.

Previously the extracted passthroughs (`+++…+++`, `++…++`, `$$…$$`, `pass:[…]`, inline STEM macros) were pulled out of the text, spliced back in on restore, and then discarded. There was no way to observe the collection except by reconstructing it from rendered `convert` output, which cannot isolate passthroughs whose text/subs are decoupled from source syntax.

## What changed

- **`Content::passthroughs()`** (new public accessor) returns the inline passthroughs extracted from that content, in extraction order. The collection is now retained on `Content` after the restore pass (it was dropped before). Empty for content with no passthroughs and for content whose substitution group never extracts them.
- **`Passthrough`** is now public, exposing:
  - `text()` – the stored, unescaped source text (mirrors Asciidoctor's `@passthroughs[i][:text]`);
  - `subs()` – the resolved `SubstitutionGroup` applied on restore (mirrors the resolved `:subs`).
- **`SubstitutionGroup::steps()`** is now public, so the resolved, ordered substitution steps for an entry are inspectable (e.g. mapping `Verbatim` → `[specialcharacters]`).
- `QuoteType` gains a `Hash` derive so `Passthrough` (and hence `Content`) can keep its `Hash` derive.

This lets `asciidoc-html5` (asciidoc-rs/asciidoc-html5#202) flip the two remaining `non_normative!` `restore_passthroughs` tests to verified and assert the collection internals of the others directly rather than only through rendered output.

## Notes

- The count requested by the issue is `passthroughs().len()`.
- No behavior change to rendering: the pipeline extracts and restores exactly as before; it just no longer throws the collection away.

## Testing

- `cargo test -p asciidoc-parser` – 4516 pass, 0 fail. Adds two tests exercising the public accessor end-to-end on a parsed block (with and without passthroughs).
- `cargo +nightly fmt --all -- --check` clean.
- `cargo clippy -p asciidoc-parser --all-targets` clean.
- `cargo doc --no-deps` clean (intra-doc links resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)