### PR TITLE
fix: Ignore an empty block anchor `[[]]` instead of rendering it literally

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -123,11 +123,11 @@ impl<'src> std::fmt::Debug for Block<'src> {
 /// Outcome of attempting to parse a single [`Block`].
 ///
 /// Most blocks parse to [`Parsed`](Self::Parsed). [`Dropped`](Self::Dropped)
-/// supports `attribute-missing=drop-line`: when a block-macro target references
-/// a missing attribute, Asciidoctor discards the whole block, which the parser
-/// must distinguish both from a successful parse and from "no block matched"
-/// (so the block-collection loops advance past the dropped source rather than
-/// spinning or mis-parsing it).
+/// covers input that was consumed but yields no block – a drop-line block
+/// macro, or block metadata (such as a lone empty `[[]]` anchor) that decorates
+/// no block – which the parser must distinguish both from a successful parse
+/// and from "no block matched" (so the block-collection loops advance past the
+/// consumed source rather than spinning or mis-parsing it).
 // `Parsed` embeds a `Block`, which is itself a large enum (see the matching
 // allow on `Block`). This outcome is short-lived and returned by value on the
 // hot parse path, so boxing it would just trade the size for an allocation.
@@ -136,10 +136,16 @@ pub(crate) enum BlockParseOutcome<'src> {
     /// A block was parsed.
     Parsed(MatchedItem<'src, Block<'src>>),
 
-    /// The input was recognized as a block macro but dropped at parse time
-    /// because its target referenced a missing attribute under
-    /// `attribute-missing=drop-line`. The contained span is where parsing
-    /// should resume (the dropped block's `after`).
+    /// The input was consumed but yielded no block, so parsing must resume at
+    /// the contained span (where the consumed input ends) rather than treat the
+    /// source as unmatched. Two cases produce this:
+    ///
+    /// * A block macro whose target referenced a missing attribute under
+    ///   `attribute-missing=drop-line`, which Asciidoctor discards entirely.
+    ///
+    /// * Block metadata that named nothing and decorates no block – notably a
+    ///   lone empty `[[]]` anchor at the end of a block scope – which is
+    ///   dropped rather than rendered.
     Dropped(Span<'src>),
 
     /// No block matched. This happens only for empty or all-blank input.
@@ -652,24 +658,39 @@ impl<'src> Block<'src> {
                 SimpleBlock::parse(&metadata, parser)
             };
 
-            if simple_block_mi.is_none() && !metadata.is_empty() {
-                // We have a metadata with no block. Treat it as a simple block but issue a
-                // warning.
+            if simple_block_mi.is_none() {
+                if !metadata.is_empty() {
+                    // We have a metadata with no block. Treat it as a simple block but issue a
+                    // warning.
 
-                warnings.push(Warning {
-                    source: metadata.source,
-                    warning: WarningType::MissingBlockAfterTitleOrAttributeList,
-                    origin: None,
-                });
+                    warnings.push(Warning {
+                        source: metadata.source,
+                        warning: WarningType::MissingBlockAfterTitleOrAttributeList,
+                        origin: None,
+                    });
 
-                // Remove the metadata content so that SimpleBlock will read the title/attrlist
-                // line(s) as regular content. The speculative parse failed, so the
-                // block is re-parsed below with this stripped metadata.
-                metadata.title_source = None;
-                metadata.title = None;
-                metadata.anchor = None;
-                metadata.attrlist = None;
-                metadata.block_start = metadata.source;
+                    // Remove the metadata content so that SimpleBlock will read the title/attrlist
+                    // line(s) as regular content. The speculative parse failed, so the
+                    // block is re-parsed below with this stripped metadata.
+                    metadata.title_source = None;
+                    metadata.title = None;
+                    metadata.anchor = None;
+                    metadata.attrlist = None;
+                    metadata.block_start = metadata.source;
+                } else if !metadata.source.data().is_empty() {
+                    // The metadata scan consumed one or more do-nothing lines
+                    // (e.g. a lone empty `[[]]` anchor) that produced no title,
+                    // anchor, or attribute list, and no block follows them. The
+                    // lines are still consumed, so report the source as dropped
+                    // (resuming at `block_start`) rather than falling through to
+                    // `NoMatch`: a non-blank source left unadvanced would spin
+                    // the block-collection loop. Genuinely empty/blank input
+                    // (nothing consumed) still reaches `NoMatch` below.
+                    return MatchAndWarnings {
+                        item: BlockParseOutcome::Dropped(metadata.block_start),
+                        warnings,
+                    };
+                }
             }
         }
 

--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -96,45 +96,54 @@ impl<'src> BlockMetadata<'src> {
             }
 
             if let Some(mi) = anchor_maw.item {
-                if let Some(comma_position) = mi.item.position(|c| c == ',')
-                    && comma_position < mi.item.len() - 1
-                {
-                    let anchor_span = mi.item.slice_to(RangeTo {
-                        end: comma_position,
-                    });
-                    let reftext_span = mi.item.slice_from(RangeFrom {
-                        start: comma_position + 1,
-                    });
-
-                    // Validate anchor name.
-                    if anchor_span.is_xml_name() {
-                        anchor = Some(anchor_span);
-                        reftext = Some(reftext_span);
-                        block_start = mi.after;
-                    } else {
-                        warnings.push(Warning {
-                            source: anchor_span,
-                            warning: WarningType::InvalidBlockAnchorName,
-                            origin: None,
+                if let Some(anchor_content) = mi.item {
+                    if let Some(comma_position) = anchor_content.position(|c| c == ',')
+                        && comma_position < anchor_content.len() - 1
+                    {
+                        let anchor_span = anchor_content.slice_to(RangeTo {
+                            end: comma_position,
                         });
+
+                        let reftext_span = anchor_content.slice_from(RangeFrom {
+                            start: comma_position + 1,
+                        });
+
+                        // Validate anchor name.
+                        if anchor_span.is_xml_name() {
+                            anchor = Some(anchor_span);
+                            reftext = Some(reftext_span);
+                            block_start = mi.after;
+                        } else {
+                            warnings.push(Warning {
+                                source: anchor_span,
+                                warning: WarningType::InvalidBlockAnchorName,
+                                origin: None,
+                            });
+                        }
+                    } else {
+                        // Validate anchor name.
+                        if anchor_content.is_xml_name() {
+                            anchor = Some(anchor_content);
+
+                            // A later plain anchor (`[[foo]]`) clears any reftext
+                            // carried by an earlier `[[bar,text]]`, keeping the
+                            // last-wins semantics consistent across both fields.
+                            reftext = None;
+                            block_start = mi.after;
+                        } else {
+                            warnings.push(Warning {
+                                source: anchor_content,
+                                warning: WarningType::InvalidBlockAnchorName,
+                                origin: None,
+                            });
+                        }
                     }
                 } else {
-                    // Validate anchor name.
-                    if mi.item.is_xml_name() {
-                        anchor = Some(mi.item);
-
-                        // A later plain anchor (`[[foo]]`) clears any reftext
-                        // carried by an earlier `[[bar,text]]`, keeping the
-                        // last-wins semantics consistent across both fields.
-                        reftext = None;
-                        block_start = mi.after;
-                    } else {
-                        warnings.push(Warning {
-                            source: mi.item,
-                            warning: WarningType::InvalidBlockAnchorName,
-                            origin: None,
-                        });
-                    }
+                    // An empty `[[]]` anchor names nothing. Consume the line so
+                    // it is not emitted as a literal paragraph, but leave the
+                    // running anchor untouched (matching Asciidoctor, which
+                    // drops it). The empty-anchor warning was collected above.
+                    block_start = mi.after;
                 }
 
                 if block_start != original_block_start {
@@ -357,7 +366,7 @@ pub(crate) fn block_title_text(line: Span<'_>) -> Option<Span<'_>> {
 
 fn parse_maybe_block_anchor(
     source: Span<'_>,
-) -> MatchAndWarnings<'_, Option<MatchedItem<'_, Span<'_>>>> {
+) -> MatchAndWarnings<'_, Option<MatchedItem<'_, Option<Span<'_>>>>> {
     if !source.starts_with("[[") {
         return MatchAndWarnings {
             item: None,
@@ -380,8 +389,16 @@ fn parse_maybe_block_anchor(
     // Drop opening and closing brace pairs now that we know they are there.
     let anchor_src = line.slice(2..line.len() - 2);
     if anchor_src.is_empty() {
+        // An empty `[[]]` anchor is still a recognized (if do-nothing) anchor
+        // line: it names nothing, so the caller consumes it – setting no anchor
+        // – rather than leaving it to render as a literal paragraph (matching
+        // Asciidoctor, which drops it). The `None` payload signals the empty
+        // form, and the warning notes that the anchor name was empty.
         return MatchAndWarnings {
-            item: None,
+            item: Some(MatchedItem {
+                item: None,
+                after: block_start,
+            }),
             warnings: vec![Warning {
                 source: anchor_src,
                 warning: WarningType::EmptyBlockAnchorName,
@@ -392,7 +409,7 @@ fn parse_maybe_block_anchor(
 
     MatchAndWarnings {
         item: Some(MatchedItem {
-            item: anchor_src,
+            item: Some(anchor_src),
             after: block_start,
         }),
         warnings: vec![],

--- a/parser/src/blocks/tests/simple.rs
+++ b/parser/src/blocks/tests/simple.rs
@@ -821,12 +821,12 @@ fn err_empty_block_anchor() {
         Block::Simple(SimpleBlock {
             content: Content {
                 original: Span {
-                    data: "[[]]\nThis paragraph gets a lot of attention.",
-                    line: 1,
+                    data: "This paragraph gets a lot of attention.",
+                    line: 2,
                     col: 1,
-                    offset: 0,
+                    offset: 5,
                 },
-                rendered: "[[]]\nThis paragraph gets a lot of attention.",
+                rendered: "This paragraph gets a lot of attention.",
             },
             source: Span {
                 data: "[[]]\nThis paragraph gets a lot of attention.",
@@ -858,7 +858,7 @@ fn err_empty_block_anchor() {
     assert_eq!(mi.item.content_model(), ContentModel::Simple);
     assert_eq!(
         mi.item.rendered_content(),
-        Some("[[]]\nThis paragraph gets a lot of attention.")
+        Some("This paragraph gets a lot of attention.")
     );
     assert_eq!(mi.item.raw_context().deref(), "paragraph");
     assert_eq!(mi.item.resolved_context().deref(), "paragraph");

--- a/parser/src/blocks/tests/simple.rs
+++ b/parser/src/blocks/tests/simple.rs
@@ -886,6 +886,39 @@ fn err_empty_block_anchor() {
 }
 
 #[test]
+fn terminal_empty_block_anchor_does_not_spin() {
+    // A lone empty `[[]]` anchor at the end of a block scope names nothing and
+    // decorates no block, so it is consumed (dropped) and yields no block.
+    // Regression: an empty anchor consumed into empty metadata with no block
+    // following once returned `NoMatch` on a non-blank source, which the
+    // block-collection loop leaves unadvanced – spinning forever.
+    let doc = Parser::default().parse("--\nBlock content\n[[]]\n--\n");
+
+    let block = doc.child_blocks().next().unwrap();
+    assert_eq!(block.raw_context().deref(), "open");
+
+    // Only the paragraph survives inside the open block; the trailing `[[]]`
+    // produces nothing.
+    let mut inner = block.child_blocks();
+    assert_eq!(
+        inner.next().unwrap().rendered_content(),
+        Some("Block content")
+    );
+    assert!(inner.next().is_none());
+
+    assert_eq!(doc.child_blocks().count(), 1);
+}
+
+#[test]
+fn lone_empty_block_anchor_document_does_not_spin() {
+    // An empty `[[]]` anchor as the entire document body is consumed and
+    // produces no block (rather than hanging or rendering the literal `[[]]`).
+    let doc = Parser::default().parse("[[]]\n");
+
+    assert_eq!(doc.child_blocks().count(), 0);
+}
+
+#[test]
 fn err_invalid_block_anchor() {
     let mut parser = Parser::default();
 

--- a/parser/src/tests/asciidoc_lang/attributes/id.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/id.rs
@@ -71,12 +71,12 @@ All the language requires in this case is that the value be non-empty.
             Block::Simple(SimpleBlock {
                 content: Content {
                     original: Span {
-                        data: "[[]]\nThis paragraph gets a lot of attention.",
-                        line: 1,
+                        data: "This paragraph gets a lot of attention.",
+                        line: 2,
                         col: 1,
-                        offset: 0,
+                        offset: 5,
                     },
-                    rendered: "[[]]\nThis paragraph gets a lot of attention.",
+                    rendered: "This paragraph gets a lot of attention.",
                 },
                 source: Span {
                     data: "[[]]\nThis paragraph gets a lot of attention.",

--- a/parser/src/tests/asciidoctor_rb/blocks_test.rs
+++ b/parser/src/tests/asciidoctor_rb/blocks_test.rs
@@ -4878,12 +4878,6 @@ mod metadata {
         refute_rendered_contains(&doc, "[]");
     }
 
-    // NOTE: divergence from Asciidoctor. An empty block anchor `[[]]` is not
-    // recognized as an (empty) anchor by this crate and is rendered as a
-    // paragraph containing the literal text `[[]]`. Kept `#[ignore]`d with the
-    // Ruby-intended assertions.
-    // TODO: treat an empty block anchor `[[]]` as an ignored anchor.
-    #[ignore]
     #[test]
     fn empty_block_anchor_should_not_appear_in_output() {
         verifies!(


### PR DESCRIPTION
## Summary

Fixes #1023.

An empty bracketed block anchor (`[[]]`) on its own line above a block names nothing. Asciidoctor drops it, but this crate was leaving the line in place, so it rendered as a literal `[[]]` paragraph ahead of the block:

```adoc
[[]]
--
Block content
--
```

Before this change the parser emitted an extra `<div class="paragraph"><p>[[]]</p></div>` before the open block; now the `[[]]` line is recognized as a do-nothing anchor and consumed.

## Changes

- `parse_maybe_block_anchor` now distinguishes three cases: not an anchor line, an empty `[[]]` anchor (consumed, no name), and a named anchor. The empty form is carried as a `Some(MatchedItem { item: None, .. })` payload so the caller advances past the line and sets no anchor.
- The empty-anchor warning (`EmptyBlockAnchorName`) is still emitted — an empty anchor is flagged, just no longer rendered literally. This mirrors the crate's existing extra diagnostics (e.g. `InvalidBlockAnchorName`).
- A non-empty but invalid anchor name (e.g. `[[3 blind mice]]`) is unchanged: it does not match the anchor form, stays in place, and renders literally with an `InvalidBlockAnchorName` warning.

## Tests

- Un-ignored the ported Asciidoctor `blocks_test.rb` case `empty_block_anchor_should_not_appear_in_output` (the exact repro), which now passes.
- Updated `err_empty_block_anchor` and the `id.rs` `value_non_empty` spec test: the block content no longer includes the consumed `[[]]` line (the warning assertion is retained).

Full `cargo test -p asciidoc-parser` passes (4554 tests), plus `cargo +nightly fmt --all -- --check` and `cargo clippy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)