### PR TITLE
fix: Demote the document title when block metadata precedes it

### DIFF
--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -66,7 +66,6 @@ impl<'src> Header<'src> {
 
         let mut id: Option<String> = None;
         let mut roles: Vec<String> = vec![];
-        let mut pending_block_title_source: Option<Span<'src>> = None;
         let mut attributes: Vec<Attribute> = vec![];
         let mut author_line: Option<AuthorLine<'src>> = None;
         let mut author_attribute: Option<Author> = None;
@@ -281,29 +280,36 @@ impl<'src> Header<'src> {
                 }
                 source = line_mi.after;
             } else if title.is_none()
-                && let Some(block_title) = block_title_text(line)
+                && block_title_text(line).is_some()
                 && document_title_follows_block_metadata(source, parser.level_offset())
             {
                 // A block title (`.Title`) directly above the document title is
                 // not a title *of* the document – a document has no block title.
-                // Asciidoctor demotes the following `= …` heading to a level-0
-                // section and carries the block title over to the first block of
-                // content. This crate does not represent a body-level document
-                // title as a level-0 section, so the `= …` heading remains the
-                // document title; the block title is still recognized here (so
-                // the heading is not mistaken for a paragraph) and carried over
-                // to the first body block, matching the block-title carryover
-                // above an ordinary section heading (see #782).
+                // Its presence demotes the following `= …` line: the document
+                // has no title, and `= …` is a level-0 section heading in the
+                // body rather than the document title (matching Asciidoctor,
+                // which logs "level 0 sections can only be used when doctype is
+                // book").
                 //
-                // The line is only intercepted when a document title eventually
-                // follows – possibly after further stacked block metadata lines,
-                // each folded on its own pass through this loop. A later block
-                // title overrides an earlier one (last-wins), mirroring
-                // Asciidoctor's `parse_block_metadata_lines`. Otherwise it is an
-                // ordinary block title for the body and is left for the block
-                // parser.
-                pending_block_title_source = Some(block_title);
-                source = line_mi.after;
+                // Rather than consume anything here, end the header without a
+                // title and rewind so the block parser sees the whole run –
+                // the block title, the demoted `= …`, and the content below.
+                // The body then recognizes the block title as metadata (not
+                // literal text) and carries it over to the following block, and
+                // the `= …` heading is declined as an unsupported level-0
+                // heading (raising `WarningType::Level0SectionHeadingNotSupported`).
+                // This crate does not model a body-level document title as a
+                // level-0 section, so the heading is declined rather than
+                // rendered as `<h1 class="sect0">`; the demotion and the warning
+                // still hold.
+                //
+                // `source` is left pointing at the block-title line (it is not
+                // advanced), so the header span ends above it and the body
+                // begins there. `document_title_follows_block_metadata` confirms
+                // a `= …` title actually follows – possibly past further stacked
+                // block metadata lines – so an ordinary body block title (with
+                // no document title beneath it) is not caught here.
+                break;
             } else if title.is_none()
                 && let Some((marker, count)) = document_title_marker(line, parser.level_offset())
             {
@@ -481,20 +487,6 @@ impl<'src> Header<'src> {
         // author-less parse from touching the attribute map at all.
         if !authors.is_empty() {
             parser.set_attribute_by_value_from_header("authorcount", authors.len().to_string());
-        }
-
-        // A block title recognized directly above the document title is carried
-        // over to the first block of the body. Stash it on the parser as a
-        // pending block title (the same mechanism a section heading uses); the
-        // first block parsed after the header claims it. The title travels as an
-        // owned snapshot with normal (title) substitutions already applied,
-        // matching a `.Title` line on an ordinary block. It is only ever set
-        // when a document title was seen, since the recognizing branch requires
-        // one to follow.
-        if let Some(block_title) = pending_block_title_source {
-            let mut content = Content::from(block_title);
-            SubstitutionGroup::Normal.apply(&mut content, parser, None);
-            parser.pending_block_title = Some(content.to_owned_title());
         }
 
         MatchAndWarnings {

--- a/parser/src/tests/asciidoctor_rb/blocks_test.rs
+++ b/parser/src/tests/asciidoctor_rb/blocks_test.rs
@@ -4758,25 +4758,29 @@ mod metadata {
         assert_xpath(&doc, "//*[@class=\"paragraph\"]/p[text()=\"paragraph\"]", 1);
     }
 
-    // NOTE: partially out of scope. Both tests below depend on demoting a
-    // body-level document title (`= Title`) to a level-0 section – the "level 0
-    // sections can only be used when doctype is book" behavior. This crate does
-    // not support level-0 sections in the document body (with or without
-    // `doctype: book`): a `=` heading is recognized as the *document title*
-    // rather than becoming a level-0 section, so the demoted `<h1>`/`.sect1`
-    // structure and the absent header these tests assert are never produced.
-    // That is a deliberate divergence, not a deferral, so the tests are
-    // reproduced verbatim (`non_normative!`) rather than ported.
+    // NOTE: partially out of scope. Both tests below demote a body-level
+    // document title (`= Title`) to a level-0 section – the "level 0 sections
+    // can only be used when doctype is book" behavior. A block title directly
+    // above a `= …` line means the line is *not* the document title: the header
+    // is empty and `= …` is a level-0 section heading in the body.
+    // This crate honors the demotion – the document has no title and the
+    // `Level0SectionHeadingNotSupported` warning is raised – but does not model
+    // a body-level document title as a level-0 section, so `= …` is *declined*
+    // as an unsupported level-0 heading rather than rendered as `<h1>`/`.sect0`,
+    // and the block title stays on that declined heading rather than being
+    // forwarded into the section it would have opened. The demoted `<h1>`/
+    // `.sect1` structure these tests assert is therefore never produced, a
+    // deliberate divergence rather than a deferral, so the tests are reproduced
+    // verbatim (`non_normative!`) rather than ported.
     //
-    // The block-title recognition and carryover they exercise *is* implemented:
-    // a block title directly above the document title is recognized as document
-    // metadata (rather than titling a paragraph that captures the `= Title` line
-    // as literal text), and is carried over to the first block of the body, the
-    // same way a block title above an ordinary section heading is (#782). The
-    // crate's actual behavior on the first input is asserted by
-    // `block_title_above_document_title_is_carried_over_to_first_body_block`
-    // below; see also
-    // `block_title_above_section_gets_carried_over_to_first_block_in_section`.
+    // The point both tests share – and that this crate honors – is that the
+    // block title above `= …` demotes it (empty header, level-0 warning) instead
+    // of turning the line into the document title or titling a paragraph that
+    // captures the `= …` line as escaped literal text. The crate's actual
+    // behavior on each input is asserted by
+    // `block_title_above_document_title_demotes_it` and
+    // `block_title_above_document_title_demotes_it_in_book_doctype` below; see
+    // also `block_title_above_section_gets_carried_over_to_first_block_in_section`.
     non_normative!(
         r#"
     test 'block title above document title demotes document title to a section title' do
@@ -4816,22 +4820,35 @@ mod metadata {
     );
 
     // The crate-specific counterpart to the first `non_normative!` test above.
-    // Asciidoctor demotes the `= Section Title` heading to a level-0 body
-    // section (leaving the document header empty); this crate does not model a
-    // body-level document title as a level-0 section, so it keeps `= Section
-    // Title` as the document title. The point that both share – and that this
-    // asserts – is that the block title above the title is recognized as
-    // metadata and carried over to the first block of the body, rather than
-    // titling a paragraph whose text is the escaped `= Section Title` line.
+    // A block title directly above `= Section Title` demotes the line: the
+    // document header carries no title and `= Section Title` is a level-0
+    // section heading in the body. Asciidoctor renders that heading as
+    // `<h1 class="sect0">`; this crate does not model a body-level document
+    // title as a level-0 section, so it declines the heading (raising
+    // `Level0SectionHeadingNotSupported`) and it falls back to a paragraph whose
+    // text is the `= Section Title` line. The block title stays on that declined
+    // heading – the block it immediately precedes – matching how block metadata
+    // above any declined level-0 heading behaves elsewhere in the body.
     #[test]
-    fn block_title_above_document_title_is_carried_over_to_first_body_block() {
+    fn block_title_above_document_title_demotes_it() {
         let doc = Parser::default().parse(".Block title\n= Section Title\n\nsection paragraph\n");
 
-        // `= Section Title` is the document title, not literal paragraph text.
-        assert_eq!(doc.header().title(), Some("Section Title"));
+        // The `= Section Title` line is demoted: it is not the document title.
+        assert_eq!(doc.header().title(), None);
 
-        // The block title is carried over to the (single) body paragraph.
-        assert_xpath(&doc, "//*[@class=\"paragraph\"]", 1);
+        // Demoting a level-0 heading into the body raises the level-0 warning,
+        // anchored at the `= Section Title` line.
+        let warnings: Vec<_> = doc
+            .warnings()
+            .filter(|w| w.warning == WarningType::Level0SectionHeadingNotSupported)
+            .collect();
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].source.line(), 2);
+
+        // The block title is recognized as metadata (not turned into literal
+        // text) and stays on the declined `= Section Title` heading, which falls
+        // back to a paragraph carrying the block title.
         assert_xpath(
             &doc,
             "//*[@class=\"paragraph\"]/*[@class=\"title\"][text()=\"Block title\"]",
@@ -4839,7 +4856,54 @@ mod metadata {
         );
         assert_xpath(
             &doc,
+            "//*[@class=\"paragraph\"]/p[text()=\"= Section Title\"]",
+            1,
+        );
+
+        // The content below the heading remains its own paragraph.
+        assert_xpath(
+            &doc,
             "//*[@class=\"paragraph\"]/p[text()=\"section paragraph\"]",
+            1,
+        );
+    }
+
+    // The crate-specific counterpart to the second `non_normative!` test above
+    // (`:doctype: book`). The demotion is the same: the block title above
+    // `= Document Title` empties the header and demotes the line to a declined
+    // level-0 heading (raising `Level0SectionHeadingNotSupported`). Asciidoctor
+    // forwards the block title into the first real section (`== First Section`);
+    // this crate leaves it on the declined `= Document Title` heading, since that
+    // is the block the metadata immediately precedes.
+    #[test]
+    fn block_title_above_document_title_demotes_it_in_book_doctype() {
+        let doc = Parser::default().parse(
+            ":doctype: book\n.Block title\n= Document Title\n\n== First Section\n\nparagraph\n",
+        );
+
+        // The `= Document Title` line is demoted: the document has no title.
+        assert_eq!(doc.header().title(), None);
+
+        let warnings: Vec<_> = doc
+            .warnings()
+            .filter(|w| w.warning == WarningType::Level0SectionHeadingNotSupported)
+            .collect();
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].source.line(), 3);
+
+        // The block title stays on the declined `= Document Title` heading.
+        assert_xpath(
+            &doc,
+            "//*[@class=\"paragraph\"]/*[@class=\"title\"][text()=\"Block title\"]",
+            1,
+        );
+
+        // `== First Section` is a normal level-1 section with its own paragraph.
+        assert_xpath(&doc, "//*[@class=\"sect1\"]", 1);
+        assert_xpath(
+            &doc,
+            "//*[@class=\"sect1\"]//*[@class=\"paragraph\"]/p[text()=\"paragraph\"]",
             1,
         );
     }


### PR DESCRIPTION
## Summary

Follow-up to #1022 / #1029. Fixes #1037.

When a block title (`.Title`) appears directly above the `= …` document-title line, the line is **not** the document title. Asciidoctor demotes it to a level-0 section heading in the body, leaves the header empty, and logs *"level 0 sections can only be used when doctype is book"*.

v0.29.3 delivered only the **carryover** half — the block title stopped turning the `= …` line into literal text — but the **demotion** half was missing: the `= …` line was still reported as the document title and no warning was raised.

This change honors the demotion:

- The header ends without a title and **rewinds**, so the block parser sees the whole run (the block title, the `= …` line, and the content below).
- The block title is recognized as ordinary body metadata (not literal text), and the `= …` heading is declined as an unsupported level-0 heading, raising `WarningType::Level0SectionHeadingNotSupported`.
- `header().title()` (→ downstream `doctitle()`) is now `None`.

### Deliberate divergence

This crate does not model a body-level document title as a level-0 section, so the demoted heading is **declined** (falling back to a paragraph) rather than rendered as `<h1 class="sect0">`, and the block title stays on that declined heading rather than being forwarded into the section it would have opened. The demotion and the warning still hold — this matches the crate's existing convention for level-0 headings in the body.

A nice side effect: a block title above `= …` at the document start now behaves **exactly** like the same construct mid-body.

## Before / after

For `.Block title\n= Section Title\n\nsection paragraph`:

| | before (0.29.4) | after |
|---|---|---|
| `header().title()` | `Some("Section Title")` | `None` |
| `Level0SectionHeadingNotSupported` | not raised | raised (line 2) |

## Tests

- Replaced `block_title_above_document_title_is_carried_over_to_first_body_block` with `block_title_above_document_title_demotes_it`, asserting the empty title, the warning, and the block-title placement.
- Added `block_title_above_document_title_demotes_it_in_book_doctype` covering the `:doctype: book` case from the issue.
- Updated the surrounding `non_normative!` NOTE to describe the crate's demotion behavior and its divergence from Asciidoctor's `<h1>`/`.sect1` rendering.

Full `cargo test`, `cargo clippy --all-targets`, and `cargo +nightly fmt --all -- --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)