### PR TITLE
fix: Emit a diagnostic for lines dropped under attribute-missing=drop-line

### DIFF
--- a/parser/src/blocks/media.rs
+++ b/parser/src/blocks/media.rs
@@ -950,6 +950,15 @@ mod tests {
         fn drop_line_drops_the_whole_block() {
             let mut p = parser_with_mode("drop-line");
             assert!(resolve("image::a{missing}b.png[]", &mut p).is_none());
+
+            // Dropping the block is surfaced as a diagnostic naming the missing
+            // attribute (the crate's analogue of Asciidoctor's INFO log).
+            let warnings = p.take_substitution_warnings();
+            assert_eq!(warnings.len(), 1);
+            assert_eq!(
+                warnings[0].warning,
+                WarningType::SkippingReferenceToMissingAttribute("missing".to_string())
+            );
         }
 
         #[test]

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -669,10 +669,17 @@ impl Replacer for PassthroughRestoreReplacer<'_> {
             // otherwise render verbatim. This mirrors Asciidoctor's
             // `parse_quoted_text_attributes`, which runs `sub_attributes` on the
             // attribute list.
-            let attrlist_body = pass
-                .attrlist
-                .as_ref()
-                .map(|attrlist_body| substitute_attributes_in_text(attrlist_body, self.1));
+            let attrlist_body = pass.attrlist.as_ref().map(|attrlist_body| {
+                // The stored attrlist is owned text whose offsets do not refer
+                // to the document source, so any `warn`/`drop-line` warning this
+                // substitution records cannot be mapped back to a document span.
+                // Discard such warnings rather than surface them mislocated
+                // against the document root (mirrors the docinfo text path).
+                let saved = self.1.substitution_warnings_len();
+                let substituted = substitute_attributes_in_text(attrlist_body, self.1);
+                self.1.truncate_substitution_warnings(saved);
+                substituted
+            });
 
             let attrlist = attrlist_body.as_ref().map(|attrlist_body| {
                 let span = Span::new(attrlist_body);
@@ -789,6 +796,25 @@ mod tests {
         // `+++…+++` stores the text verbatim and applies no substitutions.
         assert_eq!(passthroughs[1].text(), "{raw}");
         assert_eq!(passthroughs[1].subs(), &SubstitutionGroup::None);
+    }
+
+    #[test]
+    fn passthrough_attrlist_drop_line_does_not_leak_a_mislocated_warning() {
+        // A missing reference in a passthrough's stored attribute list is
+        // substituted against temporary (owned) text, so any warning it records
+        // carries an offset into that text rather than the document source.
+        // Such warnings must be discarded (the offset cannot be mapped back),
+        // not surfaced against the document root. Regression guard for the
+        // `drop-line`/`warn` attrlist path.
+        let mut p = Parser::default().with_intrinsic_attribute(
+            "attribute-missing",
+            "drop-line",
+            ModificationContext::ApiOnly,
+        );
+
+        let doc = p.parse("['{missing}']++x++");
+
+        assert_eq!(doc.warnings().count(), 0);
     }
 
     #[test]

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -612,9 +612,10 @@ struct AttributeReplacer<'p> {
     /// How to handle a reference to a missing attribute.
     mode: AttributeMissing,
 
-    /// Source span used to locate a `warn` warning when a precise per-reference
-    /// span cannot be recovered. This is the whole content (or line/target)
-    /// span – the coarse fallback described in the type-level docs.
+    /// Source span used to locate a recorded warning when a precise
+    /// per-reference span cannot be recovered. This is the whole content (or
+    /// line/target) span – the coarse fallback described in the type-level
+    /// docs.
     fallback_source: Span<'p>,
 
     /// Source `Span` of the line currently being processed, when known. Every
@@ -625,7 +626,8 @@ struct AttributeReplacer<'p> {
 
     /// Byte ranges (into [`source_line`](Self::source_line)'s data) of every
     /// `ATTRIBUTE_REFERENCE` match on the source line, in order. Populated only
-    /// in [`AttributeMissing::Warn`] mode and only when `source_line` is set.
+    /// in the diagnostic-recording modes ([`AttributeMissing::Warn`] and
+    /// [`AttributeMissing::DropLine`]) and only when `source_line` is set.
     source_matches: Vec<Range<usize>>,
 
     /// Index of the next reference to be processed on this line, into
@@ -655,13 +657,17 @@ impl<'p> AttributeReplacer<'p> {
         fallback_source: Span<'p>,
         source_line: Option<Span<'p>>,
     ) -> Self {
-        // The per-reference ranges are only consulted in `warn` mode, so skip the
-        // extra scan otherwise.
+        // The per-reference ranges are only consulted when a warning may be
+        // recorded – `warn` mode, and `drop-line` mode (which records a
+        // diagnostic for each dropped reference) – so skip the extra scan
+        // otherwise.
         let source_matches = match (mode, source_line) {
-            (AttributeMissing::Warn, Some(line)) => ATTRIBUTE_REFERENCE
-                .find_iter(line.data())
-                .map(|m| m.range())
-                .collect(),
+            (AttributeMissing::Warn | AttributeMissing::DropLine, Some(line)) => {
+                ATTRIBUTE_REFERENCE
+                    .find_iter(line.data())
+                    .map(|m| m.range())
+                    .collect()
+            }
             _ => Vec::new(),
         };
 
@@ -676,7 +682,7 @@ impl<'p> AttributeReplacer<'p> {
         }
     }
 
-    /// Returns the source span to attribute a `warn` warning to for the
+    /// Returns the source span to attribute a recorded warning to for the
     /// reference at `index` on this line, whose matched text (including any
     /// escape backslash) is `matched`.
     ///
@@ -771,8 +777,15 @@ impl Replacer for AttributeReplacer<'_> {
                 }
                 AttributeMissing::DropLine => {
                     // Mark the line for removal; whatever is written to `dest`
-                    // here is discarded with it.
+                    // here is discarded with it. Asciidoctor logs an `INFO`
+                    // message ("dropping line containing reference to missing
+                    // attribute") for each reference that triggers a drop, so
+                    // record the matching diagnostic here.
                     self.missing_on_line = true;
+                    self.parser.record_substitution_warning(
+                        self.warning_source(match_index, &caps[0]),
+                        WarningType::SkippingReferenceToMissingAttribute(attr_name.to_string()),
+                    );
                 }
                 AttributeMissing::Warn => {
                     dest.push_str(&caps[0]);
@@ -815,13 +828,14 @@ fn apply_attributes(content: &mut Content<'_>, parser: &Parser) {
     let mode = AttributeMissing::from_parser(parser);
     let source = content.original();
 
-    // In `warn` mode, anchor each rendered line to the source `Span` it came
-    // from so a warning can name the precise offset of the offending reference
-    // (see `AttributeReplacer`). The retained line spans are only trustworthy
-    // when they still line up one-to-one with the rendered lines; a mismatch
-    // (e.g. a multi-line passthrough that collapsed lines during extraction)
-    // withholds them, falling back to the coarse whole-content span.
-    let source_lines = if mode == AttributeMissing::Warn {
+    // In the modes that record a diagnostic (`warn` and `drop-line`), anchor
+    // each rendered line to the source `Span` it came from so the warning can
+    // name the precise offset of the offending reference (see
+    // `AttributeReplacer`). The retained line spans are only trustworthy when
+    // they still line up one-to-one with the rendered lines; a mismatch (e.g. a
+    // multi-line passthrough that collapsed lines during extraction) withholds
+    // them, falling back to the coarse whole-content span.
+    let source_lines = if mode == AttributeMissing::Warn || mode == AttributeMissing::DropLine {
         content
             .source_lines()
             .filter(|lines| lines.len() == content.rendered.split('\n').count())
@@ -1969,6 +1983,80 @@ mod tests {
                 assert_eq!(render("{missing}", &p), "");
             }
 
+            #[test]
+            fn drop_line_records_a_warning_for_the_dropped_reference() {
+                // Dropping the line is silent in Asciidoctor's output, but it
+                // logs an `INFO` diagnostic naming the missing attribute; the
+                // parser records the matching warning.
+                let p = parser_with_mode("drop-line");
+                assert_eq!(render("Hello, {name}!\nSecond line.", &p), "Second line.");
+
+                let warnings = p.take_substitution_warnings();
+                assert_eq!(warnings.len(), 1);
+                assert_eq!(
+                    warnings[0].warning,
+                    WarningType::SkippingReferenceToMissingAttribute("name".to_string())
+                );
+            }
+
+            #[test]
+            fn drop_line_records_one_warning_per_missing_reference() {
+                // Two missing references on the same dropped line each produce a
+                // diagnostic, matching Asciidoctor's per-reference logging.
+                let p = parser_with_mode("drop-line");
+                assert_eq!(render("a {x} b {y} c\ntail", &p), "tail");
+                assert_eq!(p.take_substitution_warnings().len(), 2);
+            }
+
+            #[test]
+            fn drop_line_does_not_warn_for_a_line_without_a_missing_reference() {
+                // Only the line carrying the missing reference is dropped and
+                // warned about; a line whose references all resolve is untouched.
+                let p = parser_with_mode("drop-line");
+                assert_eq!(
+                    render("first {sp}line\nsecond {missing} line\nthird line", &p),
+                    "first  line\nthird line"
+                );
+
+                let warnings = p.take_substitution_warnings();
+                assert_eq!(warnings.len(), 1);
+                assert_eq!(
+                    warnings[0].warning,
+                    WarningType::SkippingReferenceToMissingAttribute("missing".to_string())
+                );
+            }
+
+            #[test]
+            fn drop_line_points_at_the_precise_reference() {
+                // With per-line source spans retained, the drop-line diagnostic
+                // names the exact offending reference rather than the whole line.
+                let p = parser_with_mode("drop-line");
+                let text = "first {alpha} line\nsecond {beta} line";
+                let mut content = content_with_source_lines(text);
+                SubstitutionStep::AttributeReferences.apply(&mut content, &p, None);
+
+                let warnings = p.take_substitution_warnings();
+                assert_eq!(warnings.len(), 2);
+                assert_spans(&warnings[0], text, "{alpha}");
+                assert_spans(&warnings[1], text, "{beta}");
+            }
+
+            #[test]
+            fn drop_line_falls_back_to_whole_span_without_source_lines() {
+                // `Content::from` retains no per-line spans, so the drop-line
+                // diagnostic degrades to the whole-content span rather than
+                // misreporting a location.
+                let p = parser_with_mode("drop-line");
+                let text = "x {foo} y";
+                let mut content = Content::from(Span::new(text));
+                SubstitutionStep::AttributeReferences.apply(&mut content, &p, None);
+
+                let warnings = p.take_substitution_warnings();
+                assert_eq!(warnings.len(), 1);
+                assert_eq!(warnings[0].offset, 0);
+                assert_eq!(warnings[0].len, text.len());
+            }
+
             /// Exercises the free-standing text path (used for docinfo file
             /// content), which applies the same `attribute-missing` handling as
             /// [`render`] but through [`substitute_attributes_in_text`] rather
@@ -2010,6 +2098,27 @@ mod tests {
                     assert_eq!(
                         substitute_attributes_in_text("Line 1\n{missing} tail\nLine 2", &p),
                         "Line 1\nLine 2"
+                    );
+                }
+
+                #[test]
+                fn drop_line_records_a_warning() {
+                    // The diagnostic is recorded on the parser even on the
+                    // free-standing text path; a docinfo caller separately
+                    // discards it via `truncate_substitution_warnings`.
+                    use crate::warnings::WarningType;
+
+                    let p = parser_with_mode("drop-line");
+                    assert_eq!(
+                        substitute_attributes_in_text("Line 1\n{missing} tail\nLine 2", &p),
+                        "Line 1\nLine 2"
+                    );
+
+                    let warnings = p.take_substitution_warnings();
+                    assert_eq!(warnings.len(), 1);
+                    assert_eq!(
+                        warnings[0].warning,
+                        WarningType::SkippingReferenceToMissingAttribute("missing".to_string())
                     );
                 }
 

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -497,9 +497,10 @@ mod assignment {
 "#
         );
 
-        // This crate does not surface the INFO "dropping line…" log message, so
-        // only the observable result (the missing reference resolves to empty)
-        // is checked.
+        // The missing `{version}` reference resolves the header attribute value
+        // to empty, and the drop is now surfaced as a
+        // `SkippingReferenceToMissingAttribute` warning naming `version`
+        // (the crate's analogue of Asciidoctor's INFO log).
         let doc = Parser::default()
             .with_intrinsic_attribute(
                 "attribute-missing",
@@ -508,6 +509,13 @@ mod assignment {
             )
             .parse(":release: Asciidoctor {version}");
         assert_eq!(doc.attribute_value("release"), InterpretedValue::Value(""));
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::SkippingReferenceToMissingAttribute("version".to_string())
+        );
     }
 
     #[test]
@@ -530,7 +538,9 @@ mod assignment {
         // The legacy `+` continuation fuses the `{version}` line into the header
         // value (`Asciidoctor {version}`); the unresolved `{version}` reference
         // then drops the line under `attribute-missing=drop-line`, leaving the
-        // empty string. (The INFO drop-line log is not modeled.)
+        // empty string and recording the drop as a
+        // `SkippingReferenceToMissingAttribute` warning naming `version`
+        // (the crate's analogue of Asciidoctor's INFO log).
         let doc = Parser::default()
             .with_intrinsic_attribute(
                 "attribute-missing",
@@ -539,6 +549,13 @@ mod assignment {
             )
             .parse(":release: Asciidoctor +\n          {version}\n");
         assert_eq!(doc.attribute_value("release"), InterpretedValue::Value(""));
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::SkippingReferenceToMissingAttribute("version".to_string())
+        );
     }
 
     #[test]
@@ -1888,11 +1905,22 @@ mod interpolation {
 "#
         );
 
-        // Only the observable line drop is checked; the INFO log is not modeled.
+        // The line carrying the unresolved `{foobarbaz}` reference is dropped,
+        // and the drop is surfaced as a `SkippingReferenceToMissingAttribute`
+        // warning naming `foobarbaz` (the crate's analogue of Asciidoctor's
+        // INFO log).
         let doc = Parser::default().parse(
             ":attribute-missing: drop-line\n\nThis is\nblah blah {foobarbaz}\nall there is.",
         );
         assert_xpath(&doc, "//p[text()=\"This is\nall there is.\"]", 1);
+
+        let warnings: Vec<_> = doc.warnings().collect();
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(
+            warnings[0].warning,
+            WarningType::SkippingReferenceToMissingAttribute("foobarbaz".to_string())
+        );
+        assert_eq!(warnings[0].source.line(), 4);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When `attribute-missing` is set to `drop-line`, the parser correctly **drops** the offending line (and blanks a header attribute value that fails to resolve), but it recorded **no diagnostic** — so a caller had no way to observe *which* lines were dropped. Asciidoctor logs an `INFO`-level message for each such reference:

```
dropping line containing reference to missing attribute: <name>
```

This PR makes the parser record the existing `WarningType::SkippingReferenceToMissingAttribute(name)` for each reference that triggers a `drop-line` drop, matching Asciidoctor's per-reference logging. The drop/blank **behavior** is unchanged — this adds only the missing diagnostic.

## What changed

- In the shared attribute-reference replacer, the `DropLine` branch now records a `SkippingReferenceToMissingAttribute(name)` warning (previously only `warn` mode did). Because this lives in the one replacer used by every path, it covers:
  - **body content** (paragraph/block text),
  - **header attribute values** (e.g. `:release: Asciidoctor {version}`),
  - **free-standing docinfo text** (recorded, then discarded by the docinfo caller as before),
  - **block-macro targets** (e.g. a dropped `image::{missing}.png[]`).
- The precise per-reference source-span correlation that `warn` mode already used (issue #564) is extended to `drop-line`, so the warning points at the exact offending reference when per-line source spans are available, and degrades to the coarse whole-content span otherwise.

## Tests

- New unit tests in the `attribute_missing` module: single-reference, one-warning-per-reference, no-warn-for-resolvable-line, precise-span, and whole-span-fallback cases (plus the free-standing-text path).
- The two Asciidoctor-ported header-value tests (`assigns_attribute_to_empty_string…`, `assigns_multi_line_attribute…`) and the body-content test (`ignores_lines_with_bad_attributes_if_attribute_missing_is_drop_line`) — which previously noted "the INFO log is not modeled" — now assert the emitted warning, closing that gap.
- The media `drop_line_drops_the_whole_block` test now also asserts the diagnostic.

All 4527 parser tests pass; `cargo +nightly fmt --all -- --check` and `cargo clippy` are clean.

Closes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)