### PR TITLE
feat: Add IncludeResolution::NotDecodable for a found-but-undecodable include

### DIFF
--- a/parser/src/parser/include_file_handler.rs
+++ b/parser/src/parser/include_file_handler.rs
@@ -31,14 +31,19 @@ pub trait IncludeFileHandler: Debug {
     /// - [`IncludeResolution::NotReadable`] signals that the file exists but
     ///   could not be read (for example a permission or other IO error); the
     ///   parser records a [`WarningType::IncludeFileNotReadable`] warning.
+    /// - [`IncludeResolution::NotDecodable`] signals that the file exists and
+    ///   was read but is not valid UTF-8 and the handler could not transcode it
+    ///   (see the `# Encoding` section); the parser records a
+    ///   [`WarningType::IncludeFileNotDecodable`] warning.
     ///
     /// The rendered replacement (`Unresolved directive …`) is identical for the
-    /// two failure reasons; only the warning differs, mirroring Asciidoctor's
-    /// separate `include file not found` and `include file not readable`
-    /// messages.
+    /// three failure reasons; only the warning differs, mirroring Asciidoctor's
+    /// separate `include file not found`, `include file not readable`, and
+    /// `invalid byte sequence in UTF-8` messages.
     ///
     /// [`WarningType::IncludeFileNotFound`]: crate::warnings::WarningType::IncludeFileNotFound
     /// [`WarningType::IncludeFileNotReadable`]: crate::warnings::WarningType::IncludeFileNotReadable
+    /// [`WarningType::IncludeFileNotDecodable`]: crate::warnings::WarningType::IncludeFileNotDecodable
     ///
     /// # Options
     /// With the exception of `encoding` (see below), the implementation should
@@ -63,8 +68,14 @@ pub trait IncludeFileHandler: Debug {
     /// include-encoding warning in that case.
     ///
     /// If the implementation finds a file that is not encoded in UTF-8 and is
-    /// incapable of transcoding it, it should return
-    /// [`IncludeResolution::NotFound`].
+    /// incapable of transcoding it (no `encoding` attribute, or one it does not
+    /// support), it should return [`IncludeResolution::NotDecodable`] so the
+    /// parser can name the real cause. Asciidoctor treats this condition as
+    /// fatal (`invalid byte sequence in UTF-8`); this crate favors recoverable
+    /// warnings, so it instead drops the include and records a
+    /// [`WarningType::IncludeFileNotDecodable`] warning.
+    ///
+    /// [`WarningType::IncludeFileNotDecodable`]: crate::warnings::WarningType::IncludeFileNotDecodable
     fn resolve_target<'src>(
         &self,
         source: Option<&str>,
@@ -77,9 +88,10 @@ pub trait IncludeFileHandler: Debug {
 /// The outcome of an [`IncludeFileHandler::resolve_target`] call: either the
 /// resolved content, or the reason resolution failed.
 ///
-/// The two failure reasons map to distinct warnings – mirroring Asciidoctor,
-/// which distinguishes a missing include file (`include file not found`) from
-/// one that is present but unreadable (`include file not readable`).
+/// The failure reasons map to distinct warnings – mirroring Asciidoctor, which
+/// distinguishes a missing include file (`include file not found`) from one
+/// that is present but unreadable (`include file not readable`) or present but
+/// not valid UTF-8 (`invalid byte sequence in UTF-8`).
 ///
 /// This enum is `non_exhaustive`: future resolution reasons may be recognized
 /// as the parser grows, so a host matching on it needs a catch-all arm. New
@@ -102,6 +114,18 @@ pub enum IncludeResolution {
     ///
     /// [`WarningType::IncludeFileNotReadable`]: crate::warnings::WarningType::IncludeFileNotReadable
     NotReadable,
+
+    /// A file was found and read for the directive's target but is not valid
+    /// UTF-8, and the handler was unable to transcode it (no `encoding`
+    /// attribute, or one it does not support). The parser records a
+    /// [`WarningType::IncludeFileNotDecodable`] warning.
+    ///
+    /// See the `# Encoding` section of [`IncludeFileHandler::resolve_target`]
+    /// for how a handler that *can* transcode should instead return
+    /// [`IncludeContent::transcoded`].
+    ///
+    /// [`WarningType::IncludeFileNotDecodable`]: crate::warnings::WarningType::IncludeFileNotDecodable
+    NotDecodable,
 }
 
 impl From<IncludeContent> for IncludeResolution {

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -647,9 +647,10 @@ impl<'p> PreprocessorState<'p> {
 
                 // Ask the handler to resolve the target. With no handler
                 // configured, the target is treated as not found. The failure
-                // reason (`NotFound` vs `NotReadable`) selects the warning
-                // recorded below, mirroring Asciidoctor's distinct `include file
-                // not found` and `include file not readable` messages.
+                // reason (`NotFound`, `NotReadable`, or `NotDecodable`) selects
+                // the warning recorded below, mirroring Asciidoctor's distinct
+                // `include file not found`, `include file not readable`, and
+                // `invalid byte sequence in UTF-8` messages.
                 let resolution = self
                     .parser
                     .include_file_handler
@@ -661,13 +662,27 @@ impl<'p> PreprocessorState<'p> {
                 // Matched exhaustively (no catch-all) on purpose: although
                 // `IncludeResolution` is `non_exhaustive` for downstream crates,
                 // within this crate a new reason must be handled here
-                // deliberately – likely with its own warning – rather than
-                // silently collapsing into "not found".
-                let (include_content, not_readable) = match resolution {
-                    IncludeResolution::Found(content) => (Some(content), false),
-                    IncludeResolution::NotReadable => (None, true),
-                    IncludeResolution::NotFound => (None, false),
-                };
+                // deliberately – with its own warning – rather than silently
+                // collapsing into "not found". Each failure reason carries the
+                // `WarningType` constructor (a `fn(String) -> WarningType`) used
+                // to build its warning below, once the target is available to
+                // move in. The constructor paired with `Found` is never used.
+                let (include_content, failure_warning): (_, fn(String) -> WarningType) =
+                    match resolution {
+                        IncludeResolution::Found(content) => {
+                            (Some(content), WarningType::IncludeFileNotFound)
+                        }
+
+                        IncludeResolution::NotReadable => {
+                            (None, WarningType::IncludeFileNotReadable)
+                        }
+
+                        IncludeResolution::NotDecodable => {
+                            (None, WarningType::IncludeFileNotDecodable)
+                        }
+
+                        IncludeResolution::NotFound => (None, WarningType::IncludeFileNotFound),
+                    };
 
                 if let Some(include_content) = include_content {
                     // Apply `lines`/`tag(s)` selection and `indent` normalization
@@ -872,13 +887,10 @@ impl<'p> PreprocessorState<'p> {
                 } else {
                     // The target could not be resolved. Replace the directive with
                     // an "Unresolved directive" message and record a warning. A
-                    // file that exists but can't be read is reported distinctly
-                    // from a missing one, matching Asciidoctor.
-                    let warning = if not_readable {
-                        WarningType::IncludeFileNotReadable(target)
-                    } else {
-                        WarningType::IncludeFileNotFound(target)
-                    };
+                    // file that exists but can't be read (or can't be decoded as
+                    // UTF-8) is reported distinctly from a missing one, matching
+                    // Asciidoctor.
+                    let warning = failure_warning(target);
 
                     self.emit_unresolved_directive(
                         line.data(),

--- a/parser/src/tests/asciidoctor_rb/reader_test.rs
+++ b/parser/src/tests/asciidoctor_rb/reader_test.rs
@@ -106,6 +106,10 @@ enum MockResolution {
 
     /// A target whose file exists but could not be read.
     NotReadable,
+
+    /// A target whose file exists and was read but is not valid UTF-8 and could
+    /// not be transcoded.
+    NotDecodable,
 }
 
 #[derive(Clone, Debug)]
@@ -154,6 +158,17 @@ impl RecordingIncludeFileHandler {
         }
     }
 
+    /// A handler that records the call but reports the file as present and
+    /// readable yet not valid UTF-8 and impossible to transcode (returns
+    /// [`IncludeResolution::NotDecodable`]), as a real handler would for an
+    /// undeclared non-UTF-8 include.
+    fn undecodable() -> Self {
+        Self {
+            result: MockResolution::NotDecodable,
+            ..Self::new("")
+        }
+    }
+
     /// The `(source, target, encoding)` of every recorded call, in order. A
     /// clone of the handler shares this record with the copy handed to the
     /// parser.
@@ -190,6 +205,8 @@ impl IncludeFileHandler for RecordingIncludeFileHandler {
             MockResolution::NotFound => IncludeResolution::NotFound,
 
             MockResolution::NotReadable => IncludeResolution::NotReadable,
+
+            MockResolution::NotDecodable => IncludeResolution::NotDecodable,
         }
     }
 }
@@ -1928,6 +1945,65 @@ fn should_skip_include_directive_that_references_unreadable_file_if_optional_opt
     assert_eq!(
         probe.calls(),
         vec![(None, "fixtures/chapter-a.adoc".to_owned(), None)]
+    );
+    assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+}
+
+// An undeclared non-UTF-8 include (a file that exists and is readable but is
+// not valid UTF-8, with no `encoding` attribute the handler can transcode) is
+// reported distinctly from a missing or unreadable one. The handler signals it
+// with [`IncludeResolution::NotDecodable`], which the parser surfaces as an
+// `IncludeFileNotDecodable` warning while rendering the same "Unresolved
+// directive" replacement. Asciidoctor treats this as a fatal `invalid byte
+// sequence in UTF-8` error that aborts the conversion; this crate deliberately
+// favors recoverable warnings, so it drops the include instead.
+#[test]
+fn should_replace_include_directive_that_references_undecodable_file_with_message() {
+    let handler = RecordingIncludeFileHandler::undecodable();
+    let probe = handler.clone();
+    let parser = Parser::default()
+        .with_safe_mode(SafeMode::Server)
+        .with_include_file_handler(handler);
+    let (output, _source_map, warnings, _includes) = crate::parser::preprocessor::preprocess(
+        "include::fixtures/iso-8859-1.txt[]\n\ntrailing content",
+        &parser,
+    );
+    assert_eq!(
+        output,
+        "Unresolved directive in (root file) - include::fixtures/iso-8859-1.txt[]\n\ntrailing content\n"
+    );
+    assert_eq!(
+        probe.calls(),
+        vec![(None, "fixtures/iso-8859-1.txt".to_owned(), None)]
+    );
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(
+        warnings[0].warning,
+        WarningType::IncludeFileNotDecodable("fixtures/iso-8859-1.txt".to_owned())
+    );
+}
+
+// `opts=optional` suppresses the unresolved-directive replacement and the
+// warning for an *undecodable* target just as it does for a missing or
+// unreadable one: the directive is dropped silently, leaving only the trailing
+// content. This guards the crate's intentional behavior against regression
+// (twin
+// of `should_skip_include_directive_that_references_unreadable_file_if_optional_option_is_set`).
+#[test]
+fn should_skip_include_directive_that_references_undecodable_file_if_optional_option_is_set() {
+    let handler = RecordingIncludeFileHandler::undecodable();
+    let probe = handler.clone();
+    let parser = Parser::default()
+        .with_safe_mode(SafeMode::Server)
+        .with_include_file_handler(handler);
+    let (output, _source_map, warnings, _includes) = crate::parser::preprocessor::preprocess(
+        "include::fixtures/iso-8859-1.txt[opts=optional]\n\ntrailing content",
+        &parser,
+    );
+    assert_eq!(output, "\ntrailing content\n");
+    assert_eq!(
+        probe.calls(),
+        vec![(None, "fixtures/iso-8859-1.txt".to_owned(), None)]
     );
     assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
 }

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -239,6 +239,18 @@ pub enum WarningType {
     #[error("include file not readable: {0}")]
     IncludeFileNotReadable(String),
 
+    /// An `include::` directive named a file that the configured include file
+    /// handler found and read but which is not valid UTF-8, and which the
+    /// handler could not transcode (no `encoding` attribute, or one it does not
+    /// support). The field is the target as written. Asciidoctor treats this as
+    /// a fatal error (`invalid byte sequence in UTF-8`) that aborts the
+    /// conversion; this crate favors recoverable warnings, so it drops the
+    /// include and records this warning instead. This is distinct from
+    /// [`NonUtf8IncludeEncoding`](Self::NonUtf8IncludeEncoding), which reports
+    /// an unsupported `encoding` request for content the handler *did* return.
+    #[error("include file not decodable (invalid byte sequence in UTF-8): {0}")]
+    IncludeFileNotDecodable(String),
+
     /// An include directive's target referenced a missing attribute while
     /// `attribute-missing` was set to `warn`, so the directive was dropped
     /// without being resolved. (Under `drop-line` the directive line is
@@ -499,6 +511,11 @@ impl std::fmt::Debug for WarningType {
 
             WarningType::IncludeFileNotReadable(target) => f
                 .debug_tuple("WarningType::IncludeFileNotReadable")
+                .field(target)
+                .finish(),
+
+            WarningType::IncludeFileNotDecodable(target) => f
+                .debug_tuple("WarningType::IncludeFileNotDecodable")
                 .field(target)
                 .finish(),
 
@@ -981,6 +998,16 @@ mod tests {
                 assert_eq!(
                     debug_output,
                     "WarningType::IncludeFileNotReadable(\"content.adoc\")"
+                );
+            }
+
+            #[test]
+            fn include_file_not_decodable() {
+                let warning = WarningType::IncludeFileNotDecodable("content.adoc".to_string());
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(
+                    debug_output,
+                    "WarningType::IncludeFileNotDecodable(\"content.adoc\")"
                 );
             }
 


### PR DESCRIPTION
## Summary

Adds a way for an `IncludeFileHandler` to signal that it **found and read** an include file that is **not valid UTF-8** and that it **cannot transcode** (no `encoding` attribute, or one it doesn't support) — the case described in #1020.

Previously the trait docs instructed handlers to return `IncludeResolution::NotFound` in this situation, which made the parser emit `include file not found` — misrepresenting the cause (the file exists and is readable). `NotReadable` was no better (the file *is* readable, just not decodable).

## Changes

- **`IncludeResolution::NotDecodable`** — new variant on the `#[non_exhaustive]` enum for "found and read, but not valid UTF-8 and not transcodable."
- **`WarningType::IncludeFileNotDecodable(String)`** — new `#[non_exhaustive]` warning (`include file not decodable (invalid byte sequence in UTF-8): <target>`), distinct from `NonUtf8IncludeEncoding` (which reports an unsupported `encoding` request for content the handler *did* return).
- **Preprocessor** now maps `NotDecodable` to the new warning, rendering the same `Unresolved directive …` replacement as the other failure reasons. The `resolve_target` result handling was refactored from a `not_readable: bool` to a `fn(String) -> WarningType` failure-warning constructor so all three failure reasons flow through one path.
- **Docs** on `IncludeFileHandler::resolve_target` / `IncludeResolution` updated: an undecodable, non-transcodable include should now return `NotDecodable` (was: `NotFound`).

## Policy

This implements **option 1** from the issue. Asciidoctor treats an undeclared non-UTF-8 include as a **fatal** `invalid byte sequence in UTF-8` error that aborts the conversion; this crate deliberately favors recoverable warnings, so it drops the include and records the new warning instead. A fatal/abort mechanism (option 2) is left out of scope by design — the parser has no way for a handler to abort a parse today.

Both new items are additions to `#[non_exhaustive]` types, so this is backward compatible.

## Tests

- `WarningType::IncludeFileNotDecodable` `Debug` formatting.
- `reader_test`: an undecodable include is replaced with the unresolved-directive message and an `IncludeFileNotDecodable` warning; and with `opts=optional` it is dropped silently with no warning — twins of the existing unreadable-file tests.

`cargo +nightly fmt --all --check`, `cargo clippy --all-targets`, `cargo doc` (with `-D warnings`), and the full `asciidoc-parser` lib test suite all pass.

Closes #1020

🤖 Generated with [Claude Code](https://claude.com/claude-code)