### PR TITLE
feat: Record a debug-severity diagnostic for an unknown block style

### DIFF
--- a/parser/src/attributes/attrlist.rs
+++ b/parser/src/attributes/attrlist.rs
@@ -91,11 +91,7 @@ impl<'src> Attrlist<'src> {
             // reason, individual attribute parsing only returns the warning type and we
             // then map it back to the entire attrlist source.
             for warning_type in warning_types {
-                warnings.push(Warning {
-                    source,
-                    warning: warning_type,
-                    origin: None,
-                });
+                warnings.push(Warning::new(source, warning_type));
             }
 
             // Shorthand items (the `#id`, `.role`, and `%option` entries) are
@@ -148,11 +144,7 @@ impl<'src> Attrlist<'src> {
                     after = comma.after.take_whitespace().after;
 
                     if after.starts_with(',') {
-                        warnings.push(Warning {
-                            source,
-                            warning: WarningType::EmptyAttributeValue,
-                            origin: None,
-                        });
+                        warnings.push(Warning::new(source, WarningType::EmptyAttributeValue));
 
                         // Consume the blank slot between consecutive commas here,
                         // advancing the position counter past it.
@@ -171,11 +163,10 @@ impl<'src> Attrlist<'src> {
         };
 
         if after_index < source_cow.len() {
-            warnings.push(Warning {
+            warnings.push(Warning::new(
                 source,
-                warning: WarningType::MissingCommaAfterQuotedAttributeValue,
-                origin: None,
-            });
+                WarningType::MissingCommaAfterQuotedAttributeValue,
+            ));
         }
 
         MatchAndWarnings {

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -4,8 +4,8 @@ use crate::{
     blocks::{
         AdmonitionBlock, Break, CompoundDelimitedBlock, ContentModel, IsBlock, ListBlock, ListItem,
         ListItemMarker, MediaBlock, Preamble, QuoteBlock, RawDelimitedBlock, SectionBlock,
-        SimpleBlock, TableBlock, TocBlock, media::TargetResolution, metadata::BlockMetadata,
-        starts_with_admonition_label,
+        SimpleBlock, TableBlock, TocBlock, is_built_in_context, media::TargetResolution,
+        metadata::BlockMetadata, starts_with_admonition_label,
     },
     content::{Content, SubstitutionGroup, substitute_attributes_in_reftext},
     document::{Attribute, InterpretedValue, RefType},
@@ -1282,36 +1282,33 @@ impl<'src> HasSpan<'src> for Block<'src> {
 /// is always recognized: it turns the block into an admonition.
 const ADMONITION_STYLES: &[&str] = &["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"];
 
-/// Every block style this parser understands.
+/// Block style keywords this parser understands that are *not* themselves
+/// built-in contexts.
 ///
 /// A declared block style (the first positional attribute, e.g. `[source]`) is
-/// recognized when it names a built-in context this parser can adopt, a style
-/// keyword it interprets (`source`, `abstract`, `normal`, `partintro`, the
-/// `stem` flavors), or – via [`ADMONITION_STYLES`] – an admonition label.
-/// Anything else is an unknown style. This is the union of Asciidoctor's
-/// `PARAGRAPH_STYLES`, its delimited-block masquerade styles, and the built-in
-/// contexts; because this parser lets any built-in context style masquerade
-/// over any delimited block (see
-/// [`resolved_context`](crate::blocks::IsBlock::resolved_context)), a single
-/// shared set – rather than Asciidoctor's per-delimiter masquerade tables –
-/// matches how this parser actually resolves a style.
-const KNOWN_BLOCK_STYLES: &[&str] = &[
+/// recognized when it names a built-in context this parser can adopt (any
+/// [`is_built_in_context`] style – `example`, `listing`, `sidebar`, `image`,
+/// `table`, and so on), one of these interpreting keywords, or – via
+/// [`ADMONITION_STYLES`] – an admonition label. Anything else is an unknown
+/// style.
+///
+/// Deferring the built-in contexts to [`is_built_in_context`] keeps this check
+/// in lock-step with
+/// [`resolved_context`](crate::blocks::IsBlock::resolved_context), which adopts
+/// exactly those styles as the block's context: a style that
+/// `resolved_context` acts on is never reported as unknown. These keywords are
+/// the remaining styles this parser interprets without their being a context –
+/// `source` specializes `listing`, `abstract` an open block, the `stem`
+/// flavors a `stem` block, and `comment`/`normal`/`partintro` round out
+/// Asciidoctor's `PARAGRAPH_STYLES`.
+const KNOWN_STYLE_KEYWORDS: &[&str] = &[
     "abstract",
     "asciimath",
     "comment",
-    "example",
     "latexmath",
-    "listing",
-    "literal",
     "normal",
-    "open",
     "partintro",
-    "pass",
-    "quote",
-    "sidebar",
     "source",
-    "stem",
-    "verse",
 ];
 
 /// The block contexts for which an unknown declared style is diagnosed.
@@ -1369,7 +1366,9 @@ fn unknown_block_style_warning(block: &Block<'_>) -> Option<WarningType> {
         return None;
     }
 
-    if style == context || KNOWN_BLOCK_STYLES.contains(&style) || ADMONITION_STYLES.contains(&style)
+    if is_built_in_context(style)
+        || KNOWN_STYLE_KEYWORDS.contains(&style)
+        || ADMONITION_STYLES.contains(&style)
     {
         return None;
     }
@@ -1461,6 +1460,19 @@ mod tests {
             assert_eq!(only_warning("[verse]\n____\nx\n____\n"), None);
             assert_eq!(only_warning("[abstract]\n--\nx\n--\n"), None);
             assert_eq!(only_warning("[asciimath]\n++++\nx\n++++\n"), None);
+        }
+
+        #[test]
+        fn any_built_in_context_style_does_not_warn() {
+            // Every built-in context this parser can adopt as a block's context
+            // (via `resolved_context`) is a recognized style, even one it does
+            // not otherwise treat as a masquerade keyword (e.g. `image`,
+            // `audio`, `video`, `table`). Reporting these would contradict the
+            // context the parser actually resolved.
+            assert_eq!(only_warning("[image]\nbar\n"), None);
+            assert_eq!(only_warning("[audio]\n--\nx\n--\n"), None);
+            assert_eq!(only_warning("[video]\nbar\n"), None);
+            assert_eq!(only_warning("[table]\nbar\n"), None);
         }
 
         #[test]

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -211,7 +211,41 @@ impl<'src> Block<'src> {
 
     /// Shared parser for [`parse_with_outcome`](Self::parse_with_outcome) and
     /// [`parse_for_list_item`](Self::parse_for_list_item).
+    ///
+    /// This wraps [`parse_internal_inner`](Self::parse_internal_inner) so that
+    /// every parsed block – whichever branch produced it – passes through the
+    /// unknown-block-style check on the way out. Every block is born here (the
+    /// block-collection loops call one of the public `parse_*` entry points,
+    /// which funnel into this), so this is the single point at which a declared
+    /// style that this parser could not act on is diagnosed.
     fn parse_internal(
+        source: Span<'src>,
+        parser: &mut Parser,
+        parent_list_markers: Option<&[ListItemMarker<'src>]>,
+        is_continuation: bool,
+    ) -> MatchAndWarnings<'src, BlockParseOutcome<'src>> {
+        let mut result =
+            Self::parse_internal_inner(source, parser, parent_list_markers, is_continuation);
+
+        // Record a DEBUG-severity diagnostic when a block declared a style this
+        // parser does not recognize for its context. The block keeps the
+        // default context implied by its syntax (the style is retained but
+        // otherwise ignored); Asciidoctor logs the same condition at debug
+        // level (below its default WARN threshold), so this is surfaced only
+        // for a host that opts in to low-severity diagnostics.
+        if let BlockParseOutcome::Parsed(matched_item) = &result.item
+            && let Some(warning) = unknown_block_style_warning(&matched_item.item)
+        {
+            result
+                .warnings
+                .push(Warning::new(matched_item.item.span(), warning));
+        }
+
+        result
+    }
+
+    /// Shared parser body for [`parse_internal`](Self::parse_internal).
+    fn parse_internal_inner(
         source: Span<'src>,
         parser: &mut Parser,
         parent_list_markers: Option<&[ListItemMarker<'src>]>,
@@ -663,11 +697,10 @@ impl<'src> Block<'src> {
                     // We have a metadata with no block. Treat it as a simple block but issue a
                     // warning.
 
-                    warnings.push(Warning {
-                        source: metadata.source,
-                        warning: WarningType::MissingBlockAfterTitleOrAttributeList,
-                        origin: None,
-                    });
+                    warnings.push(Warning::new(
+                        metadata.source,
+                        WarningType::MissingBlockAfterTitleOrAttributeList,
+                    ));
 
                     // Remove the metadata content so that SimpleBlock will read the title/attrlist
                     // line(s) as regular content. The speculative parse failed, so the
@@ -847,11 +880,7 @@ impl<'src> Block<'src> {
                 }
                 Err(_duplicate_error) => {
                     // If registration fails due to duplicate ID, issue a warning.
-                    warnings.push(Warning {
-                        source: span,
-                        warning: WarningType::DuplicateId(id.to_string()),
-                        origin: None,
-                    });
+                    warnings.push(Warning::new(span, WarningType::DuplicateId(id.to_string())));
                 }
             }
         }
@@ -1245,6 +1274,241 @@ impl<'src> HasSpan<'src> for Block<'src> {
             Self::Break(b) => b.span(),
             Self::Toc(b) => b.span(),
             Self::DocumentAttribute(b) => b.span(),
+        }
+    }
+}
+
+/// The five admonition labels (`NOTE`, `TIP`, …). A style naming one of these
+/// is always recognized: it turns the block into an admonition.
+const ADMONITION_STYLES: &[&str] = &["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"];
+
+/// Every block style this parser understands.
+///
+/// A declared block style (the first positional attribute, e.g. `[source]`) is
+/// recognized when it names a built-in context this parser can adopt, a style
+/// keyword it interprets (`source`, `abstract`, `normal`, `partintro`, the
+/// `stem` flavors), or – via [`ADMONITION_STYLES`] – an admonition label.
+/// Anything else is an unknown style. This is the union of Asciidoctor's
+/// `PARAGRAPH_STYLES`, its delimited-block masquerade styles, and the built-in
+/// contexts; because this parser lets any built-in context style masquerade
+/// over any delimited block (see
+/// [`resolved_context`](crate::blocks::IsBlock::resolved_context)), a single
+/// shared set – rather than Asciidoctor's per-delimiter masquerade tables –
+/// matches how this parser actually resolves a style.
+const KNOWN_BLOCK_STYLES: &[&str] = &[
+    "abstract",
+    "asciimath",
+    "comment",
+    "example",
+    "latexmath",
+    "listing",
+    "literal",
+    "normal",
+    "open",
+    "partintro",
+    "pass",
+    "quote",
+    "sidebar",
+    "source",
+    "stem",
+    "verse",
+];
+
+/// The block contexts for which an unknown declared style is diagnosed.
+///
+/// Asciidoctor reports an unknown style only for delimited blocks and
+/// paragraphs; a style on a list, section, media macro, or thematic break is
+/// interpreted differently (a list marker style, a discrete-heading style,
+/// etc.) and is never reported this way. These are the corresponding
+/// [`raw_context`](crate::blocks::IsBlock::raw_context) values.
+///
+/// [`raw_context`]: crate::blocks::IsBlock::raw_context
+const STYLED_BLOCK_CONTEXTS: &[&str] = &[
+    "comment",
+    "example",
+    "listing",
+    "literal",
+    "open",
+    "paragraph",
+    "pass",
+    "quote",
+    "sidebar",
+    "stem",
+    "table",
+    "verse",
+];
+
+/// Diagnose a block that declared a style this parser does not recognize for
+/// its context, returning the [`WarningType`] to record or `None` when the
+/// block has no style, the style is recognized, or the block's context is not
+/// one for which an unknown style is reported.
+///
+/// The block keeps the default context implied by its syntax regardless; the
+/// diagnostic only reports that the declared style had no effect. This mirrors
+/// Asciidoctor, which logs `unknown style for <context> block: <style>` at
+/// debug level and falls back to the block's context.
+fn unknown_block_style_warning(block: &Block<'_>) -> Option<WarningType> {
+    let style = block.declared_style()?;
+    let context = block.raw_context();
+    let context = context.as_ref();
+
+    // Only diagnose something that actually looks like a style name. A malformed
+    // attribute list (for example a mangled `[[anchor]`, or a positional whose
+    // value is `-foo = bar`) can leave debris in the first positional slot that
+    // is not a plausible style; reporting it as an "unknown style" would be
+    // noise. Asciidoctor only reaches this check with a properly-parsed style
+    // token, so a value carrying spaces, brackets, or other punctuation is not
+    // one this diagnostic is meant for.
+    if !is_plausible_style_name(style) {
+        return None;
+    }
+
+    // Only delimited blocks and paragraphs report an unknown style; on any
+    // other block a first positional attribute means something else.
+    if !STYLED_BLOCK_CONTEXTS.contains(&context) {
+        return None;
+    }
+
+    if style == context || KNOWN_BLOCK_STYLES.contains(&style) || ADMONITION_STYLES.contains(&style)
+    {
+        return None;
+    }
+
+    Some(WarningType::UnknownBlockStyle(
+        context.to_string(),
+        style.to_string(),
+    ))
+}
+
+/// Whether `style` looks like an authored block-style name – a non-empty token
+/// of ASCII letters, digits, `_`, or `-`. This screens out the debris a
+/// malformed attribute list can leave in the first positional slot (values
+/// carrying spaces, brackets, `=`, quotes, and so on), which is not a style the
+/// unknown-style diagnostic is meant to report.
+fn is_plausible_style_name(style: &str) -> bool {
+    !style.is_empty()
+        && style
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    mod unknown_block_style {
+        use crate::{
+            Parser,
+            warnings::{WarningSeverity, WarningType},
+        };
+
+        /// The single warning a parse produced, or `None` if there were none.
+        fn only_warning(input: &str) -> Option<(WarningSeverity, WarningType)> {
+            let doc = Parser::default().parse(input);
+            let mut warnings = doc.warnings();
+            let warning = warnings.next()?;
+            assert!(
+                warnings.next().is_none(),
+                "expected at most one warning for {input:?}"
+            );
+
+            Some((warning.severity, warning.warning.clone()))
+        }
+
+        #[test]
+        fn unknown_style_on_open_block_is_debug() {
+            assert_eq!(
+                only_warning("[foo]\n--\nbar\n--\n"),
+                Some((
+                    WarningSeverity::Debug,
+                    WarningType::UnknownBlockStyle("open".to_string(), "foo".to_string())
+                ))
+            );
+        }
+
+        #[test]
+        fn unknown_style_on_paragraph_is_debug() {
+            assert_eq!(
+                only_warning("[foo]\nbar\n"),
+                Some((
+                    WarningSeverity::Debug,
+                    WarningType::UnknownBlockStyle("paragraph".to_string(), "foo".to_string())
+                ))
+            );
+        }
+
+        #[test]
+        fn nested_unknown_style_is_reported() {
+            assert_eq!(
+                only_warning("====\n[bar]\n--\nx\n--\n====\n"),
+                Some((
+                    WarningSeverity::Debug,
+                    WarningType::UnknownBlockStyle("open".to_string(), "bar".to_string())
+                ))
+            );
+        }
+
+        #[test]
+        fn recognized_context_style_does_not_warn() {
+            // A built-in context masquerading over a delimited block.
+            assert_eq!(only_warning("[example]\n--\nx\n--\n"), None);
+            assert_eq!(only_warning("[sidebar]\n--\nx\n--\n"), None);
+        }
+
+        #[test]
+        fn recognized_keyword_style_does_not_warn() {
+            assert_eq!(only_warning("[source]\n----\nx\n----\n"), None);
+            assert_eq!(only_warning("[verse]\n____\nx\n____\n"), None);
+            assert_eq!(only_warning("[abstract]\n--\nx\n--\n"), None);
+            assert_eq!(only_warning("[asciimath]\n++++\nx\n++++\n"), None);
+        }
+
+        #[test]
+        fn admonition_style_does_not_warn() {
+            assert_eq!(only_warning("[NOTE]\n--\nx\n--\n"), None);
+        }
+
+        #[test]
+        fn style_naming_its_own_context_does_not_warn() {
+            // A `[table]` style on a table names the block's own context.
+            assert_eq!(only_warning("[table]\n|===\n| x\n|===\n"), None);
+        }
+
+        #[test]
+        fn style_on_list_or_section_does_not_warn() {
+            // A first positional on a list or a section heading is not a block
+            // style (a list marker style, a discrete-heading flag, and so on).
+            assert_eq!(only_warning("[square]\n* a\n* b\n"), None);
+            assert_eq!(only_warning("[discrete]\n== Heading\n"), None);
+        }
+
+        #[test]
+        fn malformed_attrlist_debris_does_not_warn() {
+            // A mangled anchor (`[[notice]`) leaves `[notice` in the first
+            // positional slot; it is not a plausible style name.
+            assert_eq!(only_warning("[[notice]\nThis is a paragraph.\n"), None);
+        }
+    }
+
+    mod is_plausible_style_name {
+        use crate::blocks::block::is_plausible_style_name;
+
+        #[test]
+        fn accepts_style_tokens() {
+            assert!(is_plausible_style_name("foo"));
+            assert!(is_plausible_style_name("NOTE"));
+            assert!(is_plausible_style_name("foo-bar"));
+            assert!(is_plausible_style_name("foo_bar"));
+            assert!(is_plausible_style_name("style2"));
+        }
+
+        #[test]
+        fn rejects_debris_and_empty() {
+            assert!(!is_plausible_style_name(""));
+            assert!(!is_plausible_style_name("[notice"));
+            assert!(!is_plausible_style_name("-foo = bar"));
+            assert!(!is_plausible_style_name("a,b"));
+            assert!(!is_plausible_style_name("has space"));
         }
     }
 }

--- a/parser/src/blocks/compound_delimited.rs
+++ b/parser/src/blocks/compound_delimited.rs
@@ -209,11 +209,7 @@ impl<'src> CompoundDelimitedBlock<'src> {
                 let mut warnings = maw_blocks.warnings;
                 warnings.insert(
                     0,
-                    Warning {
-                        source: delimiter.item,
-                        warning: WarningType::UnterminatedDelimitedBlock,
-                        origin: None,
-                    },
+                    Warning::new(delimiter.item, WarningType::UnterminatedDelimitedBlock),
                 );
                 warnings
             } else {

--- a/parser/src/blocks/list.rs
+++ b/parser/src/blocks/list.rs
@@ -181,14 +181,10 @@ impl<'src> ListBlock<'src> {
                             first_marker.ordinal_to_marker_text(expected),
                             first_marker.ordinal_to_marker_text(actual_ordinal),
                         ) {
-                            warnings.push(Warning {
-                                source: this_item_marker.span(),
-                                warning: WarningType::ListItemOutOfSequence(
-                                    expected_text,
-                                    actual_text,
-                                ),
-                                origin: None,
-                            });
+                            warnings.push(Warning::new(
+                                this_item_marker.span(),
+                                WarningType::ListItemOutOfSequence(expected_text, actual_text),
+                            ));
                         }
                     }
                     expected_ordinal = Some(actual_ordinal + 1);
@@ -274,22 +270,20 @@ impl<'src> ListBlock<'src> {
                     .and_then(|li| li.list_item_marker().callout_number())
                     && marker_number != position
                 {
-                    warnings.push(Warning {
-                        source: item.span(),
-                        warning: WarningType::CalloutListItemOutOfSequence(
+                    warnings.push(Warning::new(
+                        item.span(),
+                        WarningType::CalloutListItemOutOfSequence(
                             position as usize,
                             marker_number as usize,
                         ),
-                        origin: None,
-                    });
+                    ));
                 }
 
                 if !parser.callout_defined(position) {
-                    warnings.push(Warning {
-                        source: item.span(),
-                        warning: WarningType::NoCalloutFound(position as usize),
-                        origin: None,
-                    });
+                    warnings.push(Warning::new(
+                        item.span(),
+                        WarningType::NoCalloutFound(position as usize),
+                    ));
                 }
             }
             parser.close_callout_list();

--- a/parser/src/blocks/list_item_marker.rs
+++ b/parser/src/blocks/list_item_marker.rs
@@ -229,11 +229,10 @@ impl<'src> ListItemMarker<'src> {
             if let Err(_duplicate_error) =
                 parser.register_ref(id, reftext.as_deref(), RefType::Anchor)
             {
-                warnings.push(Warning {
-                    source: term.original(),
-                    warning: WarningType::DuplicateId(id.to_string()),
-                    origin: None,
-                });
+                warnings.push(Warning::new(
+                    term.original(),
+                    WarningType::DuplicateId(id.to_string()),
+                ));
             }
         }
 

--- a/parser/src/blocks/media.rs
+++ b/parser/src/blocks/media.rs
@@ -118,11 +118,7 @@ impl<'src> MediaBlock<'src> {
         let Some(colons) = name.after.take_prefix("::") else {
             return MatchAndWarnings {
                 item: None,
-                warnings: vec![Warning {
-                    source: name.after,
-                    warning: WarningType::MacroMissingSeparator,
-                    origin: None,
-                }],
+                warnings: vec![Warning::new(name.after, WarningType::MacroMissingSeparator)],
             };
         };
 
@@ -132,22 +128,20 @@ impl<'src> MediaBlock<'src> {
         if target.item.is_empty() {
             return MatchAndWarnings {
                 item: None,
-                warnings: vec![Warning {
-                    source: target.after,
-                    warning: WarningType::MediaMacroMissingTarget,
-                    origin: None,
-                }],
+                warnings: vec![Warning::new(
+                    target.after,
+                    WarningType::MediaMacroMissingTarget,
+                )],
             };
         }
 
         let Some(open_brace) = target.after.take_prefix("[") else {
             return MatchAndWarnings {
                 item: None,
-                warnings: vec![Warning {
-                    source: target.after,
-                    warning: WarningType::MacroMissingAttributeList,
-                    origin: None,
-                }],
+                warnings: vec![Warning::new(
+                    target.after,
+                    WarningType::MacroMissingAttributeList,
+                )],
             };
         };
 

--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -114,11 +114,10 @@ impl<'src> BlockMetadata<'src> {
                             reftext = Some(reftext_span);
                             block_start = mi.after;
                         } else {
-                            warnings.push(Warning {
-                                source: anchor_span,
-                                warning: WarningType::InvalidBlockAnchorName,
-                                origin: None,
-                            });
+                            warnings.push(Warning::new(
+                                anchor_span,
+                                WarningType::InvalidBlockAnchorName,
+                            ));
                         }
                     } else {
                         // Validate anchor name.
@@ -131,11 +130,10 @@ impl<'src> BlockMetadata<'src> {
                             reftext = None;
                             block_start = mi.after;
                         } else {
-                            warnings.push(Warning {
-                                source: anchor_content,
-                                warning: WarningType::InvalidBlockAnchorName,
-                                origin: None,
-                            });
+                            warnings.push(Warning::new(
+                                anchor_content,
+                                WarningType::InvalidBlockAnchorName,
+                            ));
                         }
                     }
                 } else {
@@ -399,11 +397,7 @@ fn parse_maybe_block_anchor(
                 item: None,
                 after: block_start,
             }),
-            warnings: vec![Warning {
-                source: anchor_src,
-                warning: WarningType::EmptyBlockAnchorName,
-                origin: None,
-            }],
+            warnings: vec![Warning::new(anchor_src, WarningType::EmptyBlockAnchorName)],
         };
     }
 

--- a/parser/src/blocks/quote.rs
+++ b/parser/src/blocks/quote.rs
@@ -256,11 +256,7 @@ impl<'src> QuoteBlock<'src> {
         if closing_delimiter.is_empty() {
             warnings.insert(
                 0,
-                Warning {
-                    source: delimiter.item,
-                    warning: WarningType::UnterminatedDelimitedBlock,
-                    origin: None,
-                },
+                Warning::new(delimiter.item, WarningType::UnterminatedDelimitedBlock),
             );
         }
 
@@ -501,11 +497,7 @@ impl<'src> QuoteBlock<'src> {
 
         let warnings = nested_warning_types
             .into_iter()
-            .map(|warning| Warning {
-                source,
-                warning,
-                origin: None,
-            })
+            .map(|warning| Warning::new(source, warning))
             .collect();
 
         Some(MatchAndWarnings {

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -287,11 +287,10 @@ impl<'src> RawDelimitedBlock<'src> {
                 },
                 after: next,
             }),
-            warnings: vec![Warning {
-                source: delimiter.item,
-                warning: WarningType::UnterminatedDelimitedBlock,
-                origin: None,
-            }],
+            warnings: vec![Warning::new(
+                delimiter.item,
+                WarningType::UnterminatedDelimitedBlock,
+            )],
         })
     }
 

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -321,16 +321,13 @@ impl<'src> SectionBlock<'src> {
                 if let Block::Section(subsection) = block
                     && subsection.section_type() != SectionType::Discrete
                 {
-                    warnings.push(Warning {
-                        source: subsection
+                    warnings.push(Warning::new(
+                        subsection
                             .section_title_source()
                             .take_normalized_line()
                             .item,
-                        warning: WarningType::SpecialSectionCannotHaveNestedSections(
-                            style.to_string(),
-                        ),
-                        origin: None,
-                    });
+                        WarningType::SpecialSectionCannotHaveNestedSections(style.to_string()),
+                    ));
                 }
             }
         }
@@ -375,11 +372,10 @@ impl<'src> SectionBlock<'src> {
                         }
                     }
                     Err(_duplicate_error) => {
-                        warnings.push(Warning {
-                            source: metadata.source.trim_remainder(level_and_title.after),
-                            warning: WarningType::DuplicateId(manual_id.to_string()),
-                            origin: None,
-                        });
+                        warnings.push(Warning::new(
+                            metadata.source.trim_remainder(level_and_title.after),
+                            WarningType::DuplicateId(manual_id.to_string()),
+                        ));
                     }
                 }
             }
@@ -779,11 +775,10 @@ fn parse_title_line<'src>(
     }
 
     if count > 6 {
-        warnings.push(Warning {
-            source: source.take_normalized_line().item,
-            warning: WarningType::SectionHeadingLevelExceedsMaximum(count - 1),
-            origin: None,
-        });
+        warnings.push(Warning::new(
+            source.take_normalized_line().item,
+            WarningType::SectionHeadingLevelExceedsMaximum(count - 1),
+        ));
 
         return None;
     }
@@ -806,11 +801,10 @@ fn parse_title_line<'src>(
     // not the document title, so a level-0 discrete heading is legitimate and is
     // carried through with level 0 rather than rejected.
     if !discrete && syntactic_level == 0 && effective_level < MIN_SECTION_LEVEL {
-        warnings.push(Warning {
-            source: source.take_normalized_line().item,
-            warning: WarningType::Level0SectionHeadingNotSupported,
-            origin: None,
-        });
+        warnings.push(Warning::new(
+            source.take_normalized_line().item,
+            WarningType::Level0SectionHeadingNotSupported,
+        ));
 
         return None;
     }
@@ -830,24 +824,16 @@ fn parse_title_line<'src>(
     let min_level = if discrete { 0 } else { MIN_SECTION_LEVEL };
 
     let level = if effective_level < min_level {
-        warnings.push(Warning {
-            source: source.take_normalized_line().item,
-            warning: WarningType::SectionHeadingLevelOutOfRange(
-                effective_level,
-                min_level as usize,
-            ),
-            origin: None,
-        });
+        warnings.push(Warning::new(
+            source.take_normalized_line().item,
+            WarningType::SectionHeadingLevelOutOfRange(effective_level, min_level as usize),
+        ));
         min_level as usize
     } else if effective_level > MAX_SECTION_LEVEL {
-        warnings.push(Warning {
-            source: source.take_normalized_line().item,
-            warning: WarningType::SectionHeadingLevelOutOfRange(
-                effective_level,
-                MAX_SECTION_LEVEL as usize,
-            ),
-            origin: None,
-        });
+        warnings.push(Warning::new(
+            source.take_normalized_line().item,
+            WarningType::SectionHeadingLevelOutOfRange(effective_level, MAX_SECTION_LEVEL as usize),
+        ));
         MAX_SECTION_LEVEL as usize
     } else {
         effective_level as usize
@@ -927,11 +913,10 @@ fn peer_or_ancestor_section<'src>(
         let found_level = mi.item.0;
 
         if found_level > *most_recent_level + 1 {
-            warnings.push(Warning {
-                source: source.take_normalized_line().item,
-                warning: WarningType::SectionHeadingLevelSkipped(*most_recent_level, found_level),
-                origin: None,
-            });
+            warnings.push(Warning::new(
+                source.take_normalized_line().item,
+                WarningType::SectionHeadingLevelSkipped(*most_recent_level, found_level),
+            ));
         }
 
         *most_recent_level = found_level;
@@ -987,11 +972,10 @@ pub(crate) fn root_section_sequence_warnings<'src>(blocks: &[Block<'src>]) -> Ve
         let found_level = section.level();
 
         if found_level > most_recent_level + 1 {
-            warnings.push(Warning {
-                source: section.span().take_normalized_line().item,
-                warning: WarningType::SectionHeadingLevelSkipped(most_recent_level, found_level),
-                origin: None,
-            });
+            warnings.push(Warning::new(
+                section.span().take_normalized_line().item,
+                WarningType::SectionHeadingLevelSkipped(most_recent_level, found_level),
+            ));
         }
 
         most_recent_level = found_level;

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -367,11 +367,10 @@ impl<'src> TableBlock<'src> {
             .trim_trailing_whitespace();
 
         if closing_delimiter.is_empty() {
-            warnings.push(Warning {
-                source: delimiter.item,
-                warning: WarningType::UnterminatedDelimitedBlock,
-                origin: None,
-            });
+            warnings.push(Warning::new(
+                delimiter.item,
+                WarningType::UnterminatedDelimitedBlock,
+            ));
         }
 
         Some(MatchAndWarnings {
@@ -1156,11 +1155,10 @@ fn build_psv_table<'src>(
 
     let (raw_cells, recovered_first_cell) = scan_cells(inside, separator);
     if let Some(source) = recovered_first_cell {
-        warnings.push(Warning {
+        warnings.push(Warning::new(
             source,
-            warning: WarningType::TableMissingLeadingSeparator,
-            origin: None,
-        });
+            WarningType::TableMissingLeadingSeparator,
+        ));
     }
 
     let raw_cells = expand_duplicates(raw_cells);
@@ -1218,11 +1216,10 @@ fn build_psv_table<'src>(
                     // Discard the whole row so the remaining cells stay aligned to
                     // the grid.
                     current_row.clear();
-                    warnings.push(Warning {
-                        source: cell_source,
-                        warning: WarningType::TableCellExceedsColumnCount,
-                        origin: None,
-                    });
+                    warnings.push(Warning::new(
+                        cell_source,
+                        WarningType::TableCellExceedsColumnCount,
+                    ));
                 }
                 column_visits = 0;
                 active_rowspans.pop_front();
@@ -1237,11 +1234,10 @@ fn build_psv_table<'src>(
         // `close_table`, that incomplete row is dropped and an error is logged
         // against its last cell.
         if let Some(last) = current_row.last() {
-            warnings.push(Warning {
-                source: last.content,
-                warning: WarningType::TableIncompleteRowAtEndOfTable,
-                origin: None,
-            });
+            warnings.push(Warning::new(
+                last.content,
+                WarningType::TableIncompleteRowAtEndOfTable,
+            ));
         }
     }
 
@@ -1458,11 +1454,10 @@ fn make_csv_field<'src>(
     let data = trimmed.data();
 
     let content = if data == "\"" {
-        warnings.push(Warning {
-            source: trimmed,
-            warning: WarningType::TableCsvDataHasUnclosedQuote,
-            origin: None,
-        });
+        warnings.push(Warning::new(
+            trimmed,
+            WarningType::TableCsvDataHasUnclosedQuote,
+        ));
         trimmed.slice(0..0)
     } else if data.len() >= 2 && data.starts_with('"') && data.ends_with('"') {
         trim_surrounding_whitespace(trimmed.slice(1..data.len() - 1))
@@ -1833,11 +1828,7 @@ fn process_content<'src>(
                     // `origin` (e.g. an unresolved include target) keep
                     // `directive_line` as their only anchor.
                     let origin = absolute_cell_directive_origin(pw.origin, cell_origin.as_ref());
-                    warnings.push(Warning {
-                        source: directive_line,
-                        warning: pw.warning,
-                        origin,
-                    });
+                    warnings.push(Warning::with_origin(directive_line, pw.warning, origin));
                 }
             } else {
                 // `directive_line` indexes an enclosing owned cell's private
@@ -1914,11 +1905,11 @@ fn process_content<'src>(
             // cells leave them queued for the document-level cell enclosing them.
             if at_document_level {
                 for rw in parser.take_owned_cell_warnings() {
-                    warnings.push(Warning {
-                        source: directive_line,
-                        warning: rw.warning,
-                        origin: Some(rw.origin),
-                    });
+                    warnings.push(Warning::with_origin(
+                        directive_line,
+                        rw.warning,
+                        Some(rw.origin),
+                    ));
                 }
             }
 

--- a/parser/src/document/document.rs
+++ b/parser/src/document/document.rs
@@ -150,19 +150,18 @@ impl<'src> Document<'src> {
             // Warnings raised during preprocessing (e.g. an unresolved include
             // directive) are carried the same way and reconstituted here.
             for pw in preprocessor_warnings {
-                warnings.push(Warning {
-                    source: root.slice(pw.offset..pw.offset + pw.len),
-                    warning: pw.warning,
-                    origin: pw.origin,
-                });
+                warnings.push(Warning::with_origin(
+                    root.slice(pw.offset..pw.offset + pw.len),
+                    pw.warning,
+                    pw.origin,
+                ));
             }
 
             for sw in parser.take_substitution_warnings() {
-                warnings.push(Warning {
-                    source: root.slice(sw.offset..sw.offset + sw.len),
-                    warning: sw.warning,
-                    origin: None,
-                });
+                warnings.push(Warning::new(
+                    root.slice(sw.offset..sw.offset + sw.len),
+                    sw.warning,
+                ));
             }
 
             let mut blocks = maw_blocks.item.item;
@@ -211,11 +210,10 @@ impl<'src> Document<'src> {
                     if block.declared_style() == Some("abstract")
                         && block.resolved_context().as_ref() == "open"
                     {
-                        warnings.push(Warning {
-                            source: block.span(),
-                            warning: WarningType::AbstractBlockInBookWithoutDoctitle,
-                            origin: None,
-                        });
+                        warnings.push(Warning::new(
+                            block.span(),
+                            WarningType::AbstractBlockInBookWithoutDoctitle,
+                        ));
                     }
                 }
             }
@@ -237,11 +235,10 @@ impl<'src> Document<'src> {
                     ContentModel::Compound | ContentModel::Empty
                 )
             {
-                warnings.push(Warning {
-                    source: first.span(),
-                    warning: WarningType::NoInlineDoctypeCandidate,
-                    origin: None,
-                });
+                warnings.push(Warning::new(
+                    first.span(),
+                    WarningType::NoInlineDoctypeCandidate,
+                ));
             }
 
             // The `toc` family of attributes is header-only, so the resolved

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -111,11 +111,7 @@ impl<'src> Header<'src> {
                 // delimiter. This mirrors the body-level comment block path,
                 // which reports the same `UnterminatedDelimitedBlock` warning.
                 if !terminated {
-                    warnings.push(Warning {
-                        source: line,
-                        warning: WarningType::UnterminatedDelimitedBlock,
-                        origin: None,
-                    });
+                    warnings.push(Warning::new(line, WarningType::UnterminatedDelimitedBlock));
                 }
 
                 source = after;
@@ -349,11 +345,7 @@ impl<'src> Header<'src> {
                 source = line_mi.after;
             } else {
                 if title.is_some() {
-                    warnings.push(Warning {
-                        source: line,
-                        warning: WarningType::DocumentHeaderNotTerminated,
-                        origin: None,
-                    });
+                    warnings.push(Warning::new(line, WarningType::DocumentHeaderNotTerminated));
                 }
                 break;
             }

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -1151,11 +1151,10 @@ impl Parser {
         source: crate::Span<'src>,
         warnings: &mut Vec<Warning<'src>>,
     ) {
-        warnings.push(Warning {
+        warnings.push(Warning::new(
             source,
-            warning: WarningType::MaxBlockNestingExceeded(self.block_nesting_limit),
-            origin: None,
-        });
+            WarningType::MaxBlockNestingExceeded(self.block_nesting_limit),
+        ));
     }
 
     /// Returns the effective `max-attribute-value-size`: the byte limit applied
@@ -1275,11 +1274,10 @@ impl Parser {
             && let Ok(offset) = v.trim().parse::<i32>()
             && !leveloffset_admits_any_heading(offset)
         {
-            warnings.push(Warning {
-                source: span,
-                warning: WarningType::LeveloffsetExcludesAllHeadingLevels(offset),
-                origin: None,
-            });
+            warnings.push(Warning::new(
+                span,
+                WarningType::LeveloffsetExcludesAllHeadingLevels(offset),
+            ));
         }
 
         value
@@ -2418,11 +2416,10 @@ impl Parser {
             // A silently-locked intrinsic rejects the write without recording a
             // warning (see `AttributeValue::silent_when_locked`).
             if !existing_attr.silent_when_locked {
-                warnings.push(Warning {
-                    source: attr.span(),
-                    warning: WarningType::AttributeValueIsLocked(attr_name),
-                    origin: None,
-                });
+                warnings.push(Warning::new(
+                    attr.span(),
+                    WarningType::AttributeValueIsLocked(attr_name),
+                ));
             }
             return;
         }
@@ -2579,11 +2576,10 @@ impl Parser {
             // A silently-locked intrinsic rejects the write without recording a
             // warning (see `AttributeValue::silent_when_locked`).
             if !existing_attr.silent_when_locked {
-                warnings.push(Warning {
-                    source: attr.span(),
-                    warning: WarningType::AttributeValueIsLocked(attr_name),
-                    origin: None,
-                });
+                warnings.push(Warning::new(
+                    attr.span(),
+                    WarningType::AttributeValueIsLocked(attr_name),
+                ));
             }
             return;
         }

--- a/parser/src/parser/reference_resolver.rs
+++ b/parser/src/parser/reference_resolver.rs
@@ -223,11 +223,10 @@ impl<'src> ReferenceWarnings<'src> {
             kind: ReferenceWarningKind::Unresolved,
         });
 
-        self.doc.push(Warning {
+        self.doc.push(Warning::new(
             source,
-            warning: WarningType::PossibleInvalidReference(target.to_string()),
-            origin: None,
-        });
+            WarningType::PossibleInvalidReference(target.to_string()),
+        ));
     }
 
     /// Folds warnings gathered from a privately-owned sub-parse – the blocks of
@@ -244,11 +243,11 @@ impl<'src> ReferenceWarnings<'src> {
     ) {
         dest.host.extend(self.host);
 
-        dest.doc.extend(self.doc.into_iter().map(|warning| Warning {
-            source: anchor,
-            warning: warning.warning,
-            origin: warning.origin,
-        }));
+        dest.doc.extend(
+            self.doc
+                .into_iter()
+                .map(|warning| Warning::with_origin(anchor, warning.warning, warning.origin)),
+        );
     }
 }
 

--- a/parser/src/tests/asciidoc_lang/attributes/element_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/element_attributes.rs
@@ -184,13 +184,34 @@ If the text cannot be parsed, an error message will be emitted to the log.
 
         let mut parser = Parser::default();
 
-        let block = crate::blocks::Block::parse(
+        let parsed = crate::blocks::Block::parse(
             crate::Span::new("[style,second-positional,named=\"value of named\"]\nSimple block\n"),
             &mut parser,
-        )
-        .unwrap_if_no_warnings()
-        .unwrap()
-        .item;
+        );
+
+        // `style` is a placeholder for a real style name in this doc example, not
+        // a style this parser recognizes, so it records a DEBUG-severity
+        // unknown-style diagnostic. That is incidental to the attribute-list
+        // parsing this test verifies.
+        assert_eq!(parsed.warnings.len(), 1);
+        assert_eq!(parsed.warnings[0].severity, WarningSeverity::Debug);
+        assert_eq!(
+            parsed.warnings[0],
+            Warning {
+                source: Span {
+                    data: "[style,second-positional,named=\"value of named\"]\nSimple block",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                warning: WarningType::UnknownBlockStyle(
+                    "paragraph".to_string(),
+                    "style".to_string()
+                ),
+            }
+        );
+
+        let block = parsed.item.unwrap().item;
 
         assert_eq!(
             block,

--- a/parser/src/tests/asciidoctor_rb/blocks_test.rs
+++ b/parser/src/tests/asciidoctor_rb/blocks_test.rs
@@ -4684,12 +4684,23 @@ mod custom_blocks {
         );
 
         let doc = Parser::default().parse("[foo]\n--\nbar\n--\n");
-        assert_eq!(doc.warnings().count(), 0);
+
+        // Asciidoctor asserts no messages at its *default* (WARN) severity. This
+        // crate surfaces the unknown style as a `WarningSeverity::Debug`
+        // diagnostic (see the debug-level test below), which a host suppresses
+        // by default. The default-severity view – warnings at WARN or above – is
+        // therefore empty, mirroring Asciidoctor.
+        assert_eq!(
+            doc.warnings()
+                .filter(|w| w.severity >= WarningSeverity::Warning)
+                .count(),
+            0
+        );
     }
 
     #[test]
     fn should_log_debug_message_if_block_style_is_unknown_and_debug_level_is_enabled() {
-        non_normative!(
+        verifies!(
             r#"
     test 'should log debug message if block style is unknown and debug level is enabled' do
       input = <<~'EOS'
@@ -4707,8 +4718,29 @@ mod custom_blocks {
 "#
         );
 
-        // Not ported: this crate has no DEBUG-severity logging channel for
-        // unknown block styles.
+        // Asciidoctor logs this only at DEBUG severity (below its default WARN
+        // threshold). This crate records it as a single `WarningSeverity::Debug`
+        // warning, observable via `Document::warnings()`. The block keeps its
+        // default `open` context; the style `foo` is retained but otherwise
+        // ignored. The warning anchors at the block (the `[foo]` line), naming
+        // the offending style directly.
+        let doc = Parser::default().parse("[foo]\n--\nbar\n--\n");
+
+        let warning = doc.warnings().next().unwrap();
+        assert_eq!(warning.severity, WarningSeverity::Debug);
+        assert_eq!(
+            warning,
+            &Warning {
+                source: Span {
+                    data: "[foo]\n--\nbar\n--",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                warning: WarningType::UnknownBlockStyle("open".to_string(), "foo".to_string()),
+            }
+        );
+        assert_eq!(doc.warnings().count(), 1);
     }
 
     non_normative!(

--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -35,10 +35,10 @@
 //! documented in [`super`].
 //!
 //! Compatibility mode and non-HTML backends are out of scope for this crate, so
-//! the DocBook `simpara`/`indexterm` tests and the DEBUG-severity
-//! unknown-style-logging test are reproduced verbatim in `non_normative!`
-//! blocks (they account for those Ruby lines without asserting behavior this
-//! crate does not model). A handful of `inline_doctype` tests have no Ruby
+//! the DocBook `simpara`/`indexterm` tests are reproduced verbatim in
+//! `non_normative!` blocks (they account for those Ruby lines without asserting
+//! behavior this crate does not model). A handful of `inline_doctype` tests
+//! have no Ruby
 //! counterpart in v2.0.26 — they extend coverage of the boundary cases and so
 //! carry no `verifies!` block.
 
@@ -3563,19 +3563,22 @@ mod custom {
         assert_eq!(block.declared_style(), Some("foo"));
         assert_eq!(block.rendered_content(), Some("bar"));
 
-        // No warning is produced.
-        assert_eq!(doc.warnings().count(), 0);
+        // Asciidoctor asserts no messages at its *default* (WARN) severity. This
+        // crate surfaces the unknown style as a `WarningSeverity::Debug`
+        // diagnostic (see the debug-level test below), which a host suppresses
+        // by default, so the default-severity view is empty.
+        assert_eq!(
+            doc.warnings()
+                .filter(|w| w.severity >= WarningSeverity::Warning)
+                .count(),
+            0
+        );
     }
 
-    // Not ported: 'should log debug message if paragraph style is unknown and
-    // debug level is enabled'. Asciidoctor logs `unknown style for paragraph:
-    // foo` only at DEBUG severity. This crate has no debug-severity logging
-    // channel — its `Warning` mechanism conveys WARN-level possible parse
-    // errors only (see `crate::warnings`) — so there is no equivalent behavior
-    // to assert. The observable behavior at default severity (no warning) is
-    // covered by `should_not_warn_if_paragraph_style_is_unregistered` above.
-    non_normative!(
-        r#"
+    #[test]
+    fn should_log_debug_message_if_paragraph_style_is_unknown_and_debug_level_is_enabled() {
+        verifies!(
+            r#"
     test 'should log debug message if paragraph style is unknown and debug level is enabled' do
       input = <<~'EOS'
       [foo]
@@ -3587,7 +3590,31 @@ mod custom {
       end
     end
 "#
-    );
+        );
+
+        // Asciidoctor logs this only at DEBUG severity (below its default WARN
+        // threshold). This crate records it as a single `WarningSeverity::Debug`
+        // warning, observable via `Document::warnings()`. The paragraph keeps
+        // its default context; the style `foo` is retained but otherwise
+        // ignored.
+        let doc = Parser::default().parse("[foo]\nbar");
+
+        let warning = doc.warnings().next().unwrap();
+        assert_eq!(warning.severity, WarningSeverity::Debug);
+        assert_eq!(
+            warning,
+            &Warning {
+                source: Span {
+                    data: "[foo]\nbar",
+                    line: 1,
+                    col: 1,
+                    offset: 0,
+                },
+                warning: WarningType::UnknownBlockStyle("paragraph".to_string(), "foo".to_string()),
+            }
+        );
+        assert_eq!(doc.warnings().count(), 1);
+    }
 }
 
 non_normative!(

--- a/parser/src/tests/prelude.rs
+++ b/parser/src/tests/prelude.rs
@@ -17,7 +17,7 @@ pub(crate) use crate::{
         fixtures::{attributes::*, blocks::*, content::*, document::*, parser::*, warnings::*, *},
         sdd::*,
     },
-    warnings::WarningType,
+    warnings::{WarningSeverity, WarningType},
 };
 
 /// Collects the rendered (post-substitution) text of every simple block

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -19,9 +19,9 @@ use crate::{Span, parser::SourceLine};
 /// entries where `warning.severity >= WarningSeverity::Warning` suppresses the
 /// low-severity [`Debug`](Self::Debug) diagnostics.
 ///
-/// A warning's severity is an intrinsic property of its
-/// [`WarningType`](WarningType); it is assigned when the warning is constructed
-/// and never varies from one occurrence of a given type to another.
+/// A warning's severity is an intrinsic property of its [`WarningType`]; it is
+/// assigned when the warning is constructed and never varies from one
+/// occurrence of a given type to another.
 ///
 /// This enum is `non_exhaustive`: further severities may be recognized as the
 /// parser grows, so a host matching on it needs a catch-all arm.
@@ -65,9 +65,9 @@ pub struct Warning<'src> {
 
     /// Severity of this warning.
     ///
-    /// This is derived from [`warning`](Self::warning) – each
-    /// [`WarningType`](WarningType) has a fixed severity – so a host can filter
-    /// the [`Document::warnings`](crate::Document::warnings) stream by
+    /// This is derived from [`warning`](Self::warning) – each [`WarningType`]
+    /// has a fixed severity – so a host can filter the
+    /// [`Document::warnings`](crate::Document::warnings) stream by
     /// importance without matching on every individual type. Most diagnostics
     /// are [`WarningSeverity::Warning`]; a handful (such as an unknown block
     /// style) are [`WarningSeverity::Debug`], which a host suppresses by

--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -9,6 +9,47 @@ use thiserror::Error;
 
 use crate::{Span, parser::SourceLine};
 
+/// The severity of a [`Warning`].
+///
+/// Every diagnostic this parser records is surfaced through
+/// [`Document::warnings`](crate::Document::warnings) regardless of severity; a
+/// host filters on this value to decide which diagnostics to act on. The
+/// variants are ordered from least to most severe, so a host can select "at or
+/// above" a threshold with an ordinary comparison – for example, keeping only
+/// entries where `warning.severity >= WarningSeverity::Warning` suppresses the
+/// low-severity [`Debug`](Self::Debug) diagnostics.
+///
+/// A warning's severity is an intrinsic property of its
+/// [`WarningType`](WarningType); it is assigned when the warning is constructed
+/// and never varies from one occurrence of a given type to another.
+///
+/// This enum is `non_exhaustive`: further severities may be recognized as the
+/// parser grows, so a host matching on it needs a catch-all arm.
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Hash)]
+#[non_exhaustive]
+pub enum WarningSeverity {
+    /// A low-severity diagnostic that a host is expected to suppress by
+    /// default. It reports something a host may wish to observe (for example,
+    /// via tooling or a verbose mode) but which does not, on its own, suggest
+    /// the parse result is wrong. Asciidoctor logs the equivalent messages
+    /// below its default `WARN` threshold.
+    Debug,
+
+    /// A condition where the parse result might be unexpected. This is the
+    /// severity of the overwhelming majority of this parser's diagnostics and
+    /// the level a host should surface by default.
+    Warning,
+}
+
+impl std::fmt::Debug for WarningSeverity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WarningSeverity::Debug => write!(f, "WarningSeverity::Debug"),
+            WarningSeverity::Warning => write!(f, "WarningSeverity::Warning"),
+        }
+    }
+}
+
 /// Describes a possible parse error (i.e. a "warning") and its location.
 ///
 /// In `asciidoc-parser`, all documents are parseable, so this mechanism is used
@@ -21,6 +62,17 @@ pub struct Warning<'src> {
 
     /// Type of warning detected.
     pub warning: WarningType,
+
+    /// Severity of this warning.
+    ///
+    /// This is derived from [`warning`](Self::warning) – each
+    /// [`WarningType`](WarningType) has a fixed severity – so a host can filter
+    /// the [`Document::warnings`](crate::Document::warnings) stream by
+    /// importance without matching on every individual type. Most diagnostics
+    /// are [`WarningSeverity::Warning`]; a handful (such as an unknown block
+    /// style) are [`WarningSeverity::Debug`], which a host suppresses by
+    /// default.
+    pub severity: WarningSeverity,
 
     /// A pre-resolved originating `(file, line)` for this warning, independent
     /// of the document source map.
@@ -42,6 +94,44 @@ pub struct Warning<'src> {
     ///
     /// [`Document::source_map`]: crate::Document::source_map
     pub origin: Option<SourceLine>,
+}
+
+impl<'src> Warning<'src> {
+    /// Build a warning anchored at `source`, taking its severity from
+    /// `warning`'s [`WarningType::severity`] and leaving
+    /// [`origin`](Self::origin) unset. This is the constructor used for the
+    /// overwhelming majority of warnings, whose location is recovered from the
+    /// document source map.
+    pub(crate) fn new(source: Span<'src>, warning: WarningType) -> Self {
+        let severity = warning.severity();
+
+        Self {
+            source,
+            warning,
+            severity,
+            origin: None,
+        }
+    }
+
+    /// Build a warning anchored at `source` and carrying a pre-resolved
+    /// [`origin`](Self::origin), taking its severity from `warning`'s
+    /// [`WarningType::severity`]. This is used for the rare warnings that arise
+    /// from privately-expanded content with no document span of its own (see
+    /// [`origin`](Self::origin)).
+    pub(crate) fn with_origin(
+        source: Span<'src>,
+        warning: WarningType,
+        origin: Option<SourceLine>,
+    ) -> Self {
+        let severity = warning.severity();
+
+        Self {
+            source,
+            warning,
+            severity,
+            origin,
+        }
+    }
 }
 
 /// Type of possible parse error that was detected.
@@ -366,6 +456,38 @@ pub enum WarningType {
     /// counterpart in Ruby Asciidoctor.
     #[error("rejected link with potentially unsafe scheme (rendered as text): {0}")]
     UnsafeLinkSchemeRejected(String),
+
+    /// A block declared a style (the first positional attribute, e.g. `[foo]`)
+    /// that this parser does not recognize for the block's context, and which
+    /// no built-in masquerade accepts. The style is retained on the block but
+    /// otherwise ignored: the block keeps the default context implied by its
+    /// syntax (for example, `[foo]` over a `--` delimiter stays an open block).
+    ///
+    /// The first field is the block's context (for example `open` or
+    /// `paragraph`); the second is the unrecognized style as the author wrote
+    /// it. This is a [`WarningSeverity::Debug`] diagnostic – Asciidoctor logs
+    /// the equivalent message (`unknown style for <context> block: <style>`)
+    /// only below its default `WARN` threshold – so a host suppresses it by
+    /// default.
+    #[error("unknown style for {0} block: {1}")]
+    UnknownBlockStyle(String, String),
+}
+
+impl WarningType {
+    /// The intrinsic [`WarningSeverity`] of this warning type.
+    ///
+    /// Almost every type is [`WarningSeverity::Warning`]; the exceptions are
+    /// low-severity diagnostics (such as [`UnknownBlockStyle`]) that a host
+    /// suppresses by default. [`Warning::new`] uses this to stamp each
+    /// constructed [`Warning`] with its severity.
+    ///
+    /// [`UnknownBlockStyle`]: Self::UnknownBlockStyle
+    pub(crate) fn severity(&self) -> WarningSeverity {
+        match self {
+            WarningType::UnknownBlockStyle(..) => WarningSeverity::Debug,
+            _ => WarningSeverity::Warning,
+        }
+    }
 }
 
 impl std::fmt::Debug for WarningType {
@@ -607,6 +729,12 @@ impl std::fmt::Debug for WarningType {
                 .debug_tuple("WarningType::UnsafeLinkSchemeRejected")
                 .field(target)
                 .finish(),
+
+            WarningType::UnknownBlockStyle(context, style) => f
+                .debug_tuple("WarningType::UnknownBlockStyle")
+                .field(context)
+                .field(style)
+                .finish(),
         }
     }
 }
@@ -649,11 +777,7 @@ mod tests {
         #[test]
         fn impl_clone() {
             // Silly test to mark the #[derive(...)] line as covered.
-            let w1 = Warning {
-                source: crate::Span::new("abc"),
-                warning: WarningType::EmptyAttributeValue,
-                origin: None,
-            };
+            let w1 = Warning::new(crate::Span::new("abc"), WarningType::EmptyAttributeValue);
 
             let w2 = w1.clone();
             assert_eq!(w1, w2);
@@ -1187,6 +1311,51 @@ mod tests {
                     "WarningType::UnsafeLinkSchemeRejected(\"javascript:alert(1)\")"
                 );
             }
+
+            #[test]
+            fn unknown_block_style() {
+                let warning = WarningType::UnknownBlockStyle("open".to_string(), "foo".to_string());
+                let debug_output = format!("{:?}", warning);
+                assert_eq!(
+                    debug_output,
+                    "WarningType::UnknownBlockStyle(\"open\", \"foo\")"
+                );
+            }
+        }
+
+        mod severity {
+            use crate::warnings::{WarningSeverity, WarningType};
+
+            #[test]
+            fn unknown_block_style_is_debug() {
+                let warning = WarningType::UnknownBlockStyle("open".to_string(), "foo".to_string());
+                assert_eq!(warning.severity(), WarningSeverity::Debug);
+            }
+
+            #[test]
+            fn most_types_are_warning() {
+                assert_eq!(
+                    WarningType::EmptyAttributeValue.severity(),
+                    WarningSeverity::Warning
+                );
+            }
+
+            #[test]
+            fn debug_is_less_severe_than_warning() {
+                assert!(WarningSeverity::Debug < WarningSeverity::Warning);
+            }
+
+            #[test]
+            fn impl_debug() {
+                assert_eq!(
+                    format!("{:?}", WarningSeverity::Debug),
+                    "WarningSeverity::Debug"
+                );
+                assert_eq!(
+                    format!("{:?}", WarningSeverity::Warning),
+                    "WarningSeverity::Warning"
+                );
+            }
         }
     }
 
@@ -1198,11 +1367,10 @@ mod tests {
             // Silly test to mark the #[derive(...)] line as covered.
             let maw1 = MatchAndWarnings {
                 item: "xyz",
-                warnings: vec![Warning {
-                    source: crate::Span::new("abc"),
-                    warning: WarningType::EmptyAttributeValue,
-                    origin: None,
-                }],
+                warnings: vec![Warning::new(
+                    crate::Span::new("abc"),
+                    WarningType::EmptyAttributeValue,
+                )],
             };
 
             let maw2 = maw1.clone();
@@ -1225,11 +1393,10 @@ mod tests {
         fn unwrap_if_no_warnings_panic() {
             let maw = MatchAndWarnings {
                 item: "xyz",
-                warnings: vec![Warning {
-                    source: crate::Span::new("abc"),
-                    warning: WarningType::EmptyAttributeValue,
-                    origin: None,
-                }],
+                warnings: vec![Warning::new(
+                    crate::Span::new("abc"),
+                    WarningType::EmptyAttributeValue,
+                )],
             };
 
             let _ = maw.unwrap_if_no_warnings();


### PR DESCRIPTION
Fixes #1036.

## Summary

An unknown block style — `[foo]` over a `--` open block, or `[foo]` on a paragraph — was silently accepted (the block fell back to its default context) with nothing recorded in `Document::warnings()`. Asciidoctor logs `unknown style for <context> block: <style>` for this, but only at **DEBUG** severity (below its default WARN threshold), and its sibling test `should not warn if block style is unknown` asserts the default-level log stays empty.

This records the diagnostic while honoring that severity nuance.

## Design (confirmed with the maintainer)

Per the issue's severity note, `Warning` gains a severity and `Document::warnings()` yields **all** severities so a host filters by `.severity`:

- **`WarningSeverity`** enum (`Debug` < `Warning`), ordered so a host can select "at or above" a threshold with a plain comparison.
- **`Warning.severity`** field, derived from the warning type (an intrinsic property, not a per-instance value). It's populated by a new `Warning::new` / `Warning::with_origin` constructor that stamps severity from `WarningType::severity()`; all existing construction sites were migrated to those constructors (mechanical, behavior-preserving).
- **`WarningType::UnknownBlockStyle(context, style)`** — the only `Debug`-severity type today; everything else stays `Warning`.
- The default-severity view is `doc.warnings().filter(|w| w.severity >= WarningSeverity::Warning)`, which stays empty for an unknown style — matching Asciidoctor's "should not warn" test.

## Detection

Runs once per parsed block, in `Block::parse` (a thin wrapper over the parse body, so every early-returning branch is covered uniformly, including nested blocks). A style is **recognized** (no diagnostic) when it names the block's own context, a known style keyword (the union of Asciidoctor's `PARAGRAPH_STYLES`, the delimited-block masquerade styles, and the built-in contexts), or an admonition label. Only delimited-block and paragraph contexts are diagnosed — a first positional on a list, section, media macro, or break means something else.

Because this parser lets any built-in context style masquerade over any delimited block (via `resolved_context`), a single shared known-style set matches how it actually resolves a style, rather than replicating Asciidoctor's per-delimiter masquerade tables — this avoids false positives on styles the parser genuinely honors (e.g. `[example]` over `****`). Malformed attribute-list debris (a mangled `[[anchor]`, a non-style positional like `-foo = bar`) is screened out so it isn't misreported as a style.

## Tests

- Ports the previously non-normative `should log debug message if block/paragraph style is unknown` tests (`blocks_test.rb`, `paragraphs_test.rb`) to real assertions, and updates the `should_not_warn…` siblings to assert the default-severity view is empty.
- Adds focused coverage of the detection matrix (recognized keywords, admonitions, self-context styles, lists/sections, nested blocks, malformed debris) plus `WarningSeverity` and the new `WarningType` variant.
- One incidental `asciidoc-lang` doc test whose example uses `[style,…]` (a placeholder that is itself an unknown style) now asserts the incidental Debug warning.

Full suite (4594), `cargo +nightly fmt --all --check`, and `cargo clippy --all-targets` are green.

## Note for review

`UnknownBlockStyle`'s message renders as `unknown style for paragraph block: foo` (uniform `<context> block` wording), vs Asciidoctor's `unknown style for paragraph: foo`. The structured `(context, style)` fields carry the same information; happy to special-case the wording if you'd prefer an exact string match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)