### PR TITLE
fix: Anchor the unknown-block-style diagnostic at the block delimiter

### DIFF
--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -224,8 +224,19 @@ impl<'src> Block<'src> {
         parent_list_markers: Option<&[ListItemMarker<'src>]>,
         is_continuation: bool,
     ) -> MatchAndWarnings<'src, BlockParseOutcome<'src>> {
-        let mut result =
-            Self::parse_internal_inner(source, parser, parent_list_markers, is_continuation);
+        // The span at which the block's content begins, once its metadata (title,
+        // anchor, attribute list) has been read. `parse_internal_inner` fills this
+        // in so an unknown-style diagnostic can anchor at the block's delimiter or
+        // first content line rather than at the preceding style-attribute line.
+        let mut content_start: Option<Span<'src>> = None;
+
+        let mut result = Self::parse_internal_inner(
+            source,
+            parser,
+            parent_list_markers,
+            is_continuation,
+            &mut content_start,
+        );
 
         // Record a DEBUG-severity diagnostic when a block declared a style this
         // parser does not recognize for its context. The block keeps the
@@ -236,9 +247,18 @@ impl<'src> Block<'src> {
         if let BlockParseOutcome::Parsed(matched_item) = &result.item
             && let Some(warning) = unknown_block_style_warning(&matched_item.item)
         {
-            result
-                .warnings
-                .push(Warning::new(matched_item.item.span(), warning));
+            // Anchor the diagnostic at the block's first content line – the
+            // delimiter of a delimited block, or the opening line of a paragraph
+            // – matching Asciidoctor, which reports `unknown style for …` at that
+            // line rather than at the `[style]` line above it. `content_start` is
+            // always set when a block carries a declared style (that requires an
+            // attribute list, which only the metadata path parses).
+            let span = content_start
+                .unwrap_or_else(|| matched_item.item.span())
+                .take_normalized_line()
+                .item;
+
+            result.warnings.push(Warning::new(span, warning));
         }
 
         result
@@ -250,6 +270,7 @@ impl<'src> Block<'src> {
         parser: &mut Parser,
         parent_list_markers: Option<&[ListItemMarker<'src>]>,
         is_continuation: bool,
+        content_start: &mut Option<Span<'src>>,
     ) -> MatchAndWarnings<'src, BlockParseOutcome<'src>> {
         // Optimization: If the first line doesn't match any of the early indications
         // for delimited blocks, titles, or attrlists, we can skip directly to treating
@@ -370,6 +391,12 @@ impl<'src> Block<'src> {
                 metadata.block_start = after_blanks;
             }
         }
+
+        // Expose the content start (past the metadata) so `parse_internal` can
+        // anchor an unknown-style diagnostic at the block's delimiter or first
+        // content line. Every block-type dispatch below reads its content from
+        // here, so this is the block's true starting line whichever branch wins.
+        *content_start = Some(metadata.block_start);
 
         // Resolve attribute references in a `[[id,reftext]]` anchor reftext now,
         // while the parser still holds the attributes in effect where the anchor

--- a/parser/src/tests/asciidoc_lang/attributes/element_attributes.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/element_attributes.rs
@@ -199,10 +199,10 @@ If the text cannot be parsed, an error message will be emitted to the log.
             parsed.warnings[0],
             Warning {
                 source: Span {
-                    data: "[style,second-positional,named=\"value of named\"]\nSimple block",
-                    line: 1,
+                    data: "Simple block",
+                    line: 2,
                     col: 1,
-                    offset: 0,
+                    offset: 49,
                 },
                 warning: WarningType::UnknownBlockStyle(
                     "paragraph".to_string(),

--- a/parser/src/tests/asciidoctor_rb/blocks_test.rs
+++ b/parser/src/tests/asciidoctor_rb/blocks_test.rs
@@ -4722,8 +4722,9 @@ mod custom_blocks {
         // threshold). This crate records it as a single `WarningSeverity::Debug`
         // warning, observable via `Document::warnings()`. The block keeps its
         // default `open` context; the style `foo` is retained but otherwise
-        // ignored. The warning anchors at the block (the `[foo]` line), naming
-        // the offending style directly.
+        // ignored. The warning anchors at the block's delimiter line (the `--`,
+        // line 2) – not the `[foo]` style line above it – matching the `line 2`
+        // Asciidoctor reports, and naming the offending style directly.
         let doc = Parser::default().parse("[foo]\n--\nbar\n--\n");
 
         let warning = doc.warnings().next().unwrap();
@@ -4732,10 +4733,10 @@ mod custom_blocks {
             warning,
             &Warning {
                 source: Span {
-                    data: "[foo]\n--\nbar\n--",
-                    line: 1,
+                    data: "--",
+                    line: 2,
                     col: 1,
-                    offset: 0,
+                    offset: 6,
                 },
                 warning: WarningType::UnknownBlockStyle("open".to_string(), "foo".to_string()),
             }

--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -3596,7 +3596,9 @@ mod custom {
         // threshold). This crate records it as a single `WarningSeverity::Debug`
         // warning, observable via `Document::warnings()`. The paragraph keeps
         // its default context; the style `foo` is retained but otherwise
-        // ignored.
+        // ignored. The warning anchors at the paragraph's first content line
+        // (`bar`, line 2) – not the `[foo]` style line above it – matching the
+        // `line 2` Asciidoctor reports.
         let doc = Parser::default().parse("[foo]\nbar");
 
         let warning = doc.warnings().next().unwrap();
@@ -3605,10 +3607,10 @@ mod custom {
             warning,
             &Warning {
                 source: Span {
-                    data: "[foo]\nbar",
-                    line: 1,
+                    data: "bar",
+                    line: 2,
                     col: 1,
-                    offset: 0,
+                    offset: 6,
                 },
                 warning: WarningType::UnknownBlockStyle("paragraph".to_string(), "foo".to_string()),
             }


### PR DESCRIPTION
## Summary

Fixes #1043.

The `UnknownBlockStyle` debug diagnostic anchored at the block's full span, which starts at the `[style]` attribute line. Asciidoctor reports `unknown style for <context> block: <style>` at the block's **delimiter** line (or, for a paragraph, its first content line) instead.

For the repro:

```adoc
[foo]
--
bar
--
```

we now anchor the warning at the `--` delimiter (**line 2**), matching Asciidoctor's `<stdin>: line 2: unknown style for open block: foo`, rather than at `[foo]` (line 1). The paragraph form (`[foo]\nbar`) likewise moves from line 1 to line 2 (`bar`).

## Approach

`BlockMetadata` already tracks `block_start` – the span where a block's content begins once its title/anchor/attribute list have been read. The diagnostic is emitted in `Block::parse_internal`, which has the finished block but not its metadata, so this threads the content-start span out of `parse_internal_inner` via an out-parameter and anchors the warning at its first line (the delimiter, or the paragraph's opening line).

The diagnostic *content* is unchanged – only the anchored line moves – so this is purely the low-priority line-anchoring fix the issue describes.

## Tests

- Updated the three tests that assert the warning span (`blocks_test.rs`, `paragraphs_test.rs`, `element_attributes.rs`) to expect line 2, matching the `verifies!`-quoted Asciidoctor output that was already present in those tests.
- Full workspace test suite passes; `cargo +nightly fmt --all -- --check` and `cargo clippy` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)