### PR TITLE
feat: Mirror title cross-reference resolution into the inline tree (inline-ast Phase 2, step 3)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -649,10 +649,27 @@ Each phase is a reviewable unit with a clear exit gate.
   spans and reference children. So a consumer that walks `inlines()` after a parse sees
   resolved `#id` destinations rather than the parse-time `resolved: None` state the tree is
   first built with. This is non-destructive and re-resolvable, exactly like the string path.
-  Two resolution sites remain unmirrored for now and are tracked as follow-ups: section- and
-  block-title cross-references (owned by the separate document-order title pass,
+  Two resolution sites remained unmirrored after this step and were tracked as follow-ups:
+  section- and block-title cross-references (owned by the separate document-order title pass,
   [`title_refs`](../../parser/src/document/title_refs.rs)) and footnote-embedded
-  cross-references (which live in a footnote subtree the tree does not yet populate).
+  cross-references (which live in a footnote subtree the tree does not yet populate). The first
+  is closed by step 3 below.
+
+  *Step 3 landed as (title cross-reference resolution reaches the tree):* the document-order
+  title pass ([`title_refs`](../../parser/src/document/title_refs.rs)) now **mirrors** the
+  destinations it resolves for each section heading and block `.Title` into that title's own
+  inline tree, closing the first of the two step-2 follow-ups. The title pass exists precisely
+  because a title's cross-references need cross-title coordination (forward and circular
+  references between headings) that the per-content pass cannot do; it computes each title's
+  resolved references once, in document order, and — reusing the *same* resolved segments that
+  produce the rendered title (not a second resolution) — installs them into the title tree via
+  the same walk the block path uses. The tree-facing mirror is factored into one shared entry
+  point ([`Content::mirror_tree_xref_resolution`](../../parser/src/content/content.rs), fed by
+  the placeholder-ordered [`ordered_tree_xrefs`](../../parser/src/content/content.rs)) that
+  both the block pass and the title pass call, so the two paths cannot drift. Block titles —
+  which the per-content pass never resolved at all — now carry resolved tree destinations too.
+  The remaining unmirrored site is footnote-embedded cross-references, which still await the
+  footnote subtree the tree does not yet populate.
 
   *Still remaining in Phase 2 (not in these steps):* making `rendered()` *authoritatively* a
   fold of the tree (which additionally requires the title pass to mirror into the tree, so

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     document::{InterpretedValue, RefType},
     internal::debug::DebugSliceReference,
-    parser::XrefSignifier,
+    parser::{ResolvedReference, XrefSignifier},
     span::MatchedItem,
     strings::CowStr,
     warnings::{Warning, WarningType},
@@ -506,6 +506,27 @@ impl<'src> SectionBlock<'src> {
     /// with cross-title coordination.
     pub(crate) fn set_section_title_rendered(&mut self, rendered: String) {
         self.section_title.set_rendered(rendered);
+    }
+
+    /// Mirrors the section title's resolved cross-reference destinations –
+    /// computed by the document-order title resolution pass – into the title's
+    /// inline tree, so a caller that walks the title's
+    /// [`inlines`](Content::inlines) sees the same destinations
+    /// [`set_section_title_rendered`](Self::set_section_title_rendered)
+    /// installed in the rendered string. A no-op when no inline tree was built.
+    pub(crate) fn mirror_section_title_tree_xrefs(
+        &mut self,
+        ordered: &[Option<ResolvedReference>],
+    ) {
+        self.section_title.mirror_tree_xref_resolution(ordered);
+    }
+
+    /// Returns the section title's inline tree. Used by the inline-tree tests
+    /// to inspect the title's mirrored cross-reference resolution; empty
+    /// unless tree building is enabled on the [`Parser`](crate::Parser).
+    #[cfg(test)]
+    pub(crate) fn section_title_inlines(&self) -> &[crate::inlines::InlineNode<'src>] {
+        self.section_title.inlines()
     }
 
     /// Returns the ID under which this section is registered in the catalog, if

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -84,6 +84,14 @@ impl<'src> SimpleBlock<'src> {
         self.title.as_mut()
     }
 
+    /// Returns the block's title as a read-only [`Content`], if the block has
+    /// one. Used by the inline-tree tests to inspect a block title's mirrored
+    /// cross-reference resolution.
+    #[cfg(test)]
+    pub(crate) fn title_content(&self) -> Option<&Content<'src>> {
+        self.title.as_ref()
+    }
+
     pub(crate) fn parse(
         metadata: &BlockMetadata<'src>,
         parser: &mut Parser,

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -635,30 +635,37 @@ impl<'src> Content<'src> {
             return;
         };
 
-        // The block-level segments, in placeholder (document) order: those whose
-        // placeholder still appears in the template. A footnote-embedded
-        // cross-reference is re-homed out of the template (and lives in a
-        // footnote subtree the tree does not yet populate), so filtering on the
-        // template keeps this list aligned one-to-one with the tree's
-        // cross-reference nodes. A segment that resolved to nothing contributes a
-        // `None`, so an unresolved node is left unresolved, exactly as the
-        // rendered string leaves it.
-        let ordered: Vec<Option<ResolvedReference>> = deferred
-            .xrefs
-            .iter()
-            .enumerate()
-            .filter(|(index, _)| {
-                deferred
-                    .template
-                    .contains(&Content::xref_placeholder(*index))
-            })
-            .map(|(_, xref)| xref.resolved.clone())
-            .collect();
+        let ordered = ordered_tree_xrefs(&deferred.template, &deferred.xrefs);
+        self.mirror_tree_xref_resolution(&ordered);
+    }
+
+    /// Installs a pre-computed list of resolved cross-reference destinations –
+    /// in placeholder (document) order, as produced by
+    /// [`ordered_tree_xrefs`] – into this content's inline tree.
+    ///
+    /// This is the tree-facing half of
+    /// [`resolve_references`](Self::resolve_references): where that method
+    /// resolves this content's *own* deferred segments and then calls here,
+    /// the **document-order title resolution pass** (the `title_refs`
+    /// module) resolves a title's cross-references with cross-title
+    /// coordination the per-content pass cannot do, and calls here directly
+    /// with the destinations it computed. Either way the mirroring is the
+    /// same tree walk, so a caller that reads [`inlines`](Self::inlines)
+    /// sees the resolved destinations the rendered string reflects.
+    ///
+    /// It is a no-op when no inline tree was built (see
+    /// [`Parser::with_inline_tree`](crate::Parser::with_inline_tree)),
+    /// non-destructive, and re-resolvable: each call overwrites the tree's
+    /// resolved state from `ordered`.
+    pub(crate) fn mirror_tree_xref_resolution(&mut self, ordered: &[Option<ResolvedReference>]) {
+        if self.inlines.is_empty() {
+            return;
+        }
 
         let mut next = 0;
-        assign_tree_xrefs(&mut self.inlines, &ordered, &mut next);
+        assign_tree_xrefs(&mut self.inlines, ordered, &mut next);
 
-        // Each block-level segment must line up with exactly one tree node. A
+        // Each ordered segment must line up with exactly one tree node. A
         // mismatch means the recording pass and the authoritative pass
         // enumerated cross-references differently, which would silently misplace
         // a resolved destination; catch that in debug/test builds.
@@ -678,6 +685,29 @@ impl<'src> Content<'src> {
 
         self.rendered = render_template(&deferred.template, &deferred.xrefs, renderer).into();
     }
+}
+
+/// Builds the placeholder-ordered list of resolved destinations that
+/// [`Content::mirror_tree_xref_resolution`] installs into an inline tree.
+///
+/// The list holds one entry per deferred segment whose placeholder **still
+/// appears in `template`**, in placeholder (document) order. A
+/// footnote-embedded cross-reference is re-homed out of the template (and lives
+/// in a footnote subtree the tree does not yet populate), so filtering on the
+/// template keeps this list aligned one-to-one with the tree's cross-reference
+/// nodes. A segment that resolved to nothing contributes a `None`, so an
+/// unresolved node is left unresolved, exactly as the rendered string leaves
+/// it.
+pub(crate) fn ordered_tree_xrefs(
+    template: &str,
+    xrefs: &[XrefSegment],
+) -> Vec<Option<ResolvedReference>> {
+    xrefs
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| template.contains(&Content::xref_placeholder(*index)))
+        .map(|(_, xref)| xref.resolved.clone())
+        .collect()
 }
 
 /// Walks an inline node slice in document order and installs each

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -7,7 +7,8 @@ mod content;
 pub use content::Content;
 pub(crate) use content::{
     FOOTNOTE_MARKER_END, FOOTNOTE_MARKER_START, FootnoteDeferred, OwnedTitle, XrefSegment,
-    rehome_xref_placeholders, render_xref_template, strip_footnote_marker_spans,
+    ordered_tree_xrefs, rehome_xref_placeholders, render_xref_template,
+    strip_footnote_marker_spans,
 };
 
 pub(crate) mod inline_tree;

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -25,10 +25,31 @@ use std::collections::HashMap;
 use crate::{
     HasSpan, Span,
     blocks::{Block, IsBlock},
-    content::{XrefSegment, render_xref_template},
+    content::{XrefSegment, ordered_tree_xrefs, render_xref_template},
     document::Catalog,
-    parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext},
+    parser::{
+        InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext,
+        ResolvedReference,
+    },
 };
+
+/// The resolved outcome of one title: its final rendering, plus the resolved
+/// destinations of its cross-references in placeholder order.
+///
+/// The rendering is installed into the title's rendered string; the ordered
+/// destinations are mirrored into the title's inline tree (see
+/// [`Content::mirror_tree_xref_resolution`]), so both views of the title agree.
+///
+/// [`Content::mirror_tree_xref_resolution`]: crate::content::Content::mirror_tree_xref_resolution
+struct Resolution {
+    /// The title's final rendered form, with cross-title references
+    /// coordinated.
+    rendered: String,
+
+    /// The resolved destination of each title-level cross-reference, in
+    /// placeholder order, ready for [`ordered_tree_xrefs`]-aligned mirroring.
+    ordered: Vec<Option<ResolvedReference>>,
+}
 
 /// One title carrying cross-references, captured for the resolution pass.
 struct TitleNode<'src> {
@@ -82,7 +103,7 @@ pub(crate) fn resolve_title_references<'src>(
         }
     }
 
-    let mut memo: Vec<Option<String>> = vec![None; nodes.len()];
+    let mut memo: Vec<Option<Resolution>> = (0..nodes.len()).map(|_| None).collect();
     let mut in_progress: Vec<bool> = vec![false; nodes.len()];
 
     for (index, node) in nodes.iter().enumerate() {
@@ -150,22 +171,27 @@ fn collect<'src>(blocks: &mut [Block<'src>], nodes: &mut Vec<TitleNode<'src>>) {
     }
 }
 
-/// Installs the computed rendering for each collected title, walking `blocks`
-/// in the same document order as [`collect`] so `index` stays aligned.
-fn write_back<'src>(blocks: &mut [Block<'src>], memo: &[Option<String>], index: &mut usize) {
+/// Installs each collected title's computed resolution, walking `blocks` in the
+/// same document order as [`collect`] so `index` stays aligned. For every title
+/// this installs both views the resolution carries: the coordinated rendered
+/// string, and – mirrored into the title's inline tree – the resolved
+/// destinations of its cross-references.
+fn write_back<'src>(blocks: &mut [Block<'src>], memo: &[Option<Resolution>], index: &mut usize) {
     for block in blocks.iter_mut() {
         if let Block::Section(section) = block {
             if section.section_title_deferred_parts().is_some() {
-                if let Some(rendered) = memo.get(*index).and_then(Option::as_ref) {
-                    section.set_section_title_rendered(rendered.clone());
+                if let Some(resolution) = memo.get(*index).and_then(Option::as_ref) {
+                    section.set_section_title_rendered(resolution.rendered.clone());
+                    section.mirror_section_title_tree_xrefs(&resolution.ordered);
                 }
                 *index += 1;
             }
         } else if let Some(title) = block.block_title_content_mut()
             && title.deferred_parts().is_some()
         {
-            if let Some(rendered) = memo.get(*index).and_then(Option::as_ref) {
-                title.set_rendered(rendered.clone());
+            if let Some(resolution) = memo.get(*index).and_then(Option::as_ref) {
+                title.set_rendered(resolution.rendered.clone());
+                title.mirror_tree_xref_resolution(&resolution.ordered);
             }
             *index += 1;
         }
@@ -190,12 +216,12 @@ fn compute<'src>(
     catalog: &Catalog,
     resolver: &dyn ReferenceResolver,
     renderer: &dyn InlineSubstitutionRenderer,
-    memo: &mut [Option<String>],
+    memo: &mut [Option<Resolution>],
     in_progress: &mut [bool],
     warnings: &mut ReferenceWarnings<'src>,
 ) -> String {
-    if let Some(Some(rendered)) = memo.get(index) {
-        return rendered.clone();
+    if let Some(Some(resolution)) = memo.get(index) {
+        return resolution.rendered.clone();
     }
 
     if let Some(flag) = in_progress.get_mut(index) {
@@ -277,11 +303,21 @@ fn compute<'src>(
 
     let rendered = render_xref_template(&node.template, &xrefs, renderer);
 
+    // The resolved destinations, in placeholder order and filtered to those the
+    // template still splices, so they line up one-to-one with the title tree's
+    // cross-reference nodes when mirrored (see `write_back`). This reuses the
+    // very `xrefs` that produced `rendered`, so the tree cannot disagree with
+    // the string.
+    let ordered = ordered_tree_xrefs(&node.template, &xrefs);
+
     if let Some(flag) = in_progress.get_mut(index) {
         *flag = false;
     }
     if let Some(slot) = memo.get_mut(index) {
-        *slot = Some(rendered.clone());
+        *slot = Some(Resolution {
+            rendered: rendered.clone(),
+            ordered,
+        });
     }
     rendered
 }

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -1087,3 +1087,163 @@ fn inline_tree_build_rejects_a_stateful_renderer() {
 
     let _doc = parser.parse("a < b");
 }
+
+// ─── Wiring: title cross-reference resolution reaches the tree ───────────────
+//
+// A cross-reference embedded in a section heading or a block `.Title` is owned
+// by the separate document-order title pass (`title_refs`), which coordinates
+// cross-title references – including forward and circular ones – that the
+// per-content pass cannot. That pass now mirrors each resolved destination into
+// the title's own inline tree, so a consumer that walks a title's `inlines()`
+// sees the same destinations the rendered title reflects – closing the
+// section-/block-title follow-up of Phase 2 step 2 (design §4.3).
+
+/// Collects every cross-reference/link node from the inline tree of every
+/// section heading in `doc`, recursing into nested sections and into formatting
+/// spans and reference children within each title.
+fn collect_section_title_refs<'a>(doc: &'a crate::Document<'a>) -> Vec<crate::inlines::Ref<'a>> {
+    use crate::blocks::{Block, FindBlocks};
+
+    fn refs_in<'a>(nodes: &[InlineNode<'a>], out: &mut Vec<crate::inlines::Ref<'a>>) {
+        for node in nodes {
+            match node {
+                InlineNode::Ref(reference) => {
+                    out.push(reference.clone());
+                    refs_in(&reference.children, out);
+                }
+
+                InlineNode::Styled(styled) => refs_in(&styled.children, out),
+                InlineNode::Footnote(footnote) => refs_in(&footnote.children, out),
+                _ => {}
+            }
+        }
+    }
+
+    fn walk<'a>(
+        blocks: impl Iterator<Item = &'a Block<'a>>,
+        out: &mut Vec<crate::inlines::Ref<'a>>,
+    ) {
+        for block in blocks {
+            if let Block::Section(section) = block {
+                refs_in(section.section_title_inlines(), out);
+            }
+
+            walk(block.child_blocks(), out);
+        }
+    }
+
+    let mut out = vec![];
+    walk(doc.child_blocks(), &mut out);
+    out
+}
+
+#[test]
+fn section_title_forward_xref_is_resolved_in_the_tree() {
+    // The first heading forward-references a section defined later. The title
+    // pass resolves it in document order and mirrors the destination into the
+    // heading's tree, so the title's `Ref` node carries `#the-end`.
+    let mut parser = Parser::default().with_inline_tree(true);
+    let doc = parser.parse("== See <<the-end>>\n\n[#the-end]\n== The End\n");
+
+    let refs = collect_section_title_refs(&doc);
+    let reference = refs
+        .iter()
+        .find(|r| r.variant == RefVariant::Xref)
+        .expect("expected an xref node in a section heading");
+
+    assert_eq!(
+        reference
+            .resolved
+            .as_ref()
+            .expect("the title xref should be resolved after parse")
+            .href,
+        "#the-end"
+    );
+}
+
+#[test]
+fn circular_section_title_xrefs_are_both_resolved_in_the_tree() {
+    // Two headings reference each other. The title pass breaks the cycle for the
+    // rendered link *text*, but each reference still resolves to its target's
+    // destination – and both destinations are now mirrored into the two
+    // headings' trees.
+    let mut parser = Parser::default().with_inline_tree(true);
+    let doc = parser.parse("[#a]\n== See <<b>>\n\n[#b]\n== See <<a>>\n");
+
+    let hrefs: Vec<String> = collect_section_title_refs(&doc)
+        .iter()
+        .filter(|r| r.variant == RefVariant::Xref)
+        .map(|r| {
+            r.resolved
+                .as_ref()
+                .expect("each circular title xref should resolve")
+                .href
+                .clone()
+        })
+        .collect();
+
+    assert_eq!(hrefs, vec!["#b".to_string(), "#a".to_string()]);
+}
+
+#[test]
+fn unresolved_section_title_xref_stays_none_in_the_tree() {
+    // A heading whose cross-reference names no catalog entry is left unresolved
+    // in the tree, mirroring the unresolved fallback the rendered title shows.
+    let mut parser = Parser::default().with_inline_tree(true);
+    let doc = parser.parse("== See <<missing>>\n");
+
+    let refs = collect_section_title_refs(&doc);
+    let reference = refs
+        .iter()
+        .find(|r| r.variant == RefVariant::Xref)
+        .expect("expected an xref node in the heading");
+
+    assert!(
+        reference.resolved.is_none(),
+        "an unresolvable title target must not carry a resolved destination"
+    );
+}
+
+#[test]
+fn block_title_xref_is_resolved_in_the_tree() {
+    // A block `.Title` carrying a cross-reference is resolved by the same title
+    // pass, which mirrors the destination into the block title's tree – a site
+    // the per-content pass never resolved at all.
+    let mut parser = Parser::default().with_inline_tree(true);
+    let doc =
+        parser.parse("[[tgt]]The target paragraph.\n\n.See <<tgt>>\nA captioned paragraph.\n");
+
+    use crate::blocks::Block;
+
+    let title = doc
+        .child_blocks()
+        .filter_map(|block| match block {
+            Block::Simple(simple) => simple.title_content(),
+            _ => None,
+        })
+        .find(|content| {
+            content
+                .inlines()
+                .iter()
+                .any(|node| matches!(node, InlineNode::Ref(_)))
+        })
+        .expect("expected a block title carrying a cross-reference");
+
+    let reference = title
+        .inlines()
+        .iter()
+        .find_map(|node| match node {
+            InlineNode::Ref(reference) if reference.variant == RefVariant::Xref => Some(reference),
+            _ => None,
+        })
+        .expect("expected an xref node in the block title");
+
+    assert_eq!(
+        reference
+            .resolved
+            .as_ref()
+            .expect("the block title xref should be resolved after parse")
+            .href,
+        "#tgt"
+    );
+}

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -1247,3 +1247,55 @@ fn block_title_xref_is_resolved_in_the_tree() {
         "#tgt"
     );
 }
+
+#[test]
+fn re_resolving_a_title_clears_a_now_unresolved_tree_destination() {
+    // Resolving a document twice, the second time with a resolver that no longer
+    // recognizes the title's target, must leave the title tree's `Ref` node
+    // *unresolved* – not stale at the first pass's destination. The title pass
+    // rebuilds the ordered destinations each run (the template, and so the list
+    // length, is stable), and the mirror overwrites each slot unconditionally
+    // (to `Some` or `None`), so the tree tracks the rendered title rather than
+    // retaining a superseded link.
+    use crate::parser::{
+        HtmlSubstitutionRenderer, ReferenceResolver, ResolutionContext, ResolvedReference,
+    };
+
+    /// Resolves every target to a fixed destination, or to nothing when `None`.
+    #[derive(Debug)]
+    struct FixedResolver(Option<&'static str>);
+
+    impl ReferenceResolver for FixedResolver {
+        fn resolve(&self, _context: &ResolutionContext<'_>) -> Option<ResolvedReference> {
+            self.0
+                .map(|href| ResolvedReference::new(href.to_string(), None))
+        }
+    }
+
+    /// The resolved `href` of the first cross-reference in any section heading,
+    /// scoped so the tree borrow is released before the next resolution.
+    fn title_xref_href(doc: &crate::Document<'_>) -> Option<String> {
+        collect_section_title_refs(doc)
+            .iter()
+            .find(|r| r.variant == RefVariant::Xref)
+            .and_then(|r| r.resolved.as_ref())
+            .map(|resolved| resolved.href.clone())
+    }
+
+    let mut parser = Parser::default().with_inline_tree(true);
+    let mut doc = parser.parse_deferred("== See <<tgt>>\n\n[#tgt]\n== Target\n");
+
+    // First pass: the resolver recognizes the target, so the heading's tree xref
+    // carries its destination.
+    doc.resolve_references(&FixedResolver(Some("#tgt")), &HtmlSubstitutionRenderer {});
+    assert_eq!(title_xref_href(&doc).as_deref(), Some("#tgt"));
+
+    // Second pass: the resolver no longer recognizes the target, so the tree xref
+    // must fall back to unresolved rather than keep the stale destination.
+    doc.resolve_references(&FixedResolver(None), &HtmlSubstitutionRenderer {});
+    assert_eq!(
+        title_xref_href(&doc),
+        None,
+        "a re-resolution that fails must clear the title tree's stale destination"
+    );
+}


### PR DESCRIPTION
## Summary

Continues **Phase 2** of the [inline AST architecture](docs/design/inline-ast-architecture.md), building on step 1 (#1065, promote the tree into `Content`) and step 2 (#1070, block-content cross-reference resolution reaches the tree).

This is **step 3**: the document-order title resolution pass now mirrors the cross-reference destinations it resolves into each title's own inline tree, closing the first of the two follow-ups that step 2 explicitly deferred.

### The gap this closes

A cross-reference embedded in a section heading or a block `.Title` is owned by the separate `title_refs` pass, because a title's references need cross-title coordination — forward and circular references between headings — that the per-content pass cannot do. That pass previously installed only the resolved rendered *string*; a consumer walking a title's `inlines()` still saw the parse-time `resolved: None` state. Block titles were never resolved into the tree at all.

Now the title pass, after computing each title's resolution once in document order, mirrors the resolved destinations into that title's tree — **reusing the very segments that produce the rendered title** (not a second, independent resolution), so the tree and the string cannot disagree.

### Design

- One shared tree-facing entry point, `Content::mirror_tree_xref_resolution`, fed by the placeholder-ordered `ordered_tree_xrefs` helper (factored out of step 2's `resolve_tree_references`). **Both** the block path and the title path now call it, so they cannot drift.
- `title_refs::compute` memoizes each title's resolved `ordered` destinations alongside its rendered string; `write_back` installs both — the string via the existing setters, the destinations via the new mirror.

### Safety

Tree building stays **opt-in** (`Parser::with_inline_tree`). With it off (the default), the mirror is a no-op, so the default parse path is byte- and performance-identical and **all ~277 golden `.rendered()` assertions are unchanged**. Full suite: 4642 passed, 0 failed; `clippy` clean; `cargo +nightly fmt --check` clean.

### Tests

New structural tests in `tests/inline_recorder.rs`:
- `section_title_forward_xref_is_resolved_in_the_tree` — a heading forward-references a later section.
- `circular_section_title_xrefs_are_both_resolved_in_the_tree` — mutually-referencing headings both resolve in the tree even as the rendered link text falls back (the case only the title pass can get right).
- `unresolved_section_title_xref_stays_none_in_the_tree` — unresolvable target stays `None`, mirroring the rendered fallback.
- `block_title_xref_is_resolved_in_the_tree` — a block `.Title` xref, a site the per-content pass never resolved.

### Remaining in Phase 2

The one still-unmirrored resolution site is **footnote-embedded cross-references**, which await the footnote subtree the tree does not yet populate. Making `rendered()` *authoritatively* a fold and deleting the sentinel systems remain sequenced with the Phase 4 single-pass builder, per the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)