### PR TITLE
fix: Reflect an indexed `:author_N:` override in the combined `authors` string

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -902,9 +902,10 @@ fn resolve_authors(
         // per-author name-part) attributes. A value that matches the computed
         // value leaves the implicit list untouched.
         //
-        // Only the multi-author `:authors:` path is reconciled here; the single
-        // `:author:` and indexed `:author_N:` entry paths keep their existing
-        // inline handling.
+        // The `:authors:` path is reconciled first (matching Asciidoctor's
+        // precedence: an explicit `:authors:` entry outranks the indexed
+        // `:author_N:` entries reconciled just below); the single `:author:`
+        // entry path keeps its existing inline handling.
         if let Some(authors_value) = attribute_string(parser, "authors") {
             let computed = implicit_authors
                 .iter()
@@ -928,6 +929,60 @@ fn resolve_authors(
                 // regression test in this module.
                 set_author_metadata(parser, &authors);
                 return authors;
+            }
+        }
+
+        // Reconcile explicit indexed `:author_N:` entries against the implicit
+        // author line, mirroring the indexed branch of Asciidoctor's
+        // `parse_header_metadata`. Each `author_N` attribute whose value still
+        // equals the implicit author's name leaves that position untouched; any
+        // position whose value differs is overridden.
+        // When at least one position was overridden, the reconciled list
+        // repopulates the derived attributes – including the combined `authors`
+        // string – so `{authors}` and `Document::authors()` reflect the
+        // override, not just the individual `author_N` attribute.
+        //
+        // The indexed `author_N` attributes are only assigned once the implicit
+        // line carries two or more authors, so a single-author line has no
+        // `author_1` and needs no reconciliation here.
+        if attribute_string(parser, "author_1").is_some() {
+            let mut reconciled: Vec<Author> = Vec::new();
+            let mut any_override = false;
+            let mut index = 1;
+
+            while let Some(current) = attribute_string(parser, &format!("author_{index}")) {
+                match implicit_authors.get(index - 1) {
+                    // The position is unchanged from the implicit line: reuse the
+                    // already-parsed author so its name partition is preserved. A
+                    // multi-word `lastname` such as `het Draeke` would otherwise
+                    // be re-split into a middle and last name by the names-only
+                    // partitioning below.
+                    Some(implicit) if current == implicit.name() => {
+                        reconciled.push(implicit.clone());
+                    }
+
+                    // The position was overridden (or added beyond the implicit
+                    // list): partition the entry value with the names-only rules,
+                    // exactly as Asciidoctor does for an attribute-supplied
+                    // author.
+                    _ => {
+                        any_override = true;
+
+                        if let Some(author) = Author::parse(&current, parser, true) {
+                            reconciled.push(author);
+                        }
+                    }
+                }
+
+                index += 1;
+            }
+
+            if any_override {
+                let reconciled = collect_indexed_authors(reconciled.into_iter(), parser);
+
+                set_author_metadata(parser, &reconciled);
+
+                return reconciled;
             }
         }
 

--- a/parser/src/tests/asciidoctor_rb/parser_test.rs
+++ b/parser/src/tests/asciidoctor_rb/parser_test.rs
@@ -1504,13 +1504,12 @@ fn allows_authors_to_be_overridden_using_explicit_author_attributes() {
 
     // The `:author_2:` entry overrides the second author computed from the
     // implicit author line. The first author is now exposed both unsuffixed
-    // (`author`) and as `author_1`. This crate does not derive
-    // `authorcount`, and – unlike Asciidoctor – it does not re-derive the
-    // combined `authors` attribute after the explicit override, so `authors`
-    // still reflects the implicit line (`... Johnny Bravo ...`, not `... Danger
-    // Mouse ...`).
+    // (`author`) and as `author_1`. The override is reconciled back into the
+    // combined `authors` string and the resolved author list, so `{authors}`,
+    // `Document::authors()`, and `authorcount` all reflect `Danger Mouse` rather
+    // than the implicit `Johnny Bravo`.
     let mut parser = Parser::default();
-    let _ = parser.parse(
+    let doc = parser.parse(
         "= Document Title\nKismet Chameleon; Johnny Bravo; Lazarus het_Draeke\n:author_2: Danger Mouse",
     );
     assert_eq!(
@@ -1533,6 +1532,22 @@ fn allows_authors_to_be_overridden_using_explicit_author_attributes() {
         parser.attribute_value("lastname_3"),
         InterpretedValue::Value("het Draeke")
     );
+    assert_eq!(
+        parser.attribute_value("authorcount"),
+        InterpretedValue::Value("3")
+    );
+    assert_eq!(
+        parser.attribute_value("authors"),
+        InterpretedValue::Value("Kismet Chameleon, Danger Mouse, Lazarus het Draeke")
+    );
+
+    // The resolved author list reflects the override as well.
+    let authors = doc.authors();
+    assert_eq!(authors.len(), 3);
+    assert_eq!(authors[0].name(), "Kismet Chameleon");
+    assert_eq!(authors[1].name(), "Danger Mouse");
+    assert_eq!(authors[2].name(), "Lazarus het Draeke");
+    assert_eq!(authors[2].lastname(), Some("het Draeke"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #1013.

When an indexed `:author_N:` attribute entry overrides one author of a multi-author implicit author line, the individual `author_N` attribute was updated correctly, but the combined `authors` string (and `Document::authors()`) still reflected the original, un-overridden author.

```rust
let doc = asciidoc_parser::Parser::new().parse(
    "= T\nKismet Chameleon; Johnny Bravo; Lazarus het_Draeke\n:author_2: Danger Mouse\n",
);
```

Before this change, `{authors}` was `Kismet Chameleon, Johnny Bravo, Lazarus het Draeke` and `authors()[1].name()` was `Johnny Bravo`. Asciidoctor instead reflects the override throughout.

## What changed

`resolve_authors` now reconciles explicit indexed `:author_N:` entries against the implicit author line, mirroring the indexed branch of Asciidoctor's `parse_header_metadata`:

- Each `author_N` attribute whose value still equals the implicit author's name leaves that position untouched; a position that differs is treated as an override.
- An unchanged position **reuses the already-parsed `Author`**, so its name partition (e.g. a multi-word `lastname` such as `het Draeke`) is preserved rather than being re-split by the names-only partitioning. Asciidoctor achieves the same by rebuilding the implicit name with underscore joiners before reparsing; reusing the parsed author is the direct equivalent here.
- An overridden position is partitioned with the names-only rules, exactly as Asciidoctor does for an attribute-supplied author.
- When at least one position is overridden, the reconciled list repopulates the derived attributes – including the combined `authors` string and `authorcount` – so `{authors}`, `Document::authors()`, and the resolved author list all reflect the override.

This slots in after the existing `:authors:` reconciliation (#1006), preserving Asciidoctor's precedence: an explicit `:authors:` entry outranks the indexed `:author_N:` entries.

## Expected result (now matching Asciidoctor 2.0.26)

- `author_2` = `Danger Mouse`
- `author_3` = `Lazarus het Draeke`, `lastname_3` = `het Draeke`
- `authors` = `Kismet Chameleon, Danger Mouse, Lazarus het Draeke`
- `authorcount` = `3`
- `Document::authors()[1].name()` = `Danger Mouse`

## Testing

- Updated the ported `allows_authors_to_be_overridden_using_explicit_author_attributes` test (previously documented the divergence) to assert the reconciled `authors` string, `authorcount`, and the resolved `Document::authors()` list.
- `cargo test -p asciidoc-parser`: 4542 passed, 0 failed.
- `cargo +nightly fmt --all -- --check` and `cargo clippy -p asciidoc-parser --all-targets`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)