### PR TITLE
fix: Warn when a special section that doesn't support subsections contains a nested section

### DIFF
--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -301,14 +301,20 @@ impl<'src> SectionBlock<'src> {
         // Emit an error for each subsection found directly inside a special
         // section that does not support nested sections. The error points at the
         // offending subsection's heading line, mirroring Asciidoctor's
-        // `<sectname> sections do not support nested sections` diagnostic.
+        // `<sectname> sections do not support nested sections` diagnostic. The
+        // subsection's title source is used rather than its whole span, whose
+        // first line is any block metadata (an anchor, attribute list, or block
+        // title) that precedes the heading.
         if let Some(style) = no_subsection_style {
             for block in &blocks.item {
                 if let Block::Section(subsection) = block
                     && subsection.section_type() != SectionType::Discrete
                 {
                     warnings.push(Warning {
-                        source: subsection.span().take_normalized_line().item,
+                        source: subsection
+                            .section_title_source()
+                            .take_normalized_line()
+                            .item,
                         warning: WarningType::SpecialSectionCannotHaveNestedSections(
                             style.to_string(),
                         ),

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -253,6 +253,22 @@ impl<'src> SectionBlock<'src> {
         let previously_in_bibliography_section = parser.parsing_bibliography_section_body;
         parser.parsing_bibliography_section_body = is_bibliography_section;
 
+        // A special section that does not support nested sections (a `glossary`,
+        // `bibliography`, `colophon`, `dedication`, or `index` section) logs an
+        // error for each subsection found directly within it. Only a level-1
+        // section carries a special-section style, and a discrete heading is not
+        // part of the section hierarchy, so the check is limited accordingly.
+        // The offending subsections are detected below, once the body is parsed.
+        let no_subsection_style = if !discrete && level == 1 {
+            metadata
+                .attrlist
+                .as_ref()
+                .and_then(|attrlist| attrlist.block_style())
+                .filter(|style| special_section_forbids_subsections(style))
+        } else {
+            None
+        };
+
         // A block title above a section heading does not become the section's
         // title; it is carried over to the first block inside the section
         // (matching Asciidoctor). Stash it on the parser: the next block parsed
@@ -281,6 +297,26 @@ impl<'src> SectionBlock<'src> {
 
         let blocks = maw_blocks.item;
         let source = metadata.source.trim_remainder(blocks.after);
+
+        // Emit an error for each subsection found directly inside a special
+        // section that does not support nested sections. The error points at the
+        // offending subsection's heading line, mirroring Asciidoctor's
+        // `<sectname> sections do not support nested sections` diagnostic.
+        if let Some(style) = no_subsection_style {
+            for block in &blocks.item {
+                if let Block::Section(subsection) = block
+                    && subsection.section_type() != SectionType::Discrete
+                {
+                    warnings.push(Warning {
+                        source: subsection.span().take_normalized_line().item,
+                        warning: WarningType::SpecialSectionCannotHaveNestedSections(
+                            style.to_string(),
+                        ),
+                        origin: None,
+                    });
+                }
+            }
+        }
 
         let proposed_base_id = generate_section_id(&title_reftext, parser);
 
@@ -869,6 +905,21 @@ fn peer_or_ancestor_section<'src>(
     } else {
         false
     }
+}
+
+/// Returns `true` if a section carrying the given block style is a special
+/// section that does not support nested sections.
+///
+/// Asciidoctor treats every section style other than the numbered `sect0`–
+/// `sect5` styles as a special section, and permits subsections only within the
+/// `appendix`, `preface`, and `abstract` special sections. The remaining
+/// well-known special sections – `glossary`, `bibliography`, `colophon`,
+/// `dedication`, and `index` – forbid them.
+fn special_section_forbids_subsections(style: &str) -> bool {
+    matches!(
+        style,
+        "glossary" | "bibliography" | "colophon" | "dedication" | "index"
+    )
 }
 
 /// Records a "section title out of sequence" warning for a *top-level* section

--- a/parser/src/tests/asciidoctor_rb/sections_test.rs
+++ b/parser/src/tests/asciidoctor_rb/sections_test.rs
@@ -2244,12 +2244,11 @@ mod nesting {
         );
     }
 
-    // NOTE: Special sections (glossary, bibliography, etc.) and the rule that
-    // certain kinds do not support nested sections are not modeled, so the crate
-    // emits no error for subsections found within them. These two tests are out
-    // of scope.
-    non_normative!(
-        r##"
+    #[test]
+    fn should_log_error_if_subsections_are_found_in_special_sections_in_article_that_do_not_support_subsections()
+     {
+        verifies!(
+            r##"
     test 'should log error if subsections are found in special sections in article that do not support subsections' do
       input = <<~'EOS'
       = Document Title
@@ -2291,6 +2290,38 @@ mod nesting {
       end
     end
 
+"##
+        );
+
+        let doc = Parser::default().parse(
+            "= Document Title\n\n== Section\n\n=== Subsection of Section\n\nallowed\n\n[appendix]\n== Appendix\n\n=== Subsection of Appendix\n\nallowed\n\n[glossary]\n== Glossary\n\n=== Subsection of Glossary\n\nnot allowed\n\n[bibliography]\n== Bibliography\n\n=== Subsection of Bibliography\n\nnot allowed\n",
+        );
+
+        // A `glossary` and a `bibliography` section do not support nested
+        // sections, so each subsection found directly within one is reported, in
+        // document order. An `appendix` section – and an ordinary section –
+        // support subsections and raise no such error.
+        let warnings: Vec<_> = doc.warnings().collect();
+
+        let special_warnings: Vec<&str> = warnings
+            .iter()
+            .filter_map(|w| match &w.warning {
+                WarningType::SpecialSectionCannotHaveNestedSections(style) => Some(style.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(special_warnings, vec!["glossary", "bibliography"]);
+    }
+
+    // NOTE: The book variant relies on the `book` doctype and its level-0 (`=`)
+    // special sections (colophon, dedication, glossary, bibliography). The crate
+    // does not model the book doctype – a `=` heading outside the document
+    // header is declined as an unsupported level-0 heading rather than parsed as
+    // a section – so the nested-section rule can't be exercised for it. This
+    // test stays out of scope until the book doctype is supported.
+    non_normative!(
+        r##"
     test 'should log error if subsections are found in special sections in book that do not support subsections' do
       input = <<~'EOS'
       = Document Title

--- a/parser/src/tests/asciidoctor_rb/sections_test.rs
+++ b/parser/src/tests/asciidoctor_rb/sections_test.rs
@@ -2314,6 +2314,34 @@ mod nesting {
         assert_eq!(special_warnings, vec!["glossary", "bibliography"]);
     }
 
+    // The "does not support nested sections" error must point at the offending
+    // subsection's heading line, even when block metadata (an anchor, attribute
+    // list, or block title) precedes it – the section span begins at that
+    // metadata, so its first line is not the heading. (No Ruby counterpart.)
+    #[test]
+    fn nested_section_error_points_at_heading_not_preceding_metadata() {
+        let doc = Parser::default().parse(
+            "= Document Title\n\n[glossary]\n== Glossary\n\n[[mysub]]\n.A title\n=== Subsection of Glossary\n\nnot allowed\n",
+        );
+
+        let warnings: Vec<_> = doc.warnings().collect();
+
+        let nested_warning = warnings
+            .iter()
+            .find(|w| {
+                matches!(
+                    &w.warning,
+                    WarningType::SpecialSectionCannotHaveNestedSections(style) if style == "glossary"
+                )
+            })
+            .expect("special-section warning");
+
+        // Line 8 is `=== Subsection of Glossary`; lines 6 and 7 are the anchor
+        // and block title above it.
+        assert_eq!(nested_warning.source.line(), 8);
+        assert_eq!(nested_warning.source.data(), "Subsection of Glossary");
+    }
+
     // NOTE: The book variant relies on the `book` doctype and its level-0 (`=`)
     // special sections (colophon, dedication, glossary, bibliography). The crate
     // does not model the book doctype – a `=` heading outside the document

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -160,6 +160,14 @@ pub enum WarningType {
     #[error("leveloffset {0} places every section heading outside the supported range 1-5")]
     LeveloffsetExcludesAllHeadingLevels(i32),
 
+    /// A special section that does not support nested sections (a `glossary`,
+    /// `bibliography`, `colophon`, `dedication`, or `index` section) contains a
+    /// subsection. The field is the section's style name. Mirrors Asciidoctor,
+    /// which permits subsections only within the `appendix`, `preface`, and
+    /// `abstract` special sections.
+    #[error("{0} sections do not support nested sections")]
+    SpecialSectionCannotHaveNestedSections(String),
+
     /// An explicitly-numbered list item does not continue the sequence its list
     /// established. The fields are the expected and actual indexes.
     #[error("list item index: expected {0}, got {1}")]
@@ -427,6 +435,11 @@ impl std::fmt::Debug for WarningType {
             WarningType::LeveloffsetExcludesAllHeadingLevels(offset) => f
                 .debug_tuple("WarningType::LeveloffsetExcludesAllHeadingLevels")
                 .field(offset)
+                .finish(),
+
+            WarningType::SpecialSectionCannotHaveNestedSections(style) => f
+                .debug_tuple("WarningType::SpecialSectionCannotHaveNestedSections")
+                .field(style)
                 .finish(),
 
             WarningType::ListItemOutOfSequence(expected, actual) => f
@@ -844,6 +857,17 @@ mod tests {
                 assert_eq!(
                     debug_output,
                     "WarningType::LeveloffsetExcludesAllHeadingLevels(2147483647)"
+                );
+            }
+
+            #[test]
+            fn special_section_cannot_have_nested_sections() {
+                let warning =
+                    WarningType::SpecialSectionCannotHaveNestedSections("glossary".to_string());
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(
+                    debug_output,
+                    "WarningType::SpecialSectionCannotHaveNestedSections(\"glossary\")"
                 );
             }
 


### PR DESCRIPTION
Fixes #1015.

## What

Special sections such as `glossary`, `bibliography`, `colophon`, `dedication`, and `index` do not support nested sections. Asciidoctor logs an error when a subsection is found inside one, e.g.:

```
<stdin>: line 19: glossary sections do not support nested sections
```

`asciidoc-parser` previously emitted no such warning, so the condition could not be verified via `Document::warnings()`.

## How

- Added a new `WarningType::SpecialSectionCannotHaveNestedSections(String)` variant (the field carries the section's style name, so the rendered message reads `<style> sections do not support nested sections`).
- In `SectionBlock::parse`, when a level-1 section carries one of the no-subsection special styles, each direct subsection found in its body now raises that warning, pointing at the offending subsection's heading line.
- Subsections remain allowed in the `appendix`, `preface`, and `abstract` special sections, matching Asciidoctor's rule (a special section permits subsections only for those three `sectname`s).

## Tests

- Ported the article-doctype Ruby test (`should log error if subsections are found in special sections in article that do not support subsections`) from `sections_test.rb` into a real `#[test]` under `mod nesting`. It asserts the `glossary` and `bibliography` subsections each warn while the `appendix` and ordinary sections do not.
- Added the `impl_debug` coverage for the new warning variant in `warnings.rs`.

## Deferred

The **book** variant of the Ruby test relies on the `book` doctype and its level-0 (`=`) special sections (colophon, dedication, glossary, bibliography). The crate does not model the book doctype — a `=` heading outside the document header is declined as an unsupported level-0 heading rather than parsed as a section — so that rule can't be exercised there yet. It remains in a `non_normative!` block with an explanatory NOTE.

## Verification

- `cargo test -p asciidoc-parser` — all pass (4544 unit + doctests).
- `cargo +nightly fmt --all -- --check` — clean.
- `cargo clippy -p asciidoc-parser --all-targets` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)