### PR TITLE
fix: Preserve empty ({empty}) list-item principal text as a signal

### DIFF
--- a/parser/src/blocks/list.rs
+++ b/parser/src/blocks/list.rs
@@ -743,7 +743,7 @@ mod tests {
 
         assert_eq!(
             format!("{:#?}", list.item),
-            "ListBlock {\n    type_: ListType::Unordered,\n    items: &[\n        Block::ListItem(\n            ListItem {\n                marker: ListItemMarker::Hyphen(\n                    Span {\n                        data: \"-\",\n                        line: 1,\n                        col: 1,\n                        offset: 0,\n                    },\n                ),\n                blocks: &[\n                    Block::Simple(\n                        SimpleBlock {\n                            content: Content {\n                                original: Span {\n                                    data: \"blah\",\n                                    line: 1,\n                                    col: 3,\n                                    offset: 2,\n                                },\n                                rendered: \"blah\",\n                            },\n                            source: Span {\n                                data: \"blah\",\n                                line: 1,\n                                col: 3,\n                                offset: 2,\n                            },\n                            style: SimpleBlockStyle::Paragraph,\n                            title_source: None,\n                            title: None,\n                            caption: None,\n                            number: None,\n                            anchor: None,\n                            anchor_reftext: None,\n                            attrlist: None,\n                        },\n                    ),\n                ],\n                source: Span {\n                    data: \"- blah\",\n                    line: 1,\n                    col: 1,\n                    offset: 0,\n                },\n                anchor: None,\n                anchor_reftext: None,\n                attrlist: None,\n                checkbox: None,\n            },\n        ),\n    ],\n    source: Span {\n        data: \"- blah\",\n        line: 1,\n        col: 1,\n        offset: 0,\n    },\n    title_source: None,\n    title: None,\n    anchor: None,\n    anchor_reftext: None,\n    attrlist: None,\n    is_checklist: false,\n    is_bibliography: false,\n}"
+            "ListBlock {\n    type_: ListType::Unordered,\n    items: &[\n        Block::ListItem(\n            ListItem {\n                marker: ListItemMarker::Hyphen(\n                    Span {\n                        data: \"-\",\n                        line: 1,\n                        col: 1,\n                        offset: 0,\n                    },\n                ),\n                blocks: &[\n                    Block::Simple(\n                        SimpleBlock {\n                            content: Content {\n                                original: Span {\n                                    data: \"blah\",\n                                    line: 1,\n                                    col: 3,\n                                    offset: 2,\n                                },\n                                rendered: \"blah\",\n                            },\n                            source: Span {\n                                data: \"blah\",\n                                line: 1,\n                                col: 3,\n                                offset: 2,\n                            },\n                            style: SimpleBlockStyle::Paragraph,\n                            title_source: None,\n                            title: None,\n                            caption: None,\n                            number: None,\n                            anchor: None,\n                            anchor_reftext: None,\n                            attrlist: None,\n                        },\n                    ),\n                ],\n                source: Span {\n                    data: \"- blah\",\n                    line: 1,\n                    col: 1,\n                    offset: 0,\n                },\n                anchor: None,\n                anchor_reftext: None,\n                attrlist: None,\n                checkbox: None,\n                has_empty_principal_text: false,\n            },\n        ),\n    ],\n    source: Span {\n        data: \"- blah\",\n        line: 1,\n        col: 1,\n        offset: 0,\n    },\n    title_source: None,\n    title: None,\n    anchor: None,\n    anchor_reftext: None,\n    attrlist: None,\n    is_checklist: false,\n    is_bibliography: false,\n}"
         );
 
         assert_eq!(
@@ -1518,6 +1518,70 @@ mod tests {
         fn non_numeric_start_attribute_falls_back_to_marker() {
             let mi = list_parse("[start=abc]\n7. one\n8. two").unwrap();
             assert_eq!(mi.item.start(), Some(7));
+        }
+    }
+
+    mod has_empty_principal_text {
+        use crate::blocks::{Block, FindBlocks};
+
+        /// Returns the child list items of the first (list) block in `doc`.
+        fn items<'a>(doc: &'a crate::Document<'a>) -> Vec<&'a crate::blocks::ListItem<'a>> {
+            let Some(Block::List(list)) = doc.child_blocks().next() else {
+                panic!("expected a list block");
+            };
+
+            list.child_blocks()
+                .map(|item| item.as_list_item().unwrap())
+                .collect()
+        }
+
+        #[test]
+        fn empty_principal_with_continuation_keeps_attached_block() {
+            // An empty (`{empty}`) principal followed by a continuation-attached
+            // listing: the principal-text node is dropped, so the listing is the
+            // item's only child block, but the item records the empty principal
+            // text so a renderer knows the listing is an attached block (and can
+            // emit the empty principal paragraph ahead of it).
+            let doc = crate::Parser::default().parse(". {empty}\n+\n----\nprint(\"one\")\n----\n");
+            let items = items(&doc);
+
+            assert_eq!(items.len(), 1);
+            assert!(items[0].has_empty_principal_text());
+
+            let mut children = items[0].child_blocks();
+            assert!(matches!(children.next(), Some(Block::RawDelimited(_))));
+            assert!(children.next().is_none());
+        }
+
+        #[test]
+        fn bare_empty_principal_has_no_child_blocks() {
+            // An empty principal with no attached block: the flag is still set,
+            // and the item has no child blocks at all.
+            let doc = crate::Parser::default().parse(". {empty}\n. second\n");
+            let items = items(&doc);
+
+            assert_eq!(items.len(), 2);
+            assert!(items[0].has_empty_principal_text());
+            assert_eq!(items[0].child_blocks().count(), 0);
+
+            // The second item has ordinary principal text, so the flag is clear.
+            assert!(!items[1].has_empty_principal_text());
+        }
+
+        #[test]
+        fn non_empty_principal_with_continuation_is_not_flagged() {
+            // The contrasting case from the issue: with non-empty principal text,
+            // the principal is the first child block and the flag is clear.
+            let doc = crate::Parser::default().parse(". text\n+\n----\nprint(\"one\")\n----\n");
+            let items = items(&doc);
+
+            assert_eq!(items.len(), 1);
+            assert!(!items[0].has_empty_principal_text());
+
+            let mut children = items[0].child_blocks();
+            assert!(matches!(children.next(), Some(Block::Simple(_))));
+            assert!(matches!(children.next(), Some(Block::RawDelimited(_))));
+            assert!(children.next().is_none());
         }
     }
 }

--- a/parser/src/blocks/list_item.rs
+++ b/parser/src/blocks/list_item.rs
@@ -29,6 +29,7 @@ pub struct ListItem<'src> {
     anchor_reftext: Option<Span<'src>>,
     attrlist: Option<Attrlist<'src>>,
     checkbox: Option<bool>,
+    has_empty_principal_text: bool,
 }
 
 impl<'src> ListItem<'src> {
@@ -125,12 +126,23 @@ impl<'src> ListItem<'src> {
 
         parser.in_bibliography_list_item.set(false);
 
+        let mut has_empty_principal_text = false;
+
         let mut next = if let Some(simple_block_mi) = simple_block_for_list_item {
-            // If the principal text is empty (e.g. from {empty} attribute reference),
-            // drop it from the parse tree.
-            if !simple_block_mi.item.content().is_empty() {
+            // If the principal text is present but renders empty (e.g. from an
+            // `{empty}` attribute reference), the node for the principal text is
+            // dropped from the parse tree rather than emitted as an empty child
+            // block. We record that it was present, however: the item still has
+            // an (empty) principal text distinct from a list item that carries
+            // no principal text at all. A renderer uses this to emit the empty
+            // principal paragraph ahead of any continuation-attached blocks,
+            // matching Asciidoctor (whose `text?` is true with `text` empty).
+            if simple_block_mi.item.content().is_empty() {
+                has_empty_principal_text = true;
+            } else {
                 blocks.push(Block::Simple(simple_block_mi.item));
             }
+
             simple_block_mi.after
         } else if matches!(marker, ListItemMarker::DefinedTerm { .. }) {
             // Description list items can have empty content on the same line as the marker.
@@ -555,6 +567,7 @@ impl<'src> ListItem<'src> {
                 anchor_reftext: metadata.anchor_reftext,
                 attrlist: metadata.attrlist.clone(),
                 checkbox,
+                has_empty_principal_text,
             },
             after: next,
         })
@@ -574,6 +587,21 @@ impl<'src> ListItem<'src> {
     /// item.
     pub fn checkbox(&self) -> Option<bool> {
         self.checkbox
+    }
+
+    /// Reports whether this item has principal text that is present in the
+    /// source but renders empty (for example, principal text written as the
+    /// `{empty}` attribute reference).
+    ///
+    /// Such an empty principal text node is not emitted as a child block (see
+    /// [`child_blocks`](Self::child_blocks)); this flag preserves the fact that
+    /// it was there. It distinguishes an item whose principal text is empty –
+    /// so a renderer emits an empty principal paragraph ahead of any
+    /// continuation-attached blocks (as Asciidoctor does) – from an item that
+    /// simply has no principal text. When it is `true`, the item's first child
+    /// block is an attached block rather than the principal text.
+    pub fn has_empty_principal_text(&self) -> bool {
+        self.has_empty_principal_text
     }
 }
 
@@ -632,6 +660,7 @@ impl std::fmt::Debug for ListItem<'_> {
             .field("anchor_reftext", &self.anchor_reftext)
             .field("attrlist", &self.attrlist)
             .field("checkbox", &self.checkbox)
+            .field("has_empty_principal_text", &self.has_empty_principal_text)
             .finish()
     }
 }
@@ -783,7 +812,7 @@ mod tests {
 
         assert_eq!(
             format!("{:#?}", li.item),
-            "ListItem {\n    marker: ListItemMarker::Hyphen(\n        Span {\n            data: \"-\",\n            line: 1,\n            col: 1,\n            offset: 0,\n        },\n    ),\n    blocks: &[\n        Block::Simple(\n            SimpleBlock {\n                content: Content {\n                    original: Span {\n                        data: \"blah\",\n                        line: 1,\n                        col: 3,\n                        offset: 2,\n                    },\n                    rendered: \"blah\",\n                },\n                source: Span {\n                    data: \"blah\",\n                    line: 1,\n                    col: 3,\n                    offset: 2,\n                },\n                style: SimpleBlockStyle::Paragraph,\n                title_source: None,\n                title: None,\n                caption: None,\n                number: None,\n                anchor: None,\n                anchor_reftext: None,\n                attrlist: None,\n            },\n        ),\n    ],\n    source: Span {\n        data: \"- blah\",\n        line: 1,\n        col: 1,\n        offset: 0,\n    },\n    anchor: None,\n    anchor_reftext: None,\n    attrlist: None,\n    checkbox: None,\n}"
+            "ListItem {\n    marker: ListItemMarker::Hyphen(\n        Span {\n            data: \"-\",\n            line: 1,\n            col: 1,\n            offset: 0,\n        },\n    ),\n    blocks: &[\n        Block::Simple(\n            SimpleBlock {\n                content: Content {\n                    original: Span {\n                        data: \"blah\",\n                        line: 1,\n                        col: 3,\n                        offset: 2,\n                    },\n                    rendered: \"blah\",\n                },\n                source: Span {\n                    data: \"blah\",\n                    line: 1,\n                    col: 3,\n                    offset: 2,\n                },\n                style: SimpleBlockStyle::Paragraph,\n                title_source: None,\n                title: None,\n                caption: None,\n                number: None,\n                anchor: None,\n                anchor_reftext: None,\n                attrlist: None,\n            },\n        ),\n    ],\n    source: Span {\n        data: \"- blah\",\n        line: 1,\n        col: 1,\n        offset: 0,\n    },\n    anchor: None,\n    anchor_reftext: None,\n    attrlist: None,\n    checkbox: None,\n    has_empty_principal_text: false,\n}"
         );
     }
 

--- a/parser/src/tests/asciidoc_lang/lists/continuation.rs
+++ b/parser/src/tests/asciidoc_lang/lists/continuation.rs
@@ -2103,6 +2103,27 @@ include::example$complex.adoc[tag=complex-only]
                 },
             }
         );
+
+        // The principal-text node is dropped from each item's child blocks (the
+        // listing block is the only child, so it lines up with the marker), but
+        // each item records that it had an empty principal text. A renderer uses
+        // this to emit the empty principal paragraph ahead of the attached
+        // listing block, matching Asciidoctor.
+        let Some(crate::blocks::Block::List(list)) = doc.child_blocks().next() else {
+            panic!("expected a list block");
+        };
+
+        for item in list.child_blocks() {
+            let item = item.as_list_item().unwrap();
+            assert!(item.has_empty_principal_text());
+
+            let mut children = item.child_blocks();
+            assert!(matches!(
+                children.next(),
+                Some(crate::blocks::Block::RawDelimited(_))
+            ));
+            assert!(children.next().is_none());
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1053.

## Problem

When a list item's principal text is made empty with `{empty}` and a block is attached with a list continuation (`+`), a downstream renderer (`asciidoc-html5`) folded the attached block's content into the principal paragraph:

```adoc
. {empty}
+
----
print("one")
----
```

At the **parse-tree** level the listing block was actually attached correctly — the real defect is subtler. This parser models a list item's *principal text* as its **first child block**. When the principal renders empty, the parser dropped that node entirely (per the AsciiDoc language spec: "the node for the principal text is dropped … so the first block lines up with the list marker"). That left the tree ambiguous:

- `. text` + continuation → `blocks = [Simple("text"), listing]`
- `. {empty}` + continuation → `blocks = [listing]`

A renderer that treats `blocks[0]` as the principal text can't tell these apart, so it renders the listing's content as the principal `<p>`.

Asciidoctor 2.0.26 keeps the two concepts separate — the principal `text` is **not** a block:

```
text.inspect: ""      # empty, but present
text?:         true
blocks.size:   1      # just the listing
```

and emits `<li><p></p><div class="listingblock">…</div></li>`.

## Fix

Preserve the fact that an empty principal text was present, without changing the child-block structure. `ListItem` gains a `has_empty_principal_text()` accessor (set exactly where the empty node is dropped). This mirrors the pattern already used for `checkbox` — a real-struct field asserted via its accessor, deliberately kept out of the test fixtures so existing `ListItem` literals are untouched.

A renderer can now:

- render `blocks[0]` as the principal when `has_empty_principal_text()` is `false` (unchanged behavior), or
- emit an empty principal `<p></p>` ahead of all attached blocks when it is `true`.

This also makes the bare `. {empty}` case (no continuation) reportable as `<p></p>`, matching Asciidoctor.

## Design note

The child-block tree and **all** parse control flow are intentionally left unchanged — only a boolean and its accessor are added. Keeping the empty principal *as* a child `SimpleBlock` was considered and rejected: the continuation loop keys several decisions off `blocks.len()`/`blocks.is_empty()`, so injecting an empty block would perturb list-breaking behavior. The signal-flag approach keeps the spec-normative "node is dropped" wording literally true while giving renderers what they need.

## Tests

- Extended the existing normative `drop_principal_text::use_empty_attribute` test (which asserts the exact issue input) to check `has_empty_principal_text()` on both items and confirm the listing is still the only child block.
- Added a focused `has_empty_principal_text` regression module covering: empty principal + continuation, bare `. {empty}`, and the non-empty contrast case.

Full suite (`cargo test -p asciidoc-parser`): 4599 passed. `cargo +nightly fmt --all -- --check` and `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
