### PR TITLE
fix: Set the combined `authors` attribute from a single `:author:` entry

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -1151,7 +1151,17 @@ fn resolve_authors(
     if attribute_string(parser, "author").is_some()
         && let Some(author) = author_attribute
     {
-        return vec![author.with_email(attribute_string(parser, "email"))];
+        let author = author.with_email(attribute_string(parser, "email"));
+
+        // Mirror Asciidoctor's `process_authors`, which sets the combined
+        // `authors` attribute to the single author's name. The remaining derived
+        // keys (`firstname`, `authorinitials`, …) were populated inline as the
+        // `:author:` entry was parsed – deliberately, so an explicit
+        // `:authorinitials:` override survives – but `authors` was still left
+        // unset there (see issue #1027).
+        parser.set_attribute_by_value_from_header("authors", author.name());
+
+        return vec![author];
     }
 
     // A semicolon-separated `authors` attribute entry contributes one author
@@ -2065,6 +2075,54 @@ mod tests {
             doc.attribute_value("authorinitials"),
             InterpretedValue::Value("DW")
         );
+    }
+
+    #[test]
+    fn single_author_entry_sets_combined_authors_attribute() {
+        // A single `:author:` entry sets the combined `authors` attribute to the
+        // author's name, matching Asciidoctor (`{authors}` equals `{author}`),
+        // just as the implicit author line already does.
+        let doc = Parser::default().parse(":author: Doc Writer\n\nBody.");
+
+        assert_eq!(
+            doc.attribute_value("author"),
+            InterpretedValue::Value("Doc Writer")
+        );
+        assert_eq!(
+            doc.attribute_value("authors"),
+            InterpretedValue::Value("Doc Writer")
+        );
+
+        // The name is reconstructed the same way in the `authors` string, and an
+        // explicit `:authorinitials:` override is still preserved (the reason
+        // this path populates `authors` inline rather than via the shared
+        // metadata routine).
+        let doc = Parser::default()
+            .parse("= T\n:authorinitials: DOC\n:author: Kismet R. Chameleon\n\nBody.");
+
+        assert_eq!(
+            doc.attribute_value("author"),
+            InterpretedValue::Value("Kismet R. Chameleon")
+        );
+        assert_eq!(
+            doc.attribute_value("authors"),
+            InterpretedValue::Value("Kismet R. Chameleon")
+        );
+        assert_eq!(
+            doc.attribute_value("authorinitials"),
+            InterpretedValue::Value("DOC")
+        );
+    }
+
+    #[test]
+    fn author_unset_after_entry_leaves_authors_unset() {
+        // A later `:author!:` removes the single author, so the combined
+        // `authors` attribute must not be materialized from the earlier entry.
+        let doc = Parser::default().parse(":author: Jane Doe\n:author!:\n\nBody.");
+
+        assert_eq!(doc.attribute_value("author"), InterpretedValue::Unset);
+        assert_eq!(doc.attribute_value("authors"), InterpretedValue::Unset);
+        assert!(doc.authors().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1027.

## Problem

A single `:author:` attribute entry set `author` (and the derived `firstname`, `lastname`, `authorinitials`, …) but left the combined `authors` attribute unset, so a document referencing `{authors}` rendered empty. The implicit author line and the `:authors:` / indexed `:author_N:` entry forms all populate `authors`; only the single `:author:` path did not — a follow-up gap from #1005.

```asciidoc
= T
:author: Doc Writer

authors=[{authors}]
```

Before: `authors=[]` — After / Asciidoctor 2.0.26: `authors=[Doc Writer]`.

## Fix

The single-`:author:` branch of `resolve_authors` now sets `authors` to the author's name, mirroring Asciidoctor's `process_authors` (which makes `{authors}` equal `{author}` for one author).

This is done inline rather than by delegating to `set_author_metadata`, deliberately: that shared routine always re-derives `authorinitials`, which would clobber an explicit `:authorinitials:` override that this path is required to preserve. Setting only `authors` here keeps that override intact.

## Tests

- `single_author_entry_sets_combined_authors_attribute` — `{authors}` equals `{author}` for a plain name and a reconstructed multi-part name, with an explicit `:authorinitials:` override still preserved.
- `author_unset_after_entry_leaves_authors_unset` — a later `:author!:` leaves `authors` unset (no stale materialization).

Full `asciidoc-parser` lib suite passes (4572 tests); `cargo +nightly fmt --check` and clippy are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)