### PR TITLE
fix: Apply the normal substitution group to description-list terms

### DIFF
--- a/parser/src/blocks/list_item_marker.rs
+++ b/parser/src/blocks/list_item_marker.rs
@@ -178,13 +178,16 @@ impl<'src> ListItemMarker<'src> {
         }
     }
 
-    /// Register any leading inline anchors found in a description list term.
+    /// Apply the term's inline substitutions and register any leading inline
+    /// anchors found in a description list term.
     ///
     /// This should be called after parsing a `DefinedTerm` marker when the list
-    /// item is being kept (not just checked for existence). It detects anchors
-    /// like `[[id]]` or `[[id,reftext]]` at the start of the term text,
-    /// registers them in the catalog, and applies macros substitution to
-    /// render the anchor.
+    /// item is being kept (not just checked for existence). A description-list
+    /// term receives the full `normal` substitution group, matching
+    /// Asciidoctor, so `&`, `<`, and `>` are escaped and inline formatting is
+    /// rendered. It also detects anchors like `[[id]]` or `[[id,reftext]]` at
+    /// the start of the term text, registers them in the catalog, and renders
+    /// the anchor.
     ///
     /// This method is a no-op for non-`DefinedTerm` markers.
     pub(crate) fn register_leading_anchors(
@@ -201,11 +204,23 @@ impl<'src> ListItemMarker<'src> {
             return;
         };
 
+        // A description-list term is substituted with the `normal` group. The
+        // attribute-references step already ran during parsing (so the marker
+        // could be recognized), so apply the remaining steps that precede
+        // macros here: special characters, quotes, and character replacements.
+        // The macros step (which also handles the leading inline anchor) and
+        // the post-replacement step follow below.
+        SubstitutionStep::SpecialCharacters.apply(term, parser, None);
+        SubstitutionStep::Quotes.apply(term, parser, None);
+        SubstitutionStep::CharacterReplacements.apply(term, parser, None);
+
         // Check if term starts with `[[` indicating a potential inline anchor.
         let term_text = term.rendered();
         if !term_text.starts_with("[[") {
-            // Apply macros substitution even if no leading anchor.
+            // Apply the remaining `normal` steps even if there is no leading
+            // anchor.
             SubstitutionStep::Macros.apply(term, parser, None);
+            SubstitutionStep::PostReplacement.apply(term, parser, None);
             return;
         }
 
@@ -240,6 +255,10 @@ impl<'src> ListItemMarker<'src> {
         // leading anchor was already registered above, so suppress only that
         // duplicate registration warning in the macro pass.
         apply_macros_with_leading_anchor_registered(term, parser);
+
+        // Finish the `normal` substitution group with the post-replacement
+        // step.
+        SubstitutionStep::PostReplacement.apply(term, parser, None);
     }
 
     /// Return a mutable reference to the term content of a description-list
@@ -646,6 +665,43 @@ mod tests {
     ) -> Option<MatchedItem<'a, crate::blocks::ListItemMarker<'a>>> {
         let parser = Parser::default();
         crate::blocks::ListItemMarker::parse(crate::Span::new(source), &parser)
+    }
+
+    /// Parses `source` as a description-list marker and returns the term text
+    /// after the term's inline substitutions have run (i.e. after
+    /// `register_leading_anchors`).
+    fn term_rendered(source: &str) -> String {
+        let mut parser = Parser::default();
+
+        let mut item = crate::blocks::ListItemMarker::parse(crate::Span::new(source), &parser)
+            .unwrap()
+            .item;
+
+        let mut warnings = vec![];
+        item.register_leading_anchors(&mut parser, &mut warnings);
+        assert!(warnings.is_empty());
+
+        match &item {
+            crate::blocks::ListItemMarker::DefinedTerm { term, .. } => term.rendered().to_string(),
+            other => panic!("expected a defined-term marker, got {other:#?}"),
+        }
+    }
+
+    #[test]
+    fn term_special_characters_are_escaped() {
+        // A description-list term receives the full `normal` substitution group,
+        // so the special characters `&`, `<`, and `>` are escaped rather than
+        // passed through verbatim. The horizontal and qanda list variants share
+        // this code path, since their terms are the same `DefinedTerm` marker.
+        assert_eq!(term_rendered("a & b:: desc"), "a &amp; b");
+        assert_eq!(term_rendered("a < b:: desc"), "a &lt; b");
+        assert_eq!(term_rendered("a > b:: desc"), "a &gt; b");
+
+        // The remaining `normal` steps also apply: inline formatting (quotes)
+        // and character replacements are rendered in the term.
+        assert_eq!(term_rendered("*bold*:: desc"), "<strong>bold</strong>");
+        assert_eq!(term_rendered("A(C):: desc"), "A&#169;");
+        assert_eq!(term_rendered("A(TM):: desc"), "A&#8482;");
     }
 
     #[test]

--- a/parser/src/blocks/list_item_marker.rs
+++ b/parser/src/blocks/list_item_marker.rs
@@ -224,10 +224,6 @@ impl<'src> ListItemMarker<'src> {
         // during that pass. Any other term goes straight through the macros
         // step.
         if term.rendered().starts_with("[[") {
-            // NOTE: Code coverage for this branch will be missing until we
-            // complete MAJOR REFACTOR: Split parsing and inline substitution
-            // steps.
-            // (See https://github.com/asciidoc-rs/asciidoc-parser/issues/461.)
             if let Some(captures) = LEADING_INLINE_ANCHOR.captures(term.rendered()) {
                 let id = &captures[1];
 
@@ -716,6 +712,16 @@ mod tests {
 
         // Only special characters are applied inside a double-plus span.
         assert_eq!(term_rendered("++<b>++:: desc"), "&lt;b&gt;");
+    }
+
+    #[test]
+    fn term_with_bracket_prefix_but_no_valid_anchor() {
+        // A term that starts with `[[` but is not a well-formed inline anchor
+        // (an ID may not start with a digit, and the anchor must be closed) is
+        // not registered as a reference; the bracketed text is left as-is by
+        // the macros step and no warning is emitted.
+        assert_eq!(term_rendered("[[1bad]] foo:: desc"), "[[1bad]] foo");
+        assert_eq!(term_rendered("[[ nope:: desc"), "[[ nope");
     }
 
     #[test]

--- a/parser/src/blocks/list_item_marker.rs
+++ b/parser/src/blocks/list_item_marker.rs
@@ -4,7 +4,9 @@ use regex::Regex;
 
 use crate::{
     HasSpan, Parser, Span,
-    content::{Content, SubstitutionStep, apply_macros_with_leading_anchor_registered},
+    content::{
+        Content, Passthroughs, SubstitutionStep, apply_macros_with_leading_anchor_registered,
+    },
     document::RefType,
     span::MatchedItem,
     warnings::{Warning, WarningType},
@@ -206,59 +208,59 @@ impl<'src> ListItemMarker<'src> {
 
         // A description-list term is substituted with the `normal` group. The
         // attribute-references step already ran during parsing (so the marker
-        // could be recognized), so apply the remaining steps that precede
-        // macros here: special characters, quotes, and character replacements.
-        // The macros step (which also handles the leading inline anchor) and
-        // the post-replacement step follow below.
+        // could be recognized), so the remaining steps run here. Passthrough
+        // spans are extracted first and restored last so their payloads are
+        // shielded from the intervening substitutions, mirroring the structure
+        // of `SubstitutionGroup::apply` for the normal group.
+        let passthroughs = Passthroughs::extract_from(term, parser);
+
         SubstitutionStep::SpecialCharacters.apply(term, parser, None);
         SubstitutionStep::Quotes.apply(term, parser, None);
         SubstitutionStep::CharacterReplacements.apply(term, parser, None);
 
-        // Check if term starts with `[[` indicating a potential inline anchor.
-        let term_text = term.rendered();
-        if !term_text.starts_with("[[") {
-            // Apply the remaining `normal` steps even if there is no leading
-            // anchor.
-            SubstitutionStep::Macros.apply(term, parser, None);
-            SubstitutionStep::PostReplacement.apply(term, parser, None);
-            return;
-        }
-
-        // NOTE: Code coverage for the remainder of this function will be
-        // missing until we complete MAJOR REFACTOR: Split parsing and
-        // inline substitution steps.
-        // (See https://github.com/asciidoc-rs/asciidoc-parser/issues/461.)
-
-        // Detect leading inline anchor pattern: [[id]] or [[id,reftext]]
-        if let Some(captures) = LEADING_INLINE_ANCHOR.captures(term_text) {
-            let id = &captures[1];
-
-            // If reftext is provided, use it. Otherwise, use the text after the anchor
-            // as the default reftext.
-            let reftext = captures.get(2).map(|m| m.as_str().to_string()).or_else(|| {
-                // Use the text after the anchor as default reftext.
-                captures.get(3).map(|m| m.as_str().trim().to_string())
-            });
-
-            // Register the anchor in the catalog.
-            if let Err(_duplicate_error) =
-                parser.register_ref(id, reftext.as_deref(), RefType::Anchor)
-            {
-                warnings.push(Warning::new(
-                    term.original(),
-                    WarningType::DuplicateId(id.to_string()),
-                ));
-            }
-        }
-
-        // Apply macros substitution to render the inline anchor as HTML. The
-        // leading anchor was already registered above, so suppress only that
-        // duplicate registration warning in the macro pass.
-        apply_macros_with_leading_anchor_registered(term, parser);
-
-        // Finish the `normal` substitution group with the post-replacement
+        // A leading inline anchor (`[[id]]` or `[[id,reftext]]`) at the start of
+        // the term is registered in the catalog before the macros step renders
+        // it, so that only its own duplicate-registration warning is suppressed
+        // during that pass. Any other term goes straight through the macros
         // step.
+        if term.rendered().starts_with("[[") {
+            // NOTE: Code coverage for this branch will be missing until we
+            // complete MAJOR REFACTOR: Split parsing and inline substitution
+            // steps.
+            // (See https://github.com/asciidoc-rs/asciidoc-parser/issues/461.)
+            if let Some(captures) = LEADING_INLINE_ANCHOR.captures(term.rendered()) {
+                let id = &captures[1];
+
+                // If reftext is provided, use it. Otherwise, use the text after
+                // the anchor as the default reftext.
+                let reftext = captures.get(2).map(|m| m.as_str().to_string()).or_else(|| {
+                    // Use the text after the anchor as default reftext.
+                    captures.get(3).map(|m| m.as_str().trim().to_string())
+                });
+
+                // Register the anchor in the catalog.
+                if let Err(_duplicate_error) =
+                    parser.register_ref(id, reftext.as_deref(), RefType::Anchor)
+                {
+                    warnings.push(Warning::new(
+                        term.original(),
+                        WarningType::DuplicateId(id.to_string()),
+                    ));
+                }
+            }
+
+            apply_macros_with_leading_anchor_registered(term, parser);
+        } else {
+            SubstitutionStep::Macros.apply(term, parser, None);
+        }
+
         SubstitutionStep::PostReplacement.apply(term, parser, None);
+
+        // Restore the extracted passthroughs and finalize any deferred
+        // cross-references, matching the tail of `SubstitutionGroup::apply`.
+        passthroughs.restore_to(term, parser);
+        term.set_passthroughs(passthroughs.0);
+        term.finalize_deferred(&*parser.renderer);
     }
 
     /// Return a mutable reference to the term content of a description-list
@@ -702,6 +704,18 @@ mod tests {
         assert_eq!(term_rendered("*bold*:: desc"), "<strong>bold</strong>");
         assert_eq!(term_rendered("A(C):: desc"), "A&#169;");
         assert_eq!(term_rendered("A(TM):: desc"), "A&#8482;");
+    }
+
+    #[test]
+    fn term_passthrough_payload_is_protected() {
+        // Passthrough spans in a term are extracted before the substitution
+        // steps run and restored afterward, so their payloads bypass special
+        // characters and quotes exactly as they would in ordinary content.
+        assert_eq!(term_rendered("+++<b>a & b</b>+++:: desc"), "<b>a & b</b>");
+        assert_eq!(term_rendered("pass:[<b>]:: desc"), "<b>");
+
+        // Only special characters are applied inside a double-plus span.
+        assert_eq!(term_rendered("++<b>++:: desc"), "&lt;b&gt;");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1051. A description-list **term** was only run through the macros substitution step, so `&`, `<`, and `>` in a term leaked into the output unescaped (and inline formatting/character replacements were not applied). Asciidoctor applies the full `normal` substitution group to a term.

### Before

```adoc
a & b:: desc
```

```html
<dt class="hdlist1">a & b</dt>
```

### After (matches Asciidoctor 2.0.26)

```html
<dt class="hdlist1">a &amp; b</dt>
```

## Change

`ListItemMarker::register_leading_anchors` (`parser/src/blocks/list_item_marker.rs`) now applies the remaining `normal` steps around the existing macros/leading-anchor logic:

- attribute references already run during parsing (so the `::` marker can be recognized when the term contains `{attr}` references);
- **special characters**, **quotes**, and **character replacements** now run before the macros step;
- the **post-replacement** step runs after it.

Horizontal and qanda list terms come from the same `DefinedTerm` marker, so they are fixed by the same change.

## Testing

- New unit test `term_special_characters_are_escaped` covers `&`/`<`/`>` escaping plus quotes and character replacements in a term.
- Full workspace suite passes (4597 tests); `cargo +nightly fmt --all -- --check` and `cargo clippy` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)