### PR TITLE
fix: Model a demoted level-0 title as a sect0 section

### DIFF
--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -89,6 +89,22 @@ impl<'src> SectionBlock<'src> {
 
         let level = level_and_title.item.0;
 
+        // A level-0 section heading in the document body (a bare `=` that no
+        // positive `leveloffset` promoted to a real section) is only valid under
+        // `:doctype: book`, where it is a book part. Under any other doctype
+        // Asciidoctor logs "level 0 sections can only be used when doctype is
+        // book"; raise that warning here, where the doctype is known. The heading
+        // is still modeled as a level-0 section either way, so a renderer can emit
+        // `<h1 class="sect0">`. A discrete level-0 heading is a floating `<h1>`,
+        // not a section, and is exempt.
+        if !discrete && level == 0 && !is_book_doctype(parser) {
+            warnings.push(Warning {
+                source: source.take_normalized_line().item,
+                warning: WarningType::Level0SectionHeadingNotSupported,
+                origin: None,
+            });
+        }
+
         // An explicit ID supplied *above* the heading (a `[#id]`/`[id=…]` block
         // attribute or a `[[id]]` block anchor) always wins. It also suppresses
         // embedded-anchor processing below, so a `[[id]]` embedded in the title
@@ -138,8 +154,13 @@ impl<'src> SectionBlock<'src> {
         // root – the section that directly carries the `appendix` style –
         // therefore always advances the appendix counter so it (and the numbering
         // of any subsection) can derive its letter, even when `sectnums` is unset.
-        let sectnums_active =
-            parser.is_attribute_set("sectnums") && level <= parser.sectnumlevels && !discrete;
+        // A level-0 section (a book part) is not numbered through `sectnums`
+        // (parts use the separate `partnums` attribute, which this crate does not
+        // yet model), so section numbering is restricted to level 1 and deeper.
+        let sectnums_active = parser.is_attribute_set("sectnums")
+            && level >= MIN_SECTION_LEVEL as usize
+            && level <= parser.sectnumlevels
+            && !discrete;
 
         let is_appendix_root = !discrete && level == 1 && section_type == SectionType::Appendix;
 
@@ -438,8 +459,9 @@ impl<'src> SectionBlock<'src> {
     /// equal signs and must be followed by a space.
     ///
     /// This function will return an integer between 1 and 5 for an ordinary
-    /// section. A `discrete` (floating) heading may also return 0, for a
-    /// level-0 (`=`) discrete heading rendered as an `<h1>` floating title.
+    /// section. It returns 0 for a level-0 (`=`) heading modeled as a `sect0`
+    /// section – a body document title / book part – and for a level-0 (`=`)
+    /// `discrete` (floating) heading rendered as an `<h1>` floating title.
     pub fn level(&self) -> usize {
         self.level
     }
@@ -546,6 +568,15 @@ fn join_signifier(signifier: Option<&str>, number: &str) -> String {
         Some(signifier) if !signifier.is_empty() => format!("{signifier} {number}"),
         _ => number.to_string(),
     }
+}
+
+/// Returns `true` when the active `doctype` is `book`, the only doctype under
+/// which a level-0 section heading (a book part) is valid.
+fn is_book_doctype(parser: &Parser) -> bool {
+    matches!(
+        parser.attribute_value("doctype"),
+        InterpretedValue::Value(ref v) if v == "book"
+    )
 }
 
 impl<'src> IsBlock<'src> for SectionBlock<'src> {
@@ -739,16 +770,18 @@ fn match_embedded_section_anchor<'src>(
 ///
 /// The syntactic level is 0-based: a bare `=` is 0, `==` is 1, up to `======`
 /// at 5. `offset` shifts it to the effective level, which is then constrained
-/// to the [`MIN_SECTION_LEVEL`]..=[`MAX_SECTION_LEVEL`] range:
+/// to a supported range:
 ///
 /// * A bare `=` (syntactic level 0) that no positive offset lifts to level 1 or
-///   beyond has no section representation; it is rejected as an unsupported
-///   level-0 heading (recording a warning), preserving the single-document-
-///   title rule. A `discrete` heading is exempt: it may occupy level 0 (an
-///   `<h1>` floating title) and so is not rejected there.
-/// * Any other heading whose effective level falls outside the supported range
-///   is clamped to the nearest valid level and a warning is recorded. The lower
-///   bound is [`MIN_SECTION_LEVEL`], or 0 for a `discrete` heading.
+///   beyond is modeled as a level-0 section (Asciidoctor's `sect0`): a body
+///   document title / book part. The caller ([`SectionBlock::parse`]) raises
+///   [`WarningType::Level0SectionHeadingNotSupported`] for it under any doctype
+///   other than `book`. A `discrete` heading may likewise occupy level 0 (an
+///   `<h1>` floating title).
+/// * Any other heading whose effective level falls outside the
+///   [`MIN_SECTION_LEVEL`]..=[`MAX_SECTION_LEVEL`] range is clamped to the
+///   nearest valid level and a warning is recorded. The lower bound is
+///   [`MIN_SECTION_LEVEL`], or 0 for a `discrete` heading or a bare `=`.
 fn parse_title_line<'src>(
     source: Span<'src>,
     offset: i32,
@@ -795,49 +828,57 @@ fn parse_title_line<'src>(
     let syntactic_level = (count - 1) as i32;
     let effective_level = syntactic_level.saturating_add(offset);
 
-    // A bare `=` (syntactic level 0) that no positive offset lifts to level 1
-    // or beyond is a document title appearing in the body, which is not a
-    // section (the single-document-title rule). Decline it exactly as an
-    // un-offset level-0 heading is declined, rather than clamping it into a
-    // section. This is checked before the whitespace requirement below so a
-    // spaceless `=blah` is still reported, matching a bare level-0 heading.
-    //
-    // A `discrete`/`float` heading is exempt: it renders as a floating `<h1>`,
-    // not the document title, so a level-0 discrete heading is legitimate and is
-    // carried through with level 0 rather than rejected.
-    if !discrete && syntactic_level == 0 && effective_level < MIN_SECTION_LEVEL {
-        warnings.push(Warning {
-            source: source.take_normalized_line().item,
-            warning: WarningType::Level0SectionHeadingNotSupported,
-            origin: None,
-        });
-
-        return None;
-    }
-
     // The marker must be followed by whitespace to be a section title at all;
     // validate that before clamping the level so a non-title line such as
-    // `==x` is declined quietly, without a spurious out-of-range warning.
+    // `==x` (or a bare `=blah`) is declined quietly, falling through to a
+    // paragraph without a spurious warning.
     let title = line.take_required_whitespace()?;
 
     let title_span = strip_symmetric_title_close(title.after, marker_char, count);
 
+    // A bare `=` (syntactic level 0) that no positive offset lifts to level 1 or
+    // beyond is a document title appearing in the body. Rather than the document
+    // title (the single-document-title rule forbids a second one), it models a
+    // level-0 section – Asciidoctor's `sect0`, rendered as `<h1 class="sect0">`,
+    // a book part under `:doctype: book`. It is carried through with level 0 so
+    // the block model can represent it; `SectionBlock::parse` raises
+    // [`WarningType::Level0SectionHeadingNotSupported`] for it under any doctype
+    // other than `book`, where it knows the doctype.
+    //
+    // A `discrete`/`float` heading is likewise valid at level 0: it renders as a
+    // floating `<h1>` rather than the document title.
+    //
     // A real section heading whose offset-adjusted level lands outside the
     // supported range is clamped into range and reported, rather than producing
     // an out-of-range (or, under a hostile offset, absurd) level. The lower
-    // bound is [`MIN_SECTION_LEVEL`] normally, but 0 for a `discrete` heading,
-    // which may legitimately occupy level 0.
-    let min_level = if discrete { 0 } else { MIN_SECTION_LEVEL };
+    // bound is [`MIN_SECTION_LEVEL`] normally, but 0 for a `discrete` heading or
+    // a bare `=` (syntactic level 0), each of which may legitimately occupy
+    // level 0.
+    let min_level = if discrete || syntactic_level == 0 {
+        0
+    } else {
+        MIN_SECTION_LEVEL
+    };
+
+    // A bare `=` (syntactic level 0) whose effective level a negative offset
+    // pushes below 0 still floors at level 0 – the level-0 case – rather than
+    // being reported as an out-of-range clamp. Its diagnostic is the
+    // doctype-gated [`WarningType::Level0SectionHeadingNotSupported`] that
+    // `SectionBlock::parse` raises, so no clamp warning is added for it here.
+    let is_level_0_heading = syntactic_level == 0 && !discrete;
 
     let level = if effective_level < min_level {
-        warnings.push(Warning {
-            source: source.take_normalized_line().item,
-            warning: WarningType::SectionHeadingLevelOutOfRange(
-                effective_level,
-                min_level as usize,
-            ),
-            origin: None,
-        });
+        if !is_level_0_heading {
+            warnings.push(Warning {
+                source: source.take_normalized_line().item,
+                warning: WarningType::SectionHeadingLevelOutOfRange(
+                    effective_level,
+                    min_level as usize,
+                ),
+                origin: None,
+            });
+        }
+
         min_level as usize
     } else if effective_level > MAX_SECTION_LEVEL {
         warnings.push(Warning {
@@ -2115,17 +2156,22 @@ mod tests {
         }
 
         #[test]
-        fn err_level_0_section_heading() {
+        fn level_0_section_heading_models_sect0() {
             let mut parser = Parser::default();
             let mut warnings: Vec<crate::warnings::Warning<'_>> = vec![];
 
-            let result = crate::blocks::SectionBlock::parse(
+            // A bare `=` in the body is modeled as a level-0 section (Asciidoctor's
+            // `sect0`), not declined. Under the default (article) doctype it also
+            // raises the level-0 warning.
+            let mi = crate::blocks::SectionBlock::parse(
                 &BlockMetadata::new("= Document Title"),
                 &mut parser,
                 &mut warnings,
-            );
+            )
+            .unwrap();
 
-            assert!(result.is_none());
+            assert_eq!(mi.item.level(), 0);
+            assert_eq!(mi.item.section_title(), "Document Title");
 
             assert_eq!(
                 warnings,
@@ -3050,17 +3096,23 @@ mod tests {
         }
 
         #[test]
-        fn err_level_0_section_heading() {
+        fn level_0_section_heading_models_sect0() {
             let mut parser = Parser::default();
             let mut warnings: Vec<crate::warnings::Warning<'_>> = vec![];
 
-            let result = crate::blocks::SectionBlock::parse(
+            // A bare `#` (the Markdown-style level-0 marker) in the body is
+            // modeled as a level-0 section (Asciidoctor's `sect0`), not declined.
+            // Under the default (article) doctype it also raises the level-0
+            // warning.
+            let mi = crate::blocks::SectionBlock::parse(
                 &BlockMetadata::new("# Document Title"),
                 &mut parser,
                 &mut warnings,
-            );
+            )
+            .unwrap();
 
-            assert!(result.is_none());
+            assert_eq!(mi.item.level(), 0);
+            assert_eq!(mi.item.section_title(), "Document Title");
 
             assert_eq!(
                 warnings,

--- a/parser/src/blocks/tests/section.rs
+++ b/parser/src/blocks/tests/section.rs
@@ -64,18 +64,10 @@ fn err_missing_space_before_title() {
         }
     );
 
-    assert_eq!(
-        warnings,
-        [Warning {
-            source: Span {
-                data: "=blah blah",
-                line: 1,
-                col: 1,
-                offset: 0,
-            },
-            warning: WarningType::Level0SectionHeadingNotSupported,
-        },]
-    );
+    // `=blah blah` has no space after the marker, so it is not a section title
+    // at all – it is an ordinary paragraph, and no level-0 warning is raised.
+    // (Only a well-formed bare `= Title` models a level-0 section.)
+    assert!(warnings.is_empty());
 }
 
 #[test]

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -295,13 +295,11 @@ impl<'src> Header<'src> {
                 // title and rewind so the block parser sees the whole run –
                 // the block title, the demoted `= …`, and the content below.
                 // The body then recognizes the block title as metadata (not
-                // literal text) and carries it over to the following block, and
-                // the `= …` heading is declined as an unsupported level-0
-                // heading (raising `WarningType::Level0SectionHeadingNotSupported`).
-                // This crate does not model a body-level document title as a
-                // level-0 section, so the heading is declined rather than
-                // rendered as `<h1 class="sect0">`; the demotion and the warning
-                // still hold.
+                // literal text) and carries it over into the following section,
+                // and the `= …` heading is modeled as a level-0 section
+                // (Asciidoctor's `sect0`, rendered as an `<h1>`). Under any
+                // doctype other than `book`, `SectionBlock::parse` also raises
+                // `WarningType::Level0SectionHeadingNotSupported` for it.
                 //
                 // `source` is left pointing at the block-title line (it is not
                 // advanced), so the header span ends above it and the body

--- a/parser/src/tests/asciidoc_lang/directives/include_with_leveloffset.rs
+++ b/parser/src/tests/asciidoc_lang/directives/include_with_leveloffset.rs
@@ -85,7 +85,9 @@ This allows you to publish each chapter as a standalone document (complete with 
     );
 
     // Without the offset the level-0 document title of the included file is not
-    // a valid body heading, so no shifting occurs and the title is rejected.
+    // shifted, so it stays at level 0: a body-level `= Chapter Title` modeled as
+    // a level-0 section (Asciidoctor's `sect0`) that contains the level-1
+    // `== A Section`.
     let handler = InlineFileHandler::from_pairs([(
         "chapter01.adoc",
         "= Chapter Title\n\nChapter intro.\n\n== A Section\n\nSection body.",
@@ -96,7 +98,13 @@ This allows you to publish each chapter as a standalone document (complete with 
         .with_include_file_handler(handler)
         .parse("= My Book\n\ninclude::chapter01.adoc[]");
 
-    assert_eq!(section_levels(&doc), vec![(1, "A Section".to_string())]);
+    assert_eq!(
+        section_levels(&doc),
+        vec![
+            (0, "Chapter Title".to_string()),
+            (1, "A Section".to_string()),
+        ]
+    );
 }
 
 non_normative!(
@@ -392,11 +400,13 @@ fn negative_offset_clamps_real_section_up_to_one() {
 }
 
 #[test]
-fn document_title_with_nonpositive_offset_is_still_rejected() {
-    // The single-document-title rule is preserved: a bare `= Title` in the body
-    // that no positive offset lifts into range is declined (not clamped into a
-    // level-1 section). Offset `-1` is usable, so only the level-0 warning is
-    // raised and no section is produced.
+fn document_title_with_nonpositive_offset_models_a_level_0_section() {
+    // A bare `= Title` in the body that no positive offset lifts into range is
+    // modeled as a level-0 section (Asciidoctor's `sect0`), not the document
+    // title (the single-document-title rule forbids a second one) and not
+    // clamped up into a level-1 section. A negative offset that would push it
+    // below 0 simply floors at level 0, so no out-of-range clamp is reported –
+    // only the level-0 warning, raised because the doctype is not `book`.
     let doc = Parser::default().parse(concat!(
         "= My Book\n\n",
         ":leveloffset: -1\n\n",
@@ -404,7 +414,7 @@ fn document_title_with_nonpositive_offset_is_still_rejected() {
         "body",
     ));
 
-    assert!(section_levels(&doc).is_empty());
+    assert_eq!(section_levels(&doc), vec![(0, "Orphan Title".to_string())]);
     assert_eq!(
         warning_types(&doc),
         vec![WarningType::Level0SectionHeadingNotSupported]

--- a/parser/src/tests/asciidoc_lang/root/syntax_quick_reference.rs
+++ b/parser/src/tests/asciidoc_lang/root/syntax_quick_reference.rs
@@ -444,25 +444,29 @@ include::sections:example$section.adoc[tag=b-base]
 "#
     );
 
-    // Out of scope (https://github.com/asciidoc-rs/asciidoc-parser/issues/380):
-    // multiple level-0 headings are only valid for the `book` doctype, where the
-    // additional level-0 titles are interpreted as parts of a multi-part book. We
-    // don't support the `book` doctype's parts, so this is treated as
-    // non-normative.
-    non_normative!(
+    verifies!(
         r#"
 The `book` document type can have additional level 0 section titles, which are interpreted as xref:sections:parts.adoc[parts].
 The presence of at least one part implicitly makes the document a multi-part book.
 "#
     );
 
-    // The `book` doctype's parts are out of scope (see above): today a second
-    // level-0 heading always warns, regardless of `:doctype: book`.
+    // Under `:doctype: book`, an additional level-0 heading is a valid book
+    // *part*, so it does not warn – unlike the default doctype, where a second
+    // level-0 heading raises `Level0SectionHeadingNotSupported`. The part is
+    // modeled as a level-0 section (Asciidoctor's `sect0`); the fuller part
+    // semantics (roman-numeral `partnums` numbering, `partintro`, and the
+    // multi-part book framing) remain out of scope
+    // (https://github.com/asciidoc-rs/asciidoc-parser/issues/800).
     let doc = Parser::default()
         .parse("= Book Title\n:doctype: book\n\n== Chapter One\n\n= Part Two\n\n== Chapter Two");
     assert!(
-        doc.warnings()
+        !doc.warnings()
             .any(|w| w.warning == WarningType::Level0SectionHeadingNotSupported)
+    );
+    assert!(
+        doc.child_blocks()
+            .any(|b| matches!(b, Block::Section(s) if s.level() == 0))
     );
 
     verifies!(

--- a/parser/src/tests/asciidoc_lang/sections/titles_and_levels.rs
+++ b/parser/src/tests/asciidoc_lang/sections/titles_and_levels.rs
@@ -380,41 +380,21 @@ include::example$section.adoc[tag=content]
                     offset: 0,
                 },
             },
-            blocks: &[
-                Block::Preamble(Preamble {
-                    blocks: &[Block::Simple(SimpleBlock {
-                        content: Content {
-                            original: Span {
-                                data: "= Illegal Level 0 Section (violates rule #1)",
-                                line: 3,
-                                col: 1,
-                                offset: 18,
-                            },
-                            rendered: "= Illegal Level 0 Section (violates rule #1)",
-                        },
-                        source: Span {
-                            data: "= Illegal Level 0 Section (violates rule #1)",
-                            line: 3,
-                            col: 1,
-                            offset: 18,
-                        },
-                        style: SimpleBlockStyle::Paragraph,
-                        title_source: None,
-                        title: None,
-                        caption: None,
-                        number: None,
-                        anchor: None,
-                        anchor_reftext: None,
-                        attrlist: None,
-                    },),],
-                    source: Span {
-                        data: "= Illegal Level 0 Section (violates rule #1)",
+            blocks: &[Block::Section(SectionBlock {
+                // A bare `=` in the body is modeled as a level-0 section
+                // (Asciidoctor's `sect0`), not declined into a preamble
+                // paragraph. It absorbs the following sections as its children.
+                level: 0,
+                section_title: Content {
+                    original: Span {
+                        data: "Illegal Level 0 Section (violates rule #1)",
                         line: 3,
-                        col: 1,
-                        offset: 18,
+                        col: 3,
+                        offset: 20,
                     },
-                },),
-                Block::Section(SectionBlock {
+                    rendered: "Illegal Level 0 Section (violates rule #1)",
+                },
+                blocks: &[Block::Section(SectionBlock {
                     level: 1,
                     section_title: Content {
                         original: Span {
@@ -468,8 +448,23 @@ include::example$section.adoc[tag=content]
                     section_id: Some("_first_section"),
                     caption: None,
                     section_number: None,
-                },),
-            ],
+                },),],
+                source: Span {
+                    data: "= Illegal Level 0 Section (violates rule #1)\n\n== First Section\n\n==== Illegal Nested Section (violates rule #2)",
+                    line: 3,
+                    col: 1,
+                    offset: 18,
+                },
+                title_source: None,
+                title: None,
+                anchor: None,
+                anchor_reftext: None,
+                attrlist: None,
+                section_type: SectionType::Normal,
+                section_id: Some("_illegal_level_0_section_violates_rule_1"),
+                caption: None,
+                section_number: None,
+            },),],
             source: Span {
                 data: "= Document Title\n\n= Illegal Level 0 Section (violates rule #1)\n\n== First Section\n\n==== Illegal Nested Section (violates rule #2)",
                 line: 1,
@@ -508,6 +503,14 @@ include::example$section.adoc[tag=content]
                         }
                     ),
                     (
+                        "_illegal_level_0_section_violates_rule_1",
+                        RefEntry {
+                            id: "_illegal_level_0_section_violates_rule_1",
+                            reftext: Some("Illegal Level 0 Section (violates rule #1)",),
+                            ref_type: RefType::Section,
+                        }
+                    ),
+                    (
                         "_illegal_nested_section_violates_rule_2",
                         RefEntry {
                             id: "_illegal_nested_section_violates_rule_2",
@@ -518,6 +521,10 @@ include::example$section.adoc[tag=content]
                 ]),
                 reftext_to_id: HashMap::from([
                     ("First Section", "_first_section"),
+                    (
+                        "Illegal Level 0 Section (violates rule #1)",
+                        "_illegal_level_0_section_violates_rule_1"
+                    ),
                     (
                         "Illegal Nested Section (violates rule #2)",
                         "_illegal_nested_section_violates_rule_2"

--- a/parser/src/tests/asciidoctor_rb/blocks_test.rs
+++ b/parser/src/tests/asciidoctor_rb/blocks_test.rs
@@ -4758,26 +4758,22 @@ mod metadata {
         assert_xpath(&doc, "//*[@class=\"paragraph\"]/p[text()=\"paragraph\"]", 1);
     }
 
-    // NOTE: partially out of scope. Both tests below demote a body-level
-    // document title (`= Title`) to a level-0 section – the "level 0 sections
-    // can only be used when doctype is book" behavior. A block title directly
-    // above a `= …` line means the line is *not* the document title: the header
-    // is empty and `= …` is a level-0 section heading in the body.
-    // This crate honors the demotion – the document has no title and the
-    // `Level0SectionHeadingNotSupported` warning is raised – but does not model
-    // a body-level document title as a level-0 section, so `= …` is *declined*
-    // as an unsupported level-0 heading rather than rendered as `<h1>`/`.sect0`,
-    // and the block title stays on that declined heading rather than being
-    // forwarded into the section it would have opened. The demoted `<h1>`/
-    // `.sect1` structure these tests assert is therefore never produced, a
-    // deliberate divergence rather than a deferral, so the tests are reproduced
-    // verbatim (`non_normative!`) rather than ported.
+    // NOTE: the DOM-framing assertions are out of scope. Both tests below demote
+    // a body-level document title (`= Title`) to a level-0 section: a block title
+    // directly above a `= …` line means the line is *not* the document title, so
+    // the header is empty and `= …` is a level-0 section heading in the body.
+    // This crate now honors the demotion *and* models the `= …` line as a
+    // level-0 section (Asciidoctor's `sect0`) that a renderer emits as an `<h1>`
+    // heading, with the block title forwarded into that section's first block –
+    // matching Asciidoctor's structure. What the crate does not reproduce is the
+    // converter's page framing (`#header` / `#content` / `#preamble` wrappers)
+    // nor the exact `h1.sect0` class placement (the test virtual DOM carries the
+    // `sect0` class on the section's container, not the `<h1>`), so the Ruby
+    // tests stay `non_normative!` for those framing assertions.
     //
-    // The point both tests share – and that this crate honors – is that the
-    // block title above `= …` demotes it (empty header, level-0 warning) instead
-    // of turning the line into the document title or titling a paragraph that
-    // captures the `= …` line as escaped literal text. The crate's actual
-    // behavior on each input is asserted by
+    // The crate's actual behavior on each input – the empty header, the level-0
+    // section, the forwarded block title, and (under a non-`book` doctype) the
+    // `Level0SectionHeadingNotSupported` warning – is asserted by
     // `block_title_above_document_title_demotes_it` and
     // `block_title_above_document_title_demotes_it_in_book_doctype` below; see
     // also `block_title_above_section_gets_carried_over_to_first_block_in_section`.
@@ -4823,12 +4819,11 @@ mod metadata {
     // A block title directly above `= Section Title` demotes the line: the
     // document header carries no title and `= Section Title` is a level-0
     // section heading in the body. Asciidoctor renders that heading as
-    // `<h1 class="sect0">`; this crate does not model a body-level document
-    // title as a level-0 section, so it declines the heading (raising
-    // `Level0SectionHeadingNotSupported`) and it falls back to a paragraph whose
-    // text is the `= Section Title` line. The block title stays on that declined
-    // heading – the block it immediately precedes – matching how block metadata
-    // above any declined level-0 heading behaves elsewhere in the body.
+    // `<h1 class="sect0">`; this crate models it as a level-0 section (rendered
+    // as an `<h1>` inside a `sect0` container), raising
+    // `Level0SectionHeadingNotSupported` under the default (non-`book`) doctype.
+    // The block title is forwarded into that section's first block – the
+    // `section paragraph` – exactly as Asciidoctor forwards it.
     #[test]
     fn block_title_above_document_title_demotes_it() {
         let doc = Parser::default().parse(".Block title\n= Section Title\n\nsection paragraph\n");
@@ -4846,35 +4841,38 @@ mod metadata {
         assert_eq!(warnings.len(), 1);
         assert_eq!(warnings[0].source.line(), 2);
 
-        // The block title is recognized as metadata (not turned into literal
-        // text) and stays on the declined `= Section Title` heading, which falls
-        // back to a paragraph carrying the block title.
+        // `= Section Title` is modeled as a level-0 section, rendered as an
+        // `<h1>` heading inside a `sect0` container – not as a literal paragraph.
+        assert_xpath(&doc, "//*[@class=\"sect0\"]", 1);
         assert_xpath(
             &doc,
-            "//*[@class=\"paragraph\"]/*[@class=\"title\"][text()=\"Block title\"]",
-            1,
-        );
-        assert_xpath(
-            &doc,
-            "//*[@class=\"paragraph\"]/p[text()=\"= Section Title\"]",
+            "//*[@class=\"sect0\"]/h1[text()=\"Section Title\"]",
             1,
         );
 
-        // The content below the heading remains its own paragraph.
+        // The block title is recognized as metadata and forwarded into the
+        // section's first block, the `section paragraph`.
         assert_xpath(
             &doc,
-            "//*[@class=\"paragraph\"]/p[text()=\"section paragraph\"]",
+            "//*[@class=\"sect0\"]//*[@class=\"paragraph\"]/*[@class=\"title\"][text()=\"Block title\"]",
+            1,
+        );
+        assert_xpath(
+            &doc,
+            "//*[@class=\"sect0\"]//*[@class=\"paragraph\"]/p[text()=\"section paragraph\"]",
             1,
         );
     }
 
     // The crate-specific counterpart to the second `non_normative!` test above
     // (`:doctype: book`). The demotion is the same: the block title above
-    // `= Document Title` empties the header and demotes the line to a declined
-    // level-0 heading (raising `Level0SectionHeadingNotSupported`). Asciidoctor
-    // forwards the block title into the first real section (`== First Section`);
-    // this crate leaves it on the declined `= Document Title` heading, since that
-    // is the block the metadata immediately precedes.
+    // `= Document Title` empties the header and demotes the line to a level-0
+    // section. Under `:doctype: book` that level-0 section is a legitimate book
+    // *part*, so – unlike the default-doctype case – no
+    // `Level0SectionHeadingNotSupported` warning is raised. The part has no
+    // direct content before `== First Section`, so the forwarded block title
+    // travels through the empty part onto the first block of that first section,
+    // matching Asciidoctor.
     #[test]
     fn block_title_above_document_title_demotes_it_in_book_doctype() {
         let doc = Parser::default().parse(
@@ -4884,23 +4882,31 @@ mod metadata {
         // The `= Document Title` line is demoted: the document has no title.
         assert_eq!(doc.header().title(), None);
 
-        let warnings: Vec<_> = doc
-            .warnings()
-            .filter(|w| w.warning == WarningType::Level0SectionHeadingNotSupported)
-            .collect();
-
-        assert_eq!(warnings.len(), 1);
-        assert_eq!(warnings[0].source.line(), 3);
-
-        // The block title stays on the declined `= Document Title` heading.
-        assert_xpath(
-            &doc,
-            "//*[@class=\"paragraph\"]/*[@class=\"title\"][text()=\"Block title\"]",
-            1,
+        // Under `:doctype: book` a level-0 section is a valid part, so the
+        // "level 0 sections can only be used when doctype is book" warning is
+        // not raised.
+        assert!(
+            !doc.warnings()
+                .any(|w| w.warning == WarningType::Level0SectionHeadingNotSupported)
         );
 
-        // `== First Section` is a normal level-1 section with its own paragraph.
-        assert_xpath(&doc, "//*[@class=\"sect1\"]", 1);
+        // `= Document Title` is modeled as a level-0 section (`sect0`) that
+        // contains the level-1 `== First Section`.
+        assert_xpath(&doc, "//*[@class=\"sect0\"]", 1);
+        assert_xpath(
+            &doc,
+            "//*[@class=\"sect0\"]/h1[text()=\"Document Title\"]",
+            1,
+        );
+        assert_xpath(&doc, "//*[@class=\"sect0\"]//*[@class=\"sect1\"]", 1);
+
+        // The block title is forwarded through the empty part onto the first
+        // block of the first section – the `paragraph`.
+        assert_xpath(
+            &doc,
+            "//*[@class=\"sect1\"]//*[@class=\"paragraph\"]/*[@class=\"title\"][text()=\"Block title\"]",
+            1,
+        );
         assert_xpath(
             &doc,
             "//*[@class=\"sect1\"]//*[@class=\"paragraph\"]/p[text()=\"paragraph\"]",

--- a/parser/src/tests/asciidoctor_rb/sections_test.rs
+++ b/parser/src/tests/asciidoctor_rb/sections_test.rs
@@ -2389,10 +2389,11 @@ mod nesting {
 
     // NOTE: The book variant relies on the `book` doctype and its level-0 (`=`)
     // special sections (colophon, dedication, glossary, bibliography). The crate
-    // does not model the book doctype – a `=` heading outside the document
-    // header is declined as an unsupported level-0 heading rather than parsed as
-    // a section – so the nested-section rule can't be exercised for it. This
-    // test stays out of scope until the book doctype is supported.
+    // now models a body-level `=` heading as a level-0 section, but it does not
+    // apply the special-section styles or their no-nested-sections rule at level
+    // 0 (that rule is recognized only for level-1 special sections), so this
+    // book variant can't be exercised. It stays out of scope until the book
+    // doctype's parts and special sections are supported.
     non_normative!(
         r##"
     test 'should log error if subsections are found in special sections in book that do not support subsections' do
@@ -3110,9 +3111,14 @@ non_normative!(
 mod level_offset {
     use crate::tests::prelude::*;
 
-    // NOTE: The crate does not emit the "level 0 sections can only be used when
-    // doctype is book" error for a second level-0 heading in the body — it
-    // produces no diagnostic here. Out of scope.
+    // NOTE: The crate produces no diagnostic for *this* input, because the
+    // `= Standalone Document` line is not recognized as a section here: the
+    // `//`-comment line above it and the `:author:` line below it (no blank
+    // lines between) are absorbed with it into a single paragraph, so there is
+    // no level-0 heading to flag. (A cleanly separated body level-0 heading does
+    // now raise `Level0SectionHeadingNotSupported`; see
+    // `should_print_error_if_level_0_section_comes_after_nested_section_and_doctype_is_not_book`.)
+    // Out of scope.
     non_normative!(
         r##"
     test 'should print error if standalone document is included without level offset' do
@@ -6118,9 +6124,10 @@ non_normative!(
 mod book_doctype {
     use crate::tests::prelude::*;
 
-    // NOTE: Book *parts* (level-0 `=` headings under `:doctype: book`, their
-    // `sect0` rendering, `partintro`, and the standalone `#header` / `#content`
-    // framing) are not modeled by this crate, so this test is out of scope.
+    // NOTE: A body-level `=` heading is now modeled as a level-0 `sect0`
+    // section, but the fuller book-*part* semantics this test exercises –
+    // `partintro` promotion and the standalone `#header` / `#content` page
+    // framing – are not, so this test is out of scope.
     non_normative!(
         r##"
     test 'document title with level 0 headings' do


### PR DESCRIPTION
## Summary

Fixes #1042 (follow-up to #1037 / #1038).

A `= …` heading in the document body – a level-0 section that is not the document title, whether **demoted** by a block title above it (#1038) or simply a second `= …` line – was declined as an unsupported level-0 heading and fell back to a **literal paragraph**. Asciidoctor instead renders it as `<h1 class="sect0">`, and a block title above it is **forwarded** into the section it opens.

This models the level-0 heading as a level-0 `SectionBlock` (Asciidoctor's `sect0`) rather than declining it.

### Before / after — `.Block title\n= Section Title\n\nsection paragraph`

| | before (0.29.5) | after |
|---|---|---|
| `= Section Title` | literal paragraph `<p>= Section Title</p>` | `sect0` section, `<h1>Section Title</h1>` |
| block title | attaches to the `= …` paragraph | forwarded onto `section paragraph` |
| `Level0SectionHeadingNotSupported` | raised (line 2) | raised (line 2) |

The test virtual DOM now produces exactly Asciidoctor's structure:

```
div.sect0
  h1#_section_title "Section Title"
  div.paragraph
    div.title "Block title"
    p "section paragraph"
```

## What changed

- **`parse_title_line`** now carries a bare `=` through at level 0 instead of returning `None`. A negative `leveloffset` that would push it below 0 floors at level 0 rather than reporting an out-of-range clamp (its single diagnostic is the level-0 warning below).
- **`SectionBlock::parse`** raises `Level0SectionHeadingNotSupported` for a level-0 heading **only under a non-`book` doctype**. Under `:doctype: book` a level-0 heading is a legitimate **book part**, so it no longer warns — the message *"level 0 sections can only be used when doctype is book"* would be self-contradictory there. The block-doctype case from the issue (block title forwarded onto the first section's paragraph) falls out of the existing carryover machinery.
- Section numbering is restricted to level ≥ 1 (parts use `partnums`, not `sectnums`, which is unmodeled).

## Deliberate decision to flag for review

Under `:doctype: book`, a body level-0 heading **no longer warns** (previously it always warned, a divergence noted in #1038). This matches Asciidoctor and avoids the self-contradictory message, and it's what the issue's book-doctype case asks for. Please confirm this is the desired behavior.

## Scope

This lands the structural `sect0` modeling #1042 asks for. The **fuller book-part semantics** — roman-numeral `partnums` numbering, `partintro` promotion, and the standalone `#header` / `#content` page framing — remain out of scope (#800). Affected `non_normative!` NOTEs were updated to reflect the new boundary.

## Tests

- Updated the two demotion tests (`block_title_above_document_title_demotes_it` and `…_in_book_doctype`) to assert the `sect0` structure and forwarded block title; the book case now asserts **no** level-0 warning.
- Rewrote the in-file `level_0_section_heading_models_sect0` tests (ASCIIDoc `=` and Markdown `#`), the `section_levels_cant_be_skipped` full-AST literal, the leveloffset tests, and `syntax_quick_reference::section_titles`.
- `=blah` (no space after the marker) is now a plain paragraph with **no** warning (Asciidoctor doesn't flag it).
- Refreshed the now-stale "declined / not modeled" NOTEs in `header.rs` and `sections_test.rs`.

Full `cargo test`, `cargo clippy --all-targets`, and `cargo +nightly fmt --all -- --check` pass (4578 + 4 doctests).

> Note: the two demotion tests in asciidoc-rs/asciidoc-html5#121 that stay `non_normative!` pending this can be revisited once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)