### PR TITLE
fix: Apply post-replacement line break to a trailing ` +` at end of content

### DIFF
--- a/parser/src/blocks/metadata.rs
+++ b/parser/src/blocks/metadata.rs
@@ -581,6 +581,11 @@ mod tests {
 
     #[test]
     fn title_does_not_extend_via_plus_syntax() {
+        // A trailing ` +` on a block title does not join the following line
+        // (`def`) into the title: the title is a single line and `def` remains a
+        // separate paragraph. The ` +` is, however, still a hard line break, so
+        // the post_replacements step renders it as `<br>` within the title
+        // itself (the raw `title_source` keeps the literal ` +`).
         let doc: crate::Document<'_> =
             Parser::default().parse(".Title abc +\ndef\n****\nStuff > nonsense\n****");
 
@@ -625,7 +630,7 @@ mod tests {
                             col: 2,
                             offset: 1,
                         },),
-                        title: Some("Title abc +",),
+                        title: Some("Title abc<br>",),
                         caption: None,
                         number: None,
                         anchor: None,

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -1268,7 +1268,15 @@ fn apply_post_replacements(
         content.rendered = new_result.into();
     } else {
         let rendered = content.rendered.as_ref();
-        if !(rendered.contains('+') && rendered.contains('\n')) {
+
+        // A hard line break is a ` +` at the end of a line. Because the
+        // `HARD_LINE_BREAK` regex anchors on `$` in multiline mode – which
+        // matches at the end of the haystack as well as before each `\n` – the
+        // final line of the content is eligible too, even when it is not
+        // followed by a newline (e.g. a one-line paragraph, a block title, or a
+        // section title ending in ` +`). So the cheap pre-check requires only a
+        // `+`, not also a `\n`.
+        if !rendered.contains('+') {
             return;
         }
 

--- a/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
+++ b/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
@@ -282,6 +282,20 @@ mod default_post_replacements_substitution {
         };
 
         assert_eq!(block1.content().rendered(), "abc<br>\ndef");
+
+        // A trailing ` +` on the *final* line of a paragraph – with no newline
+        // following it – is also converted to a line break, matching
+        // Asciidoctor 2.0.26. Here the paragraph is a single line, so the ` +`
+        // ends the block's content.
+        let doc = Parser::default().parse("only +");
+
+        let block1 = doc.child_blocks().next().unwrap();
+
+        let Block::Simple(block1) = block1 else {
+            panic!("Unexpected block type: {block1:?}");
+        };
+
+        assert_eq!(block1.content().rendered(), "only<br>");
     }
 
     #[test]
@@ -388,15 +402,47 @@ mod default_post_replacements_substitution {
         assert_eq!(literal_cell.rendered(), "abc +\nghi");
     }
 
-    // A block title cannot span multiple lines via a trailing `+`: a title is a
-    // single line, and a trailing ` +` is retained literally rather than joined to
-    // the following line. Because a title never spans lines, the post_replacements
-    // line-break substitution has nothing to act on here, so the `|Titles |{y}`
-    // row has no observable effect to assert and is out of scope for verification.
-    // Treated as non-normative.
+    #[test]
+    fn titles() {
+        verifies!(
+            r#"
+|Titles |{y}
+"#
+        );
+
+        // A title is a single line, so it never spans lines the way a paragraph
+        // does. It can, however, *end* in a trailing ` +`, and the
+        // post_replacements step converts that to a line break just as it does
+        // for the final line of a paragraph (verified against Asciidoctor
+        // 2.0.26). This applies identically to block titles and section titles,
+        // both of which use `SubstitutionGroup::Title` (which includes the
+        // post_replacements step).
+
+        // A block title ending in ` +`.
+        let doc = Parser::default().parse(".first +\ncontent");
+
+        let block1 = doc.child_blocks().next().unwrap();
+
+        let Block::Simple(block1) = block1 else {
+            panic!("Unexpected block type: {block1:?}");
+        };
+
+        assert_eq!(block1.title().unwrap(), "first<br>");
+
+        // A section title ending in ` +`.
+        let doc = Parser::default().parse("== sect +\n\ncontent");
+
+        let block1 = doc.child_blocks().next().unwrap();
+
+        let Block::Section(section) = block1 else {
+            panic!("Unexpected block type: {block1:?}");
+        };
+
+        assert_eq!(section.section_title(), "sect<br>");
+    }
+
     non_normative!(
         r#"
-|Titles |{y}
 |===
 
 "#


### PR DESCRIPTION
## Summary

Fixes #1067.

The post_replacements substitution step converted a hard line break (` +`) into `<br>` only when the ` +` was immediately followed by a newline. A ` +` that ended a block's content with **no trailing newline** was skipped, so a one-line paragraph, a block title, or a section title ending in ` +` did not get the line break that Asciidoctor 2.0.26 produces.

| AsciiDoc | Before | After / Asciidoctor 2.0.26 |
|---|---|---|
| `only +` (whole paragraph) | `only +` | `only<br>` |
| `.first +` (block title) | `first +` | `first<br>` |
| `== sect +` (section title) | `sect +` | `sect<br>` |

## Root cause

`apply_post_replacements` (non-`hardbreaks` branch) guarded on `rendered.contains('+') && rendered.contains('\n')`. The `\n` requirement returned early for end-of-content ` +`. The `HARD_LINE_BREAK` regex `(?m)^(.*) \+$` already anchors on `$` in multiline mode, which matches at the end of the haystack as well as before each `\n`, so the final line was always eligible — only the guard held it back. The fix drops the `\n` requirement.

## Tests

- New assertion in `paragraphs()` for a single-line paragraph (`only +` → `only<br>`).
- New `titles()` test covering a block title and a section title ending in ` +`, promoting the previously non-normative `|Titles |{y}` spec row to a verified one.
- Updated `title_does_not_extend_via_plus_syntax` to expect the rendered `<br>` in the title (its actual invariant — that the following line is not joined into the title — is unchanged).

Full parser suite (`cargo test -p asciidoc-parser`), `cargo clippy --all-targets --all-features`, and `cargo +nightly fmt --all -- --check` all pass. The spec-coverage tool now maps line 45 (`|Titles |{y}`) as covered with no downstream drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)