### PR TITLE
feat: Expose WarningType::severity as a public accessor

### DIFF
--- a/parser/src/warnings.rs
+++ b/parser/src/warnings.rs
@@ -478,11 +478,22 @@ impl WarningType {
     ///
     /// Almost every type is [`WarningSeverity::Warning`]; the exceptions are
     /// low-severity diagnostics (such as [`UnknownBlockStyle`]) that a host
-    /// suppresses by default. [`Warning::new`] uses this to stamp each
-    /// constructed [`Warning`] with its severity.
+    /// suppresses by default. Each constructed [`Warning`] is stamped with this
+    /// value in its [`severity`](Warning::severity) field, so reading that
+    /// field is usually more convenient; this accessor exists for when a
+    /// host holds a bare [`WarningType`].
+    ///
+    /// ```
+    /// use asciidoc_parser::warnings::{WarningSeverity, WarningType};
+    ///
+    /// assert_eq!(
+    ///     WarningType::EmptyAttributeValue.severity(),
+    ///     WarningSeverity::Warning,
+    /// );
+    /// ```
     ///
     /// [`UnknownBlockStyle`]: Self::UnknownBlockStyle
-    pub(crate) fn severity(&self) -> WarningSeverity {
+    pub fn severity(&self) -> WarningSeverity {
         match self {
             WarningType::UnknownBlockStyle(..) => WarningSeverity::Debug,
             _ => WarningSeverity::Warning,


### PR DESCRIPTION
## Summary

Makes `WarningType::severity` a public accessor so a host can read a warning's severity from a bare `WarningType`.

`0.29.5` (#1040) added the public `WarningSeverity` enum and classifies `UnknownBlockStyle` as `Debug`, but the `severity` accessor on `WarningType` was `pub(crate)`. The `Warning::severity` *field* is already public, so a host with a full `Warning` could already filter (e.g. `w.severity >= WarningSeverity::Warning`); this change additionally lets a host compute the severity of a bare `WarningType`.

## Changes

- `WarningType::severity(&self) -> WarningSeverity` changed from `pub(crate)` to `pub`.
- Reworded its doc comment (a now-public item's docs must not link to the `pub(crate)` `Warning::new`) and added a runnable doctest that exercises the accessor through the public crate API.

## Testing

- `cargo test -p asciidoc-parser` — all pass (incl. new doctest)
- `cargo clippy -p asciidoc-parser --all-features` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo +nightly doc --all-features --no-deps` (docs.rs env) — no warnings

closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)