### PR TITLE
fix: Recognize a block title above the document title as document metadata

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -1,6 +1,7 @@
 use crate::{
     HasSpan, Parser, Span,
     attributes::{Attrlist, AttrlistContext},
+    blocks::metadata::block_title_text,
     content::{Content, SubstitutionGroup, substitute_attributes_in_reftext},
     document::{
         Attribute, Author, AuthorLine, InterpretedValue, RefType, RevisionLine,
@@ -65,6 +66,7 @@ impl<'src> Header<'src> {
 
         let mut id: Option<String> = None;
         let mut roles: Vec<String> = vec![];
+        let mut pending_block_title_source: Option<Span<'src>> = None;
         let mut attributes: Vec<Attribute> = vec![];
         let mut author_line: Option<AuthorLine<'src>> = None;
         let mut author_attribute: Option<Author> = None;
@@ -279,6 +281,30 @@ impl<'src> Header<'src> {
                 }
                 source = line_mi.after;
             } else if title.is_none()
+                && let Some(block_title) = block_title_text(line)
+                && document_title_follows_block_metadata(source)
+            {
+                // A block title (`.Title`) directly above the document title is
+                // not a title *of* the document – a document has no block title.
+                // Asciidoctor demotes the following `= …` heading to a level-0
+                // section and carries the block title over to the first block of
+                // content. This crate does not represent a body-level document
+                // title as a level-0 section, so the `= …` heading remains the
+                // document title; the block title is still recognized here (so
+                // the heading is not mistaken for a paragraph) and carried over
+                // to the first body block, matching the block-title carryover
+                // above an ordinary section heading (see #782).
+                //
+                // The line is only intercepted when a document title eventually
+                // follows – possibly after further stacked block metadata lines,
+                // each folded on its own pass through this loop. A later block
+                // title overrides an earlier one (last-wins), mirroring
+                // Asciidoctor's `parse_block_metadata_lines`. Otherwise it is an
+                // ordinary block title for the body and is left for the block
+                // parser.
+                pending_block_title_source = Some(block_title);
+                source = line_mi.after;
+            } else if title.is_none()
                 && let Some(marker) = document_title_marker(line)
             {
                 // Strip an optional symmetric close (a trailing ` =` or ` #`
@@ -455,6 +481,20 @@ impl<'src> Header<'src> {
         // author-less parse from touching the attribute map at all.
         if !authors.is_empty() {
             parser.set_attribute_by_value_from_header("authorcount", authors.len().to_string());
+        }
+
+        // A block title recognized directly above the document title is carried
+        // over to the first block of the body. Stash it on the parser as a
+        // pending block title (the same mechanism a section heading uses); the
+        // first block parsed after the header claims it. The title travels as an
+        // owned snapshot with normal (title) substitutions already applied,
+        // matching a `.Title` line on an ordinary block. It is only ever set
+        // when a document title was seen, since the recognizing branch requires
+        // one to follow.
+        if let Some(block_title) = pending_block_title_source {
+            let mut content = Content::from(block_title);
+            SubstitutionGroup::Normal.apply(&mut content, parser, None);
+            parser.pending_block_title = Some(content.to_owned_title());
         }
 
         MatchAndWarnings {
@@ -652,8 +692,9 @@ fn document_title_marker(line: Span<'_>) -> Option<char> {
 /// scan).
 ///
 /// Consecutive document-metadata block attribute lines (see
-/// [`is_document_metadata_line`]) are consumed, and the first line that is not
-/// one is tested for a document title marker. This generalizes the original
+/// [`is_document_metadata_line`]) and block title lines (`.Title`, see
+/// [`block_title_text`]) are consumed, and the first line that is neither is
+/// tested for a document title marker. This generalizes the original
 /// single-line lookahead so that stacked metadata lines above the title are all
 /// folded, mirroring Asciidoctor's `parse_block_metadata_lines`.
 ///
@@ -684,6 +725,14 @@ fn document_title_follows_block_metadata(source: Span<'_>) -> bool {
 
         if document_title_marker(line).is_some() {
             return !effective_style_is_discrete;
+        }
+
+        // A block title (`.Title`) may appear anywhere in the metadata run above
+        // the document title; it carries no block style, so it leaves the
+        // running effective style unchanged and the scan continues.
+        if block_title_text(line).is_some() {
+            next = line_mi.after;
+            continue;
         }
 
         if !is_document_metadata_line(line) {

--- a/parser/src/tests/asciidoctor_rb/blocks_test.rs
+++ b/parser/src/tests/asciidoctor_rb/blocks_test.rs
@@ -4758,16 +4758,24 @@ mod metadata {
         assert_xpath(&doc, "//*[@class=\"paragraph\"]/p[text()=\"paragraph\"]", 1);
     }
 
-    // NOTE: out of scope. Both tests below depend on demoting a body-level
-    // document title (`= Title`) to a level-0 section — the "level 0 sections
-    // can only be used when doctype is book" behavior. This crate does not
-    // support level-0 sections in the document body (with or without
-    // `doctype: book`): a `=` heading in the body is declined as an unsupported
-    // level-0 heading rather than becoming a level-0 section, so the demoted
-    // `<h1>`/`.sect1` structure these tests assert is never produced. That is a
-    // deliberate divergence, not a deferral, so the tests are reproduced
-    // verbatim (`non_normative!`) rather than ported. The block-title carryover
-    // they also exercise is itself implemented (#782); see
+    // NOTE: partially out of scope. Both tests below depend on demoting a
+    // body-level document title (`= Title`) to a level-0 section – the "level 0
+    // sections can only be used when doctype is book" behavior. This crate does
+    // not support level-0 sections in the document body (with or without
+    // `doctype: book`): a `=` heading is recognized as the *document title*
+    // rather than becoming a level-0 section, so the demoted `<h1>`/`.sect1`
+    // structure and the absent header these tests assert are never produced.
+    // That is a deliberate divergence, not a deferral, so the tests are
+    // reproduced verbatim (`non_normative!`) rather than ported.
+    //
+    // The block-title recognition and carryover they exercise *is* implemented:
+    // a block title directly above the document title is recognized as document
+    // metadata (rather than titling a paragraph that captures the `= Title` line
+    // as literal text), and is carried over to the first block of the body, the
+    // same way a block title above an ordinary section heading is (#782). The
+    // crate's actual behavior on the first input is asserted by
+    // `block_title_above_document_title_is_carried_over_to_first_body_block`
+    // below; see also
     // `block_title_above_section_gets_carried_over_to_first_block_in_section`.
     non_normative!(
         r#"
@@ -4806,6 +4814,35 @@ mod metadata {
 
 "#
     );
+
+    // The crate-specific counterpart to the first `non_normative!` test above.
+    // Asciidoctor demotes the `= Section Title` heading to a level-0 body
+    // section (leaving the document header empty); this crate does not model a
+    // body-level document title as a level-0 section, so it keeps `= Section
+    // Title` as the document title. The point that both share – and that this
+    // asserts – is that the block title above the title is recognized as
+    // metadata and carried over to the first block of the body, rather than
+    // titling a paragraph whose text is the escaped `= Section Title` line.
+    #[test]
+    fn block_title_above_document_title_is_carried_over_to_first_body_block() {
+        let doc = Parser::default().parse(".Block title\n= Section Title\n\nsection paragraph\n");
+
+        // `= Section Title` is the document title, not literal paragraph text.
+        assert_eq!(doc.header().title(), Some("Section Title"));
+
+        // The block title is carried over to the (single) body paragraph.
+        assert_xpath(&doc, "//*[@class=\"paragraph\"]", 1);
+        assert_xpath(
+            &doc,
+            "//*[@class=\"paragraph\"]/*[@class=\"title\"][text()=\"Block title\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "//*[@class=\"paragraph\"]/p[text()=\"section paragraph\"]",
+            1,
+        );
+    }
 
     // NOTE: divergence from Asciidoctor. This crate does not render a macro
     // link inside a block title (nor were the referenced attributes supplied),


### PR DESCRIPTION
Fixes #1022.

## Problem

A block title line (`.Title`) directly above the document title (`= …`) was not recognized in the document header. The header parser broke on the `.Title` line, leaving the whole run for the block parser, which:

- treated `= Section Title` as an unsupported level-0 heading and demoted it to a paragraph whose text was the escaped `= Section Title` line, and
- attached the block title to *that* paragraph.

So for:

```asciidoc
.Block title
= Section Title

section paragraph
```

the parser produced a paragraph titled "Block title" whose body was the literal text `= Section Title`, plus a second `section paragraph`.

## Fix

Recognize the block title in the header parser, paralleling the existing handling of block **attributes** (`[reftext=…]`, `[#id]`) and **anchors** (`[[id]]`) above the document title:

- `= Section Title` is kept as the **document title**.
- The block title is carried over to the **first block of the body** (here, `section paragraph`), using the same `pending_block_title` mechanism a section heading already uses (#782).

The block-title line is only intercepted when a document title actually follows (possibly after further stacked metadata lines). A `[discrete]`/`[float]` run still suppresses folding, a later block title overrides an earlier one (last-wins), and a `.Title` with no following document title is left untouched for the block parser.

## Design note (divergence from Asciidoctor — please confirm)

Asciidoctor demotes the `= …` heading to a **level-0 body section** and leaves the document header empty (`refute doc.header?`, emitting `level 0 sections can only be used when doctype is book`). **This crate deliberately does not model a body-level document title as a level-0 section** (a pre-existing, documented divergence). Rather than leave `= Section Title` as literal paragraph text — the bug this issue reports — the fix keeps it as the document title. This is the crate-consistent parallel to the already-merged block-attribute/anchor cases and makes the `=` line "a title" as the issue asks.

The two Asciidoctor tests that assert the level-0-section demotion and empty header remain reproduced verbatim in a `non_normative!` block (their comment is updated to note the recognition/carryover is now implemented). A new crate-specific test, `block_title_above_document_title_is_carried_over_to_first_body_block`, asserts this crate's actual behavior.

## Verification

- New regression test passes; full suite green (`4554 passed; 0 failed`).
- Edge cases checked manually (stacked attribute + block title in either order, last-wins across two block titles, `[discrete]` suppression, `:doctype: book` with no preamble carrying into the first section's paragraph, and `.Title` with no following title unchanged).
- `cargo +nightly fmt --all -- --check` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)