### PR TITLE
feat: Promote the inline AST into Content (inline-ast Phase 2, step 1)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -612,7 +612,7 @@ Each phase is a reviewable unit with a clear exit gate.
   section with a *formatted* title, whose rendered (marker-bearing) text feeds the reference
   catalog. The single-pass builder (Phase 4) retires it by never re-rendering.
 
-[`RecordingRenderer`]: ../../parser/src/tests/inline_recorder.rs
+[`RecordingRenderer`]: ../../parser/src/content/inline_tree.rs
 [`parser/src/tests/inline_recorder.rs`]: ../../parser/src/tests/inline_recorder.rs
 
 - **Phase 2 — make the tree canonical; `rendered()` becomes a fold.** 🔶 **In progress.**

--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -615,11 +615,37 @@ Each phase is a reviewable unit with a clear exit gate.
 [`RecordingRenderer`]: ../../parser/src/tests/inline_recorder.rs
 [`parser/src/tests/inline_recorder.rs`]: ../../parser/src/tests/inline_recorder.rs
 
-- **Phase 2 — make the tree canonical; `rendered()` becomes a fold.** Flip `Content` so
-  the tree is the source of truth and `rendered()` is computed from it. Retire the sentinel
-  systems (§4.2). This is the load-bearing internal cutover.
+- **Phase 2 — make the tree canonical; `rendered()` becomes a fold.** 🔶 **In progress.**
+  Flip `Content` so the tree is the source of truth and `rendered()` is computed from it.
+  Retire the sentinel systems (§4.2). This is the load-bearing internal cutover.
   *Exit:* all ~277 golden `.rendered()` assertions pass unchanged; sentinels deleted;
   benchmarks within an agreed budget of `main`.
+
+  *Step 1 landed as (promote the tree into `Content`):* the Phase 1 recorder machinery
+  moved out of the test build into a production module
+  ([`content::inline_tree`](../../parser/src/content/inline_tree.rs)) that wraps the
+  parser's *own* renderer (so the fold reproduces that renderer's bytes, not a hard-coded
+  HTML backend). `Content` now carries a live
+  [`inlines`](../../parser/src/content/content.rs) tree, populated during substitution and
+  exposed via `Content::inlines()`. Tree building is gated behind an **opt-in** flag
+  ([`Parser::with_inline_tree`](../../parser/src/parser/parser.rs)); with it off (the
+  default) the parse path is byte- and performance-identical to before, so all ~277 golden
+  assertions pass unchanged. With it on, each block's tree is built by a **counter-safe
+  second pass**: `SubstitutionGroup::apply` clones the parser *before* the authoritative
+  pass advances any document counter, runs the recording pipeline on the clone, and parses
+  the recorded markers into the tree — so footnotes, callouts, and `{counter:…}` values are
+  numbered identically to the authoritative output (regression-tested). The
+  [`inline_recorder`](../../parser/src/tests/inline_recorder.rs) differential corpus now
+  drives the production module directly, so its byte-for-byte fold parity is a test of the
+  shipped code.
+
+  *Still remaining in Phase 2 (not in this step):* making `rendered()` *authoritatively* a
+  fold of the tree (which requires the tree to carry resolution through cross-reference and
+  title passes, so `rendered()` reflects resolved destinations) and **deleting** the three
+  production sentinel systems. These are deferred because, with Strategy A, an authoritative
+  fold would inherit the known formatted-section-title drift (§4.1) and require re-folding
+  refs at resolution time; the design sequences the true single-artifact cutover with the
+  single-pass builder in Phase 4. The opt-in flag retires with it.
 
 - **Phase 3 — expose the public inline API.** `Content::inlines()`, `IsBlock::inlines()`,
   the public node types, and `render_with`/`render_to`. Rename `rendered()` →

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -92,7 +92,7 @@ pub struct Content<'src> {
     /// This is a **derived artifact** – a projection of the rendered content,
     /// not an independent source of truth (yet; see the [inline AST
     /// architecture] design, Phase 2). It is populated only when inline-tree
-    /// building is enabled on the [`Parser`]
+    /// building is enabled on the [`Parser`](crate::Parser)
     /// ([`with_inline_tree`](crate::Parser::with_inline_tree)); otherwise it is
     /// empty and the default parse path is byte- and performance-identical to
     /// before. Because it is derived, it is deliberately excluded from

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -6,6 +6,7 @@
 use crate::{
     Span,
     content::Passthrough,
+    inlines::InlineNode,
     parser::{
         InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext,
         XrefRenderParams,
@@ -36,7 +37,7 @@ use crate::{
 /// [`RawDelimitedBlock`]: crate::blocks::RawDelimitedBlock
 /// [`Document::resolve_references`]: crate::Document::resolve_references
 /// [`rendered()`]: Self::rendered
-#[derive(Clone, Eq, Hash, PartialEq)]
+#[derive(Clone)]
 pub struct Content<'src> {
     /// The original [`Span`] from which this content was derived.
     original: Span<'src>,
@@ -83,6 +84,23 @@ pub struct Content<'src> {
     /// with no passthroughs, and for content whose substitution group does not
     /// extract them.
     passthroughs: Vec<Passthrough>,
+
+    /// The inline AST for this content: the structured representation of its
+    /// inline nodes, folded from the same substitution pass that produced
+    /// [`rendered`](Self::rendered).
+    ///
+    /// This is a **derived artifact** – a projection of the rendered content,
+    /// not an independent source of truth (yet; see the [inline AST
+    /// architecture] design, Phase 2). It is populated only when inline-tree
+    /// building is enabled on the [`Parser`]
+    /// ([`with_inline_tree`](crate::Parser::with_inline_tree)); otherwise it is
+    /// empty and the default parse path is byte- and performance-identical to
+    /// before. Because it is derived, it is deliberately excluded from
+    /// [`PartialEq`]/[`Eq`]/[`Hash`]: two `Content`s with equal rendered text
+    /// compare equal regardless of whether the tree was built.
+    ///
+    /// [inline AST architecture]: https://github.com/scouten/asciidoc-parser/blob/main/docs/design/inline-ast-architecture.md
+    inlines: Vec<InlineNode<'src>>,
 }
 
 /// The deferred (cross-reference-bearing) portion of a [`Content`].
@@ -221,6 +239,7 @@ impl<'src> Content<'src> {
             source_lines: None,
             deferred: None,
             passthroughs: Vec::new(),
+            inlines: Vec::new(),
         }
     }
 
@@ -249,6 +268,7 @@ impl<'src> Content<'src> {
                 .deferred
                 .map(|(template, xrefs)| Box::new(DeferredContent { template, xrefs })),
             passthroughs: Vec::new(),
+            inlines: Vec::new(),
         }
     }
 
@@ -286,6 +306,7 @@ impl<'src> Content<'src> {
             source_lines: Some(line_spans.into_boxed_slice()),
             deferred: None,
             passthroughs: Vec::new(),
+            inlines: Vec::new(),
         }
     }
 
@@ -363,6 +384,30 @@ impl<'src> Content<'src> {
     /// them back in.
     pub(crate) fn set_passthroughs(&mut self, passthroughs: Vec<Passthrough>) {
         self.passthroughs = passthroughs;
+    }
+
+    /// Returns the inline AST for this content: the structured representation
+    /// of its inline nodes.
+    ///
+    /// This is populated only when inline-tree building is enabled on the
+    /// [`Parser`](crate::Parser) (see
+    /// [`with_inline_tree`](crate::Parser::with_inline_tree)); it is an empty
+    /// slice otherwise. The tree is a projection of the rendered content – the
+    /// fold of the tree reproduces [`rendered`](Self::rendered) byte-for-byte –
+    /// and is not yet the canonical representation (see the inline AST
+    /// architecture design, Phase 2).
+    // Consumed by the differential and structural tests (and, in Phase 3, by
+    // the public inline API); the accessor is part of the tree's internal
+    // surface even where non-test code does not yet read it.
+    #[allow(dead_code)]
+    pub(crate) fn inlines(&self) -> &[InlineNode<'src>] {
+        &self.inlines
+    }
+
+    /// Installs the inline AST built for this content by the recording pass
+    /// (see [`inline_tree`](crate::content::inline_tree)).
+    pub(crate) fn set_inlines(&mut self, inlines: Vec<InlineNode<'src>>) {
+        self.inlines = inlines;
     }
 
     /// Removes the [`FOOTNOTE_MARKER_START`]/[`FOOTNOTE_MARKER_END`] sentinels
@@ -763,7 +808,35 @@ impl<'src> From<Span<'src>> for Content<'src> {
             source_lines: None,
             deferred: None,
             passthroughs: Vec::new(),
+            inlines: Vec::new(),
         }
+    }
+}
+
+// `inlines` is a derived cache (see the field's doc comment), so it is excluded
+// from equality and hashing: a `Content` compares and hashes by its rendered
+// output and resolution state, whether or not the inline tree was built. This
+// preserves the semantics the old `#[derive(Eq, Hash, PartialEq)]` had before
+// the field was added.
+impl PartialEq for Content<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.original == other.original
+            && self.rendered == other.rendered
+            && self.source_lines == other.source_lines
+            && self.deferred == other.deferred
+            && self.passthroughs == other.passthroughs
+    }
+}
+
+impl Eq for Content<'_> {}
+
+impl std::hash::Hash for Content<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.original.hash(state);
+        self.rendered.hash(state);
+        self.source_lines.hash(state);
+        self.deferred.hash(state);
+        self.passthroughs.hash(state);
     }
 }
 

--- a/parser/src/content/inline_tree.rs
+++ b/parser/src/content/inline_tree.rs
@@ -989,3 +989,104 @@ pub(crate) fn fold_marked(marked: &str, events: &[Event]) -> String {
 pub(crate) fn open_marker_count(marked: &str) -> usize {
     marked.matches(MARK_OPEN).count()
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use std::rc::Rc;
+
+    use super::*;
+    use crate::{
+        Parser, Span,
+        attributes::{Attrlist, AttrlistContext},
+        parser::{LinkRenderParams, QuoteScope, QuoteType},
+    };
+
+    /// A renderer that discards the body it is handed, so the recorder's
+    /// placeholder probe never survives – exercising the defensive
+    /// "the wrapper did not contain the placeholder body" fallbacks in
+    /// [`RecordingRenderer::split_quote`] and
+    /// [`RecordingRenderer::render_link`]. A real renderer always echoes the
+    /// body, so these paths are otherwise unreachable.
+    #[derive(Debug)]
+    struct DroppingRenderer;
+
+    impl InlineSubstitutionRenderer for DroppingRenderer {
+        fn render_quoted_substitution(
+            &self,
+            _type_: QuoteType,
+            _scope: QuoteScope,
+            _attrlist: Option<Attrlist<'_>>,
+            _id: Option<String>,
+            _body: &str,
+            dest: &mut String,
+        ) {
+            dest.push_str("<q/>");
+        }
+
+        fn render_link(&self, _params: &LinkRenderParams, dest: &mut String) {
+            dest.push_str("<a/>");
+        }
+    }
+
+    #[test]
+    fn push_text_keeps_an_unterminated_ampersand() {
+        // The wrapped renderer always emits terminated entities, but the
+        // ampersand-without-`;` guard keeps a stray `&` as plain text rather
+        // than mis-reading it as an entity.
+        let mut out = Vec::new();
+        push_text("a & b", &mut out);
+
+        let mut folded = String::new();
+        fold_into(&out, &mut folded);
+        assert_eq!(folded, "a & b");
+
+        // No character reference was manufactured from the bare ampersand.
+        assert!(out.iter().all(|rec| !matches!(rec, Rec::CharRef { .. })));
+    }
+
+    #[test]
+    fn quoted_substitution_falls_back_when_the_body_is_dropped() {
+        let (recorder, events) = RecordingRenderer::new(Rc::new(DroppingRenderer));
+
+        let mut dest = String::new();
+        recorder.render_quoted_substitution(
+            QuoteType::Strong,
+            QuoteScope::Constrained,
+            None,
+            None,
+            "body",
+            &mut dest,
+        );
+
+        // A container event was still recorded, and the fallback did not panic.
+        assert_eq!(events.borrow().len(), 1);
+        assert!(dest.contains("<q/>"));
+    }
+
+    #[test]
+    fn link_falls_back_when_the_text_is_dropped() {
+        let (recorder, events) = RecordingRenderer::new(Rc::new(DroppingRenderer));
+
+        let parser = Parser::default();
+        let attrlist = Attrlist::parse(Span::new(""), &parser, AttrlistContext::Inline)
+            .item
+            .item;
+
+        let params = LinkRenderParams {
+            target: "https://example.org".to_string(),
+            link_text: "text".to_string(),
+            extra_roles: vec![],
+            window: None,
+            attrlist: &attrlist,
+            parser: &parser,
+        };
+
+        let mut dest = String::new();
+        recorder.render_link(&params, &mut dest);
+
+        assert_eq!(events.borrow().len(), 1);
+        assert!(dest.contains("<a/>"));
+    }
+}

--- a/parser/src/content/inline_tree.rs
+++ b/parser/src/content/inline_tree.rs
@@ -1,0 +1,991 @@
+//! Builds the inline AST as a **live artifact of a parsed [`Content`]**.
+//!
+//! This is the production home of the tree-building machinery that landed in
+//! Phase 1 as a test-only oracle ([`inline_recorder`]). It promotes that
+//! machinery into the parser proper so that – when tree building is enabled on
+//! the [`Parser`] – every [`Content`] carries a
+//! [`Vec<InlineNode>`](crate::inlines::InlineNode) alongside its rendered
+//! string.
+//!
+//! # Strategy A, unchanged
+//!
+//! The construction strategy is still "Strategy A" (design §4.1): the existing
+//! substitution pipeline is re-run with a **transparent marker-recording
+//! decorator** ([`RecordingRenderer`]) wrapped around the parser's own inline
+//! renderer. The decorator writes the exact bytes the wrapped renderer would,
+//! and additionally brackets each recognized construct with inert
+//! Private-Use-Area sentinels. Two facts follow directly (and are asserted by
+//! the Phase 1 corpus):
+//!
+//! 1. Stripping the sentinels reproduces the wrapped renderer's output
+//!    byte-for-byte (the *no-perturbation* invariant).
+//! 2. Parsing the sentinel structure recovers a tree of
+//!    [`InlineNode`](crate::inlines::InlineNode)s, and folding that tree
+//!    reconstructs the same bytes.
+//!
+//! Because the decorator wraps whatever renderer the [`Parser`] carries, the
+//! fold reproduces *that* renderer's bytes, not a hard-coded HTML backend.
+//!
+//! # Why a second pass (for now)
+//!
+//! Making the tree the recognition sink directly – so there is no second pass
+//! and no markers – is "Strategy B", the Phase 4 single-pass builder. Until
+//! then the tree is built by a **second, counter-safe substitution pass**: the
+//! caller clones the [`Parser`] *before* the authoritative pass advances any
+//! document counter, so the recording pass numbers footnotes, callouts, and
+//! counters exactly as the authoritative pass did, then discards the clone. The
+//! authoritative rendered string is never produced by the recorder, so this is
+//! purely additive and cannot regress output.
+//!
+//! # Status
+//!
+//! This is the "promote the tree into [`Content`]" step of Phase 2. The tree is
+//! a real, live artifact, but it is built behind an **opt-in** flag
+//! ([`Parser::with_inline_tree`]) so the default parse path is byte- and
+//! performance-identical to before. Making the tree *canonical* (with
+//! `rendered()` folding it, and the three production sentinel systems retired)
+//! is the remainder of Phase 2 and Phase 4.
+//!
+//! [`inline_recorder`]: ../../tests/inline_recorder.rs
+//! [`Content`]: crate::content::Content
+//! [`Parser::with_inline_tree`]: crate::Parser::with_inline_tree
+
+// Some node metadata is captured but not yet read by every consumer while the
+// tree is not yet canonical; the tree carries the full structure the public API
+// (Phase 3) and the single-pass builder (Phase 4) will consume.
+#![allow(dead_code)]
+
+use std::{cell::RefCell, rc::Rc};
+
+use crate::{
+    Span,
+    attributes::Attrlist,
+    inlines::{
+        Anchor, Callout, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref, RefVariant,
+        SpanForm, Stem, StemNotation, StyleVariant, Styled, Ui, UiKind,
+    },
+    parser::{
+        CalloutRenderParams, FootnoteRenderParams, IconRenderParams, ImageRenderParams,
+        IndexTermRenderParams, InlineSubstitutionRenderer, LinkRenderParams, MenuRenderParams,
+        QuoteScope, QuoteType, XrefRenderParams,
+    },
+    strings::CowStr,
+};
+
+// ─── Sentinels ────────────────────────────────────────────────────────────
+//
+// All in the Unicode Private Use Area, chosen to be inert to every step's
+// regexes, exactly as the production pipeline's xref (`\u{E000}`) and
+// passthrough (`\u{96}`) sentinels already are. Digits are encoded as PUA
+// characters too, so a recorded marker injects no ASCII word characters that a
+// later step could key off of.
+//
+// Unlike the three production sentinel systems, these never reach shipped
+// output: they are stripped (or folded away) the instant the recording pass
+// finishes, before the tree is stored on the `Content`.
+
+/// Opens a recorded construct; immediately followed by the PUA-encoded index of
+/// its [`Event`].
+const MARK_OPEN: char = '\u{E010}';
+
+/// Closes a recorded construct.
+const MARK_CLOSE: char = '\u{E011}';
+
+/// Base of the ten PUA "digit" characters (`\u{E020}`..=`\u{E029}`) used to
+/// encode an [`Event`] index inside a marker.
+const PUA_DIGIT_BASE: u32 = 0xe020;
+
+/// A transient placeholder spliced in as a [quote substitution]'s body so the
+/// fixed open/close wrapper can be recovered by splitting on it. It never
+/// appears in real content.
+///
+/// [quote substitution]: https://docs.asciidoctor.org/asciidoc/latest/subs/quotes/
+const SPLIT_PLACEHOLDER: char = '\u{E0FF}';
+
+fn is_pua_digit(c: char) -> bool {
+    let n = c as u32;
+    (PUA_DIGIT_BASE..PUA_DIGIT_BASE + 10).contains(&n)
+}
+
+fn write_index(index: usize, dest: &mut String) {
+    for ch in index.to_string().chars() {
+        let digit = ch as u32 - '0' as u32;
+        if let Some(pua) = char::from_u32(PUA_DIGIT_BASE + digit) {
+            dest.push(pua);
+        }
+    }
+}
+
+fn is_marker(c: char) -> bool {
+    c == MARK_OPEN || c == MARK_CLOSE || is_pua_digit(c)
+}
+
+/// Reports whether `c` is a codepoint the recorder reserves for its own framing
+/// (a marker, a marker index digit, or the split placeholder).
+pub(crate) fn is_reserved_sentinel(c: char) -> bool {
+    is_marker(c) || c == SPLIT_PLACEHOLDER
+}
+
+/// Removes every recorder sentinel from `chars`, leaving the real bytes.
+fn strip_markers(chars: &[char]) -> String {
+    chars.iter().copied().filter(|c| !is_marker(*c)).collect()
+}
+
+// ─── Recorded events ────────────────────────────────────────────────────────
+
+/// The metadata captured for one recognized construct, looked up by the index
+/// encoded in its [`MARK_OPEN`] marker.
+#[derive(Clone, Debug)]
+pub(crate) enum Event {
+    /// A parent construct (a [quote substitution] or a link). `open`/`close`
+    /// are the fixed wrapper bytes the wrapped renderer emits around the body.
+    ///
+    /// [quote substitution]: https://docs.asciidoctor.org/asciidoc/latest/subs/quotes/
+    Container {
+        open: String,
+        close: String,
+        node: ContainerNode,
+    },
+
+    /// A leaf construct. Its rendered bytes are recovered from the marked
+    /// string, so only the structural metadata is stored here.
+    Leaf(LeafNode),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum ContainerNode {
+    Styled {
+        variant: StyleVariant,
+        form: SpanForm,
+        id: Option<String>,
+        roles: Vec<String>,
+    },
+    Reference {
+        variant: RefVariant,
+        target: String,
+        roles: Vec<String>,
+        window: Option<String>,
+    },
+    Stem {
+        notation: StemNotation,
+    },
+}
+
+/// The recovered kind of a character reference. Special characters and
+/// character replacements are *not* marked by the recorder (their escaped
+/// output is re-consumed by later steps, so bracketing it would perturb
+/// recognition); instead they are recovered by splitting text runs on the
+/// entities the wrapped renderer emits.
+#[derive(Clone, Debug)]
+enum CharRefKind {
+    Special(char),
+    Replacement(&'static str),
+    Entity(String),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum LeafNode {
+    LineBreak,
+    Image {
+        target: String,
+        alt: Option<String>,
+        width: Option<String>,
+        height: Option<String>,
+    },
+    Reference {
+        variant: RefVariant,
+        target: String,
+        roles: Vec<String>,
+        window: Option<String>,
+    },
+    Anchor {
+        id: String,
+    },
+    Callout {
+        number: String,
+    },
+    IndexTerm {
+        terms: Vec<String>,
+        visible: bool,
+    },
+    Ui(UiMeta),
+    Footnote {
+        id: Option<String>,
+        number: Option<String>,
+        is_reference: bool,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum UiMeta {
+    Button(String),
+    Keyboard(Vec<String>),
+    Menu {
+        menu: String,
+        submenus: Vec<String>,
+        item: Option<String>,
+    },
+}
+
+// ─── The recording renderer ───────────────────────────────────────────────
+
+/// A transparent decorator over the parser's own inline renderer that brackets
+/// each recognized construct with recorder sentinels and captures its
+/// structural metadata into a shared event log.
+///
+/// Every method delegates to the wrapped `inner` renderer, so the bytes are
+/// whatever `inner` would have produced; the decorator only adds inert
+/// sentinels (and, for the structural constructs, records an [`Event`]).
+#[derive(Debug)]
+pub(crate) struct RecordingRenderer {
+    inner: Rc<dyn InlineSubstitutionRenderer>,
+    events: Rc<RefCell<Vec<Event>>>,
+}
+
+impl RecordingRenderer {
+    /// Wraps `inner`, returning the decorator and a handle to the shared event
+    /// log it fills in (the log is read back by [`build_inline_tree`]).
+    pub(crate) fn new(
+        inner: Rc<dyn InlineSubstitutionRenderer>,
+    ) -> (Self, Rc<RefCell<Vec<Event>>>) {
+        let events = Rc::new(RefCell::new(Vec::new()));
+
+        let renderer = Self {
+            inner,
+            events: events.clone(),
+        };
+
+        (renderer, events)
+    }
+
+    fn push(&self, event: Event) -> usize {
+        let mut events = self.events.borrow_mut();
+        events.push(event);
+        events.len() - 1
+    }
+
+    /// Writes `MARK_OPEN index fragment MARK_CLOSE` into `dest`. `fragment` is
+    /// the exact output the wrapped renderer produced, so `dest` still contains
+    /// every real byte and only inert sentinels are added.
+    fn wrap(&self, index: usize, fragment: &str, dest: &mut String) {
+        dest.push(MARK_OPEN);
+        write_index(index, dest);
+        dest.push_str(fragment);
+        dest.push(MARK_CLOSE);
+    }
+
+    fn leaf(&self, node: LeafNode, fragment: &str, dest: &mut String) {
+        let index = self.push(Event::Leaf(node));
+        self.wrap(index, fragment, dest);
+    }
+
+    /// Recovers the fixed open/close wrapper a quote substitution emits, by
+    /// rendering it once with [`SPLIT_PLACEHOLDER`] as the body and splitting.
+    fn split_quote(
+        &self,
+        type_: QuoteType,
+        scope: QuoteScope,
+        attrlist: Option<Attrlist<'_>>,
+        id: Option<String>,
+    ) -> (String, String) {
+        let mut probe = String::new();
+
+        self.inner.render_quoted_substitution(
+            type_,
+            scope,
+            attrlist,
+            id,
+            &SPLIT_PLACEHOLDER.to_string(),
+            &mut probe,
+        );
+
+        match probe.split_once(SPLIT_PLACEHOLDER) {
+            Some((open, close)) => (open.to_string(), close.to_string()),
+
+            // A body that does not survive the wrapper (should not happen for
+            // any quote type) degrades to "whole fragment is the open".
+            None => (probe, String::new()),
+        }
+    }
+}
+
+fn optional(value: Option<&str>) -> Option<String> {
+    value.map(str::to_string)
+}
+
+impl InlineSubstitutionRenderer for RecordingRenderer {
+    // `render_special_character` and `render_character_replacement` delegate to
+    // `inner` *without* bracketing: their escaped output (`&lt;`, `&gt;`,
+    // `&#8594;`, …) is re-matched by later steps (callouts on `&lt;N&gt;`, the
+    // xref shorthand on `&lt;&lt;`, arrow replacements on `&lt;-`), so wrapping
+    // it in sentinels would break that recognition. Their `CharRef` nodes are
+    // recovered from the resulting text runs instead (see `push_text`).
+
+    fn render_special_character(&self, type_: crate::parser::SpecialCharacter, dest: &mut String) {
+        self.inner.render_special_character(type_, dest);
+    }
+
+    fn render_character_replacement(
+        &self,
+        type_: crate::parser::CharacterReplacementType,
+        dest: &mut String,
+    ) {
+        self.inner.render_character_replacement(type_, dest);
+    }
+
+    fn render_quoted_substitution(
+        &self,
+        type_: QuoteType,
+        scope: QuoteScope,
+        attrlist: Option<Attrlist<'_>>,
+        id: Option<String>,
+        body: &str,
+        dest: &mut String,
+    ) {
+        let roles: Vec<String> = attrlist
+            .as_ref()
+            .map(|a| a.roles().iter().map(|r| r.to_string()).collect())
+            .unwrap_or_default();
+
+        let (open, close) = self.split_quote(type_, scope, attrlist.clone(), id.clone());
+
+        let node = match type_ {
+            QuoteType::AsciiMath => ContainerNode::Stem {
+                notation: StemNotation::AsciiMath,
+            },
+
+            QuoteType::LatexMath => ContainerNode::Stem {
+                notation: StemNotation::LatexMath,
+            },
+
+            _ => ContainerNode::Styled {
+                variant: style_variant(type_),
+                form: span_form(scope),
+                id: id.clone(),
+                roles,
+            },
+        };
+
+        let index = self.push(Event::Container {
+            open: open.clone(),
+            close: close.clone(),
+            node,
+        });
+
+        // Re-render with the real body (which already carries the sentinels of
+        // any nested constructs) so `dest` holds `open + body + close`, exactly
+        // as the wrapped renderer would, bracketed in this construct's markers.
+        let mut fragment = String::new();
+        self.inner
+            .render_quoted_substitution(type_, scope, attrlist, id, body, &mut fragment);
+
+        self.wrap(index, &fragment, dest);
+    }
+
+    fn render_line_break(&self, dest: &mut String) {
+        let mut fragment = String::new();
+        self.inner.render_line_break(&mut fragment);
+        self.leaf(LeafNode::LineBreak, &fragment, dest);
+    }
+
+    fn render_image(&self, params: &ImageRenderParams, dest: &mut String) {
+        let mut fragment = String::new();
+        self.inner.render_image(params, &mut fragment);
+
+        self.leaf(
+            LeafNode::Image {
+                target: params.target.to_string(),
+                alt: Some(params.alt.clone()),
+                width: optional(params.width),
+                height: optional(params.height),
+            },
+            &fragment,
+            dest,
+        );
+    }
+
+    fn render_icon(&self, params: &IconRenderParams, dest: &mut String) {
+        let mut fragment = String::new();
+        self.inner.render_icon(params, &mut fragment);
+
+        // The public vocabulary has no dedicated icon node yet; an icon projects
+        // onto `Image` (its closest kin) for now.
+        self.leaf(
+            LeafNode::Image {
+                target: params.target.to_string(),
+                alt: Some(params.alt.clone()),
+                width: None,
+                height: None,
+            },
+            &fragment,
+            dest,
+        );
+    }
+
+    fn render_link(&self, params: &LinkRenderParams, dest: &mut String) {
+        let mut roles: Vec<String> = params.extra_roles.iter().map(|r| r.to_string()).collect();
+        roles.extend(params.attrlist.roles().iter().map(|r| r.to_string()));
+
+        // A link's display text is inserted verbatim between a fixed open/close,
+        // so – like a quote span – its wrapper is recovered by rendering once
+        // with a placeholder body, and the real text becomes the container's
+        // children (so `link:x[*bold*]` decomposes into a `Ref` over a `Styled`).
+        let probe_params = LinkRenderParams {
+            target: params.target.clone(),
+            link_text: SPLIT_PLACEHOLDER.to_string(),
+            extra_roles: params.extra_roles.clone(),
+            window: params.window,
+            attrlist: params.attrlist,
+            parser: params.parser,
+        };
+
+        let mut probe = String::new();
+        self.inner.render_link(&probe_params, &mut probe);
+
+        let (open, close) = match probe.split_once(SPLIT_PLACEHOLDER) {
+            Some((open, close)) => (open.to_string(), close.to_string()),
+            None => (probe, String::new()),
+        };
+
+        let index = self.push(Event::Container {
+            open: open.clone(),
+            close: close.clone(),
+            node: ContainerNode::Reference {
+                variant: RefVariant::Link,
+                target: params.target.clone(),
+                roles,
+                window: optional(params.window),
+            },
+        });
+
+        let mut fragment = String::new();
+        self.inner.render_link(params, &mut fragment);
+
+        self.wrap(index, &fragment, dest);
+    }
+
+    fn render_anchor(&self, id: &str, reftext: Option<String>, dest: &mut String) {
+        let mut fragment = String::new();
+        self.inner.render_anchor(id, reftext, &mut fragment);
+        self.leaf(LeafNode::Anchor { id: id.to_string() }, &fragment, dest);
+    }
+
+    fn render_xref(&self, params: &XrefRenderParams, dest: &mut String) {
+        let mut fragment = String::new();
+        self.inner.render_xref(params, &mut fragment);
+
+        self.leaf(
+            LeafNode::Reference {
+                variant: RefVariant::Xref,
+                target: params.target.to_string(),
+                roles: params.roles.to_vec(),
+                window: optional(params.window),
+            },
+            &fragment,
+            dest,
+        );
+    }
+
+    fn render_callout(&self, params: &CalloutRenderParams, dest: &mut String) {
+        let mut fragment = String::new();
+        self.inner.render_callout(params, &mut fragment);
+
+        self.leaf(
+            LeafNode::Callout {
+                number: params.number.to_string(),
+            },
+            &fragment,
+            dest,
+        );
+    }
+
+    fn render_index_term(&self, params: &IndexTermRenderParams, dest: &mut String) {
+        let mut fragment = String::new();
+        self.inner.render_index_term(params, &mut fragment);
+
+        // `render_index_term` only receives the visible primary term; the
+        // concealed levels are not exposed here, so the term list is
+        // best-effort while the tree is not yet the recognition sink.
+        let (terms, visible) = match params.visible_term {
+            Some(term) => (vec![term.to_string()], true),
+            None => (vec![], false),
+        };
+
+        self.leaf(LeafNode::IndexTerm { terms, visible }, &fragment, dest);
+    }
+
+    fn render_button(&self, text: &str, dest: &mut String) {
+        let mut fragment = String::new();
+        self.inner.render_button(text, &mut fragment);
+        self.leaf(
+            LeafNode::Ui(UiMeta::Button(text.to_string())),
+            &fragment,
+            dest,
+        );
+    }
+
+    fn render_keyboard(&self, keys: &[String], dest: &mut String) {
+        let mut fragment = String::new();
+        self.inner.render_keyboard(keys, &mut fragment);
+        self.leaf(
+            LeafNode::Ui(UiMeta::Keyboard(keys.to_vec())),
+            &fragment,
+            dest,
+        );
+    }
+
+    fn render_menu(&self, params: &MenuRenderParams, dest: &mut String) {
+        let mut fragment = String::new();
+        self.inner.render_menu(params, &mut fragment);
+
+        self.leaf(
+            LeafNode::Ui(UiMeta::Menu {
+                menu: params.menu.to_string(),
+                submenus: params.submenus.to_vec(),
+                item: optional(params.menuitem),
+            }),
+            &fragment,
+            dest,
+        );
+    }
+
+    fn render_footnote(&self, params: &FootnoteRenderParams, dest: &mut String) {
+        let mut fragment = String::new();
+        self.inner.render_footnote(params, &mut fragment);
+
+        self.leaf(
+            LeafNode::Footnote {
+                id: optional(params.id),
+                number: optional(params.index),
+                is_reference: params.is_reference,
+            },
+            &fragment,
+            dest,
+        );
+    }
+}
+
+fn style_variant(type_: QuoteType) -> StyleVariant {
+    match type_ {
+        QuoteType::Strong => StyleVariant::Strong,
+        QuoteType::Emphasis => StyleVariant::Emphasis,
+        QuoteType::Monospaced => StyleVariant::Code,
+        QuoteType::Mark => StyleVariant::Mark,
+        QuoteType::Superscript => StyleVariant::Superscript,
+        QuoteType::Subscript => StyleVariant::Subscript,
+        QuoteType::DoubleQuote => StyleVariant::DoubleQuote,
+        QuoteType::SingleQuote => StyleVariant::SingleQuote,
+
+        // AsciiMath/LatexMath are handled as STEM before this is reached;
+        // `Unquoted` and any residue map to the unquoted span.
+        _ => StyleVariant::Unquoted,
+    }
+}
+
+fn span_form(scope: QuoteScope) -> SpanForm {
+    match scope {
+        QuoteScope::Constrained => SpanForm::Constrained,
+        QuoteScope::Unconstrained => SpanForm::Unconstrained,
+    }
+}
+
+// ─── The recorded tree ──────────────────────────────────────────────────────
+
+/// The intermediate tree recovered from the marked string. Each node carries
+/// what the fold needs to reconstruct its bytes, alongside the structural
+/// metadata that projects to a public [`InlineNode`].
+#[derive(Clone, Debug)]
+enum Rec {
+    Text(String),
+
+    /// A character reference recovered from a text run. `html` is the exact
+    /// entity the wrapped renderer emitted (`&lt;`, `&#8594;`, …).
+    CharRef {
+        html: String,
+        kind: CharRefKind,
+    },
+    Leaf {
+        html: String,
+        node: LeafNode,
+    },
+    Container {
+        open: String,
+        close: String,
+        children: Vec<Rec>,
+        node: ContainerNode,
+    },
+}
+
+/// Pushes `text` onto `out`, splitting it into plain [`Rec::Text`] and
+/// [`Rec::CharRef`] runs. Every `&` in the wrapped renderer's output opens an
+/// entity (a literal `&` is escaped to `&amp;`), so an ampersand-to-semicolon
+/// span is always a character reference.
+fn push_text(text: &str, out: &mut Vec<Rec>) {
+    if text.is_empty() {
+        return;
+    }
+
+    let mut plain = String::new();
+    let mut rest = text;
+
+    while let Some(amp) = rest.find('&') {
+        plain.push_str(&rest[..amp]);
+        let after = &rest[amp..];
+
+        let Some(semi) = after.find(';') else {
+            // No terminator: not an entity (should not occur). Keep the `&`.
+            plain.push('&');
+            rest = &after[1..];
+            continue;
+        };
+
+        let entity = &after[..=semi];
+
+        if !plain.is_empty() {
+            out.push(Rec::Text(std::mem::take(&mut plain)));
+        }
+
+        out.push(Rec::CharRef {
+            html: entity.to_string(),
+            kind: classify_entity(entity),
+        });
+
+        rest = &after[semi + 1..];
+    }
+
+    plain.push_str(rest);
+
+    if !plain.is_empty() {
+        out.push(Rec::Text(plain));
+    }
+}
+
+fn classify_entity(entity: &str) -> CharRefKind {
+    match entity {
+        "&lt;" => CharRefKind::Special('<'),
+        "&gt;" => CharRefKind::Special('>'),
+        "&amp;" => CharRefKind::Special('&'),
+
+        "&#169;" => CharRefKind::Replacement("\u{a9}"),
+        "&#174;" => CharRefKind::Replacement("\u{ae}"),
+        "&#8482;" => CharRefKind::Replacement("\u{2122}"),
+        "&#8201;" => CharRefKind::Replacement("\u{2009}"),
+        "&#8212;" => CharRefKind::Replacement("\u{2014}"),
+        "&#8203;" => CharRefKind::Replacement("\u{200b}"),
+        "&#8230;" => CharRefKind::Replacement("\u{2026}"),
+        "&#8592;" => CharRefKind::Replacement("\u{2190}"),
+        "&#8656;" => CharRefKind::Replacement("\u{21d0}"),
+        "&#8594;" => CharRefKind::Replacement("\u{2192}"),
+        "&#8658;" => CharRefKind::Replacement("\u{21d2}"),
+        "&#8217;" => CharRefKind::Replacement("\u{2019}"),
+        "&#8216;" => CharRefKind::Replacement("\u{2018}"),
+
+        // A numeric or named entity written by the author, carried through as
+        // written.
+        other => CharRefKind::Entity(other.to_string()),
+    }
+}
+
+/// Parses a recorder-marked string into the recovered tree, resolving each
+/// marker against `events`.
+fn parse(chars: &[char], events: &[Event]) -> Vec<Rec> {
+    let mut out = Vec::new();
+    let mut text = String::new();
+    let mut i = 0;
+
+    while let Some(&c) = chars.get(i) {
+        if c != MARK_OPEN {
+            text.push(c);
+            i += 1;
+            continue;
+        }
+
+        push_text(&std::mem::take(&mut text), &mut out);
+
+        i += 1;
+
+        // Read the PUA-encoded event index.
+        let mut index = 0usize;
+        while let Some(&d) = chars.get(i) {
+            if !is_pua_digit(d) {
+                break;
+            }
+
+            index = index * 10 + (d as u32 - PUA_DIGIT_BASE) as usize;
+            i += 1;
+        }
+
+        // Find the matching close, honoring nesting.
+        let start = i;
+        let mut depth = 1;
+
+        while let Some(&d) = chars.get(i) {
+            match d {
+                MARK_OPEN => depth += 1,
+
+                MARK_CLOSE => {
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
+                    }
+                }
+
+                _ => {}
+            }
+
+            i += 1;
+        }
+
+        let region = chars.get(start..i).unwrap_or(&[]);
+
+        // Skip the matching close.
+        i += 1;
+
+        if let Some(event) = events.get(index) {
+            out.push(build_rec(event, region, events));
+        }
+    }
+
+    push_text(&text, &mut out);
+
+    out
+}
+
+fn build_rec(event: &Event, region: &[char], events: &[Event]) -> Rec {
+    match event {
+        Event::Container { open, close, node } => {
+            // `region` is `open + body + close`; the body carries the nested
+            // markers. Slice off the known (marker-free) wrapper and recurse.
+            let open_len = open.chars().count();
+            let close_len = close.chars().count();
+            let body_end = region.len().saturating_sub(close_len);
+
+            let body = region.get(open_len..body_end).unwrap_or(&[]);
+
+            Rec::Container {
+                open: open.clone(),
+                close: close.clone(),
+                children: parse(body, events),
+                node: node.clone(),
+            }
+        }
+
+        Event::Leaf(node) => Rec::Leaf {
+            html: strip_markers(region),
+            node: node.clone(),
+        },
+    }
+}
+
+/// Folds the recovered tree back to output bytes: text verbatim, a leaf as its
+/// captured bytes, a container as open + folded children + close.
+fn fold_into(recs: &[Rec], out: &mut String) {
+    for rec in recs {
+        match rec {
+            Rec::Text(text) => out.push_str(text),
+
+            Rec::CharRef { html, .. } => out.push_str(html),
+
+            Rec::Leaf { html, .. } => out.push_str(html),
+
+            Rec::Container {
+                open,
+                close,
+                children,
+                ..
+            } => {
+                out.push_str(open);
+                fold_into(children, out);
+                out.push_str(close);
+            }
+        }
+    }
+}
+
+// ─── Projection to the public inline vocabulary ─────────────────────────────
+
+fn to_inline<'src>(recs: &[Rec], span: Span<'src>) -> Vec<InlineNode<'src>> {
+    recs.iter().map(|rec| node_of(rec, span)).collect()
+}
+
+fn node_of<'src>(rec: &Rec, span: Span<'src>) -> InlineNode<'src> {
+    match rec {
+        Rec::Text(text) => InlineNode::Text {
+            value: CowStr::from(text.clone()),
+            location: span,
+        },
+
+        Rec::CharRef { kind, .. } => InlineNode::CharRef {
+            value: match kind {
+                CharRefKind::Special(ch) => CharRef::Special(*ch),
+                CharRefKind::Replacement(value) => CharRef::Replacement(value),
+                CharRefKind::Entity(name) => CharRef::Entity(CowStr::from(name.clone())),
+            },
+            location: span,
+        },
+
+        Rec::Leaf { node, .. } => leaf_node_of(node, span),
+
+        Rec::Container { children, node, .. } => match node {
+            ContainerNode::Styled {
+                variant,
+                form,
+                id,
+                roles,
+            } => InlineNode::Styled(Styled {
+                variant: *variant,
+                form: *form,
+                id: id.clone().map(CowStr::from),
+                roles: roles.iter().cloned().map(CowStr::from).collect(),
+                attrs: None,
+                children: to_inline(children, span),
+                location: span,
+            }),
+
+            ContainerNode::Reference {
+                variant,
+                target,
+                roles,
+                window,
+            } => InlineNode::Ref(Ref {
+                variant: *variant,
+                target: CowStr::from(target.clone()),
+                children: to_inline(children, span),
+                roles: roles.iter().cloned().map(CowStr::from).collect(),
+                window: window.clone().map(CowStr::from),
+                resolved: None,
+                location: span,
+            }),
+
+            ContainerNode::Stem { notation } => {
+                let mut value = String::new();
+                fold_into(children, &mut value);
+
+                InlineNode::Stem(Stem {
+                    notation: *notation,
+                    value: CowStr::from(value),
+                    location: span,
+                })
+            }
+        },
+    }
+}
+
+fn leaf_node_of<'src>(node: &LeafNode, span: Span<'src>) -> InlineNode<'src> {
+    match node {
+        LeafNode::LineBreak => InlineNode::LineBreak { location: span },
+
+        LeafNode::Image {
+            target,
+            alt,
+            width,
+            height,
+        } => InlineNode::Image(Image {
+            target: CowStr::from(target.clone()),
+            alt: alt.clone().map(CowStr::from),
+            width: width.clone().map(CowStr::from),
+            height: height.clone().map(CowStr::from),
+            attrs: None,
+            location: span,
+        }),
+
+        LeafNode::Reference {
+            variant,
+            target,
+            roles,
+            window,
+        } => InlineNode::Ref(Ref {
+            variant: *variant,
+            target: CowStr::from(target.clone()),
+            children: vec![],
+            roles: roles.iter().cloned().map(CowStr::from).collect(),
+            window: window.clone().map(CowStr::from),
+            resolved: None,
+            location: span,
+        }),
+
+        LeafNode::Anchor { id } => InlineNode::Anchor(Anchor {
+            id: CowStr::from(id.clone()),
+            reftext: None,
+            location: span,
+        }),
+
+        LeafNode::Callout { number } => InlineNode::Callout(Callout {
+            number: CowStr::from(number.clone()),
+            location: span,
+        }),
+
+        LeafNode::IndexTerm { terms, visible } => InlineNode::IndexTerm(IndexTerm {
+            terms: terms.iter().cloned().map(CowStr::from).collect(),
+            visible: *visible,
+            location: span,
+        }),
+
+        LeafNode::Ui(ui) => InlineNode::Ui(Ui {
+            kind: match ui {
+                UiMeta::Button(text) => UiKind::Button(CowStr::from(text.clone())),
+
+                UiMeta::Keyboard(keys) => {
+                    UiKind::Keyboard(keys.iter().cloned().map(CowStr::from).collect())
+                }
+
+                UiMeta::Menu {
+                    menu,
+                    submenus,
+                    item,
+                } => UiKind::Menu {
+                    menu: CowStr::from(menu.clone()),
+                    submenus: submenus.iter().cloned().map(CowStr::from).collect(),
+                    item: item.clone().map(CowStr::from),
+                },
+            },
+            location: span,
+        }),
+
+        LeafNode::Footnote {
+            id,
+            number,
+            is_reference,
+        } => InlineNode::Footnote(Footnote {
+            id: id.clone().map(CowStr::from),
+            number: number.clone().map(CowStr::from),
+            is_reference: *is_reference,
+            children: vec![],
+            location: span,
+        }),
+    }
+}
+
+// ─── Public (crate) entry points ────────────────────────────────────────────
+
+/// Builds the inline tree from a recorder-marked string and its event log,
+/// giving every node the coarse `location` span (Phase 1/2 carry no precise
+/// per-node spans; see design §4.4). `marked` is the string a
+/// [`RecordingRenderer`] produced; `events` is the log it filled in.
+pub(crate) fn build_inline_tree<'src>(
+    marked: &str,
+    events: &[Event],
+    location: Span<'src>,
+) -> Vec<InlineNode<'src>> {
+    let chars: Vec<char> = marked.chars().collect();
+    let recs = parse(&chars, events);
+    to_inline(&recs, location)
+}
+
+/// Folds a recorder-marked string back to output bytes. Used by the
+/// differential tests to assert the fold reproduces the authoritative rendered
+/// string.
+pub(crate) fn fold_marked(marked: &str, events: &[Event]) -> String {
+    let chars: Vec<char> = marked.chars().collect();
+    let recs = parse(&chars, events);
+    let mut out = String::new();
+    fold_into(&recs, &mut out);
+    out
+}
+
+/// The number of open-markers in a recorder-marked string – i.e. the number of
+/// recorded constructs that reached the string. Used by the differential tests
+/// to cross-check the recovered tree against the recorder.
+pub(crate) fn open_marker_count(marked: &str) -> usize {
+    marked.matches(MARK_OPEN).count()
+}

--- a/parser/src/content/inline_tree.rs
+++ b/parser/src/content/inline_tree.rs
@@ -19,9 +19,8 @@
 //!
 //! 1. Stripping the sentinels reproduces the wrapped renderer's output
 //!    byte-for-byte (the *no-perturbation* invariant).
-//! 2. Parsing the sentinel structure recovers a tree of
-//!    [`InlineNode`](crate::inlines::InlineNode)s, and folding that tree
-//!    reconstructs the same bytes.
+//! 2. Parsing the sentinel structure recovers a tree of [`InlineNode`]s, and
+//!    folding that tree reconstructs the same bytes.
 //!
 //! Because the decorator wraps whatever renderer the [`Parser`] carries, the
 //! fold reproduces *that* renderer's bytes, not a hard-coded HTML backend.
@@ -48,6 +47,7 @@
 //!
 //! [`inline_recorder`]: ../../tests/inline_recorder.rs
 //! [`Content`]: crate::content::Content
+//! [`Parser`]: crate::Parser
 //! [`Parser::with_inline_tree`]: crate::Parser::with_inline_tree
 
 // Some node metadata is captured but not yet read by every consumer while the

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -10,6 +10,8 @@ pub(crate) use content::{
     rehome_xref_placeholders, render_xref_template, strip_footnote_marker_spans,
 };
 
+pub(crate) mod inline_tree;
+
 mod macros;
 pub(crate) use macros::apply_macros_with_leading_anchor_registered;
 

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -1,7 +1,11 @@
+use std::rc::Rc;
+
 use crate::{
     HasSpan, Parser,
     attributes::Attrlist,
-    content::{Content, Passthroughs, SubstitutionStep},
+    content::{
+        Content, Passthroughs, SubstitutionStep, inline_tree, inline_tree::RecordingRenderer,
+    },
     warnings::WarningType,
 };
 
@@ -226,6 +230,39 @@ impl SubstitutionGroup {
         parser: &Parser,
         attrlist: Option<&Attrlist>,
     ) {
+        // Snapshot the content and parser *before* the authoritative pass runs,
+        // when inline-tree building is enabled. The clone captures every
+        // document counter (footnote/callout numbers, `{counter:…}` values) at
+        // its pre-substitution value, so the recording pass below numbers
+        // constructs exactly as the authoritative pass does; the clone's
+        // mutations are then discarded, leaving the real parser advanced once.
+        let recording_seed = if parser.build_inline_tree {
+            Some((content.clone(), parser.clone()))
+        } else {
+            None
+        };
+
+        self.run_pipeline(content, parser, attrlist);
+
+        if let Some((mut recording_content, mut recording_parser)) = recording_seed {
+            self.build_inline_tree(
+                content,
+                &mut recording_content,
+                &mut recording_parser,
+                attrlist,
+            );
+        }
+    }
+
+    /// Runs the substitution pipeline for this group over `content`: extract
+    /// passthroughs (when the group includes them), apply each step in order,
+    /// restore the passthroughs, and finalize any deferred cross-references.
+    fn run_pipeline(
+        &self,
+        content: &mut Content<'_>,
+        parser: &Parser,
+        attrlist: Option<&Attrlist>,
+    ) {
         let steps = self.steps();
 
         let passthroughs: Option<Passthroughs> =
@@ -252,6 +289,36 @@ impl SubstitutionGroup {
         // references are resolved. This is a no-op when no cross-references were
         // found.
         content.finalize_deferred(&*parser.renderer);
+    }
+
+    /// Builds the inline AST for `content` by re-running the pipeline over the
+    /// pre-substitution snapshot with a [`RecordingRenderer`] wrapped around
+    /// the parser's own renderer, then parsing the recorded markers into a
+    /// tree and storing it on `content`.
+    ///
+    /// This is Strategy A (design §4.1): a transparent recording pass whose
+    /// fold reproduces the authoritative `rendered()` byte-for-byte. It is
+    /// a second pass for now; the Phase 4 single-pass builder retires it.
+    fn build_inline_tree(
+        &self,
+        content: &mut Content<'_>,
+        recording_content: &mut Content<'_>,
+        recording_parser: &mut Parser,
+        attrlist: Option<&Attrlist>,
+    ) {
+        let (recorder, events) = RecordingRenderer::new(recording_parser.renderer.clone());
+        recording_parser.renderer = Rc::new(recorder);
+
+        // The recording pass must not recurse into tree building itself (nested
+        // content would clone the parser again and again); it only needs to
+        // record this content's own constructs.
+        recording_parser.build_inline_tree = false;
+
+        self.run_pipeline(recording_content, recording_parser, attrlist);
+
+        let marked = recording_content.rendered_owned();
+        let tree = inline_tree::build_inline_tree(&marked, &events.borrow(), content.original());
+        content.set_inlines(tree);
     }
 
     /// Applies any block style masquerade and `subs` attribute override from

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -317,7 +317,27 @@ impl SubstitutionGroup {
         self.run_pipeline(recording_content, recording_parser, attrlist);
 
         let marked = recording_content.rendered_owned();
-        let tree = inline_tree::build_inline_tree(&marked, &events.borrow(), content.original());
+        let events = events.borrow();
+        let tree = inline_tree::build_inline_tree(&marked, &events, content.original());
+
+        // The recording pass re-runs the pipeline through a *clone* of the
+        // parser, but the clone shares the same `Rc`-held inline renderer and
+        // asset handlers as the authoritative pass. That is correct for the
+        // built-in (stateless) renderer and the default handlers, but a
+        // *stateful* custom renderer – or a one-shot asset handler – could
+        // observe different state the second time and make the recorded tree
+        // fold to something other than the authoritative `rendered()`. Assert
+        // parity so such a renderer fails loudly in debug/test builds rather
+        // than silently storing a divergent tree. (Retired with the second pass
+        // itself by the Phase 4 single-pass builder.)
+        debug_assert_eq!(
+            inline_tree::fold_marked(&marked, &events),
+            content.rendered_str(),
+            "inline tree fold diverged from rendered(); the configured inline \
+             renderer or an asset handler is stateful and unsafe for inline-tree \
+             building",
+        );
+
         content.set_inlines(tree);
     }
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2140,6 +2140,23 @@ impl Parser {
     /// tree into `Content`"), so the default parse path is unchanged in both
     /// output and performance. The switch is expected to retire once the inline
     /// AST becomes the canonical representation.
+    ///
+    /// # Requires a side-effect-free renderer
+    ///
+    /// That second pass re-invokes the configured
+    /// [`InlineSubstitutionRenderer`](crate::parser::InlineSubstitutionRenderer)
+    /// and the registered asset handlers (for example the
+    /// [`ImageFileHandler`](crate::parser::ImageFileHandler)), so it assumes
+    /// they are **idempotent**: rendering the same content twice must produce
+    /// the same bytes. The built-in HTML renderer and the default handlers
+    /// satisfy this. A *stateful* custom renderer (one whose output depends on
+    /// mutable internal state) or a *one-shot* asset handler may therefore be
+    /// invoked twice while this is enabled, and could make the tree diverge
+    /// from [`rendered`](crate::content::Content::rendered) – a divergence
+    /// caught by a debug assertion. Externally-visible reads (such as
+    /// loading an image for a `data-uri`) likewise occur an extra time. The
+    /// Phase 4 single-pass builder removes the second pass and this caveat
+    /// with it.
     #[must_use]
     pub fn with_inline_tree(mut self, enabled: bool) -> Self {
         self.build_inline_tree = enabled;

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2128,9 +2128,10 @@ impl Parser {
     /// [`Content`](crate::content::Content) this parser produces.
     ///
     /// When enabled, each block's inline content is additionally parsed into a
-    /// tree of [`InlineNode`](crate::inlines::InlineNode)s, retrievable via
-    /// [`Content::inlines`](crate::content::Content::inlines). The tree is a
-    /// projection of the rendered output: folding it reproduces
+    /// tree of [`InlineNode`](crate::inlines::InlineNode)s, retrievable from its
+    /// [`Content`](crate::content::Content) (a crate-internal accessor while the
+    /// inline AST is being brought up; the public accessor lands in Phase 3).
+    /// The tree is a projection of the rendered output: folding it reproduces
     /// [`Content::rendered`](crate::content::Content::rendered) byte-for-byte.
     ///
     /// This is **off by default**. Building the tree currently costs a second,

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2144,9 +2144,9 @@ impl Parser {
     /// # Requires a side-effect-free renderer
     ///
     /// That second pass re-invokes the configured
-    /// [`InlineSubstitutionRenderer`](crate::parser::InlineSubstitutionRenderer)
+    /// [`InlineSubstitutionRenderer`]
     /// and the registered asset handlers (for example the
-    /// [`ImageFileHandler`](crate::parser::ImageFileHandler)), so it assumes
+    /// [`ImageFileHandler`]), so it assumes
     /// they are **idempotent**: rendering the same content twice must produce
     /// the same bytes. The built-in HTML renderer and the default handlers
     /// satisfy this. A *stateful* custom renderer (one whose output depends on

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -476,6 +476,18 @@ pub struct Parser {
     /// `&Parser` attribute readers (which the substitution code paths reach
     /// with only a shared reference).
     datetime_context: RefCell<Option<DatetimeContext>>,
+
+    /// When `true`, each [`Content`](crate::content::Content) also builds its
+    /// inline AST (an additional, counter-safe recording substitution pass; see
+    /// [`content::inline_tree`](crate::content::inline_tree)) and stores it for
+    /// [`Content::inlines`](crate::content::Content::inlines).
+    ///
+    /// `false` by default, in which case the parse path is byte- and
+    /// performance-identical to before the inline AST existed. Enable it with
+    /// [`with_inline_tree`](Self::with_inline_tree). This is an opt-in switch
+    /// while the inline AST is being brought up (design Phase 2); it will
+    /// eventually become the canonical representation and the flag will retire.
+    pub(crate) build_inline_tree: bool,
 }
 
 /// A warning recorded in a form that does not borrow the source so it can live
@@ -591,6 +603,7 @@ impl Default for Parser {
             reference_time: None,
             input_mtime: None,
             datetime_context: RefCell::new(None),
+            build_inline_tree: false,
         }
     }
 }
@@ -2108,6 +2121,26 @@ impl Parser {
         renderer: ISR,
     ) -> Self {
         self.renderer = Rc::new(renderer);
+        self
+    }
+
+    /// Enables (or disables) building the **inline AST** for every
+    /// [`Content`](crate::content::Content) this parser produces.
+    ///
+    /// When enabled, each block's inline content is additionally parsed into a
+    /// tree of [`InlineNode`](crate::inlines::InlineNode)s, retrievable via
+    /// [`Content::inlines`](crate::content::Content::inlines). The tree is a
+    /// projection of the rendered output: folding it reproduces
+    /// [`Content::rendered`](crate::content::Content::rendered) byte-for-byte.
+    ///
+    /// This is **off by default**. Building the tree currently costs a second,
+    /// counter-safe substitution pass per block (design Phase 2, "promote the
+    /// tree into `Content`"), so the default parse path is unchanged in both
+    /// output and performance. The switch is expected to retire once the inline
+    /// AST becomes the canonical representation.
+    #[must_use]
+    pub fn with_inline_tree(mut self, enabled: bool) -> Self {
+        self.build_inline_tree = enabled;
         self
     }
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2128,10 +2128,11 @@ impl Parser {
     /// [`Content`](crate::content::Content) this parser produces.
     ///
     /// When enabled, each block's inline content is additionally parsed into a
-    /// tree of [`InlineNode`](crate::inlines::InlineNode)s, retrievable from its
-    /// [`Content`](crate::content::Content) (a crate-internal accessor while the
-    /// inline AST is being brought up; the public accessor lands in Phase 3).
-    /// The tree is a projection of the rendered output: folding it reproduces
+    /// tree of [`InlineNode`](crate::inlines::InlineNode)s, retrievable from
+    /// its [`Content`](crate::content::Content) (a crate-internal accessor
+    /// while the inline AST is being brought up; the public accessor lands
+    /// in Phase 3). The tree is a projection of the rendered output:
+    /// folding it reproduces
     /// [`Content::rendered`](crate::content::Content::rendered) byte-for-byte.
     ///
     /// This is **off by default**. Building the tree currently costs a second,

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -807,3 +807,37 @@ fn inline_tree_numbers_footnotes_in_document_order() {
 
     assert_eq!(numbers, vec!["1".to_string(), "2".to_string()]);
 }
+
+/// A renderer whose output depends on mutable internal state: it emits
+/// different bytes on its second invocation. Because the recording pass shares
+/// the same renderer instance as the authoritative pass, such a renderer makes
+/// the recorded tree fold to something other than `rendered()`.
+#[derive(Debug, Default)]
+struct FlipRenderer {
+    flipped: std::cell::Cell<bool>,
+}
+
+impl crate::parser::InlineSubstitutionRenderer for FlipRenderer {
+    fn render_special_character(&self, _type_: crate::parser::SpecialCharacter, dest: &mut String) {
+        if self.flipped.replace(true) {
+            dest.push_str("[second]");
+        } else {
+            dest.push_str("[first]");
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "diverged from rendered()")]
+fn inline_tree_build_rejects_a_stateful_renderer() {
+    // Guard from `SubstitutionGroup::build_inline_tree`: a stateful renderer is
+    // invoked a second time by the recording pass and diverges, which the debug
+    // assertion catches rather than silently storing a wrong tree. (Only active
+    // where `debug_assertions` are, matching the assertion itself.)
+    let mut parser = Parser::default()
+        .with_inline_substitution_renderer(FlipRenderer::default())
+        .with_inline_tree(true);
+
+    let _doc = parser.parse("a < b");
+}

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -808,33 +808,41 @@ fn inline_tree_numbers_footnotes_in_document_order() {
     assert_eq!(numbers, vec!["1".to_string(), "2".to_string()]);
 }
 
-/// A renderer whose output depends on mutable internal state: it emits
-/// different bytes on its second invocation. Because the recording pass shares
-/// the same renderer instance as the authoritative pass, such a renderer makes
-/// the recorded tree fold to something other than `rendered()`.
-#[derive(Debug, Default)]
-struct FlipRenderer {
-    flipped: std::cell::Cell<bool>,
-}
-
-impl crate::parser::InlineSubstitutionRenderer for FlipRenderer {
-    fn render_special_character(&self, _type_: crate::parser::SpecialCharacter, dest: &mut String) {
-        if self.flipped.replace(true) {
-            dest.push_str("[second]");
-        } else {
-            dest.push_str("[first]");
-        }
-    }
-}
-
+// The guard lives in `SubstitutionGroup::build_inline_tree` as a
+// `debug_assert!`, so both the test and the stateful renderer it needs are
+// gated on `debug_assertions` – otherwise the renderer is unused in release
+// (and `#![deny(warnings)]` rejects the dead code).
 #[cfg(debug_assertions)]
 #[test]
 #[should_panic(expected = "diverged from rendered()")]
 fn inline_tree_build_rejects_a_stateful_renderer() {
-    // Guard from `SubstitutionGroup::build_inline_tree`: a stateful renderer is
-    // invoked a second time by the recording pass and diverges, which the debug
-    // assertion catches rather than silently storing a wrong tree. (Only active
-    // where `debug_assertions` are, matching the assertion itself.)
+    /// A renderer whose output depends on mutable internal state: it emits
+    /// different bytes on its second invocation. Because the recording pass
+    /// shares the same renderer instance as the authoritative pass, such a
+    /// renderer makes the recorded tree fold to something other than
+    /// `rendered()`.
+    #[derive(Debug, Default)]
+    struct FlipRenderer {
+        flipped: std::cell::Cell<bool>,
+    }
+
+    impl crate::parser::InlineSubstitutionRenderer for FlipRenderer {
+        fn render_special_character(
+            &self,
+            _type_: crate::parser::SpecialCharacter,
+            dest: &mut String,
+        ) {
+            if self.flipped.replace(true) {
+                dest.push_str("[second]");
+            } else {
+                dest.push_str("[first]");
+            }
+        }
+    }
+
+    // A stateful renderer is invoked a second time by the recording pass and
+    // diverges, which the debug assertion catches rather than silently storing a
+    // wrong tree.
     let mut parser = Parser::default()
         .with_inline_substitution_renderer(FlipRenderer::default())
         .with_inline_tree(true);

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -1,125 +1,48 @@
-//! Phase 1 of the [inline AST architecture]: build the inline tree as an
-//! **internal, non-public artifact** and prove that folding it back to HTML
-//! reproduces the existing `rendered()` string **byte-for-byte**.
+//! Differential oracle for the inline AST, over the production
+//! [`inline_tree`](crate::content::inline_tree) module.
 //!
-//! This is the "Strategy A" bring-up oracle described in the design document
-//! (§4.1, §5.2, §5.4): the existing substitution pipeline is re-run with a
-//! *marker-recording* renderer ([`RecordingRenderer`]) that wraps the built-in
-//! [`HtmlSubstitutionRenderer`]. The recorder is a **transparent** decorator –
-//! it writes the exact HTML the built-in renderer would, and additionally
-//! brackets each recognized construct with inert Private-Use-Area sentinels.
-//! Because the only bytes it adds are sentinels, two facts follow directly:
+//! This began as the Phase 1 bring-up oracle (a test-only recorder). In Phase 2
+//! the recorder machinery moved into the parser proper
+//! ([`inline_tree`](crate::content::inline_tree)); this module is now the
+//! **harness** that drives it, keeping the same corpus and the two invariants
+//! it proves:
 //!
-//! 1. Stripping the sentinels from the recorded string yields the original
-//!    `rendered()` output byte-for-byte (the *no-perturbation* invariant).
-//! 2. Parsing the sentinel structure recovers a tree of [`InlineNode`]s, and
-//!    folding that tree (text verbatim, leaves by their captured HTML,
-//!    containers as open + folded children + close) reconstructs the same
-//!    bytes.
+//! 1. Stripping/folding the recorder's marked string reproduces the built-in
+//!    renderer's `rendered()` output **byte-for-byte** (the *no-perturbation*
+//!    invariant).
+//! 2. The recovered [`InlineNode`] tree is structurally faithful (node kinds,
+//!    nesting, and the `constructs <= markers <= events` cross-check).
 //!
-//! Nothing public changes: the recorder lives entirely in the test build and
-//! `Content::rendered()` remains authoritative. Later phases promote the tree
-//! to the canonical representation and make `rendered()` a fold over it.
-//!
-//! # These sentinels are temporary
-//!
-//! The `MARK_OPEN` / `MARK_CLOSE` / PUA-digit sentinels introduced below exist
-//! *only* for this Strategy A oracle. The design is explicit that Strategy A is
-//! not the end state (§4.1): the Phase 4 single-pass builder (Strategy B)
-//! constructs nodes directly as the substitution sink, so there is no recording
-//! pass and no markers at all. These sentinels are therefore retired wholesale
-//! along with the recorder, and – unlike the three production sentinel systems
-//! the node model also retires (passthrough / xref / footnote, §4.2) – they
-//! never touch shipped output even now, since this module is test-only.
-//!
-//! A missing construct degrades gracefully. If a `render_*` method is not
-//! intercepted, its output flows to the working string with no sentinels and is
-//! recovered as ordinary [`Text`](InlineNode::Text); byte parity is preserved
-//! regardless, so coverage can grow without ever risking the oracle.
+//! Because the machinery is now the production code path, this corpus doubles
+//! as the differential test for what
+//! [`Content::inlines`](crate::content::Content) stores when inline-tree
+//! building is enabled on the [`Parser`].
 //!
 //! [inline AST architecture]: ../../../docs/design/inline-ast-architecture.md
 
-// TEMPORARY: some node metadata is captured but not yet read while this is a
-// bring-up oracle; the allow goes away when the tree becomes canonical
-// (Phase 2) and every field is consumed.
-#![allow(dead_code)]
+#![allow(clippy::unwrap_used)]
 
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Rc;
 
 use crate::{
     Parser, Span,
-    attributes::Attrlist,
     blocks::FindBlocks,
-    content::{Content, SubstitutionGroup},
-    inlines::{
-        Anchor, Callout, CharRef, Footnote, Image, IndexTerm, InlineNode, Ref, RefVariant,
-        SpanForm, Stem, StemNotation, StyleVariant, Styled, Ui, UiKind,
+    content::{
+        Content, SubstitutionGroup,
+        inline_tree::{
+            RecordingRenderer, build_inline_tree, fold_marked, is_reserved_sentinel,
+            open_marker_count,
+        },
     },
-    parser::{
-        CalloutRenderParams, FootnoteRenderParams, HtmlSubstitutionRenderer, IconRenderParams,
-        ImageRenderParams, IndexTermRenderParams, InlineSubstitutionRenderer, LinkRenderParams,
-        MenuRenderParams, ModificationContext, QuoteScope, QuoteType, XrefRenderParams,
-    },
-    strings::CowStr,
+    inlines::{CharRef, InlineNode, RefVariant, SpanForm, StyleVariant, UiKind},
+    parser::{HtmlSubstitutionRenderer, ModificationContext},
 };
 
-// ─── Sentinels ────────────────────────────────────────────────────────────
-//
-// All in the Unicode Private Use Area, chosen to be inert to every step's
-// regexes, exactly as the existing pipeline's xref (`\u{E000}`) and passthrough
-// (`\u{96}`) sentinels already are. Digits are encoded as PUA characters too,
-// so a recorded marker injects no ASCII word characters that a later step could
-// key off of.
-
-/// Opens a recorded construct; immediately followed by the PUA-encoded index of
-/// its [`Event`].
-const MARK_OPEN: char = '\u{E010}';
-
-/// Closes a recorded construct.
-const MARK_CLOSE: char = '\u{E011}';
-
-/// Base of the ten PUA "digit" characters (`\u{E020}`..=`\u{E029}`) used to
-/// encode an [`Event`] index inside a marker.
-const PUA_DIGIT_BASE: u32 = 0xe020;
-
-/// A transient placeholder spliced in as a [quote substitution]'s body so the
-/// fixed open/close wrapper can be recovered by splitting on it. It never
-/// appears in real content.
-///
-/// [quote substitution]: https://docs.asciidoctor.org/asciidoc/latest/subs/quotes/
-const SPLIT_PLACEHOLDER: char = '\u{E0FF}';
-
-fn is_pua_digit(c: char) -> bool {
-    let n = c as u32;
-    (PUA_DIGIT_BASE..PUA_DIGIT_BASE + 10).contains(&n)
-}
-
-fn write_index(index: usize, dest: &mut String) {
-    for ch in index.to_string().chars() {
-        let digit = ch as u32 - '0' as u32;
-        if let Some(pua) = char::from_u32(PUA_DIGIT_BASE + digit) {
-            dest.push(pua);
-        }
-    }
-}
-
-fn is_marker(c: char) -> bool {
-    c == MARK_OPEN || c == MARK_CLOSE || is_pua_digit(c)
-}
-
-/// Reports whether `c` is a codepoint the recorder reserves for its own framing
-/// (a marker, a marker index digit, or the split placeholder).
-fn is_reserved_sentinel(c: char) -> bool {
-    is_marker(c) || c == SPLIT_PLACEHOLDER
-}
-
 /// Rejects a fixture whose source uses a reserved recorder codepoint. Such a
-/// character would be indistinguishable from recorder framing – `strip_markers`
-/// would delete it and `parse` would misread it – so the oracle fails fast
-/// rather than silently mis-validating the input. (The production pipeline
-/// likewise reserves its own PUA sentinels; those inputs are an accepted edge.)
-/// This is a limitation of the Strategy A oracle, not of the node model: the
-/// Phase 4 single-pass builder uses no markers and has nothing to collide with.
+/// character would be indistinguishable from recorder framing, so the oracle
+/// fails fast rather than silently mis-validating the input. (The production
+/// pipeline likewise reserves its own PUA sentinels; those inputs are an
+/// accepted edge.)
 fn assert_no_reserved_sentinels(source: &str) {
     assert!(
         !source.chars().any(is_reserved_sentinel),
@@ -127,857 +50,27 @@ fn assert_no_reserved_sentinels(source: &str) {
     );
 }
 
-/// Removes every recorder sentinel from `chars`, leaving the real (HTML) bytes.
-fn strip_markers(chars: &[char]) -> String {
-    chars.iter().copied().filter(|c| !is_marker(*c)).collect()
-}
-
-// ─── Recorded events ────────────────────────────────────────────────────────
-
-/// The metadata captured for one recognized construct, looked up by the index
-/// encoded in its [`MARK_OPEN`] marker.
-#[derive(Clone, Debug)]
-enum Event {
-    /// A parent construct (a [quote substitution]). `open`/`close` are the
-    /// fixed wrapper bytes the built-in renderer emits around the body.
-    ///
-    /// [quote substitution]: https://docs.asciidoctor.org/asciidoc/latest/subs/quotes/
-    Container {
-        open: String,
-        close: String,
-        node: ContainerNode,
-    },
-
-    /// A leaf construct. Its HTML is recovered from the marked string, so only
-    /// the structural metadata is stored here.
-    Leaf(LeafNode),
-}
-
-#[derive(Clone, Debug)]
-enum ContainerNode {
-    Styled {
-        variant: StyleVariant,
-        form: SpanForm,
-        id: Option<String>,
-        roles: Vec<String>,
-    },
-    Reference {
-        variant: RefVariant,
-        target: String,
-        roles: Vec<String>,
-        window: Option<String>,
-    },
-    Stem {
-        notation: StemNotation,
-    },
-}
-
-/// The recovered kind of a character reference. Special characters and
-/// character replacements are *not* marked by the recorder (their escaped
-/// output is re-consumed by later steps, so bracketing it would perturb
-/// recognition); instead they are recovered by splitting text runs on the
-/// entities the built-in renderer emits.
-#[derive(Clone, Debug)]
-enum CharRefKind {
-    Special(char),
-    Replacement(&'static str),
-    Entity(String),
-}
-
-#[derive(Clone, Debug)]
-enum LeafNode {
-    LineBreak,
-    Image {
-        target: String,
-        alt: Option<String>,
-        width: Option<String>,
-        height: Option<String>,
-    },
-    Reference {
-        variant: RefVariant,
-        target: String,
-        roles: Vec<String>,
-        window: Option<String>,
-    },
-    Anchor {
-        id: String,
-    },
-    Callout {
-        number: String,
-    },
-    IndexTerm {
-        terms: Vec<String>,
-        visible: bool,
-    },
-    Ui(UiMeta),
-    Footnote {
-        id: Option<String>,
-        number: Option<String>,
-        is_reference: bool,
-    },
-}
-
-#[derive(Clone, Debug)]
-enum UiMeta {
-    Button(String),
-    Keyboard(Vec<String>),
-    Menu {
-        menu: String,
-        submenus: Vec<String>,
-        item: Option<String>,
-    },
-}
-
-// ─── The recording renderer ───────────────────────────────────────────────
-
-/// A transparent decorator over [`HtmlSubstitutionRenderer`] that brackets each
-/// recognized construct with recorder sentinels and captures its structural
-/// metadata into a shared event log.
-#[derive(Debug)]
-struct RecordingRenderer {
-    html: HtmlSubstitutionRenderer,
-    events: Rc<RefCell<Vec<Event>>>,
-}
-
-impl RecordingRenderer {
-    fn new() -> (Self, Rc<RefCell<Vec<Event>>>) {
-        let events = Rc::new(RefCell::new(Vec::new()));
-
-        let renderer = Self {
-            html: HtmlSubstitutionRenderer {},
-            events: events.clone(),
-        };
-
-        (renderer, events)
-    }
-
-    fn push(&self, event: Event) -> usize {
-        let mut events = self.events.borrow_mut();
-        events.push(event);
-        events.len() - 1
-    }
-
-    /// Writes `MARK_OPEN index fragment MARK_CLOSE` into `dest`. `fragment` is
-    /// the exact HTML the built-in renderer produced, so `dest` still contains
-    /// every real byte and only inert sentinels are added.
-    fn wrap(&self, index: usize, fragment: &str, dest: &mut String) {
-        dest.push(MARK_OPEN);
-        write_index(index, dest);
-        dest.push_str(fragment);
-        dest.push(MARK_CLOSE);
-    }
-
-    fn leaf(&self, node: LeafNode, fragment: &str, dest: &mut String) {
-        let index = self.push(Event::Leaf(node));
-        self.wrap(index, fragment, dest);
-    }
-
-    /// Recovers the fixed open/close wrapper a quote substitution emits, by
-    /// rendering it once with [`SPLIT_PLACEHOLDER`] as the body and splitting.
-    fn split_quote(
-        &self,
-        type_: QuoteType,
-        scope: QuoteScope,
-        attrlist: Option<Attrlist<'_>>,
-        id: Option<String>,
-    ) -> (String, String) {
-        let mut probe = String::new();
-
-        self.html.render_quoted_substitution(
-            type_,
-            scope,
-            attrlist,
-            id,
-            &SPLIT_PLACEHOLDER.to_string(),
-            &mut probe,
-        );
-
-        match probe.split_once(SPLIT_PLACEHOLDER) {
-            Some((open, close)) => (open.to_string(), close.to_string()),
-
-            // A body that does not survive the wrapper (should not happen for
-            // any quote type) degrades to "whole fragment is the open".
-            None => (probe, String::new()),
-        }
-    }
-}
-
-fn optional(value: Option<&str>) -> Option<String> {
-    value.map(str::to_string)
-}
-
-impl InlineSubstitutionRenderer for RecordingRenderer {
-    // `render_special_character` and `render_character_replacement` are
-    // deliberately *not* overridden: their escaped output (`&lt;`, `&gt;`,
-    // `&#8594;`, …) is re-matched by later steps (callouts on `&lt;N&gt;`, the
-    // xref shorthand on `&lt;&lt;`, arrow replacements on `&lt;-`), so wrapping
-    // it in sentinels would break that recognition. They fall through to the
-    // built-in HTML renderer, and their `CharRef` nodes are recovered from the
-    // resulting text runs (see `push_text`).
-
-    fn render_quoted_substitution(
-        &self,
-        type_: QuoteType,
-        scope: QuoteScope,
-        attrlist: Option<Attrlist<'_>>,
-        id: Option<String>,
-        body: &str,
-        dest: &mut String,
-    ) {
-        let roles: Vec<String> = attrlist
-            .as_ref()
-            .map(|a| a.roles().iter().map(|r| r.to_string()).collect())
-            .unwrap_or_default();
-
-        let (open, close) = self.split_quote(type_, scope, attrlist.clone(), id.clone());
-
-        let node = match type_ {
-            QuoteType::AsciiMath => ContainerNode::Stem {
-                notation: StemNotation::AsciiMath,
-            },
-
-            QuoteType::LatexMath => ContainerNode::Stem {
-                notation: StemNotation::LatexMath,
-            },
-
-            _ => ContainerNode::Styled {
-                variant: style_variant(type_),
-                form: span_form(scope),
-                id: id.clone(),
-                roles,
-            },
-        };
-
-        let index = self.push(Event::Container {
-            open: open.clone(),
-            close: close.clone(),
-            node,
-        });
-
-        // Re-render with the real body (which already carries the sentinels of
-        // any nested constructs) so `dest` holds `open + body + close`, exactly
-        // as the built-in renderer would, wrapped in this construct's markers.
-        let mut fragment = String::new();
-        self.html
-            .render_quoted_substitution(type_, scope, attrlist, id, body, &mut fragment);
-
-        self.wrap(index, &fragment, dest);
-    }
-
-    fn render_line_break(&self, dest: &mut String) {
-        let mut fragment = String::new();
-        self.html.render_line_break(&mut fragment);
-        self.leaf(LeafNode::LineBreak, &fragment, dest);
-    }
-
-    fn render_image(&self, params: &ImageRenderParams, dest: &mut String) {
-        let mut fragment = String::new();
-        self.html.render_image(params, &mut fragment);
-
-        self.leaf(
-            LeafNode::Image {
-                target: params.target.to_string(),
-                alt: Some(params.alt.clone()),
-                width: optional(params.width),
-                height: optional(params.height),
-            },
-            &fragment,
-            dest,
-        );
-    }
-
-    fn render_icon(&self, params: &IconRenderParams, dest: &mut String) {
-        let mut fragment = String::new();
-        self.html.render_icon(params, &mut fragment);
-
-        // The public vocabulary has no dedicated icon node yet; an icon projects
-        // onto `Image` (its closest kin) for now.
-        self.leaf(
-            LeafNode::Image {
-                target: params.target.to_string(),
-                alt: Some(params.alt.clone()),
-                width: None,
-                height: None,
-            },
-            &fragment,
-            dest,
-        );
-    }
-
-    fn render_link(&self, params: &LinkRenderParams, dest: &mut String) {
-        let mut roles: Vec<String> = params.extra_roles.iter().map(|r| r.to_string()).collect();
-        roles.extend(params.attrlist.roles().iter().map(|r| r.to_string()));
-
-        // A link's display text is inserted verbatim between a fixed open/close,
-        // so – like a quote span – its wrapper is recovered by rendering once
-        // with a placeholder body, and the real text becomes the container's
-        // children (so `link:x[*bold*]` decomposes into a `Ref` over a `Styled`).
-        let probe_params = LinkRenderParams {
-            target: params.target.clone(),
-            link_text: SPLIT_PLACEHOLDER.to_string(),
-            extra_roles: params.extra_roles.clone(),
-            window: params.window,
-            attrlist: params.attrlist,
-            parser: params.parser,
-        };
-
-        let mut probe = String::new();
-        self.html.render_link(&probe_params, &mut probe);
-
-        let (open, close) = match probe.split_once(SPLIT_PLACEHOLDER) {
-            Some((open, close)) => (open.to_string(), close.to_string()),
-            None => (probe, String::new()),
-        };
-
-        let index = self.push(Event::Container {
-            open: open.clone(),
-            close: close.clone(),
-            node: ContainerNode::Reference {
-                variant: RefVariant::Link,
-                target: params.target.clone(),
-                roles,
-                window: optional(params.window),
-            },
-        });
-
-        let mut fragment = String::new();
-        self.html.render_link(params, &mut fragment);
-
-        self.wrap(index, &fragment, dest);
-    }
-
-    fn render_anchor(&self, id: &str, reftext: Option<String>, dest: &mut String) {
-        let mut fragment = String::new();
-        self.html.render_anchor(id, reftext, &mut fragment);
-        self.leaf(LeafNode::Anchor { id: id.to_string() }, &fragment, dest);
-    }
-
-    fn render_xref(&self, params: &XrefRenderParams, dest: &mut String) {
-        let mut fragment = String::new();
-        self.html.render_xref(params, &mut fragment);
-
-        self.leaf(
-            LeafNode::Reference {
-                variant: RefVariant::Xref,
-                target: params.target.to_string(),
-                roles: params.roles.to_vec(),
-                window: optional(params.window),
-            },
-            &fragment,
-            dest,
-        );
-    }
-
-    fn render_callout(&self, params: &CalloutRenderParams, dest: &mut String) {
-        let mut fragment = String::new();
-        self.html.render_callout(params, &mut fragment);
-
-        self.leaf(
-            LeafNode::Callout {
-                number: params.number.to_string(),
-            },
-            &fragment,
-            dest,
-        );
-    }
-
-    fn render_index_term(&self, params: &IndexTermRenderParams, dest: &mut String) {
-        let mut fragment = String::new();
-        self.html.render_index_term(params, &mut fragment);
-
-        // `render_index_term` only receives the visible primary term; the
-        // concealed levels are not exposed here, so the term list is
-        // best-effort in this bring-up oracle.
-        let (terms, visible) = match params.visible_term {
-            Some(term) => (vec![term.to_string()], true),
-            None => (vec![], false),
-        };
-
-        self.leaf(LeafNode::IndexTerm { terms, visible }, &fragment, dest);
-    }
-
-    fn render_button(&self, text: &str, dest: &mut String) {
-        let mut fragment = String::new();
-        self.html.render_button(text, &mut fragment);
-        self.leaf(
-            LeafNode::Ui(UiMeta::Button(text.to_string())),
-            &fragment,
-            dest,
-        );
-    }
-
-    fn render_keyboard(&self, keys: &[String], dest: &mut String) {
-        let mut fragment = String::new();
-        self.html.render_keyboard(keys, &mut fragment);
-        self.leaf(
-            LeafNode::Ui(UiMeta::Keyboard(keys.to_vec())),
-            &fragment,
-            dest,
-        );
-    }
-
-    fn render_menu(&self, params: &MenuRenderParams, dest: &mut String) {
-        let mut fragment = String::new();
-        self.html.render_menu(params, &mut fragment);
-
-        self.leaf(
-            LeafNode::Ui(UiMeta::Menu {
-                menu: params.menu.to_string(),
-                submenus: params.submenus.to_vec(),
-                item: optional(params.menuitem),
-            }),
-            &fragment,
-            dest,
-        );
-    }
-
-    fn render_footnote(&self, params: &FootnoteRenderParams, dest: &mut String) {
-        let mut fragment = String::new();
-        self.html.render_footnote(params, &mut fragment);
-
-        self.leaf(
-            LeafNode::Footnote {
-                id: optional(params.id),
-                number: optional(params.index),
-                is_reference: params.is_reference,
-            },
-            &fragment,
-            dest,
-        );
-    }
-}
-
-fn style_variant(type_: QuoteType) -> StyleVariant {
-    match type_ {
-        QuoteType::Strong => StyleVariant::Strong,
-        QuoteType::Emphasis => StyleVariant::Emphasis,
-        QuoteType::Monospaced => StyleVariant::Code,
-        QuoteType::Mark => StyleVariant::Mark,
-        QuoteType::Superscript => StyleVariant::Superscript,
-        QuoteType::Subscript => StyleVariant::Subscript,
-        QuoteType::DoubleQuote => StyleVariant::DoubleQuote,
-        QuoteType::SingleQuote => StyleVariant::SingleQuote,
-
-        // AsciiMath/LatexMath are handled as STEM before this is reached;
-        // `Unquoted` and any residue map to the unquoted span.
-        _ => StyleVariant::Unquoted,
-    }
-}
-
-fn span_form(scope: QuoteScope) -> SpanForm {
-    match scope {
-        QuoteScope::Constrained => SpanForm::Constrained,
-        QuoteScope::Unconstrained => SpanForm::Unconstrained,
-    }
-}
-
-// ─── The recorded tree ──────────────────────────────────────────────────────
-
-/// The internal Phase 1 tree. Each node carries what the fold needs to
-/// reconstruct its bytes, alongside the structural metadata that projects to a
-/// public [`InlineNode`].
-#[derive(Clone, Debug)]
-enum Rec {
-    Text(String),
-
-    /// A character reference recovered from a text run. `html` is the exact
-    /// entity the built-in renderer emitted (`&lt;`, `&#8594;`, …).
-    CharRef {
-        html: String,
-        kind: CharRefKind,
-    },
-    Leaf {
-        html: String,
-        node: LeafNode,
-    },
-    Container {
-        open: String,
-        close: String,
-        children: Vec<Rec>,
-        node: ContainerNode,
-    },
-}
-
-/// Pushes `text` onto `out`, splitting it into plain [`Rec::Text`] and
-/// [`Rec::CharRef`] runs. Every `&` in the built-in renderer's output opens an
-/// entity (a literal `&` is escaped to `&amp;`), so an ampersand-to-semicolon
-/// span is always a character reference.
-fn push_text(text: &str, out: &mut Vec<Rec>) {
-    if text.is_empty() {
-        return;
-    }
-
-    let mut plain = String::new();
-    let mut rest = text;
-
-    while let Some(amp) = rest.find('&') {
-        plain.push_str(&rest[..amp]);
-        let after = &rest[amp..];
-
-        let Some(semi) = after.find(';') else {
-            // No terminator: not an entity (should not occur). Keep the `&`.
-            plain.push('&');
-            rest = &after[1..];
-            continue;
-        };
-
-        let entity = &after[..=semi];
-
-        if !plain.is_empty() {
-            out.push(Rec::Text(std::mem::take(&mut plain)));
-        }
-
-        out.push(Rec::CharRef {
-            html: entity.to_string(),
-            kind: classify_entity(entity),
-        });
-
-        rest = &after[semi + 1..];
-    }
-
-    plain.push_str(rest);
-
-    if !plain.is_empty() {
-        out.push(Rec::Text(plain));
-    }
-}
-
-fn classify_entity(entity: &str) -> CharRefKind {
-    match entity {
-        "&lt;" => CharRefKind::Special('<'),
-        "&gt;" => CharRefKind::Special('>'),
-        "&amp;" => CharRefKind::Special('&'),
-
-        "&#169;" => CharRefKind::Replacement("\u{a9}"),
-        "&#174;" => CharRefKind::Replacement("\u{ae}"),
-        "&#8482;" => CharRefKind::Replacement("\u{2122}"),
-        "&#8201;" => CharRefKind::Replacement("\u{2009}"),
-        "&#8212;" => CharRefKind::Replacement("\u{2014}"),
-        "&#8203;" => CharRefKind::Replacement("\u{200b}"),
-        "&#8230;" => CharRefKind::Replacement("\u{2026}"),
-        "&#8592;" => CharRefKind::Replacement("\u{2190}"),
-        "&#8656;" => CharRefKind::Replacement("\u{21d0}"),
-        "&#8594;" => CharRefKind::Replacement("\u{2192}"),
-        "&#8658;" => CharRefKind::Replacement("\u{21d2}"),
-        "&#8217;" => CharRefKind::Replacement("\u{2019}"),
-        "&#8216;" => CharRefKind::Replacement("\u{2018}"),
-
-        // A numeric or named entity written by the author, carried through as
-        // written.
-        other => CharRefKind::Entity(other.to_string()),
-    }
-}
-
-/// Parses a recorder-marked string into the recorded tree, resolving each
-/// marker against `events`.
-fn parse(chars: &[char], events: &[Event]) -> Vec<Rec> {
-    let mut out = Vec::new();
-    let mut text = String::new();
-    let mut i = 0;
-
-    while let Some(&c) = chars.get(i) {
-        if c != MARK_OPEN {
-            text.push(c);
-            i += 1;
-            continue;
-        }
-
-        push_text(&std::mem::take(&mut text), &mut out);
-
-        i += 1;
-
-        // Read the PUA-encoded event index.
-        let mut index = 0usize;
-        while let Some(&d) = chars.get(i) {
-            if !is_pua_digit(d) {
-                break;
-            }
-
-            index = index * 10 + (d as u32 - PUA_DIGIT_BASE) as usize;
-            i += 1;
-        }
-
-        // Find the matching close, honoring nesting.
-        let start = i;
-        let mut depth = 1;
-
-        while let Some(&d) = chars.get(i) {
-            match d {
-                MARK_OPEN => depth += 1,
-
-                MARK_CLOSE => {
-                    depth -= 1;
-                    if depth == 0 {
-                        break;
-                    }
-                }
-
-                _ => {}
-            }
-
-            i += 1;
-        }
-
-        let region = chars.get(start..i).unwrap_or(&[]);
-
-        // Skip the matching close.
-        i += 1;
-
-        if let Some(event) = events.get(index) {
-            out.push(build_rec(event, region, events));
-        }
-    }
-
-    push_text(&text, &mut out);
-
-    out
-}
-
-fn build_rec(event: &Event, region: &[char], events: &[Event]) -> Rec {
-    match event {
-        Event::Container { open, close, node } => {
-            // `region` is `open + body + close`; the body carries the nested
-            // markers. Slice off the known (marker-free) wrapper and recurse.
-            let open_len = open.chars().count();
-            let close_len = close.chars().count();
-            let body_end = region.len().saturating_sub(close_len);
-
-            let body = region.get(open_len..body_end).unwrap_or(&[]);
-
-            Rec::Container {
-                open: open.clone(),
-                close: close.clone(),
-                children: parse(body, events),
-                node: node.clone(),
-            }
-        }
-
-        Event::Leaf(node) => Rec::Leaf {
-            html: strip_markers(region),
-            node: node.clone(),
-        },
-    }
-}
-
-/// Folds the recorded tree back to HTML: text verbatim, a leaf as its captured
-/// HTML, a container as open + folded children + close.
-fn fold(recs: &[Rec]) -> String {
-    let mut out = String::new();
-    fold_into(recs, &mut out);
-    out
-}
-
-fn fold_into(recs: &[Rec], out: &mut String) {
-    for rec in recs {
-        match rec {
-            Rec::Text(text) => out.push_str(text),
-
-            Rec::CharRef { html, .. } => out.push_str(html),
-
-            Rec::Leaf { html, .. } => out.push_str(html),
-
-            Rec::Container {
-                open,
-                close,
-                children,
-                ..
-            } => {
-                out.push_str(open);
-                fold_into(children, out);
-                out.push_str(close);
-            }
-        }
-    }
-}
-
 /// The number of recorded constructs (non-text nodes) in the tree – i.e. the
-/// number of [`Event`]s the tree consumed. Used to cross-check the tree against
-/// the recorder.
-fn construct_count(recs: &[Rec]) -> usize {
-    recs.iter()
-        .map(|rec| match rec {
+/// number of recorder [`Event`](crate::content::inline_tree)s the tree
+/// consumed. Used to cross-check the tree against the recorder.
+fn construct_count(nodes: &[InlineNode<'_>]) -> usize {
+    nodes
+        .iter()
+        .map(|node| match node {
             // Text and recovered character references are not recorded events.
-            Rec::Text(_) | Rec::CharRef { .. } => 0,
-            Rec::Leaf { .. } => 1,
-            Rec::Container { children, .. } => 1 + construct_count(children),
+            InlineNode::Text { .. } | InlineNode::CharRef { .. } | InlineNode::Raw { .. } => 0,
+
+            InlineNode::Styled(styled) => 1 + construct_count(&styled.children),
+            InlineNode::Ref(reference) => 1 + construct_count(&reference.children),
+            InlineNode::Footnote(footnote) => 1 + construct_count(&footnote.children),
+
+            // A STEM node folds its body into `value`, so it has no child nodes;
+            // it is one recorded construct, matching the recorder.
+            InlineNode::Stem(_) => 1,
+
+            _ => 1,
         })
         .sum()
-}
-
-// ─── Projection to the public inline vocabulary ─────────────────────────────
-
-/// Projects the recorded tree onto the public [`InlineNode`] vocabulary, giving
-/// every node the same coarse `location` (Phase 1 carries no precise spans; see
-/// design §4.4).
-fn to_inline<'src>(recs: &[Rec], span: Span<'src>) -> Vec<InlineNode<'src>> {
-    recs.iter().map(|rec| node_of(rec, span)).collect()
-}
-
-fn node_of<'src>(rec: &Rec, span: Span<'src>) -> InlineNode<'src> {
-    match rec {
-        Rec::Text(text) => InlineNode::Text {
-            value: CowStr::from(text.clone()),
-            location: span,
-        },
-
-        Rec::CharRef { kind, .. } => InlineNode::CharRef {
-            value: match kind {
-                CharRefKind::Special(ch) => CharRef::Special(*ch),
-                CharRefKind::Replacement(value) => CharRef::Replacement(value),
-                CharRefKind::Entity(name) => CharRef::Entity(CowStr::from(name.clone())),
-            },
-            location: span,
-        },
-
-        Rec::Leaf { node, .. } => leaf_node_of(node, span),
-
-        Rec::Container { children, node, .. } => match node {
-            ContainerNode::Styled {
-                variant,
-                form,
-                id,
-                roles,
-            } => InlineNode::Styled(Styled {
-                variant: *variant,
-                form: *form,
-                id: id.clone().map(CowStr::from),
-                roles: roles.iter().cloned().map(CowStr::from).collect(),
-                attrs: None,
-                children: to_inline(children, span),
-                location: span,
-            }),
-
-            ContainerNode::Reference {
-                variant,
-                target,
-                roles,
-                window,
-            } => InlineNode::Ref(Ref {
-                variant: *variant,
-                target: CowStr::from(target.clone()),
-                children: to_inline(children, span),
-                roles: roles.iter().cloned().map(CowStr::from).collect(),
-                window: window.clone().map(CowStr::from),
-                resolved: None,
-                location: span,
-            }),
-
-            ContainerNode::Stem { notation } => InlineNode::Stem(Stem {
-                notation: *notation,
-                value: CowStr::from(fold(children)),
-                location: span,
-            }),
-        },
-    }
-}
-
-fn leaf_node_of<'src>(node: &LeafNode, span: Span<'src>) -> InlineNode<'src> {
-    match node {
-        LeafNode::LineBreak => InlineNode::LineBreak { location: span },
-
-        LeafNode::Image {
-            target,
-            alt,
-            width,
-            height,
-        } => InlineNode::Image(Image {
-            target: CowStr::from(target.clone()),
-            alt: alt.clone().map(CowStr::from),
-            width: width.clone().map(CowStr::from),
-            height: height.clone().map(CowStr::from),
-            attrs: None,
-            location: span,
-        }),
-
-        LeafNode::Reference {
-            variant,
-            target,
-            roles,
-            window,
-        } => InlineNode::Ref(Ref {
-            variant: *variant,
-            target: CowStr::from(target.clone()),
-            children: vec![],
-            roles: roles.iter().cloned().map(CowStr::from).collect(),
-            window: window.clone().map(CowStr::from),
-            resolved: None,
-            location: span,
-        }),
-
-        LeafNode::Anchor { id } => InlineNode::Anchor(Anchor {
-            id: CowStr::from(id.clone()),
-            reftext: None,
-            location: span,
-        }),
-
-        LeafNode::Callout { number } => InlineNode::Callout(Callout {
-            number: CowStr::from(number.clone()),
-            location: span,
-        }),
-
-        LeafNode::IndexTerm { terms, visible } => InlineNode::IndexTerm(IndexTerm {
-            terms: terms.iter().cloned().map(CowStr::from).collect(),
-            visible: *visible,
-            location: span,
-        }),
-
-        LeafNode::Ui(ui) => InlineNode::Ui(Ui {
-            kind: match ui {
-                UiMeta::Button(text) => UiKind::Button(CowStr::from(text.clone())),
-
-                UiMeta::Keyboard(keys) => {
-                    UiKind::Keyboard(keys.iter().cloned().map(CowStr::from).collect())
-                }
-
-                UiMeta::Menu {
-                    menu,
-                    submenus,
-                    item,
-                } => UiKind::Menu {
-                    menu: CowStr::from(menu.clone()),
-                    submenus: submenus.iter().cloned().map(CowStr::from).collect(),
-                    item: item.clone().map(CowStr::from),
-                },
-            },
-            location: span,
-        }),
-
-        LeafNode::Footnote {
-            id,
-            number,
-            is_reference,
-        } => InlineNode::Footnote(Footnote {
-            id: id.clone().map(CowStr::from),
-            number: number.clone().map(CowStr::from),
-            is_reference: *is_reference,
-            children: vec![],
-            location: span,
-        }),
-    }
-}
-
-// ─── The oracle ─────────────────────────────────────────────────────────────
-
-/// The result of running the Phase 1 oracle on one source string.
-struct Oracle<'src> {
-    /// The authoritative `rendered()` output of the unmodified pipeline.
-    golden: String,
-
-    /// The recorder-marked `rendered()` string (real HTML + inert sentinels).
-    marked: String,
-
-    /// The recorded tree, projected onto the public vocabulary.
-    tree: Vec<InlineNode<'src>>,
-
-    /// The number of constructs the recorder captured.
-    events: usize,
-
-    /// The number of open-markers that reached the final string.
-    markers: usize,
-
-    /// The number of marked construct nodes in the recorded tree (recovered
-    /// character references excluded, as they are not recorded events).
-    constructs: usize,
 }
 
 /// Enables `:experimental:` so the UI macros (`kbd:`, `btn:`, `menu:`) are
@@ -986,9 +79,33 @@ fn experimental(parser: Parser) -> Parser {
     parser.with_intrinsic_attribute_bool("experimental", true, ModificationContext::Anywhere)
 }
 
+/// The result of running the oracle on one source string.
+struct Oracle<'src> {
+    /// The authoritative `rendered()` output of the unmodified pipeline.
+    golden: String,
+
+    /// The fold of the recovered tree (the recorder's marked string folded back
+    /// to output bytes).
+    folded: String,
+
+    /// The recovered tree, projected onto the public vocabulary.
+    tree: Vec<InlineNode<'src>>,
+
+    /// The number of constructs the recorder captured.
+    events: usize,
+
+    /// The number of open-markers that reached the final string.
+    markers: usize,
+
+    /// The number of marked construct nodes in the recovered tree (recovered
+    /// character references excluded, as they are not recorded events).
+    constructs: usize,
+}
+
 /// Runs `source` through the pipeline twice under `group`: once with the
-/// built-in HTML renderer (the golden output) and once with the recording
-/// renderer (from which the tree is built). Both use a default [`Parser`].
+/// built-in HTML renderer (the golden output) and once with the production
+/// [`RecordingRenderer`] (from which the tree is built). Both use a default
+/// [`Parser`].
 fn oracle<'src>(source: &'src str, group: &SubstitutionGroup) -> Oracle<'src> {
     assert_no_reserved_sentinels(source);
 
@@ -998,60 +115,44 @@ fn oracle<'src>(source: &'src str, group: &SubstitutionGroup) -> Oracle<'src> {
     group.apply(&mut golden_content, &golden_parser, None);
     let golden = golden_content.rendered_owned();
 
-    // Recording pass.
-    let (recorder, events) = RecordingRenderer::new();
+    // Recording pass, driving the production recorder.
+    let (recorder, events) = RecordingRenderer::new(Rc::new(HtmlSubstitutionRenderer {}));
     let recording_parser =
         experimental(Parser::default()).with_inline_substitution_renderer(recorder);
     let mut recording_content = Content::from(Span::new(source));
     group.apply(&mut recording_content, &recording_parser, None);
     let marked = recording_content.rendered_owned();
 
-    let markers = marked.matches(MARK_OPEN).count();
-    let chars: Vec<char> = marked.chars().collect();
-    let events = events.borrow();
-    let recs = parse(&chars, &events);
+    let markers = open_marker_count(&marked);
+    let events_len = events.borrow().len();
+    let tree = build_inline_tree(&marked, &events.borrow(), Span::new(source));
+    let folded = fold_marked(&marked, &events.borrow());
+    let constructs = construct_count(&tree);
 
     Oracle {
         golden,
-        marked,
-        tree: to_inline(&recs, Span::new(source)),
-        events: events.len(),
+        folded,
+        tree,
+        events: events_len,
         markers,
-        constructs: construct_count(&recs),
+        constructs,
     }
 }
 
-/// Asserts the two Phase 1 invariants for `source` under `group`:
+/// Asserts the oracle's invariants for `source` under `group`:
 ///
-/// 1. stripping the sentinels reproduces the golden output byte-for-byte, and
-/// 2. folding the recorded tree reproduces the golden output byte-for-byte,
+/// 1. folding the recorder's marked string reproduces the golden output
+///    byte-for-byte, and
+/// 2. the recovered tree consumed exactly the recorded events (`constructs <=
+///    markers <= events`).
 ///
-/// and cross-checks that the tree consumed exactly the recorded events. Returns
-/// the built tree for callers that also want to assert on structure.
+/// Returns the recovered tree for callers that also want to assert on
+/// structure.
 fn check<'src>(source: &'src str, group: &SubstitutionGroup) -> Vec<InlineNode<'src>> {
     let result = oracle(source, group);
 
-    let stripped = strip_markers(&result.marked.chars().collect::<Vec<_>>());
     assert_eq!(
-        stripped, result.golden,
-        "sentinel strip diverged from rendered() for {source:?}"
-    );
-
-    // Rebuild the tree independently of `oracle` so the fold is exercised on the
-    // exact same source (the tree in `result` already reflects it, but folding
-    // needs the `Rec` form).
-    let (recorder, events) = RecordingRenderer::new();
-    let recording_parser =
-        experimental(Parser::default()).with_inline_substitution_renderer(recorder);
-    let mut content = Content::from(Span::new(source));
-    group.apply(&mut content, &recording_parser, None);
-    let marked = content.rendered_owned();
-    let chars: Vec<char> = marked.chars().collect();
-    let recs = parse(&chars, &events.borrow());
-
-    assert_eq!(
-        fold(&recs),
-        result.golden,
+        result.folded, result.golden,
         "fold of the inline tree diverged from rendered() for {source:?}"
     );
 
@@ -1064,9 +165,6 @@ fn check<'src>(source: &'src str, group: &SubstitutionGroup) -> Vec<InlineNode<'
     // * `constructs <= markers` – some markers (formatting inside a construct
     //   rendered as a single leaf, e.g. a formatted xref reftext) are absorbed into
     //   that leaf's HTML rather than surfacing as their own node.
-    //
-    // A tree with *more* constructs than the recorder saw would mean the builder
-    // invented structure, which these bounds catch.
     assert!(
         result.markers <= result.events,
         "{} markers exceeded {} recorded events for {source:?}",
@@ -1091,9 +189,7 @@ fn check_normal(source: &str) -> Vec<InlineNode<'_>> {
 // ─── Byte-parity corpus ─────────────────────────────────────────────────────
 //
 // A differential harness over a broad set of inline fixtures. Each asserts the
-// two Phase 1 invariants; together they exercise every intercepted construct.
-// This is the "corpus-wide differential harness" the design (§5.3) calls for,
-// built from inline sources because the crate keeps no `.adoc` fixture files.
+// oracle's invariants; together they exercise every intercepted construct.
 
 /// Inline fixtures covering the `normal` substitution group.
 const NORMAL_CORPUS: &[&str] = &[
@@ -1248,14 +344,7 @@ fn normal_corpus_folds_byte_for_byte() {
 // items, section bodies, and the interactions between blocks.
 
 /// Collects the rendered inline content of every content-bearing location in
-/// `doc`, in a fixed document order: each block's own title, then the block's
-/// inline content (a simple block's body, a section's heading, or every simple
-/// table cell), then its children. Both parses are walked identically, so the
-/// golden and recorded vectors line up element-for-element.
-///
-/// Section headings and table cells are *not* child simple blocks, so a walk
-/// that only visited `Block::Simple` would silently skip them – leaving, for
-/// example, a table fixture green without ever folding its cells.
+/// `doc`, in a fixed document order.
 fn collect_rendered(doc: &crate::Document<'_>) -> Vec<String> {
     use crate::blocks::{Block, IsBlock, TableCellContent, TableRow};
 
@@ -1322,7 +411,7 @@ fn check_document(source: &str) {
     let golden_doc = golden_parser.parse(source);
     let golden = collect_rendered(&golden_doc);
 
-    let (recorder, events) = RecordingRenderer::new();
+    let (recorder, events) = RecordingRenderer::new(Rc::new(HtmlSubstitutionRenderer {}));
     let mut recording_parser =
         experimental(Parser::default()).with_inline_substitution_renderer(recorder);
     let recording_doc = recording_parser.parse(source);
@@ -1330,7 +419,7 @@ fn check_document(source: &str) {
 
     let folded: Vec<String> = collect_rendered(&recording_doc)
         .iter()
-        .map(|marked| fold(&parse(&marked.chars().collect::<Vec<_>>(), &events)))
+        .map(|marked| fold_marked(marked, &events))
         .collect();
 
     // Guard against a fixture that exercises nothing (e.g. a table whose cells
@@ -1632,4 +721,84 @@ fn callout_in_verbatim_is_a_callout_node() {
         tree.iter().any(|n| matches!(n, InlineNode::Callout(_))),
         "expected a callout node in {tree:?}"
     );
+}
+
+// ─── Wiring: the tree as a live artifact on `Content` ────────────────────────
+//
+// These exercise the Phase 2 wiring: `Parser::with_inline_tree` builds each
+// `Content`'s tree during the parse, so `Content::inlines()` is populated for
+// real blocks (with document counters numbered correctly), and the default
+// (flag-off) path leaves it empty.
+
+/// Collects the first simple block's content from a parsed document.
+fn first_simple_inlines<'a>(doc: &'a crate::Document<'a>) -> &'a [InlineNode<'a>] {
+    use crate::blocks::Block;
+
+    for block in doc.child_blocks() {
+        if let Block::Simple(simple) = block {
+            return simple.content().inlines();
+        }
+    }
+
+    panic!("no simple block found");
+}
+
+#[test]
+fn inline_tree_is_empty_by_default() {
+    let mut parser = Parser::default();
+    let doc = parser.parse("One *word* is strong.");
+
+    assert!(
+        first_simple_inlines(&doc).is_empty(),
+        "the inline tree must be empty when tree building is disabled"
+    );
+}
+
+#[test]
+fn inline_tree_is_built_when_enabled() {
+    let mut parser = Parser::default().with_inline_tree(true);
+    let doc = parser.parse("One *word* is strong.");
+
+    let tree = first_simple_inlines(&doc);
+
+    // "One " → Text, "*word*" → Styled(Strong), " is strong." → Text.
+    assert_eq!(tree.len(), 3);
+    assert!(matches!(&tree[0], InlineNode::Text { .. }));
+
+    let InlineNode::Styled(styled) = &tree[1] else {
+        panic!("expected a styled node, got {:?}", tree[1]);
+    };
+
+    assert_eq!(styled.variant, StyleVariant::Strong);
+    assert!(matches!(&tree[2], InlineNode::Text { .. }));
+}
+
+#[test]
+fn inline_tree_numbers_footnotes_in_document_order() {
+    // The recording pass clones the parser *before* the authoritative pass
+    // advances the footnote counter, so a footnote in the second paragraph is
+    // numbered "2" in its tree – matching `rendered()` – rather than restarting
+    // at "1" (which a fresh-parser recording pass would produce).
+    let mut parser = Parser::default().with_inline_tree(true);
+    let doc =
+        parser.parse("Body text.footnote:[the first note]\n\nMore text.footnote:[the second note]");
+
+    use crate::blocks::Block;
+
+    let numbers: Vec<String> = doc
+        .child_blocks()
+        .filter_map(|block| match block {
+            Block::Simple(simple) => Some(simple),
+            _ => None,
+        })
+        .flat_map(|simple| simple.content().inlines().to_vec())
+        .filter_map(|node| match node {
+            InlineNode::Footnote(footnote) => {
+                footnote.number.as_ref().map(|n| n.as_ref().to_string())
+            }
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(numbers, vec!["1".to_string(), "2".to_string()]);
 }

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -314,6 +314,11 @@ const NORMAL_CORPUS: &[&str] = &[
     "line one +\nline two +\nline three",
     // STEM inline (asciimath / latexmath).
     "stem:[a < b] expression",
+    "asciimath:[a < b] inline",
+    "latexmath:[x < y] inline",
+    // Inline icon macro (renders via `render_icon`).
+    "an icon:home[] icon",
+    "icon:star[2x,role=gold] rated",
     // Empty-ish and whitespace.
     "   ",
     "a\nb\nc",


### PR DESCRIPTION
## What

First step of **Phase 2** of the [inline AST architecture](docs/design/inline-ast-architecture.md): *promote the inline tree into `Content`* as a live artifact, per the scoping chosen for this draft.

- New production module [`content::inline_tree`](parser/src/content/inline_tree.rs) — the Phase 1 recorder machinery, moved out of the test build and generalized to wrap the parser's **own** inline renderer (so the fold reproduces that renderer's bytes, not a hard-coded HTML backend).
- `Content` now carries a live `inlines` tree, exposed via `Content::inlines()`. It is a *derived* artifact (excluded from `Eq`/`Hash`), so equality semantics are unchanged.
- Opt-in `Parser::with_inline_tree(true)` gates tree building. **Off by default.**
- The [`inline_recorder`](parser/src/tests/inline_recorder.rs) differential corpus now drives the production module directly (the duplicated test recorder is deleted), so byte-for-byte fold parity is a test of shipped code.

## Why this shape

Phase 2 in full is the "load-bearing internal cutover" (make the tree canonical, `rendered()` a fold, delete all three sentinel systems, keep ~277 golden assertions byte-perfect). That is a large, delicate rewrite of the ~9k-line inline pipeline. This PR lands the **safe first step** and is explicit about what remains.

### Correctness / safety

- **Default path unchanged.** With the flag off, nothing in the authoritative substitution path changes — all existing tests (4628) pass unchanged, and there is no added per-parse cost.
- **Counter-safe tree building.** With the flag on, the tree is built by a second substitution pass. `SubstitutionGroup::apply` clones the parser *before* the authoritative pass advances any document counter (counters live in owned `RefCell`/`Cell` fields, so `#[derive(Clone)]` deep-copies them), runs the recording pipeline on the clone, and discards it. Footnotes, callouts, and `{counter:…}` values are therefore numbered identically to the authoritative output — regression-tested by `inline_tree_numbers_footnotes_in_document_order`.

## Still remaining in Phase 2 (follow-ups)

- Make `rendered()` *authoritatively* a fold of the tree (needs the tree to carry resolution through the cross-reference and title passes).
- Delete the three production sentinel systems (passthrough / xref / footnote).

With Strategy A, an authoritative fold would inherit the known formatted-section-title drift (design §4.1); the design sequences the true single-artifact cutover with the single-pass builder in **Phase 4**. The opt-in flag retires with it. The design doc's Phase 2 entry is annotated accordingly (🔶 in progress, "step 1 landed").

## Tests

- `cargo test` — 4628 pass, 70 ignored (unchanged).
- New: `inline_tree_is_empty_by_default`, `inline_tree_is_built_when_enabled`, `inline_tree_numbers_footnotes_in_document_order`.
- `cargo +nightly fmt --all -- --check` and `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)