### PR TITLE
fix: Treat a section heading inside a delimited block as literal content

### DIFF
--- a/parser/src/blocks/compound_delimited.rs
+++ b/parser/src/blocks/compound_delimited.rs
@@ -159,7 +159,17 @@ impl<'src> CompoundDelimitedBlock<'src> {
 
         let inside_delimiters = delimiter.after.trim_remainder(closing_delimiter);
 
+        // A `== …` line inside a delimited block is literal content, not a
+        // section heading (sections are only recognized at the document level or
+        // within a section body). Flag the nested parse so `SectionBlock::parse`
+        // declines; the flag is saved and restored so nested delimited blocks
+        // compose correctly.
+        let previously_in_delimited_block = parser.in_delimited_block;
+        parser.in_delimited_block = true;
+
         let maw_blocks = parse_blocks_until(inside_delimiters, |_, _| false, parser);
+
+        parser.in_delimited_block = previously_in_delimited_block;
 
         let blocks = maw_blocks.item;
         let source = metadata
@@ -2198,5 +2208,48 @@ mod tests {
     attrlist: None,
 }"#
         );
+    }
+
+    mod section_heading_suppressed {
+        //! A `== …` line inside a delimited block is literal content – a
+        //! paragraph – not a section heading (matching Asciidoctor, which only
+        //! creates sections at the document level or within a section body). A
+        //! discrete heading, by contrast, is an ordinary block and remains
+        //! valid inside a delimited block.
+
+        use crate::tests::prelude::*;
+
+        fn assert_literal_heading(input: &str) {
+            let doc = Parser::default().parse(input);
+
+            // No section heading was recognized, so nothing renders as an `<h2>`.
+            assert_xpath(&doc, "//h2", 0);
+
+            // The line survives as ordinary paragraph content.
+            assert!(rendered_paragraphs(&doc).contains(&"== not a heading".to_string()));
+        }
+
+        #[test]
+        fn example_block() {
+            assert_literal_heading("====\n== not a heading\n====\n");
+        }
+
+        #[test]
+        fn open_block() {
+            assert_literal_heading("--\n== not a heading\n--\n");
+        }
+
+        #[test]
+        fn sidebar_block() {
+            assert_literal_heading("****\n== not a heading\n****\n");
+        }
+
+        #[test]
+        fn discrete_heading_is_still_recognized() {
+            // A discrete heading is an ordinary block, not a section, so it is
+            // still recognized inside a delimited block and renders as a heading.
+            let doc = Parser::default().parse("====\n[discrete]\n== Sub\n====\n");
+            assert_xpath(&doc, "//h2", 1);
+        }
     }
 }

--- a/parser/src/blocks/quote.rs
+++ b/parser/src/blocks/quote.rs
@@ -223,7 +223,15 @@ impl<'src> QuoteBlock<'src> {
         let (content_model, content, blocks, mut warnings) = match type_ {
             // A quote block contains other blocks.
             QuoteType::Quote => {
+                // A `== …` line inside the quote block is literal content, not a
+                // section heading; suppress section recognition for the nested
+                // parse (saved and restored to compose with outer contexts).
+                let previously_in_delimited_block = parser.in_delimited_block;
+                parser.in_delimited_block = true;
+
                 let maw_blocks = parse_blocks_until(inside_delimiters, |_, _| false, parser);
+
+                parser.in_delimited_block = previously_in_delimited_block;
                 (
                     ContentModel::Compound,
                     None,
@@ -469,7 +477,16 @@ impl<'src> QuoteBlock<'src> {
             // the document. Mark that so a footnote defined inside records no
             // (misleading) document location; see `Parser::owned_subsource_depth`.
             parser.owned_subsource_depth += 1;
+
+            // A `== …` line inside the blockquote is literal content, not a
+            // section heading; suppress section recognition for the nested parse
+            // (saved and restored to compose with outer contexts).
+            let previously_in_delimited_block = parser.in_delimited_block;
+            parser.in_delimited_block = true;
+
             let mut maw = parse_blocks_until(Span::new(source), |_, _| false, parser);
+
+            parser.in_delimited_block = previously_in_delimited_block;
             parser.owned_subsource_depth -= 1;
             nested_warning_types.extend(maw.warnings.drain(..).map(|w| w.warning));
             OwnedQuoteBlocksInner {
@@ -1288,6 +1305,35 @@ mod tests {
                  (a sign the quadratic quoted-paragraph rescan has returned)",
                 source.lines().count(),
             );
+        }
+    }
+
+    mod section_heading_suppressed {
+        //! A `== …` line inside a quote block or a Markdown-style blockquote is
+        //! literal content – a paragraph – not a section heading (matching
+        //! Asciidoctor, which only creates sections at the document level or
+        //! within a section body).
+
+        use crate::tests::prelude::*;
+
+        fn assert_literal_heading(input: &str) {
+            let doc = Parser::default().parse(input);
+
+            // No section heading was recognized, so nothing renders as an `<h2>`.
+            assert_xpath(&doc, "//h2", 0);
+
+            // The line survives as ordinary paragraph content.
+            assert!(rendered_paragraphs(&doc).contains(&"== not a heading".to_string()));
+        }
+
+        #[test]
+        fn quote_block() {
+            assert_literal_heading("____\n== not a heading\n____\n");
+        }
+
+        #[test]
+        fn markdown_blockquote() {
+            assert_literal_heading("> == not a heading\n");
         }
     }
 }

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -61,6 +61,17 @@ impl<'src> SectionBlock<'src> {
     ) -> Option<MatchedItem<'src, Self>> {
         let discrete = metadata.is_discrete();
 
+        // A section heading is only recognized at the document top level or
+        // within another section's body. Inside a delimited block (example,
+        // sidebar, open, or quote), a `== …` line is literal content – a
+        // paragraph – not a section, so decline here and let the line fall
+        // through to `SimpleBlock`. A discrete heading is an ordinary block, not
+        // a section, and remains valid in these contexts, so it is not
+        // suppressed.
+        if !discrete && parser.in_delimited_block {
+            return None;
+        }
+
         let source = metadata.block_start.discard_empty_lines();
 
         // The heading's effective level folds in the running `leveloffset`

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -2024,7 +2024,18 @@ fn parse_asciidoc_cell_body<'src>(
     // so a footnote defined inside records no (misleading) document location; see
     // `Parser::owned_subsource_depth`.
     parser.owned_subsource_depth += 1;
+
+    // An AsciiDoc cell is a nested document, where a section heading is again
+    // valid – it is not a delimited-block body. Clear `in_delimited_block` for
+    // the cell parse (saved and restored) so a `== …` line inside the cell is
+    // recognized as a section even when the table itself sits inside a delimited
+    // block, whose flag the parser would otherwise still be carrying.
+    let previously_in_delimited_block = parser.in_delimited_block;
+    parser.in_delimited_block = false;
+
     let mut maw = parse_blocks_until(body, |_, _| false, parser);
+
+    parser.in_delimited_block = previously_in_delimited_block;
     parser.owned_subsource_depth -= 1;
     parser.nested_document_depth -= 1;
     warnings.append(&mut maw.warnings);
@@ -3625,6 +3636,43 @@ mod tests {
 
             // The leading anchor is cataloged in the main document's catalog.
             assert!(doc.catalog().contains_id("foo"));
+        }
+    }
+
+    mod section_in_asciidoc_cell {
+        //! An AsciiDoc (`a|`) cell is a nested document, so a `== …` line
+        //! inside it is a real section heading – even when the table
+        //! itself sits inside a delimited block, whose
+        //! section-suppression context must not leak into the cell's
+        //! nested document.
+
+        use crate::{
+            blocks::{Block, BlockSelector, FindBlocks},
+            tests::prelude::*,
+        };
+
+        fn cell_section_count(input: &str) -> usize {
+            Parser::default()
+                .parse(input)
+                .find_blocks(&BlockSelector::new().traverse_documents(true))
+                .filter(|b| matches!(b, Block::Section(_)))
+                .count()
+        }
+
+        #[test]
+        fn section_recognized_in_top_level_cell() {
+            assert_eq!(
+                cell_section_count("|===\na|\n== Cell Section\n\ncell body\n|===\n"),
+                1
+            );
+        }
+
+        #[test]
+        fn section_recognized_in_cell_nested_in_delimited_block() {
+            assert_eq!(
+                cell_section_count("====\n|===\na|\n== Cell Section\n\ncell body\n|===\n====\n"),
+                1
+            );
         }
     }
 }

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -154,6 +154,22 @@ pub struct Parser {
     /// children (the style does not propagate into subsections).
     pub(crate) parsing_bibliography_section_body: bool,
 
+    /// True while parsing the body of a delimited block (an example, sidebar,
+    /// or open block, a quote block, or a Markdown-style blockquote).
+    ///
+    /// A section heading is only recognized at the document top level or within
+    /// another section's body. Inside a delimited block a `== …` line is
+    /// literal content – a paragraph – not a section (matching Asciidoctor,
+    /// which only creates sections when the parent context is the document
+    /// or a section). A discrete heading, by contrast, is an ordinary block
+    /// and remains valid in these contexts, so it is not suppressed by this
+    /// flag. The flag is saved and restored around each delimited-block
+    /// body so nesting is handled correctly. An AsciiDoc table cell is a
+    /// nested document (see
+    /// [`nested_document_depth`](Self::nested_document_depth)) where sections
+    /// are allowed, so it deliberately does not set this flag.
+    pub(crate) in_delimited_block: bool,
+
     /// True while the principal text of a bibliography list item is being
     /// substituted.
     ///
@@ -554,6 +570,7 @@ impl Default for Parser {
             sectnumlevels: 3,
             topmost_section_type: SectionType::Normal,
             parsing_bibliography_section_body: false,
+            in_delimited_block: false,
             in_bibliography_list_item: Cell::new(false),
             mark_footnote_spans: Cell::new(false),
             pending_block_title: None,

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -163,11 +163,13 @@ pub struct Parser {
     /// which only creates sections when the parent context is the document
     /// or a section). A discrete heading, by contrast, is an ordinary block
     /// and remains valid in these contexts, so it is not suppressed by this
-    /// flag. The flag is saved and restored around each delimited-block
-    /// body so nesting is handled correctly. An AsciiDoc table cell is a
-    /// nested document (see
-    /// [`nested_document_depth`](Self::nested_document_depth)) where sections
-    /// are allowed, so it deliberately does not set this flag.
+    /// flag. The flag is saved and restored around each delimited-block body so
+    /// nesting is handled correctly. An AsciiDoc table cell is a nested
+    /// document
+    /// (see [`nested_document_depth`](Self::nested_document_depth)) where
+    /// sections are again allowed, so the cell parse clears this flag (also
+    /// saved and restored) rather than inheriting a delimited-block context
+    /// from a table that happens to sit inside one.
     pub(crate) in_delimited_block: bool,
 
     /// True while the principal text of a bibliography list item is being

--- a/parser/src/tests/asciidoctor_rb/sections_test.rs
+++ b/parser/src/tests/asciidoctor_rb/sections_test.rs
@@ -5117,11 +5117,12 @@ mod special_sections {
     );
 }
 
-// NOTE: The four setext-based tests here depend on two-line (`Section` /
-// `-------`) section titles, which this crate does not support. The
-// example-block test relies on a delimited block suppressing an interior
-// `== heading`; this crate currently parses that heading as a section instead.
-// The whole "heading patterns in blocks" context is therefore out of scope.
+// NOTE: The five setext-based tests held here depend on two-line (`Section` /
+// `-------`) section titles, which this crate does not support, so they remain
+// out of scope. The sixth test, `should not match a heading in a block`, does
+// not depend on setext titles – it verifies that a delimited block suppresses
+// an interior `== heading` – and is ported as a real test in the
+// `heading_patterns_in_blocks` module below.
 non_normative!(
     r##"
 
@@ -5216,7 +5217,16 @@ non_normative!(
       assert_xpath "//h2", output, 1
       assert_xpath "//ul", output, 1
     end
+"##
+);
 
+mod heading_patterns_in_blocks {
+    use crate::tests::prelude::*;
+
+    #[test]
+    fn should_not_match_a_heading_in_a_block() {
+        verifies!(
+            r##"
     test "should not match a heading in a block" do
       input = <<~'EOS'
       ====
@@ -5231,7 +5241,22 @@ non_normative!(
     end
   end
 "##
-);
+        );
+
+        // A section heading (`== …`) inside a delimited block is literal block
+        // content, not a section: the interior line stays a paragraph inside the
+        // example block, so no `<h2>` is emitted anywhere in the document.
+        let doc = Parser::default().parse("====\n\n== not a heading\n\n====\n");
+
+        assert_xpath(&doc, "//h2", 0);
+
+        assert_xpath(
+            &doc,
+            "//div[@class=\"exampleblock\"]//p[text()=\"== not a heading\"]",
+            1,
+        );
+    }
+}
 
 non_normative!(
     r##"


### PR DESCRIPTION
## Summary

Fixes #1024. A section-heading-looking line (`== …`) inside a delimited block was parsed as a real section. Asciidoctor only recognizes section headings at the document top level or within another section's body, so inside a delimited block such a line is literal content – a paragraph.

Input from the Asciidoctor `should not match a heading in a block` test:

```
====

== not a heading

====
```

- **Before:** the parser emitted a `Section` inside the example block (the html5 renderer produced an `<h2>`).
- **After:** the interior line stays a paragraph inside the example block; no section is created.

## Approach

- Add an `in_delimited_block` flag to `Parser`, saved and restored around each delimited-block body.
- Set it around the nested `parse_blocks_until` in `CompoundDelimitedBlock::parse` (example/sidebar/open) and both `QuoteBlock` paths (`____` quote and Markdown-style blockquote).
- `SectionBlock::parse` declines (returns `None`) when the flag is set, so the line falls through to `SimpleBlock`.
- A **discrete heading** (`[discrete]`/`[float]`) is an ordinary block, not a section, so it is *not* suppressed and remains valid inside a delimited block.
- An AsciiDoc **table cell** is a nested document where sections are legitimately allowed, so it deliberately does not set the flag.

## Tests

- Ports the Ruby `should not match a heading in a block` test out of its `non_normative!` holding block in `sections_test.rs` into a real verified test, and updates the surrounding NOTE (the remaining five tests in that context still depend on unsupported two-line setext titles).
- Adds crate-native coverage in `compound_delimited.rs` and `quote.rs` for the example, open, sidebar, quote, and Markdown-blockquote contexts, plus a check that a discrete heading inside a delimited block is still recognized.
- Full suite: 4560 passed, 0 failed; `cargo +nightly fmt --all -- --check` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)