### PR TITLE
fix: Strip a trailing `@` soft-set modifier from an API attribute value

### DIFF
--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2974,8 +2974,7 @@ fn alias_attr_name(attr_name: String) -> String {
 /// A single trailing `@` on an attribute value supplied via the API (or the
 /// Asciidoctor CLI) marks the attribute as *soft set*: the effective value is
 /// the string with the `@` removed, and the attribute becomes overridable by a
-/// document `:name:` entry. That maps onto
-/// [`ModificationContext::Anywhere`](crate::parser::ModificationContext::Anywhere).
+/// document `:name:` entry. That maps onto [`ModificationContext::Anywhere`].
 ///
 /// When no trailing `@` is present the value and `modification_context` are
 /// returned unchanged. Only one `@` is stripped, mirroring Ruby's `String#chop`

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1440,6 +1440,14 @@ impl Parser {
     /// the value can be subsequently modified by the document header and/or in
     /// the document body.
     ///
+    /// A single trailing `@` on `value` is AsciiDoc's *soft-set* modifier: it
+    /// is stripped from the stored value and marks the attribute as
+    /// overridable by a document `:name:` entry (i.e. the effective
+    /// [`modification_context`](ModificationContext) becomes
+    /// [`Anywhere`](ModificationContext::Anywhere), regardless of the value
+    /// passed). To store a value that genuinely ends in `@`, set it from the
+    /// document body instead, where the trailing `@` is literal.
+    ///
     /// Subsequent calls to this function or [`with_intrinsic_attribute_bool()`]
     /// are always permitted. The last such call for any given attribute name
     /// takes precendence.
@@ -1455,7 +1463,11 @@ impl Parser {
         modification_context: ModificationContext,
     ) -> Self {
         let name = alias_attr_name(name.as_ref().to_lowercase());
-        let value = InterpretedValue::Value(value.as_ref().to_string());
+
+        let (value, modification_context) =
+            apply_soft_set_modifier(value.as_ref(), modification_context);
+
+        let value = InterpretedValue::Value(value);
         let attribute_value = AttributeValue {
             allowable_value: AllowableValue::Any,
             modification_context,
@@ -1505,7 +1517,11 @@ impl Parser {
         modification_context: ModificationContext,
     ) -> Self {
         let name = alias_attr_name(name.as_ref().to_lowercase());
-        let value = InterpretedValue::Value(value.as_ref().to_string());
+
+        let (value, modification_context) =
+            apply_soft_set_modifier(value.as_ref(), modification_context);
+
+        let value = InterpretedValue::Value(value);
         let attribute_value = AttributeValue {
             allowable_value: AllowableValue::Any,
             modification_context,
@@ -2952,6 +2968,29 @@ fn alias_attr_name(attr_name: String) -> String {
     }
 }
 
+/// Applies AsciiDoc's *soft-set* modifier to an intrinsic (API/CLI) attribute
+/// value.
+///
+/// A single trailing `@` on an attribute value supplied via the API (or the
+/// Asciidoctor CLI) marks the attribute as *soft set*: the effective value is
+/// the string with the `@` removed, and the attribute becomes overridable by a
+/// document `:name:` entry. That maps onto
+/// [`ModificationContext::Anywhere`](crate::parser::ModificationContext::Anywhere).
+///
+/// When no trailing `@` is present the value and `modification_context` are
+/// returned unchanged. Only one `@` is stripped, mirroring Ruby's `String#chop`
+/// (so `foo@@` yields `foo@`), and a `@` that is not the final character (e.g.
+/// `foo@bar`) is not a modifier and is left in place.
+fn apply_soft_set_modifier(
+    value: &str,
+    modification_context: ModificationContext,
+) -> (String, ModificationContext) {
+    match value.strip_suffix('@') {
+        Some(stripped) => (stripped.to_string(), ModificationContext::Anywhere),
+        None => (value.to_string(), modification_context),
+    }
+}
+
 /// Returns `true` if `name` is a derived backend-family attribute whose
 /// assignment must be rejected *even while it is inactive*, because the flag it
 /// would name can become active later in the same parse and the stored override
@@ -3336,6 +3375,87 @@ mod tests {
         assert!(p.is_attribute_set("foo"));
         assert!(!p.is_attribute_set("foo2"));
         assert!(!p.is_attribute_set("xyz"));
+    }
+
+    #[test]
+    fn with_intrinsic_attribute_strips_soft_set_modifier() {
+        // A single trailing `@` on an API value is AsciiDoc's soft-set modifier:
+        // it is stripped from the stored value.
+        let mut p = Parser::default().with_intrinsic_attribute(
+            "myattr",
+            "hello@",
+            ModificationContext::ApiOnly,
+        );
+
+        assert_eq!(
+            p.attribute_value("myattr"),
+            InterpretedValue::Value("hello")
+        );
+
+        // The stored value flows through to an attribute reference: `{myattr}`
+        // resolves to `hello`, not `hello@`.
+        let doc = p.parse("{myattr}");
+        assert_eq!(rendered_paragraphs(&doc), vec!["hello"]);
+    }
+
+    #[test]
+    fn soft_set_modifier_makes_value_overridable_by_document() {
+        // The soft-set `@` also relaxes the modification context to `Anywhere`,
+        // so a document `:name:` entry overrides the API value even though the
+        // caller passed the locked `ApiOnly` context.
+        let doc = Parser::default()
+            .with_intrinsic_attribute("cash", "heroes@", ModificationContext::ApiOnly)
+            .parse(":cash: money");
+
+        assert_eq!(
+            doc.attribute_value("cash"),
+            InterpretedValue::Value("money")
+        );
+    }
+
+    #[test]
+    fn without_soft_set_modifier_api_value_is_locked() {
+        // The same value *without* the `@` keeps the caller's `ApiOnly` context,
+        // so the document assignment is rejected and the API value stands.
+        let doc = Parser::default()
+            .with_intrinsic_attribute("cash", "heroes", ModificationContext::ApiOnly)
+            .parse(":cash: money");
+
+        assert_eq!(
+            doc.attribute_value("cash"),
+            InterpretedValue::Value("heroes")
+        );
+    }
+
+    #[test]
+    fn soft_set_modifier_strips_only_one_trailing_at() {
+        // Only the final `@` is the modifier, mirroring Ruby's `String#chop`; a
+        // preceding `@` is retained as part of the value.
+        let p = Parser::default().with_intrinsic_attribute(
+            "myattr",
+            "hello@@",
+            ModificationContext::ApiOnly,
+        );
+
+        assert_eq!(
+            p.attribute_value("myattr"),
+            InterpretedValue::Value("hello@")
+        );
+    }
+
+    #[test]
+    fn non_trailing_at_is_not_a_soft_set_modifier() {
+        // A `@` that is not the final character is an ordinary value character.
+        let p = Parser::default().with_intrinsic_attribute(
+            "myattr",
+            "foo@bar",
+            ModificationContext::ApiOnly,
+        );
+
+        assert_eq!(
+            p.attribute_value("myattr"),
+            InterpretedValue::Value("foo@bar")
+        );
     }
 
     #[test]

--- a/parser/src/tests/asciidoctor_rb/sections_test.rs
+++ b/parser/src/tests/asciidoctor_rb/sections_test.rs
@@ -1320,11 +1320,14 @@ mod levels {
 "##
             );
 
-            // The Ruby `'-1@'` sets `leveloffset` via the API as a soft default
-            // the document may override, which maps to a modification context of
-            // [`ModificationContext::Anywhere`].
+            // The Ruby `'-1@'` value carries the trailing `@` soft-set modifier:
+            // the effective offset is `-1`, and the attribute becomes overridable
+            // by the document. `with_intrinsic_attribute` strips the `@` and
+            // relaxes the modification context to
+            // [`ModificationContext::Anywhere`] on its own, so the raw `-1@`
+            // value can be passed through verbatim.
             let doc = Parser::default()
-                .with_intrinsic_attribute("leveloffset", "-1", ModificationContext::Anywhere)
+                .with_intrinsic_attribute("leveloffset", "-1@", ModificationContext::ApiOnly)
                 .parse("== Document Title");
             assert_eq!(doc.doctitle(), Some("Document Title"));
             assert_eq!(doc.header().id(), None);


### PR DESCRIPTION
## Summary

Fixes #1033. A trailing `@` on an API/CLI attribute value is AsciiDoc's **soft-set** (default-value) modifier: it marks the attribute as overridable by a document `:name:` entry, and the effective value is the string **without** the `@`. `asciidoc-parser` was keeping the `@` as part of the literal value instead of stripping and honoring it.

### Behavior before / after

| Input (via API) | Before (v0.29.3) | After (matches Asciidoctor) |
| --- | --- | --- |
| `myattr = "hello@"`, then `{myattr}` | `hello@` | `hello` |
| `leveloffset = "-1@"`, then `== Document Title` | level-1 section (`<h2 id="_document_title">`) | doctitle `<h1>Document Title</h1>` |

## What changed

- `Parser::with_intrinsic_attribute` and `with_intrinsic_attribute_silent` now apply the soft-set modifier via a shared `apply_soft_set_modifier` helper: a single trailing `@` is stripped from the value and the effective `ModificationContext` is relaxed to `Anywhere` (overridable by the document), regardless of the context passed by the caller.
- Only **one** trailing `@` is stripped (mirroring Ruby's `String#chop`, so `foo@@` → `foo@`), and a non-trailing `@` (e.g. `foo@bar`) is left untouched.
- **Document-body attribute entries are unaffected** — the soft-set `@` is purely an API/CLI convention, so a trailing `@` written in a `:name:` entry remains literal, matching Asciidoctor. (`Attribute::parse` is untouched.)

## Tests

- New unit tests for value stripping, single-`@` semantics, non-trailing `@`, and the soft-set → document-override / locked-without-`@` behavior.
- The existing `document title created from leveloffset shift defined in API` port now passes the raw `-1@` value through `with_intrinsic_attribute` verbatim instead of pre-translating it to `-1` + `Anywhere`, exercising the fix end-to-end.
- Full suite (`cargo test -p asciidoc-parser`) passes; `cargo +nightly fmt --all -- --check` and `cargo clippy` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)