### PR TITLE
fix: Coerce a leveloffset-shifted level-0 heading to the document title

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -1272,6 +1272,18 @@ mod tests {
     }
 
     #[test]
+    fn leveloffset_does_not_coerce_an_over_deep_heading_to_the_doctitle() {
+        // A marker run deeper than `======` is not a valid heading at all, so
+        // even a negative `:leveloffset:` whose shift would drive its effective
+        // level to 0 must not coerce it to the document title. It stays body
+        // content (which the block parser then reports as exceeding the maximum
+        // heading level), leaving the document with no doctitle.
+        let doc = Parser::default().parse(":leveloffset: -6\n======= Not A Title");
+
+        assert_eq!(doc.doctitle(), None);
+    }
+
+    #[test]
     fn impl_clone() {
         // Silly test to mark the #[derive(...)] line as covered.
         let mut parser = Parser::default();

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -703,9 +703,12 @@ fn document_title_marker(line: Span<'_>, level_offset: i32) -> Option<(char, usi
         return None;
     }
 
-    // The marker run must be followed by a space, matching the original `"= "` /
-    // `"# "` test (and the whitespace requirement of the section-title regex).
-    if !data[count..].starts_with(' ') {
+    // The marker run must be followed by a blank – a space or a tab – matching
+    // the section parser's `take_required_whitespace` and Asciidoctor's
+    // `[ \t]+` in the section-title regex. Accepting a tab (not just a space)
+    // keeps a tab-delimited heading shifted to effective level 0 on the same
+    // doctitle path as its space-delimited form.
+    if !data[count..].starts_with([' ', '\t']) {
         return None;
     }
 

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -233,7 +233,7 @@ impl<'src> Header<'src> {
             } else if title.is_none()
                 && line.starts_with('[')
                 && line.ends_with(']')
-                && document_title_follows_block_metadata(source)
+                && document_title_follows_block_metadata(source, parser.level_offset())
                 && let Some((metadata, metadata_warnings)) = parse_document_metadata(line, parser)
             {
                 warnings.extend(metadata_warnings);
@@ -279,14 +279,14 @@ impl<'src> Header<'src> {
                 }
                 source = line_mi.after;
             } else if title.is_none()
-                && let Some(marker) = document_title_marker(line)
+                && let Some((marker, count)) = document_title_marker(line, parser.level_offset())
             {
-                // Strip an optional symmetric close (a trailing ` =` or ` #`
-                // matching the single opening marker), mirroring section titles.
+                // Strip an optional symmetric close (a trailing ` ==` or ` ##`
+                // matching the opening marker run), mirroring section titles.
                 let title_span = crate::blocks::strip_symmetric_title_close(
-                    line.discard(2).discard_whitespace(),
+                    line.discard(count).discard_whitespace(),
                     marker,
-                    1,
+                    count,
                 );
                 saw_implicit_title = true;
 
@@ -630,21 +630,54 @@ fn skip_block_comment<'src>(line: Span<'src>, after: Span<'src>) -> Option<(Span
     Some((next, terminated))
 }
 
-/// Returns the ATX marker character that introduces `line` as a document
-/// title, or `None` if the line is not a document title.
+/// Returns the ATX marker character and its run length for a `line` that is a
+/// document title under the running `level_offset`, or `None` if the line is
+/// not a document title.
 ///
 /// Both the AsciiDoc marker (`=`) and the Markdown-style marker (`#`) are
 /// accepted, mirroring the alternation at the head of Asciidoctor's
-/// section-title regex. The marker character is returned so the caller can
-/// require a symmetric close to use the same marker.
-fn document_title_marker(line: Span<'_>) -> Option<char> {
-    if line.starts_with("= ") {
-        Some('=')
-    } else if line.starts_with("# ") {
-        Some('#')
+/// section-title regex. A line is the document title when its *effective* level
+/// – the syntactic level (marker run length minus one) shifted by
+/// `level_offset` – is 0, mirroring Asciidoctor's `is_next_line_doctitle?`.
+/// With no offset in effect this is exactly a single `=`/`#` marker; a negative
+/// `:leveloffset:` lets a deeper heading (`==` under `-1`) coerce to the
+/// document title, and a positive offset stops a bare `=` from being one.
+///
+/// The marker character and run length are returned so the caller can strip the
+/// markers and require a symmetric close of the same character and width.
+fn document_title_marker(line: Span<'_>, level_offset: i32) -> Option<(char, usize)> {
+    let data = line.data();
+
+    let marker = if data.starts_with('=') {
+        '='
+    } else if data.starts_with('#') {
+        '#'
     } else {
-        None
+        return None;
+    };
+
+    // Count the leading marker run; a run longer than six is not a heading at
+    // all (`======` is the deepest section title).
+    let count = data.chars().take_while(|&c| c == marker).count();
+    if count > 6 {
+        return None;
     }
+
+    // The marker run must be followed by a space, matching the original `"= "` /
+    // `"# "` test (and the whitespace requirement of the section-title regex).
+    if !data[count..].starts_with(' ') {
+        return None;
+    }
+
+    // The effective level – the syntactic level (run length minus one) shifted
+    // by the running `leveloffset` – must be 0 for the line to be the document
+    // title.
+    let syntactic_level = (count as i32) - 1;
+    if syntactic_level.saturating_add(level_offset) != 0 {
+        return None;
+    }
+
+    Some((marker, count))
 }
 
 /// Reports whether a *promotable* document title follows the block metadata run
@@ -674,7 +707,7 @@ fn document_title_marker(line: Span<'_>) -> Option<char> {
 /// none leaves it unchanged – so the header's decision always agrees with the
 /// `BlockMetadata::is_discrete` decision the block parser would make on the
 /// same run.
-fn document_title_follows_block_metadata(source: Span<'_>) -> bool {
+fn document_title_follows_block_metadata(source: Span<'_>, level_offset: i32) -> bool {
     let mut next = source;
     let mut effective_style_is_discrete = false;
 
@@ -682,7 +715,7 @@ fn document_title_follows_block_metadata(source: Span<'_>) -> bool {
         let line_mi = next.take_normalized_line();
         let line = line_mi.item;
 
-        if document_title_marker(line).is_some() {
+        if document_title_marker(line, level_offset).is_some() {
             return !effective_style_is_discrete;
         }
 

--- a/parser/src/tests/asciidoctor_rb/sections_test.rs
+++ b/parser/src/tests/asciidoctor_rb/sections_test.rs
@@ -1286,22 +1286,50 @@ mod levels {
             assert_eq!(doc.doctitle(), Some("My Title"));
         }
 
-        // NOTE: A negative `leveloffset` promoting a body heading into the
-        // document title is not modeled — `:leveloffset: -1` above `== Document
-        // Title` leaves it a level-1 section rather than the document title. Out
-        // of scope.
-        non_normative!(
-            r##"
+        // A `:leveloffset:` shift that drives a heading to effective level 0
+        // coerces it to the document title, exactly as a bare `=` would. The
+        // crate models embedded output, which does not frame the doctitle in an
+        // `<h1>`, so the promotion is verified through [`Document::doctitle`]; a
+        // doctitle carries no `id`, matching the `not(@id)` in the Ruby
+        // assertions.
+        #[test]
+        fn document_title_created_from_leveloffset_shift_defined_in_document() {
+            verifies!(
+                r##"
       test 'document title created from leveloffset shift defined in document' do
         assert_xpath "//h1[not(@id)][text() = 'Document Title']", convert_string(%(:leveloffset: -1\n== Document Title))
       end
 
+"##
+            );
+
+            let doc = Parser::default().parse(":leveloffset: -1\n== Document Title");
+            assert_eq!(doc.doctitle(), Some("Document Title"));
+            assert_eq!(doc.header().id(), None);
+            assert!(doc.warnings().next().is_none());
+        }
+
+        #[test]
+        fn document_title_created_from_leveloffset_shift_defined_in_api() {
+            verifies!(
+                r##"
       test 'document title created from leveloffset shift defined in API' do
         assert_xpath "//h1[not(@id)][text() = 'Document Title']", convert_string('== Document Title', attributes: { 'leveloffset' => '-1@' })
       end
 
 "##
-        );
+            );
+
+            // The Ruby `'-1@'` sets `leveloffset` via the API as a soft default
+            // the document may override, which maps to a modification context of
+            // [`ModificationContext::Anywhere`].
+            let doc = Parser::default()
+                .with_intrinsic_attribute("leveloffset", "-1", ModificationContext::Anywhere)
+                .parse("== Document Title");
+            assert_eq!(doc.doctitle(), Some("Document Title"));
+            assert_eq!(doc.header().id(), None);
+            assert!(doc.warnings().next().is_none());
+        }
 
         // NOTE: A document-level ID above the document title sets the `id` on
         // the standalone `<body>`. This crate models embedded output, which has

--- a/parser/src/tests/asciidoctor_rb/sections_test.rs
+++ b/parser/src/tests/asciidoctor_rb/sections_test.rs
@@ -1331,6 +1331,20 @@ mod levels {
             assert!(doc.warnings().next().is_none());
         }
 
+        // A tab (not just a space) may separate the marker run from the title, so
+        // a tab-delimited heading shifted to effective level 0 is coerced to the
+        // document title exactly as its space-delimited form is – matching the
+        // section parser's `[ \t]+` whitespace handling. This edge is not covered
+        // by a Ruby test, but guards against the header recognizer and the body
+        // section parser disagreeing on what counts as a heading.
+        #[test]
+        fn document_title_from_leveloffset_shift_allows_a_tab_after_the_marker() {
+            let doc = Parser::default().parse(":leveloffset: -1\n==\tDocument Title");
+            assert_eq!(doc.doctitle(), Some("Document Title"));
+            assert_eq!(doc.header().id(), None);
+            assert!(doc.warnings().next().is_none());
+        }
+
         // NOTE: A document-level ID above the document title sets the `id` on
         // the standalone `<body>`. This crate models embedded output, which has
         // no `<body>` element, so the `body#id` assertions below are out of


### PR DESCRIPTION
Fixes #1025.

## Problem

When a `:leveloffset:` shift drives a section heading to effective level 0, that heading should be coerced to the **document title** (doctitle). `asciidoc-parser` applied the offset to ordinary levels but skipped the level-0 → doctitle coercion, so a heading such as `== Document Title` under `:leveloffset: -1` clamped to a level-1 section instead of becoming the doctitle.

- **Asciidoctor:** `//h1[not(@id)][text()="Document Title"]` — a doctitle.
- **asciidoc-parser (v0.29.2):** a level-1 section.

## Fix

The header's document-title detection (`document_title_marker`) now recognizes any ATX heading whose *effective* level — the syntactic level shifted by the running `leveloffset` — is 0, rather than only a bare `=`/`#`. This mirrors Asciidoctor's `is_next_line_doctitle?`:

- With **no offset**, behavior is unchanged: exactly a single `=`/`#` marker is the doctitle.
- A **negative** `:leveloffset:` lets a deeper heading (`==` under `-1`) coerce to the doctitle.
- A **positive** offset stops a bare `=` from being the doctitle (it becomes an ordinary section), also matching Asciidoctor.

The symmetric-close stripping and the block-metadata lookahead were updated to use the actual marker run length rather than assuming a single marker.

## Tests

The two Ruby `document title created from leveloffset shift …` tests (defined-in-document and defined-in-API variants) were promoted from `non_normative!` to real `verifies!` tests in `parser/src/tests/asciidoctor_rb/sections_test.rs`. The crate models embedded output (no `<h1>` frame for the doctitle), so promotion is verified through `Document::doctitle`, with the doctitle carrying no `id` (matching the Ruby `not(@id)` assertion).

Full suite: 4555 passed, 0 failed; `cargo +nightly fmt --all -- --check` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)