### PR TITLE
fix: Treat a `[float]`/`[discrete]` level-0 (`=`) heading as a discrete heading

### DIFF
--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -70,7 +70,7 @@ impl<'src> SectionBlock<'src> {
         // while a negative offset pulls them up. A heading whose effective level
         // is below 1 is rejected as an unsupported level-0 heading (the warning
         // is raised inside `parse_title_line`).
-        let level_and_title = parse_title_line(source, parser.level_offset(), warnings)?;
+        let level_and_title = parse_title_line(source, parser.level_offset(), discrete, warnings)?;
 
         // Take a snapshot of `sectids` value before reading child blocks because
         // the value might be altered while parsing.
@@ -384,7 +384,9 @@ impl<'src> SectionBlock<'src> {
     /// signs represents level 1). A section marker can range from two to six
     /// equal signs and must be followed by a space.
     ///
-    /// This function will return an integer between 1 and 5.
+    /// This function will return an integer between 1 and 5 for an ordinary
+    /// section. A `discrete` (floating) heading may also return 0, for a
+    /// level-0 (`=`) discrete heading rendered as an `<h1>` floating title.
     pub fn level(&self) -> usize {
         self.level
     }
@@ -689,12 +691,15 @@ fn match_embedded_section_anchor<'src>(
 /// * A bare `=` (syntactic level 0) that no positive offset lifts to level 1 or
 ///   beyond has no section representation; it is rejected as an unsupported
 ///   level-0 heading (recording a warning), preserving the single-document-
-///   title rule.
+///   title rule. A `discrete` heading is exempt: it may occupy level 0 (an
+///   `<h1>` floating title) and so is not rejected there.
 /// * Any other heading whose effective level falls outside the supported range
-///   is clamped to the nearest valid level and a warning is recorded.
+///   is clamped to the nearest valid level and a warning is recorded. The lower
+///   bound is [`MIN_SECTION_LEVEL`], or 0 for a `discrete` heading.
 fn parse_title_line<'src>(
     source: Span<'src>,
     offset: i32,
+    discrete: bool,
     warnings: &mut Vec<Warning<'src>>,
 ) -> Option<MatchedItem<'src, (usize, Span<'src>)>> {
     let mi = source.take_non_empty_line()?;
@@ -743,7 +748,11 @@ fn parse_title_line<'src>(
     // un-offset level-0 heading is declined, rather than clamping it into a
     // section. This is checked before the whitespace requirement below so a
     // spaceless `=blah` is still reported, matching a bare level-0 heading.
-    if syntactic_level == 0 && effective_level < MIN_SECTION_LEVEL {
+    //
+    // A `discrete`/`float` heading is exempt: it renders as a floating `<h1>`,
+    // not the document title, so a level-0 discrete heading is legitimate and is
+    // carried through with level 0 rather than rejected.
+    if !discrete && syntactic_level == 0 && effective_level < MIN_SECTION_LEVEL {
         warnings.push(Warning {
             source: source.take_normalized_line().item,
             warning: WarningType::Level0SectionHeadingNotSupported,
@@ -761,18 +770,22 @@ fn parse_title_line<'src>(
     let title_span = strip_symmetric_title_close(title.after, marker_char, count);
 
     // A real section heading whose offset-adjusted level lands outside the
-    // supported 1..=5 range is clamped into range and reported, rather than
-    // producing an out-of-range (or, under a hostile offset, absurd) level.
-    let level = if effective_level < MIN_SECTION_LEVEL {
+    // supported range is clamped into range and reported, rather than producing
+    // an out-of-range (or, under a hostile offset, absurd) level. The lower
+    // bound is [`MIN_SECTION_LEVEL`] normally, but 0 for a `discrete` heading,
+    // which may legitimately occupy level 0.
+    let min_level = if discrete { 0 } else { MIN_SECTION_LEVEL };
+
+    let level = if effective_level < min_level {
         warnings.push(Warning {
             source: source.take_normalized_line().item,
             warning: WarningType::SectionHeadingLevelOutOfRange(
                 effective_level,
-                MIN_SECTION_LEVEL as usize,
+                min_level as usize,
             ),
             origin: None,
         });
-        MIN_SECTION_LEVEL as usize
+        min_level as usize
     } else if effective_level > MAX_SECTION_LEVEL {
         warnings.push(Warning {
             source: source.take_normalized_line().item,
@@ -848,9 +861,14 @@ fn peer_or_ancestor_section<'src>(
     // those warnings once – either as a child block of this section or in the
     // enclosing scope once this section ends.
     let mut ignored_warnings = vec![];
+
+    // A `discrete` heading has already been excluded above, so the boundary
+    // look-ahead never needs the level-0 exemption; pass `discrete = false` so a
+    // bare `=` here is treated as ordinary content, exactly as before.
     if let Some(mi) = parse_title_line(
         source_after_metadata,
         parser.level_offset(),
+        false,
         &mut ignored_warnings,
     ) {
         let found_level = mi.item.0;
@@ -4109,6 +4127,27 @@ mod tests {
                 mi.item.section_title(),
                 "Discrete with <strong>bold</strong> text"
             );
+            assert_eq!(mi.item.section_type(), SectionType::Discrete);
+            assert!(warnings.is_empty());
+        }
+
+        #[test]
+        fn level_0() {
+            // A `[discrete]`/`[float]` style makes a level-0 (`=`) heading a
+            // discrete floating title rather than the (rejected) document title,
+            // so it parses to a level-0 discrete section with no warning.
+            let mut parser = Parser::default();
+            let mut warnings: Vec<crate::warnings::Warning<'_>> = vec![];
+
+            let mi = crate::blocks::SectionBlock::parse(
+                &BlockMetadata::new("[discrete]\n= Level 0 Discrete"),
+                &mut parser,
+                &mut warnings,
+            )
+            .unwrap();
+
+            assert_eq!(mi.item.level(), 0);
+            assert_eq!(mi.item.section_title(), "Level 0 Discrete");
             assert_eq!(mi.item.section_type(), SectionType::Discrete);
             assert!(warnings.is_empty());
         }

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -233,8 +233,7 @@ impl<'src> Header<'src> {
             } else if title.is_none()
                 && line.starts_with('[')
                 && line.ends_with(']')
-                && !is_discrete_metadata_line(line)
-                && document_title_follows_block_metadata(line_mi.after)
+                && document_title_follows_block_metadata(source)
                 && let Some((metadata, metadata_warnings)) = parse_document_metadata(line, parser)
             {
                 warnings.extend(metadata_warnings);
@@ -648,15 +647,15 @@ fn document_title_marker(line: Span<'_>) -> Option<char> {
     }
 }
 
-/// Reports whether a document title marker eventually follows the source at
-/// `after`, allowing any number of stacked block attribute lines in between.
+/// Reports whether a *promotable* document title follows the block metadata run
+/// beginning at `source` (the current bracket-delimited line, included in the
+/// scan).
 ///
-/// Starting immediately below the block attribute line under consideration,
-/// consecutive lines that are themselves document-metadata block attribute
-/// lines (see [`is_document_metadata_line`]) are skipped, and the first line
-/// that is not is tested for a document title marker. This generalizes the
-/// original single-line lookahead so that stacked metadata lines above the
-/// title are all folded, mirroring Asciidoctor's `parse_block_metadata_lines`.
+/// Consecutive document-metadata block attribute lines (see
+/// [`is_document_metadata_line`]) are consumed, and the first line that is not
+/// one is tested for a document title marker. This generalizes the original
+/// single-line lookahead so that stacked metadata lines above the title are all
+/// folded, mirroring Asciidoctor's `parse_block_metadata_lines`.
 ///
 /// A line that starts with `[` and ends with `]` but is *not* a valid
 /// document-metadata line (e.g. a `[[anchor]]` block anchor or a leading-space
@@ -664,27 +663,37 @@ fn document_title_marker(line: Span<'_>) -> Option<char> {
 /// ever a contiguous prefix of well-formed metadata lines terminated by the
 /// title.
 ///
-/// A `[discrete]`/`[float]` style anywhere in the stacked metadata also stops
-/// the scan without matching: it marks the following heading as a discrete
-/// floating title rather than the document title, so neither the metadata nor
-/// the heading is folded here – both are left for the block parser.
-fn document_title_follows_block_metadata(after: Span<'_>) -> bool {
-    let mut next = after;
+/// The run's *effective* block style also gates promotion: if it resolves to
+/// `discrete`/`float`, the following level-0 (`=`) heading is a discrete
+/// floating title rather than the document title, so this returns `false` and
+/// neither the metadata nor the heading is folded here – both are left for the
+/// block parser, which produces a `SectionType::Discrete` heading (see #1014).
+/// The effective style is tracked with last-wins semantics that mirror
+/// `Attrlist::merge_block_attribute_line` / `merge_block_style_shorthand` – a
+/// line that specifies a block style overrides the running one, and a line with
+/// none leaves it unchanged – so the header's decision always agrees with the
+/// `BlockMetadata::is_discrete` decision the block parser would make on the
+/// same run.
+fn document_title_follows_block_metadata(source: Span<'_>) -> bool {
+    let mut next = source;
+    let mut effective_style_is_discrete = false;
 
     while !next.is_empty() {
         let line_mi = next.take_normalized_line();
         let line = line_mi.item;
 
         if document_title_marker(line).is_some() {
-            return true;
+            return !effective_style_is_discrete;
         }
 
         if !is_document_metadata_line(line) {
             return false;
         }
 
-        if is_discrete_metadata_line(line) {
-            return false;
+        // Fold this line's block style into the running effective style
+        // (last-wins), leaving it unchanged when the line specifies none.
+        if let Some(is_discrete) = metadata_line_block_style_is_discrete(line) {
+            effective_style_is_discrete = is_discrete;
         }
 
         next = line_mi.after;
@@ -693,52 +702,49 @@ fn document_title_follows_block_metadata(after: Span<'_>) -> bool {
     false
 }
 
-/// Reports whether `line` – already known to be a bracket-delimited
-/// document-metadata line – carries a `discrete` or `float` block style.
+/// Classifies the block style of a single bracket-delimited document-metadata
+/// `line`, read structurally (the attribute list is *not* parsed):
 ///
-/// Such a style marks a following level-0 (`=`) heading as a discrete floating
-/// title rather than the document title, so the header must decline to fold
-/// both the metadata and the heading and instead leave them for the block
-/// parser, which produces a `SectionType::Discrete` heading. Mirrors
-/// `BlockMetadata::is_discrete` for the block-parser side.
+/// * `None` – the line specifies no block style (a `[[id]]` anchor, a shorthand
+///   line whose first positional leads with `.`/`#`/`%`, or a named-first
+///   attribute list such as `[reftext=…]`), so it leaves a running style
+///   unchanged.
+/// * `Some(true)` – the block style is `discrete` or `float`.
+/// * `Some(false)` – the block style is some other value (e.g. `[appendix]`).
 ///
-/// The detection is purely structural – the attribute list is *not* parsed –
-/// so an embedded `{counter:…}` in an attribute *value* is never evaluated at
-/// header time (the same invariant [`document_title_follows_block_metadata`]
-/// relies on; see the `rejected_metadata_run_does_not_fire_counter` test). This
-/// is safe because a block style is always the first positional attribute's
-/// leading shorthand token – a bare name that can never itself be a counter.
-fn is_discrete_metadata_line(line: Span<'_>) -> bool {
-    if !is_document_metadata_line(line) {
-        return false;
-    }
-
-    // Drop the enclosing square brackets.
+/// Reading the style off the raw text – rather than parsing the attribute list
+/// – keeps an embedded `{counter:…}` in a *value* from being evaluated at
+/// header time (the invariant the `rejected_metadata_run_does_not_fire_counter`
+/// test guards). This is safe because a block style is always the first
+/// positional attribute's leading shorthand token – a bare name that can never
+/// itself be a counter.
+fn metadata_line_block_style_is_discrete(line: Span<'_>) -> Option<bool> {
+    // Drop the enclosing square brackets (the caller has confirmed they are
+    // present via [`is_document_metadata_line`]).
     let inner = line.slice(1..line.len() - 1).data();
 
     // A `[[id]]` / `[[id,reftext]]` block anchor still has its inner brackets
     // and carries no block style.
     if inner.starts_with('[') {
-        return false;
+        return None;
     }
 
     // The block style is the leading shorthand token of the first positional
     // attribute: a run of name characters terminated by a shorthand delimiter
-    // (`.`, `#`, `%`), a comma, whitespace, or the end of the attribute. Read it
-    // off the raw text without parsing the attribute list.
+    // (`.`, `#`, `%`), a comma, whitespace, or the end of the attribute.
     let token_len = inner
         .find(|c: char| !(c.is_ascii_alphanumeric() || c == '-' || c == '_'))
         .unwrap_or(inner.len());
-    let token = &inner[..token_len];
 
-    if token != "discrete" && token != "float" {
-        return false;
+    // A first positional that leads with a shorthand delimiter (`[#id]`,
+    // `[.role]`, `[%option]`), or a `=` that makes the token a named attribute
+    // name (`[reftext=…]`), carries no block style.
+    if token_len == 0 || inner[token_len..].starts_with('=') {
+        return None;
     }
 
-    // The token is a block style only when it is not actually the name of a
-    // named attribute (`[discrete=…]`): the character terminating it, if any,
-    // must not be `=`.
-    !inner[token_len..].starts_with('=')
+    let token = &inner[..token_len];
+    Some(token == "discrete" || token == "float")
 }
 
 /// Reports whether `line` is a block attribute line that this crate folds into
@@ -2404,6 +2410,33 @@ mod tests {
 
         assert_eq!(header.title(), Some("Some Title"));
         assert_eq!(header.id(), Some("anchor"));
+    }
+
+    #[test]
+    fn stacked_block_styles_gate_doctitle_by_effective_style() {
+        // Whether a `[float]`/`[discrete]` style above a level-0 (`=`) title
+        // suppresses doctitle promotion is decided by the run's *effective*
+        // (merged, last-wins) block style – the same value the block parser
+        // computes via `Attrlist::merge_block_attribute_line` – not by any
+        // single line in isolation.
+
+        // A later non-discrete style overrides an earlier `float`, so the
+        // effective style is not discrete: the title is still promoted rather
+        // than disappearing.
+        let doc = Parser::default().parse("[float]\n[normal]\n= Some Title\n\nbody");
+        assert_eq!(doc.header().title(), Some("Some Title"));
+        assert!(all_sections(&doc).is_empty());
+
+        // A later `float` overrides an earlier non-discrete style, so the
+        // effective style is discrete: the heading becomes a level-0 discrete
+        // floating title and is not promoted to the doctitle.
+        let doc = Parser::default().parse("[normal]\n[float]\n= Some Title\n\nbody");
+        assert_eq!(doc.header().title(), None);
+
+        let sec = first_section(&doc);
+        assert_eq!(sec.section_type(), SectionType::Discrete);
+        assert_eq!(sec.level(), 0);
+        assert_eq!(sec.section_title(), "Some Title");
     }
 
     #[test]

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -233,6 +233,7 @@ impl<'src> Header<'src> {
             } else if title.is_none()
                 && line.starts_with('[')
                 && line.ends_with(']')
+                && !is_discrete_metadata_line(line)
                 && document_title_follows_block_metadata(line_mi.after)
                 && let Some((metadata, metadata_warnings)) = parse_document_metadata(line, parser)
             {
@@ -662,6 +663,11 @@ fn document_title_marker(line: Span<'_>) -> Option<char> {
 /// form) stops the scan without matching, so the run of foldable lines is only
 /// ever a contiguous prefix of well-formed metadata lines terminated by the
 /// title.
+///
+/// A `[discrete]`/`[float]` style anywhere in the stacked metadata also stops
+/// the scan without matching: it marks the following heading as a discrete
+/// floating title rather than the document title, so neither the metadata nor
+/// the heading is folded here – both are left for the block parser.
 fn document_title_follows_block_metadata(after: Span<'_>) -> bool {
     let mut next = after;
 
@@ -677,10 +683,62 @@ fn document_title_follows_block_metadata(after: Span<'_>) -> bool {
             return false;
         }
 
+        if is_discrete_metadata_line(line) {
+            return false;
+        }
+
         next = line_mi.after;
     }
 
     false
+}
+
+/// Reports whether `line` – already known to be a bracket-delimited
+/// document-metadata line – carries a `discrete` or `float` block style.
+///
+/// Such a style marks a following level-0 (`=`) heading as a discrete floating
+/// title rather than the document title, so the header must decline to fold
+/// both the metadata and the heading and instead leave them for the block
+/// parser, which produces a `SectionType::Discrete` heading. Mirrors
+/// `BlockMetadata::is_discrete` for the block-parser side.
+///
+/// The detection is purely structural – the attribute list is *not* parsed –
+/// so an embedded `{counter:…}` in an attribute *value* is never evaluated at
+/// header time (the same invariant [`document_title_follows_block_metadata`]
+/// relies on; see the `rejected_metadata_run_does_not_fire_counter` test). This
+/// is safe because a block style is always the first positional attribute's
+/// leading shorthand token – a bare name that can never itself be a counter.
+fn is_discrete_metadata_line(line: Span<'_>) -> bool {
+    if !is_document_metadata_line(line) {
+        return false;
+    }
+
+    // Drop the enclosing square brackets.
+    let inner = line.slice(1..line.len() - 1).data();
+
+    // A `[[id]]` / `[[id,reftext]]` block anchor still has its inner brackets
+    // and carries no block style.
+    if inner.starts_with('[') {
+        return false;
+    }
+
+    // The block style is the leading shorthand token of the first positional
+    // attribute: a run of name characters terminated by a shorthand delimiter
+    // (`.`, `#`, `%`), a comma, whitespace, or the end of the attribute. Read it
+    // off the raw text without parsing the attribute list.
+    let token_len = inner
+        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '-' || c == '_'))
+        .unwrap_or(inner.len());
+    let token = &inner[..token_len];
+
+    if token != "discrete" && token != "float" {
+        return false;
+    }
+
+    // The token is a block style only when it is not actually the name of a
+    // named attribute (`[discrete=…]`): the character terminating it, if any,
+    // must not be `=`.
+    !inner[token_len..].starts_with('=')
 }
 
 /// Reports whether `line` is a block attribute line that this crate folds into

--- a/parser/src/tests/asciidoctor_rb/sections_test.rs
+++ b/parser/src/tests/asciidoctor_rb/sections_test.rs
@@ -2496,12 +2496,16 @@ non_normative!(
 mod discrete_heading {
     use crate::tests::prelude::*;
 
-    // NOTE: A `[float]`/`[discrete]` style on a level-0 (`=`) heading is not
-    // recognized as a discrete heading — the crate leaves the line as a
-    // paragraph. (Discrete headings at `==`+ are supported, as the tests below
-    // show.) These three level-0 tests are out of scope.
-    non_normative!(
-        r##"
+    // A `[float]`/`[discrete]` style on a level-0 (`=`) heading suppresses the
+    // doctitle promotion and yields a level-0 discrete (floating-title) heading,
+    // just as `==`+ discrete headings do at their own level. As with
+    // the `==`+ cases below, the crate models the heading as a
+    // `SectionType::Discrete` block and checks the normative facts against the
+    // AST rather than reproducing the Ruby `class`/following-sibling HTML shape.
+    #[test]
+    fn should_create_discrete_heading_instead_of_section_if_style_is_float() {
+        verifies!(
+            r##"
     test 'should create discrete heading instead of section if style is float' do
       input = <<~'EOS'
       [float]
@@ -2520,7 +2524,22 @@ mod discrete_heading {
     end
 
 "##
-    );
+        );
+
+        let doc = Parser::default().parse("[float]\n= Independent Heading!\n\nnot in section\n");
+
+        // The level-0 heading must not have been promoted to the document title.
+        assert!(doc.header().title().is_none());
+        assert_eq!(doc.doctitle(), None);
+
+        let sec = first_section(&doc);
+        assert_eq!(sec.section_type(), SectionType::Discrete);
+        assert_eq!(sec.level(), 0);
+        assert_eq!(sec.id(), Some("_independent_heading"));
+        assert_eq!(sec.section_title(), "Independent Heading!");
+        assert!(sec.child_blocks().next().is_none());
+        assert!(rendered_paragraphs(&doc).contains(&"not in section".to_string()));
+    }
 
     // The crate marks a discrete heading with `SectionType::Discrete` (verified
     // via the AST); its virtual DOM renders it like a normal section rather than
@@ -2592,10 +2611,15 @@ mod discrete_heading {
         assert_eq!(sec.section_title(), " Heading ");
     }
 
-    // Level-0 shorthand-style discrete headings: out of scope for the same
-    // reason as the first test in this context.
-    non_normative!(
-        r##"
+    // Level-0 discrete headings using the shorthand attribute form
+    // (`[float.role#id]` / `[discrete.role#id]`): the `#id` supplies the heading
+    // ID, the `.role` adds a role, and the level-0 doctitle promotion is still
+    // suppressed. As above, the normative facts are checked against
+    // the AST rather than the Ruby `class`/following-sibling HTML shape.
+    #[test]
+    fn should_create_discrete_heading_if_style_is_float_with_shorthand_role_and_id() {
+        verifies!(
+            r##"
     test 'should create discrete heading if style is float with shorthand role and id' do
       input = <<~'EOS'
       [float.independent#first]
@@ -2613,6 +2637,28 @@ mod discrete_heading {
       assert_xpath '/h1/following-sibling::*[@class="paragraph"]/p[text()="not in section"]', output, 1
     end
 
+"##
+        );
+
+        let doc = Parser::default()
+            .parse("[float.independent#first]\n= Independent Heading!\n\nnot in section\n");
+
+        assert!(doc.header().title().is_none());
+
+        let sec = first_section(&doc);
+        assert_eq!(sec.section_type(), SectionType::Discrete);
+        assert_eq!(sec.level(), 0);
+        assert_eq!(sec.id(), Some("first"));
+        assert_eq!(sec.roles(), vec!["independent"]);
+        assert_eq!(sec.section_title(), "Independent Heading!");
+        assert!(sec.child_blocks().next().is_none());
+        assert!(rendered_paragraphs(&doc).contains(&"not in section".to_string()));
+    }
+
+    #[test]
+    fn should_create_discrete_heading_if_style_is_discrete_with_shorthand_role_and_id() {
+        verifies!(
+            r##"
     test 'should create discrete heading if style is discrete with shorthand role and id' do
       input = <<~'EOS'
       [discrete.independent#first]
@@ -2631,7 +2677,22 @@ mod discrete_heading {
     end
 
 "##
-    );
+        );
+
+        let doc = Parser::default()
+            .parse("[discrete.independent#first]\n= Independent Heading!\n\nnot in section\n");
+
+        assert!(doc.header().title().is_none());
+
+        let sec = first_section(&doc);
+        assert_eq!(sec.section_type(), SectionType::Discrete);
+        assert_eq!(sec.level(), 0);
+        assert_eq!(sec.id(), Some("first"));
+        assert_eq!(sec.roles(), vec!["independent"]);
+        assert_eq!(sec.section_title(), "Independent Heading!");
+        assert!(sec.child_blocks().next().is_none());
+        assert!(rendered_paragraphs(&doc).contains(&"not in section".to_string()));
+    }
 
     #[test]
     fn discrete_heading_should_be_a_block_with_context_floating_title() {


### PR DESCRIPTION
Fixes #1014.

## Problem

A `[float]`/`[discrete]` style on a **level-0** (`=`) heading was promoted to the doctitle and dropped from the block stream, instead of producing a discrete floating-title block. Discrete headings at level 2+ (`==`, `===`, …) already worked.

```adoc
[float]
= Independent Heading!

not in section
```

Asciidoctor renders a floating title (`h1.float`, id `_independent_heading`) followed by the paragraph. `asciidoc-parser` instead reported `doctitle = "Independent Heading!"` and emitted only the paragraph.

## Root cause & fix

The heading was lost in two places:

1. **`document/header.rs`** — the header folded the `[float]`/`[discrete]` line into document metadata and promoted the following `= Title` to the doctitle. It now detects a `discrete`/`float` block style in the stacked metadata and declines to fold either line, leaving both for the block parser.

   The detection is **purely structural** (it reads the leading shorthand token off the raw bracket text and never parses the attribute list), preserving the existing invariant that header-time metadata look-ahead must not evaluate an embedded `{counter:…}` in an attribute value.

2. **`blocks/section.rs`** — `parse_title_line` rejected *every* level-0 heading. It now takes the `discrete` flag and lets a discrete heading occupy level 0 (an `<h1>` floating title) rather than rejecting or clamping it. `SectionBlock::parse` already routes a discrete heading to `SectionType::Discrete`, assigns no section number, and consumes no child blocks, so no further changes were needed there.

## Was this realistically portable?

Yes — this turned out **not** to be a won't-fix. The crate already fully models discrete headings (`SectionType::Discrete`, `floating_title` context, no children, no numbering) for levels 1–5; the only gap was the level-0 promotion/rejection. `level()` can now return `0` for a level-0 discrete heading (documented on the accessor); no invariant depended on discrete headings being ≥ 1 (`assign_section_number`/appendix/`topmost_section_type` paths all exclude discrete).

## Tests

- Converted the three Ruby level-0 float/discrete cases in `sections_test.rs` from `non_normative!` to real `verifies!` tests (`should_create_discrete_heading_instead_of_section_if_style_is_float`, and the `float`/`discrete` shorthand-role-and-id variants), asserting `SectionType::Discrete`, `level() == 0`, the id/roles/title, no child blocks, no doctitle promotion, and the following paragraph.
- Added a native `discrete_headings::level_0` unit test in `section.rs`.

Full workspace test suite passes (4546 tests); `cargo +nightly fmt --all -- --check` and `cargo clippy --all-targets` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)