### PR TITLE
fix: Apply the header substitution group to implicit author-line names consistently

### DIFF
--- a/parser/src/document/author.rs
+++ b/parser/src/document/author.rs
@@ -145,21 +145,13 @@ impl Author {
                 // encoding so a trailing `<email>` can still be split off.
                 Some(partition_names_only(&expanded_source))
             } else {
-                // Even after expansion, doesn't match: Treat as single name with HTML encoding.
-                let mut expanded_name = expanded_source;
-
-                if expanded_name.contains('<') && expanded_name.contains('>') {
-                    let span = crate::Span::new(&expanded_name);
-                    let mut content = crate::content::Content::from(span);
-                    crate::content::SubstitutionStep::SpecialCharacters.apply(
-                        &mut content,
-                        parser,
-                        None,
-                    );
-                    expanded_name = content.rendered().to_string();
-                }
-
-                let name_with_spaces = replace_underscores_with_spaces(expanded_name);
+                // Even after expansion the value does not match the author
+                // pattern, so it becomes a single name. `apply_author_subs`
+                // already applied the header substitution group – special
+                // characters (escaping any literal `<`, `>`, or `&`) followed by
+                // attribute references – so the expanded value is stored as is,
+                // mirroring Asciidoctor's `apply_header_subs`.
+                let name_with_spaces = replace_underscores_with_spaces(expanded_source);
                 Some(Self {
                     name: name_with_spaces.clone(),
                     firstname: name_with_spaces,
@@ -176,12 +168,18 @@ impl Author {
             // assigning any trailing parts to `lastname`.
             Some(partition_names_only(source))
         } else {
-            // Input doesn't contain attributes and doesn't match the author pattern.
-            // Asciidoctor stores the whole line as the author, condensing interior
-            // whitespace and keeping any angle brackets literal. Underscores are left
-            // literal here: Asciidoctor only converts underscore-joined names while
+            // Input doesn't contain attributes and doesn't match the author
+            // pattern. Asciidoctor stores the whole line as the author,
+            // condensing interior whitespace. Underscores are left literal here:
+            // Asciidoctor only converts underscore-joined names while
             // partitioning a *matching* line, not in this fallback.
-            let name = condense_whitespace(source);
+            //
+            // The header substitution group still applies, so any literal `<`,
+            // `>`, or `&` is escaped consistently – matching Asciidoctor's
+            // `apply_header_subs` and the attribute-reference path above, rather
+            // than returning the name raw only because it lacks an attribute
+            // reference.
+            let name = apply_author_special_characters(&condense_whitespace(source), parser);
             Some(Self {
                 name: name.clone(),
                 firstname: name,
@@ -611,40 +609,75 @@ pub(crate) fn matches_author_pattern(source: &str) -> bool {
     AUTHOR.is_match(source.trim())
 }
 
+/// Apply the header substitution group to an author-line fragment: special
+/// characters first, then attribute references – matching Asciidoctor's
+/// `apply_header_subs` (`HEADER_SUBS = [:specialcharacters, :attributes]`).
+///
+/// Running special characters *before* attribute references escapes any literal
+/// `<`, `>`, or `&` in the fragment while leaving the expanded value of an
+/// attribute reference untouched, so an attribute whose value already contains
+/// markup (or a character reference) is inserted verbatim rather than escaped a
+/// second time – exactly as Asciidoctor's header subs behave. Numeric character
+/// references in the literal text are preserved (see
+/// [`apply_author_special_characters`]).
 fn apply_author_subs(source: &str, parser: &Parser) -> String {
-    let span = Span::new(source);
-    let mut content = Content::from(span);
-
     use crate::content::SubstitutionStep;
 
-    // Apply attribute references first.
+    let with_special_characters = apply_author_special_characters(source, parser);
+
+    let span = Span::new(&with_special_characters);
+    let mut content = Content::from(span);
+
     SubstitutionStep::AttributeReferences.apply(&mut content, parser, None);
-
-    // Apply HTML encoding:
-    // - Single attribute reference (like {full-author}): No HTML encoding.
-    // - Single attribute in email position (like <{email}>): No HTML encoding.
-    // - Multiple attributes or complex patterns: HTML encoding.
-    // - Don't HTML encode if the content only has pre-existing HTML entities.
-    let is_simple_single_attribute = source.trim().starts_with('{')
-        && source.trim().ends_with('}')
-        && source.matches('{').count() == 1;
-
-    let has_multiple_attributes = source.matches('{').count() > 1;
-
-    // Check if we should apply HTML encoding.
-    let rendered = content.rendered();
-    let has_angle_brackets = rendered.contains('<') && rendered.contains('>');
-    let has_unencoded_ampersand = rendered.contains('&') && !rendered.contains("&amp;");
-
-    if !is_simple_single_attribute
-        && has_multiple_attributes
-        && (has_angle_brackets || has_unencoded_ampersand)
-    {
-        SubstitutionStep::SpecialCharacters.apply(&mut content, parser, None);
-    }
 
     content.rendered().to_string()
 }
+
+/// Apply the special-characters substitution to `source`, escaping every
+/// literal `<`, `>`, and `&` – except the leading `&` of a numeric HTML
+/// character reference, which is left intact so a name such as `AsciiDoc&#174;`
+/// keeps its ® entity rather than degrading to `AsciiDoc&amp;#174;` (issue
+/// #757).
+fn apply_author_special_characters(source: &str, parser: &Parser) -> String {
+    let mut result = String::with_capacity(source.len());
+    let mut last = 0;
+
+    // Escape the text between the character references, emitting each reference
+    // verbatim so its `&` is never doubled.
+    for m in NUMERIC_CHARACTER_REFERENCE.find_iter(source) {
+        result.push_str(&escape_special_characters(&source[last..m.start()], parser));
+        result.push_str(m.as_str());
+        last = m.end();
+    }
+
+    result.push_str(&escape_special_characters(&source[last..], parser));
+    result
+}
+
+/// Run the special-characters substitution step over `source`, escaping `<`,
+/// `>`, and `&`.
+fn escape_special_characters(source: &str, parser: &Parser) -> String {
+    if source.is_empty() {
+        return String::new();
+    }
+
+    let span = Span::new(source);
+    let mut content = Content::from(span);
+
+    crate::content::SubstitutionStep::SpecialCharacters.apply(&mut content, parser, None);
+
+    content.rendered().to_string()
+}
+
+/// Matches a numeric HTML character reference – decimal (`&#174;`) or
+/// hexadecimal (`&#xAE;`). Mirrors the guard the author line uses when deciding
+/// whether a semicolon separates two authors (see
+/// [`AuthorLine`](crate::document::AuthorLine)); the leading `&` of such a
+/// reference is preserved rather than escaped when header subs are applied.
+static NUMERIC_CHARACTER_REFERENCE: LazyLock<Regex> = LazyLock::new(|| {
+    #[allow(clippy::unwrap_used)]
+    Regex::new(r"&#(?:[0-9]+|[xX][0-9a-fA-F]+);").unwrap()
+});
 
 #[cfg(test)]
 mod tests {

--- a/parser/src/document/author_line.rs
+++ b/parser/src/document/author_line.rs
@@ -119,6 +119,8 @@ impl<'src> HasSpan<'src> for AuthorLine<'src> {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
+
     use crate::{parser::ModificationContext, tests::prelude::*};
 
     #[test]
@@ -142,10 +144,50 @@ mod tests {
     }
 
     #[test]
-    fn attr_sub_with_html_encoding_fallback() {
-        // Test case for code coverage: input contains attributes but after expansion
-        // doesn't match AUTHOR regex and contains angle brackets that need HTML
-        // encoding.
+    fn implicit_author_name_is_always_header_substituted() {
+        // The header substitution group (special characters + attribute
+        // references) is applied to the implicit author-line name consistently,
+        // whether or not the line contains an attribute reference. Previously the
+        // name was returned raw unless it happened to carry an attribute
+        // reference, which forced a downstream converter to guess whether the
+        // value was already substituted.
+        let author_name = |src: &str| {
+            let mut parser = Parser::default();
+            let doc = parser.parse(src);
+
+            doc.header()
+                .author_line()
+                .unwrap()
+                .authors()
+                .next()
+                .unwrap()
+                .name()
+                .to_string()
+        };
+
+        // A plain line with literal special characters: escaped, even though it
+        // has no attribute reference.
+        assert_eq!(author_name("= T\n<x> Blogs\n\nbody\n"), "&lt;x&gt; Blogs");
+
+        // Special characters and an attribute reference together: the literal
+        // `<x>` is escaped and `{v}` is resolved.
+        assert_eq!(
+            author_name(":v: RESOLVED\n= T\n(C) <x> {v} Blogs\n\nbody\n"),
+            "(C) &lt;x&gt; RESOLVED Blogs"
+        );
+
+        // A plain line with no special characters is unchanged.
+        assert_eq!(author_name("= T\n(C) Blogs\n\nbody\n"), "(C) Blogs");
+    }
+
+    #[test]
+    fn attr_reference_value_is_inserted_verbatim() {
+        // The header substitution group runs special characters *before*
+        // attribute references (Asciidoctor's `HEADER_SUBS = [:specialcharacters,
+        // :attributes]`), so an attribute reference's value is inserted verbatim
+        // rather than being escaped a second time. Here the literal text carries
+        // no special characters, so the resolved value's `<`, `>`, and `&` are
+        // left as they are.
         let mut parser = Parser::default().with_intrinsic_attribute(
             "weird-content",
             "Complex <weird> & stuff",
@@ -161,8 +203,8 @@ mod tests {
             al,
             AuthorLine {
                 authors: &[Author {
-                    name: "Some Complex &lt;weird&gt; &amp; stuff pattern",
-                    firstname: "Some Complex &lt;weird&gt; &amp; stuff pattern",
+                    name: "Some Complex <weird> & stuff pattern",
+                    firstname: "Some Complex <weird> & stuff pattern",
                     middlename: None,
                     lastname: None,
                     email: None,
@@ -286,8 +328,12 @@ mod tests {
             al,
             AuthorLine {
                 authors: &[Author {
-                    name: "Four Names Not Supported <doc@example.com>",
-                    firstname: "Four Names Not Supported <doc@example.com>",
+                    // A line with four or more names doesn't match the author
+                    // pattern, so the whole line becomes the name – with the
+                    // header substitution group applied, escaping the literal
+                    // angle brackets.
+                    name: "Four Names Not Supported &lt;doc@example.com&gt;",
+                    firstname: "Four Names Not Supported &lt;doc@example.com&gt;",
                     middlename: None,
                     lastname: None,
                     email: None,
@@ -1131,10 +1177,13 @@ mod tests {
             AuthorLine {
                 authors: &[
                     Author {
-                        name: "Alice &Development",
+                        // The bare `&` is not a numeric character reference, so
+                        // the header substitution group escapes it – unlike a
+                        // `&#nnn;` reference, which is preserved.
+                        name: "Alice &amp;Development",
                         firstname: "Alice",
                         middlename: None,
-                        lastname: Some("&Development"),
+                        lastname: Some("&amp;Development"),
                         email: None,
                     },
                     Author {

--- a/parser/src/tests/asciidoctor_rb/parser_test.rs
+++ b/parser/src/tests/asciidoctor_rb/parser_test.rs
@@ -1034,16 +1034,25 @@ fn parse_invalid_author_line_becomes_author() {
 
     // The author line doesn't match the author pattern (because of the embedded
     // comma), so Asciidoctor condenses the interior whitespace and stores the whole
-    // line verbatim as the author, keeping the angle brackets literal.
+    // line as the author.
+    //
+    // The Ruby assertions above check `metadata['author']`, the *raw* value that
+    // `parse_header_metadata` returns before substitution. This crate's
+    // `Author::name()` instead represents the value that populates the `author`
+    // document attribute – the one `{author}` and the converter consume – to which
+    // Asciidoctor applies the header substitution group via `apply_header_subs`
+    // (`doc.attributes['author'] = apply_header_subs val`). Applying the header
+    // subs escapes the literal angle brackets, so they appear as `&lt;`/`&gt;`
+    // here.
     let a = parse_authors("   Stuart       Rackham, founder of AsciiDoc   <founder@asciidoc.org>");
     assert_eq!(a.len(), 1);
     assert_eq!(
         a[0].name,
-        "Stuart Rackham, founder of AsciiDoc <founder@asciidoc.org>"
+        "Stuart Rackham, founder of AsciiDoc &lt;founder@asciidoc.org&gt;"
     );
     assert_eq!(
         a[0].firstname,
-        "Stuart Rackham, founder of AsciiDoc <founder@asciidoc.org>"
+        "Stuart Rackham, founder of AsciiDoc &lt;founder@asciidoc.org&gt;"
     );
     assert_eq!(a[0].middlename, None);
     assert_eq!(a[0].lastname, None);


### PR DESCRIPTION
## Summary

Fixes the implicit author line applying the header substitution group
(`specialcharacters` + `attributes`) to `author.name()` **only when the line
contained an attribute reference**. A plain line was returned raw:

```
"<x> Blogs"                        // raw — specialchars NOT applied
"(C) &lt;x&gt; RESOLVED Blogs"     // specialchars + attributes APPLIED
"(C) Blogs"                        // raw — specialchars NOT applied
```

Asciidoctor applies `apply_header_subs` (`HEADER_SUBS = [:specialcharacters,
:attributes]`) unconditionally, so those should be `&lt;x&gt; Blogs` and
`(C) Blogs` with special characters applied (and any `{…}` resolved).

The inconsistency left a downstream converter (e.g. `asciidoc-html5`) unable
to tell a raw name from an already-substituted one, so it double-escaped the
substituted case.

## Change

`author.rs` now applies the header substitution group across **every**
author-name branch, via a single `apply_author_subs` helper that runs:

1. **special characters first** — escaping any literal `<`, `>`, or `&`, and
2. **attribute references second** — so a reference's resolved value is
   inserted verbatim rather than escaped a second time.

Running special characters before attributes mirrors Asciidoctor's
`HEADER_SUBS` order and naturally avoids double-escaping attribute values.
Numeric character references (`&#174;`) are preserved rather than degraded to
`&amp;#174;`, keeping the behavior added in #757.

### Result

`author.name()` is now always header-substituted, so a downstream converter
can finish with its `replacements` step and match Asciidoctor.

## Tests

- New `implicit_author_name_is_always_header_substituted` regression test
  covering the three reproduction cases from the issue.
- Updated expectations for cases that were previously returned raw and are now
  correctly header-substituted (`too_many_names`, the ported
  `parse invalid author line becomes author`, the bare-`&` separator case).
- Reframed the former `attr_sub_with_html_encoding_fallback` test as
  `attr_reference_value_is_inserted_verbatim`, documenting that an attribute
  reference's value is now inserted verbatim (header subs run special
  characters *before* attributes).

Note: the ported Asciidoctor test checks `metadata['author']` (the *raw* value
`parse_header_metadata` returns). This crate's `Author::name()` instead
represents the value that populates the `author` document attribute — the one
`{author}` and the converter consume — to which Asciidoctor applies
`apply_header_subs`. That deliberate divergence is documented inline.

`cargo test`, `cargo clippy --all-targets`, and `cargo +nightly fmt --check`
all pass.

Closes #1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)