### PR TITLE
chore: Rename block-level inline-tree xref helpers for clarity

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -665,7 +665,7 @@ Each phase is a reviewable unit with a clear exit gate.
   produce the rendered title (not a second resolution) — installs them into the title tree via
   the same walk the block path uses. The tree-facing mirror is factored into one shared entry
   point ([`Content::mirror_tree_xref_resolution`](../../parser/src/content/content.rs), fed by
-  the placeholder-ordered [`ordered_tree_xrefs`](../../parser/src/content/content.rs)) that
+  the placeholder-ordered [`block_tree_xrefs`](../../parser/src/content/content.rs)) that
   both the block pass and the title pass call, so the two paths cannot drift. Block titles —
   which the per-content pass never resolved at all — now carry resolved tree destinations too.
   The remaining unmirrored site is footnote-embedded cross-references, which still await the
@@ -688,7 +688,7 @@ Each phase is a reviewable unit with a clear exit gate.
 
   The cross-reference mirror then follows that structure. A footnote-embedded reference is
   **re-homed out of the block template** when the footnote's text is extracted, so
-  [`ordered_tree_xrefs`](../../parser/src/content/content.rs) — which filters *to* the
+  [`block_tree_xrefs`](../../parser/src/content/content.rs) — which filters *to* the
   placeholders the template still splices — already excludes it. Its exact complement,
   [`footnote_tree_xrefs`](../../parser/src/content/content.rs), collects those same re-homed
   segments in the order the footnote subtrees hold them, and

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -516,11 +516,11 @@ impl<'src> SectionBlock<'src> {
     /// installed in the rendered string. A no-op when no inline tree was built.
     pub(crate) fn mirror_section_title_tree_xrefs(
         &mut self,
-        ordered: &[Option<ResolvedReference>],
+        block_ordered: &[Option<ResolvedReference>],
         footnote_ordered: &[Option<ResolvedReference>],
     ) {
         self.section_title
-            .mirror_tree_xref_resolution(ordered, footnote_ordered);
+            .mirror_tree_xref_resolution(block_ordered, footnote_ordered);
     }
 
     /// Returns the section title's inline tree. Used by the inline-tree tests

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -633,15 +633,15 @@ impl<'src> Content<'src> {
             return;
         };
 
-        let ordered = ordered_tree_xrefs(&deferred.template, &deferred.xrefs);
+        let block_ordered = block_tree_xrefs(&deferred.template, &deferred.xrefs);
         let footnote_ordered = footnote_tree_xrefs(&deferred.template, &deferred.xrefs);
 
-        self.mirror_tree_xref_resolution(&ordered, &footnote_ordered);
+        self.mirror_tree_xref_resolution(&block_ordered, &footnote_ordered);
     }
 
     /// Installs a pre-computed list of resolved cross-reference destinations –
     /// in placeholder (document) order, as produced by
-    /// [`ordered_tree_xrefs`] – into this content's inline tree.
+    /// [`block_tree_xrefs`] – into this content's inline tree.
     ///
     /// This is the tree-facing half of
     /// [`resolve_references`](Self::resolve_references): where that method
@@ -662,10 +662,10 @@ impl<'src> Content<'src> {
     /// It is a no-op when no inline tree was built (see
     /// [`Parser::with_inline_tree`](crate::Parser::with_inline_tree)),
     /// non-destructive, and re-resolvable: each call overwrites the tree's
-    /// resolved state from `ordered` and `footnote_ordered`.
+    /// resolved state from `block_ordered` and `footnote_ordered`.
     pub(crate) fn mirror_tree_xref_resolution(
         &mut self,
-        ordered: &[Option<ResolvedReference>],
+        block_ordered: &[Option<ResolvedReference>],
         footnote_ordered: &[Option<ResolvedReference>],
     ) {
         if self.inlines.is_empty() {
@@ -673,15 +673,15 @@ impl<'src> Content<'src> {
         }
 
         let mut next = 0;
-        assign_tree_xrefs(&mut self.inlines, ordered, &mut next);
+        assign_tree_xrefs(&mut self.inlines, block_ordered, &mut next);
 
-        // Each ordered segment must line up with exactly one tree node. A
+        // Each block-level segment must line up with exactly one tree node. A
         // mismatch means the recording pass and the authoritative pass
         // enumerated cross-references differently, which would silently misplace
         // a resolved destination; catch that in debug/test builds.
         debug_assert_eq!(
             next,
-            ordered.len(),
+            block_ordered.len(),
             "inline tree cross-reference count diverged from the resolved segments",
         );
 
@@ -717,7 +717,7 @@ impl<'src> Content<'src> {
 /// [`footnote_tree_xrefs`] instead. A segment that resolved to nothing
 /// contributes a `None`, so an unresolved node is left unresolved, exactly as
 /// the rendered string leaves it.
-pub(crate) fn ordered_tree_xrefs(
+pub(crate) fn block_tree_xrefs(
     template: &str,
     xrefs: &[XrefSegment],
 ) -> Vec<Option<ResolvedReference>> {
@@ -734,7 +734,7 @@ pub(crate) fn ordered_tree_xrefs(
 /// [`Content::mirror_tree_xref_resolution`] installs into the tree's footnote
 /// subtrees.
 ///
-/// This is the exact complement of [`ordered_tree_xrefs`]: it holds one entry
+/// This is the exact complement of [`block_tree_xrefs`]: it holds one entry
 /// per deferred segment whose placeholder **no longer appears in `template`**,
 /// in segment order. A placeholder leaves the template only by being re-homed
 /// onto a footnote (see [`rehome_xref_placeholders`]), which happens when the

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -7,7 +7,7 @@ mod content;
 pub use content::Content;
 pub(crate) use content::{
     FOOTNOTE_MARKER_END, FOOTNOTE_MARKER_START, FootnoteDeferred, OwnedTitle, XrefSegment,
-    footnote_tree_xrefs, ordered_tree_xrefs, rehome_xref_placeholders, render_xref_template,
+    block_tree_xrefs, footnote_tree_xrefs, rehome_xref_placeholders, render_xref_template,
     strip_footnote_marker_spans,
 };
 

--- a/parser/src/document/title_refs.rs
+++ b/parser/src/document/title_refs.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use crate::{
     HasSpan, Span,
     blocks::{Block, IsBlock},
-    content::{XrefSegment, footnote_tree_xrefs, ordered_tree_xrefs, render_xref_template},
+    content::{XrefSegment, block_tree_xrefs, footnote_tree_xrefs, render_xref_template},
     document::Catalog,
     parser::{
         InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, ResolutionContext,
@@ -36,9 +36,10 @@ use crate::{
 /// The resolved outcome of one title: its final rendering, plus the resolved
 /// destinations of its cross-references in placeholder order.
 ///
-/// The rendering is installed into the title's rendered string; the ordered
-/// destinations are mirrored into the title's inline tree (see
-/// [`Content::mirror_tree_xref_resolution`]), so both views of the title agree.
+/// The rendering is installed into the title's rendered string; the
+/// `block_ordered` / `footnote_ordered` destinations are mirrored into the
+/// title's inline tree (see [`Content::mirror_tree_xref_resolution`]), so both
+/// views of the title agree.
 ///
 /// [`Content::mirror_tree_xref_resolution`]: crate::content::Content::mirror_tree_xref_resolution
 struct Resolution {
@@ -47,8 +48,8 @@ struct Resolution {
     rendered: String,
 
     /// The resolved destination of each title-level cross-reference, in
-    /// placeholder order, ready for [`ordered_tree_xrefs`]-aligned mirroring.
-    ordered: Vec<Option<ResolvedReference>>,
+    /// placeholder order, ready for [`block_tree_xrefs`]-aligned mirroring.
+    block_ordered: Vec<Option<ResolvedReference>>,
 
     /// The resolved destination of each cross-reference embedded in a footnote
     /// the title carries, in segment order, ready for
@@ -189,7 +190,7 @@ fn write_back<'src>(blocks: &mut [Block<'src>], memo: &[Option<Resolution>], ind
                 if let Some(resolution) = memo.get(*index).and_then(Option::as_ref) {
                     section.set_section_title_rendered(resolution.rendered.clone());
                     section.mirror_section_title_tree_xrefs(
-                        &resolution.ordered,
+                        &resolution.block_ordered,
                         &resolution.footnote_ordered,
                     );
                 }
@@ -200,8 +201,10 @@ fn write_back<'src>(blocks: &mut [Block<'src>], memo: &[Option<Resolution>], ind
         {
             if let Some(resolution) = memo.get(*index).and_then(Option::as_ref) {
                 title.set_rendered(resolution.rendered.clone());
-                title
-                    .mirror_tree_xref_resolution(&resolution.ordered, &resolution.footnote_ordered);
+                title.mirror_tree_xref_resolution(
+                    &resolution.block_ordered,
+                    &resolution.footnote_ordered,
+                );
             }
             *index += 1;
         }
@@ -318,12 +321,12 @@ fn compute<'src>(
     // cross-reference nodes when mirrored (see `write_back`). This reuses the
     // very `xrefs` that produced `rendered`, so the tree cannot disagree with
     // the string.
-    let ordered = ordered_tree_xrefs(&node.template, &xrefs);
+    let block_ordered = block_tree_xrefs(&node.template, &xrefs);
 
     // The complementary set: a cross-reference the title's footnotes carry was
     // re-homed out of the template when the footnote text was extracted, so it
-    // is absent from `ordered` and belongs to a footnote subtree of the title
-    // tree instead.
+    // is absent from `block_ordered` and belongs to a footnote subtree of the
+    // title tree instead.
     let footnote_ordered = footnote_tree_xrefs(&node.template, &xrefs);
 
     if let Some(flag) = in_progress.get_mut(index) {
@@ -332,7 +335,7 @@ fn compute<'src>(
     if let Some(slot) = memo.get_mut(index) {
         *slot = Some(Resolution {
             rendered: rendered.clone(),
-            ordered,
+            block_ordered,
             footnote_ordered,
         });
     }


### PR DESCRIPTION
Follow-up to #1075. Renames the block-level inline-tree cross-reference helpers so they read as the clear counterpart of their `footnote_*` siblings, instead of the bare, generic-looking `ordered`.

## The rename

| before | after |
|---|---|
| `ordered_tree_xrefs` | `block_tree_xrefs` |
| the `ordered` local / param / struct field (in `Content::resolve_tree_references`, `Content::mirror_tree_xref_resolution`, `Section::mirror_section_title_tree_xrefs`, and `title_refs::Resolution`) | `block_ordered` |

This gives a symmetric `block_*` / `footnote_*` scheme for the two halves of the deferred-segment partition, matching the "block-level" vocabulary the surrounding doc comments already use.

## Deliberately left unchanged

The generic `ordered` parameter of `assign_tree_xrefs` / `assign_footnote_tree_xrefs` keeps its name: those walks consume *whichever* list they are handed — the block pass hands them the block list, the footnote pass hands them the footnote list — so `block_ordered` would be inaccurate there.

All `pub(crate)`/private items; no public API change and **no behavior change**.

## Verification

```
cargo +nightly fmt --all -- --check   # clean
cargo build --all-targets             # clean
cargo test                            # 4659 passed; 0 failed; 70 ignored (+ 5 doc-tests)
cargo clippy --all-features --all-targets -- -Dwarnings   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)