### PR TITLE
fix: Propagate column alignment to header cells

### DIFF
--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -2119,10 +2119,11 @@ impl<'src> TableCell<'src> {
     /// specifier overrides the column's [style](ColumnStyle); with no cell
     /// style operator, the cell is processed with the column's style. A
     /// header cell (`is_header`) is always processed as plain header
-    /// content, regardless of any style operator on the column or the cell, and
-    /// it ignores the column's alignment operators: with no operator on its own
-    /// specifier, a header cell falls back to the default alignment rather than
-    /// inheriting the column's.
+    /// content, regardless of any style operator on the column or the cell.
+    /// Alignment, however, is inherited from the column just as for a body
+    /// cell: with no operator on its own specifier, a header cell falls back to
+    /// the column's alignment. Only the column *style* is ignored for a header
+    /// row, not its alignment.
     ///
     /// Leading and trailing whitespace is always stripped. For every style but
     /// [`AsciiDoc`](ColumnStyle::AsciiDoc) the cell holds inline
@@ -2141,21 +2142,13 @@ impl<'src> TableCell<'src> {
         warnings: &mut Vec<Warning<'src>>,
     ) -> Self {
         // A cell's own alignment operator overrides the column's alignment; with
-        // no operator, the cell inherits the column's alignment. The header row
-        // ignores alignment operators on the column specifier, so a header cell
-        // with no operator of its own falls back to the default alignment rather
-        // than the column's; a cell specifier's own operator is still applied.
-        let (h_align, v_align) = if is_header {
-            (
-                raw.spec.h_align.unwrap_or(HorizontalAlignment::Left),
-                raw.spec.v_align.unwrap_or(VerticalAlignment::Top),
-            )
-        } else {
-            (
-                raw.spec.h_align.unwrap_or(column.h_align),
-                raw.spec.v_align.unwrap_or(column.v_align),
-            )
-        };
+        // no operator, the cell inherits the column's alignment. This applies to
+        // header and body cells alike: only the column *style* is ignored for a
+        // header row (see below), not the column alignment.
+        let (h_align, v_align) = (
+            raw.spec.h_align.unwrap_or(column.h_align),
+            raw.spec.v_align.unwrap_or(column.v_align),
+        );
 
         // A cell's own style operator overrides the column's style; with no
         // operator, the cell is processed with the column's style. The header
@@ -2223,13 +2216,9 @@ impl<'src> TableCell<'src> {
         };
 
         // A data field carries no cell specifier, so its alignment comes from the
-        // column – except in the header row, which ignores the column's alignment
-        // operators and falls back to the default alignment.
-        let (h_align, v_align) = if is_header {
-            (HorizontalAlignment::Left, VerticalAlignment::Top)
-        } else {
-            (column.h_align, column.v_align)
-        };
+        // column. This applies to header and body cells alike: only the column
+        // style is ignored for a header row, not the column alignment.
+        let (h_align, v_align) = (column.h_align, column.v_align);
 
         let source = field.content;
         let content = process_content(field.content, field.replacement, style, parser, warnings);

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -598,6 +598,66 @@ fn malformed_style_operator_falls_back_to_default() {
 }
 
 #[test]
+fn header_cell_inherits_column_alignment() {
+    // A header cell with no alignment operator of its own falls back to its
+    // column's alignment, exactly like a body cell. Only the column *style* is
+    // suppressed for a header row, not the column alignment. Here column 1 is
+    // centered horizontally and bottom-aligned vertically (`^.>`); column 2 has
+    // no operators and keeps the defaults.
+    let table = parse_table(
+        "[cols=\"^.>2,1\",options=\"header\"]\n|===\n|Header A |Header B\n\n|body a |body b\n|===",
+    );
+
+    let header = table.header_row().unwrap();
+    let header_cells = header.cells();
+
+    assert_eq!(header_cells[0].h_align(), HorizontalAlignment::Center);
+    assert_eq!(header_cells[0].v_align(), VerticalAlignment::Bottom);
+    assert_eq!(header_cells[1].h_align(), HorizontalAlignment::Left);
+    assert_eq!(header_cells[1].v_align(), VerticalAlignment::Top);
+
+    // The body cells resolve to the same column alignment, confirming the header
+    // now matches the body.
+    let body_cells = table.body_rows()[0].cells();
+
+    assert_eq!(body_cells[0].h_align(), HorizontalAlignment::Center);
+    assert_eq!(body_cells[0].v_align(), VerticalAlignment::Bottom);
+    assert_eq!(body_cells[1].h_align(), HorizontalAlignment::Left);
+    assert_eq!(body_cells[1].v_align(), VerticalAlignment::Top);
+}
+
+#[test]
+fn header_cell_operator_overrides_column_alignment() {
+    // A header cell's own alignment operator still takes precedence over the
+    // column's alignment, just as for a body cell. The column is left/top by
+    // default; the first header cell's `>` operator right-aligns it.
+    let table = parse_table(
+        "[cols=\"2,1\",options=\"header\"]\n|===\n>|Header A |Header B\n\n|body a |body b\n|===",
+    );
+
+    let header_cells = table.header_row().unwrap().cells();
+
+    assert_eq!(header_cells[0].h_align(), HorizontalAlignment::Right);
+    assert_eq!(header_cells[1].h_align(), HorizontalAlignment::Left);
+}
+
+#[test]
+fn csv_header_cell_inherits_column_alignment() {
+    // A data-format (CSV) header cell carries no per-cell specifier, so its
+    // alignment comes entirely from the column – including in the header row.
+    let table = parse_table(
+        "[format=\"csv\",cols=\"^.>2,1\",options=\"header\"]\n|===\nHeader A,Header B\nbody a,body b\n|===",
+    );
+
+    let header_cells = table.header_row().unwrap().cells();
+
+    assert_eq!(header_cells[0].h_align(), HorizontalAlignment::Center);
+    assert_eq!(header_cells[0].v_align(), VerticalAlignment::Bottom);
+    assert_eq!(header_cells[1].h_align(), HorizontalAlignment::Left);
+    assert_eq!(header_cells[1].v_align(), VerticalAlignment::Top);
+}
+
+#[test]
 fn asciidoc_cell_resolves_references_in_nested_blocks() {
     // Cross-references inside an AsciiDoc cell are resolved during the document's
     // reference-resolution pass, which descends into the cell's nested blocks.

--- a/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
@@ -107,22 +107,26 @@ TIP: The header row ignores any style operators assigned via column and cell spe
         crate::blocks::TableCellContent::AsciiDoc(_)
     ));
 
-    verifies!(
+    // This sentence is classified `non_normative!` rather than `verifies!`
+    // because the crate deliberately diverges from its first clause. It is a
+    // single spec line asserting two rules – (1) the header row ignores
+    // alignment operators on column specifiers, and (2) alignment operators on
+    // a header *cell* specifier are applied. We honor rule (2) but contradict
+    // rule (1): Asciidoctor 2.0.26 (the parity oracle) does *not* ignore column
+    // alignment for the header row. In `lib/asciidoctor/table.rb`,
+    // `Table::Cell#initialize` runs `update_attributes column.attributes` for
+    // every cell (header or body), copying the column's `halign`/`valign` onto
+    // the cell; the header-specific handling only skips
+    // `cell_style = column.style`, so the header ignores the column *style*,
+    // not its alignment. Because the SDD coverage tool matches whole spec lines,
+    // the honored and contradicted rules cannot be split, so the line is marked
+    // non-normative rather than falsely reporting rule (1) as verified.
+    non_normative!(
         r#"
 It also ignores alignment operators assigned to the table's column specifiers; however, any alignment operators assigned to a cell specifier in the header row are applied.
 
 "#
     );
-
-    // NOTE: This crate deliberately diverges from the spec TIP above for the
-    // column-alignment case. Asciidoctor 2.0.26 (the parity oracle) does *not*
-    // ignore alignment operators on a column specifier for the header row: a
-    // header cell inherits its column's `halign`/`valign` exactly like a body
-    // cell. In `lib/asciidoctor/table.rb`, `Table::Cell#initialize` runs
-    // `update_attributes column.attributes` for every cell (header or body),
-    // which copies the column's alignment onto the cell; the header-specific
-    // handling only skips `cell_style = column.style`, so the header ignores the
-    // column *style*, not its alignment. We follow Asciidoctor's behavior.
 
     // The columns carry alignment operators (`^` centers, `.>` bottom-aligns),
     // and the first row is promoted to the header. The header cells inherit the

--- a/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
@@ -114,23 +114,32 @@ It also ignores alignment operators assigned to the table's column specifiers; h
 "#
     );
 
+    // NOTE: This crate deliberately diverges from the spec TIP above for the
+    // column-alignment case. Asciidoctor 2.0.26 (the parity oracle) does *not*
+    // ignore alignment operators on a column specifier for the header row: a
+    // header cell inherits its column's `halign`/`valign` exactly like a body
+    // cell. In `lib/asciidoctor/table.rb`, `Table::Cell#initialize` runs
+    // `update_attributes column.attributes` for every cell (header or body),
+    // which copies the column's alignment onto the cell; the header-specific
+    // handling only skips `cell_style = column.style`, so the header ignores the
+    // column *style*, not its alignment. We follow Asciidoctor's behavior.
+
     // The columns carry alignment operators (`^` centers, `.>` bottom-aligns),
-    // and the first row is promoted to the header. The header row ignores the
-    // column alignment operators, so its cells fall back to the default
-    // alignment (left, top) ...
+    // and the first row is promoted to the header. The header cells inherit the
+    // column alignment (center, bottom), just as the body cells do.
     let table = parse_table(
         "[cols=\"^.>,^.>\",options=\"header\"]\n|===\n|Column 1 |Column 2\n\n|Cell 1 |Cell 2\n|===",
     );
     assert_eq!(
         header_alignments(&table),
         vec![
-            (HorizontalAlignment::Left, VerticalAlignment::Top),
-            (HorizontalAlignment::Left, VerticalAlignment::Top),
+            (HorizontalAlignment::Center, VerticalAlignment::Bottom),
+            (HorizontalAlignment::Center, VerticalAlignment::Bottom),
         ]
     );
 
-    // ... while the body cells in the same columns *do* honor the column
-    // alignment operators.
+    // The body cells in the same columns resolve to the same alignment,
+    // confirming the header now matches the body.
     assert_eq!(
         table.body_rows()[0]
             .cells()
@@ -143,12 +152,13 @@ It also ignores alignment operators assigned to the table's column specifiers; h
         ]
     );
 
-    // Alignment operators on a cell specifier *in the header row* are applied.
-    // Here the columns are centered (`^`), but the header cells carry their own
-    // operators (`>` right, `.>` bottom), which override the ignored column
-    // alignment; the horizontal alignment of the second header cell has no cell
-    // operator, so it falls back to the default (left) rather than the column's
-    // center.
+    // Alignment operators on a cell specifier *in the header row* are applied,
+    // overriding the column alignment for whichever axis the cell operator
+    // sets. Here the columns are centered (`^`); the first header cell's `>`
+    // sets its horizontal alignment to right while its vertical alignment falls
+    // back to the column (top, since `^` sets no vertical operator). The second
+    // header cell's `.>` sets its vertical alignment to bottom while its
+    // horizontal alignment falls back to the column's center.
     let table = parse_table(
         "[cols=\"2*^\",options=\"header\"]\n|===\n>|Column 1 .>|Column 2\n\n|Cell 1 |Cell 2\n|===",
     );
@@ -156,12 +166,12 @@ It also ignores alignment operators assigned to the table's column specifiers; h
         header_alignments(&table),
         vec![
             (HorizontalAlignment::Right, VerticalAlignment::Top),
-            (HorizontalAlignment::Left, VerticalAlignment::Bottom),
+            (HorizontalAlignment::Center, VerticalAlignment::Bottom),
         ]
     );
 
-    // The body cells, which have no cell specifier, still honor the column's
-    // center alignment.
+    // The body cells, which have no cell specifier, honor the column's center
+    // alignment on both axes.
     assert_eq!(
         table.body_rows()[0]
             .cells()


### PR DESCRIPTION
## Summary

Fixes #1061 — column-level alignment operators (e.g. `^` horizontal, `.>` vertical, placed on a column specifier in the `cols` attribute) were **not propagated to header (`<th>`) cells**. A header cell with no operator of its own resolved to the default `HorizontalAlignment::Left` / `VerticalAlignment::Top` instead of falling back to its column's alignment. Body cells fell back correctly; only header cells were affected.

## Root cause

`parser/src/blocks/table.rs`, the cell-alignment resolution in both `TableCell::parse` (PSV) and `TableCell::parse_data` (CSV/TSV/DSV), special-cased header cells to hardcode the default alignment:

```rust
let (h_align, v_align) = if is_header {
    (raw.spec.h_align.unwrap_or(HorizontalAlignment::Left),
     raw.spec.v_align.unwrap_or(VerticalAlignment::Top))
} else {
    (raw.spec.h_align.unwrap_or(column.h_align),
     raw.spec.v_align.unwrap_or(column.v_align))
};
```

This diverged from **Asciidoctor 2.0.26** (the parity oracle). In `lib/asciidoctor/table.rb`, `Table::Cell#initialize` runs `update_attributes column.attributes` for **every** cell — header or body — which copies the column's `halign`/`valign` onto the cell. The header-specific handling only skips `cell_style = column.style`. So a header row ignores the column **style**, not the column **alignment**.

Verified directly against the installed `asciidoctor` 2.0.26:

```
[cols="^.>,^.>",options="header"]  →  <th class="tableblock halign-center valign-bottom">
```

## Fix

Header cells now fall back to the column alignment exactly like body cells, while still preferring the header cell's own operator when present. The `is_header` special-casing remains where it belongs — `style` resolution.

## Spec divergence note

The tracked AsciiDoc language doc (`add-header-row.adoc`) contains a normative TIP stating the header row "ignores alignment operators assigned to the table's column specifiers." Asciidoctor does **not** honor that for column alignment. This crate follows Asciidoctor (the parity oracle), and the divergence is documented in the updated `header_ignores_operators` test, matching the project's existing convention for deliberate spec-vs-Asciidoctor divergences.

## Tests

- Updated `tests::asciidoc_lang::tables::add_header_row::header_ignores_operators` to assert Asciidoctor's actual behavior (header cells inherit column alignment; header **style** is still suppressed; a header cell's own operator still overrides per-axis).
- Added regression tests in `parser/src/blocks/tests/table.rs`:
  - `header_cell_inherits_column_alignment` (PSV)
  - `header_cell_operator_overrides_column_alignment` (PSV, per-cell operator precedence)
  - `csv_header_cell_inherits_column_alignment` (data-format path)

Full suite green (`cargo test -p asciidoc-parser`: 4607 passed), `cargo +nightly fmt --all -- --check` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)