### PR TITLE
feat: Add raw (pre-substitution) author name/email accessors

### DIFF
--- a/parser/src/document/author.rs
+++ b/parser/src/document/author.rs
@@ -147,17 +147,19 @@ impl Author {
                 let (name, firstname, middlename, lastname, email) =
                     matched_parts(&captures, str::to_string);
 
-                // Derive the raw components from the raw expansion when it
-                // matches the same pattern. Escaping only ever adds characters,
-                // so a rendered match almost always implies a raw match with the
-                // same structure; if it does not, fall back to the rendered
-                // components (they carry no literal special characters to unescape
-                // in that case).
+                // Derive the raw components from the raw expansion, but only when
+                // it matches the same pattern *and* agrees on whether a trailing
+                // `<email>` is present, so the two representations keep the same
+                // structure and differ only in escaping. They can disagree only
+                // if a literal author-line bracket was escaped in the rendered
+                // value; in that case fall back to the rendered components.
                 let (raw_name, raw_firstname, raw_middlename, raw_lastname, raw_email) =
                     match AUTHOR.captures(&raw_expanded) {
-                        Some(raw_captures) => matched_parts(&raw_captures, str::to_string),
+                        Some(raw_captures) if raw_captures.get(4).is_some() == email.is_some() => {
+                            matched_parts(&raw_captures, str::to_string)
+                        }
 
-                        None => (
+                        _ => (
                             name.clone(),
                             firstname.clone(),
                             middlename.clone(),
@@ -553,8 +555,22 @@ fn join_name_parts(firstname: &str, middlename: Option<&str>, lastname: Option<&
 /// attribute entry that carries no literal special characters the two arguments
 /// are identical.
 fn partition_names_only(escaped_source: &str, raw_source: &str) -> Author {
-    let escaped = partition_parts(escaped_source);
-    let raw = partition_parts(raw_source);
+    // Partition the rendered value first, then partition the raw value using the
+    // *rendered* value's trailing-email decision so the two representations keep
+    // the same structure and differ only in escaping. A literal author-line
+    // bracket is escaped in the rendered value and so is not recognized as an
+    // email delimiter; the raw value, whose bracket is still literal, must follow
+    // that same decision rather than splitting an email off on its own.
+    let escaped = partition_parts(escaped_source, EmailSplit::Detect);
+
+    let raw = partition_parts(
+        raw_source,
+        if escaped.email.is_some() {
+            EmailSplit::Detect
+        } else {
+            EmailSplit::Suppress
+        },
+    );
 
     Author {
         name: escaped.name,
@@ -579,17 +595,33 @@ struct NameParts {
     email: Option<String>,
 }
 
+/// Whether [`partition_parts`] may split a trailing `<email>` off its input.
+enum EmailSplit {
+    /// Split a trailing `<email>` off when one is present (the rendered value's
+    /// own decision).
+    Detect,
+
+    /// Never split an email off; the whole value is treated as the name. Used
+    /// for the raw value when the rendered value kept its bracket escaped, so
+    /// the two stay structurally aligned.
+    Suppress,
+}
+
 /// Partition a single names-only author value into its parts, following the
 /// rules described on [`partition_names_only`].
-fn partition_parts(source: &str) -> NameParts {
+fn partition_parts(source: &str, email_split: EmailSplit) -> NameParts {
     let source = source.trim();
 
-    let (name_source, email) = match NAMES_ONLY_EMAIL.captures(source) {
-        Some(captures) => (
-            captures.get(1).map_or(source, |m| m.as_str()),
-            Some(captures[2].to_string()),
-        ),
-        None => (source, None),
+    let (name_source, email) = match email_split {
+        EmailSplit::Detect => match NAMES_ONLY_EMAIL.captures(source) {
+            Some(captures) => (
+                captures.get(1).map_or(source, |m| m.as_str()),
+                Some(captures[2].to_string()),
+            ),
+            None => (source, None),
+        },
+
+        EmailSplit::Suppress => (source, None),
     };
 
     let mut segments = split_whitespace_max3(name_source);
@@ -823,13 +855,22 @@ fn apply_author_subs(source: &str, parser: &Parser) -> String {
 /// the [`Author`] `raw_*` fields. It is the attribute-references half of
 /// [`apply_author_subs`], mirroring the value Asciidoctor keeps in its
 /// internal, pre-substitution `metadata` hash.
+///
+/// The rendered value is always resolved from the same source first (via
+/// [`apply_author_subs`]), which records any `attribute-missing` warning, so
+/// this second, raw-value pass discards the warnings it would otherwise
+/// duplicate.
 fn resolve_attribute_references(source: &str, parser: &Parser) -> String {
     use crate::content::SubstitutionStep;
+
+    let warnings_before = parser.substitution_warnings_len();
 
     let span = Span::new(source);
     let mut content = Content::from(span);
 
     SubstitutionStep::AttributeReferences.apply(&mut content, parser, None);
+
+    parser.truncate_substitution_warnings(warnings_before);
 
     content.rendered().to_string()
 }
@@ -989,6 +1030,55 @@ mod tests {
             assert_eq!(a.raw_middlename(), None);
             assert_eq!(a.lastname(), None);
             assert_eq!(a.raw_lastname(), None);
+        }
+
+        #[test]
+        fn unresolved_attribute_reference_warns_only_once() {
+            // The raw pass resolves the same references as the rendered pass, so
+            // an author line with an unresolved reference must not record the
+            // `attribute-missing` warning twice.
+            let mut parser = Parser::default();
+            let doc =
+                parser.parse(":attribute-missing: warn\n= Doc\nJane {undefined} Smith\n\nbody\n");
+
+            assert_eq!(doc.warnings().count(), 1);
+        }
+
+        #[test]
+        fn names_only_email_split_stays_aligned_between_raw_and_rendered() {
+            // A four-part `:author:` entry that wraps an attribute reference in
+            // literal brackets fails the author pattern, so it is partitioned. The
+            // rendered value escapes the brackets and keeps no email; the raw
+            // value must follow that decision rather than splitting the still-
+            // literal `<…>` off as an email, so the two stay structurally aligned.
+            let a = only_author(":mail: someone@example.com\n:author: A B C D <{mail}>\n\nbody\n");
+
+            assert_eq!(a.name(), "A B C D &lt;someone@example.com&gt;");
+            assert_eq!(a.raw_name(), "A B C D <someone@example.com>");
+            assert_eq!(a.email(), None);
+            assert_eq!(a.raw_email(), None);
+            assert_eq!(a.lastname(), Some("C D &lt;someone@example.com&gt;"));
+            assert_eq!(a.raw_lastname(), Some("C D <someone@example.com>"));
+        }
+
+        #[test]
+        fn names_only_email_from_an_attribute_still_splits_in_both() {
+            // When the trailing `<email>` survives into the rendered expansion
+            // unescaped (here from an intrinsic attribute value, so the bracket is
+            // literal in *both* the rendered and raw expansions), the email is
+            // split off in both – the alignment fix only suppresses a raw split
+            // the rendered value did not also make.
+            let mut parser = Parser::default().with_intrinsic_attribute(
+                "tail",
+                "Jr. <boss@example.com>",
+                crate::parser::ModificationContext::Anywhere,
+            );
+
+            let doc = parser.parse("= Doc\n:author: A B C {tail}\n\nbody\n");
+            let a = doc.authors().first().cloned().unwrap();
+
+            assert_eq!(a.email(), Some("boss@example.com"));
+            assert_eq!(a.raw_email(), Some("boss@example.com"));
         }
     }
 

--- a/parser/src/document/author.rs
+++ b/parser/src/document/author.rs
@@ -15,7 +15,35 @@ use crate::{Parser, Span, content::Content};
 /// the full name is assigned to the `firstname` attribute. You can adjoin names
 /// using an underscore (`_`) character.
 ///
+/// # Rendered versus raw values
+///
+/// The [`name`], [`firstname`], [`middlename`], [`lastname`], and [`email`]
+/// accessors return the value that populates the corresponding document
+/// attribute (`author`, `firstname`, …). As in Asciidoctor, that value has the
+/// header substitution group applied – so a literal `<`, `>`, or `&` written on
+/// the author line is escaped (`&lt;`, `&gt;`, `&amp;`), matching what
+/// `{author}` and the rendered byline emit and what Asciidoctor's own
+/// `doc.author` / `authors[0].name` return.
+///
+/// Each accessor has a `raw_` counterpart ([`raw_name`], [`raw_firstname`],
+/// [`raw_middlename`], [`raw_lastname`], [`raw_email`]) that returns the same
+/// value *before* that escaping – attribute references still resolved, but the
+/// literal special characters left as they were written. This mirrors
+/// Asciidoctor's internal, pre-substitution `metadata` hash and lets a consumer
+/// that escapes for HTML itself do so exactly once, rather than double-escaping
+/// an already-escaped value.
+///
 /// [author line]: https://docs.asciidoctor.org/asciidoc/latest/document/author-line/
+/// [`name`]: Self::name
+/// [`firstname`]: Self::firstname
+/// [`middlename`]: Self::middlename
+/// [`lastname`]: Self::lastname
+/// [`email`]: Self::email
+/// [`raw_name`]: Self::raw_name
+/// [`raw_firstname`]: Self::raw_firstname
+/// [`raw_middlename`]: Self::raw_middlename
+/// [`raw_lastname`]: Self::raw_lastname
+/// [`raw_email`]: Self::raw_email
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Author {
     name: String,
@@ -23,6 +51,16 @@ pub struct Author {
     middlename: Option<String>,
     lastname: Option<String>,
     email: Option<String>,
+
+    // The `raw_*` fields hold the same values as their rendered counterparts
+    // above, but before the header substitution group escapes any literal `<`,
+    // `>`, or `&` written on the author line. Attribute references are still
+    // resolved. See the type-level "Rendered versus raw values" documentation.
+    raw_name: String,
+    raw_firstname: String,
+    raw_middlename: Option<String>,
+    raw_lastname: Option<String>,
+    raw_email: Option<String>,
 }
 
 impl Author {
@@ -55,48 +93,34 @@ impl Author {
             // name.
             let expanded_source = apply_author_subs(source, parser);
 
+            // The raw value expands the reference without applying special
+            // characters. A single reference carries no literal special
+            // characters of its own, so the raw and rendered expansions differ
+            // only if the referenced attribute's own value was already escaped.
+            let raw_expanded = resolve_attribute_references(source, parser);
+
             if names_only {
                 // An attribute-entry value is partitioned *after* its references
                 // are expanded, so a reference that resolves to a multi-part name
                 // (or one with a trailing email) yields the same metadata as the
                 // equivalent literal value.
-                Some(partition_names_only(&expanded_source))
+                Some(partition_names_only(&expanded_source, &raw_expanded))
             } else {
-                let name_with_spaces = replace_underscores_with_spaces(expanded_source);
-                Some(Self {
-                    name: name_with_spaces.clone(),
-                    firstname: name_with_spaces,
-                    middlename: None,
-                    lastname: None,
-                    email: None,
-                })
+                Some(single_name_author(
+                    replace_underscores_with_spaces(expanded_source),
+                    replace_underscores_with_spaces(raw_expanded),
+                ))
             }
         } else if let Some(captures) = AUTHOR.captures(source) {
-            // Raw input matches author pattern: Extract components then apply
-            // substitutions.
+            // Raw input matches author pattern: Extract each component and apply
+            // substitutions to it. The rendered components escape literal special
+            // characters (`apply_author_subs`); the raw components resolve
+            // attribute references only, leaving those characters as written.
+            let (name, firstname, middlename, lastname, email) =
+                matched_parts(&captures, |s| apply_author_subs(s, parser));
 
-            // Extract raw components first.
-            let firstname =
-                replace_underscores_with_spaces(apply_author_subs(&captures[1], parser));
-            let mut middlename = captures
-                .get(2)
-                .map(|m| replace_underscores_with_spaces(apply_author_subs(m.as_str(), parser)));
-            let mut lastname = captures
-                .get(3)
-                .map(|m| replace_underscores_with_spaces(apply_author_subs(m.as_str(), parser)));
-            let email = captures
-                .get(4)
-                .map(|m| apply_author_subs(m.as_str(), parser));
-
-            if middlename.is_some() && lastname.is_none() {
-                lastname = middlename;
-                middlename = None;
-            }
-
-            // Reconstruct the full name from its parsed parts so that any interior
-            // whitespace that appeared between the names in the source is condensed
-            // to a single space (matching Asciidoctor).
-            let name = join_name_parts(&firstname, middlename.as_deref(), lastname.as_deref());
+            let (raw_name, raw_firstname, raw_middlename, raw_lastname, raw_email) =
+                matched_parts(&captures, |s| resolve_attribute_references(s, parser));
 
             Some(Self {
                 name,
@@ -104,31 +128,43 @@ impl Author {
                 middlename,
                 lastname,
                 email,
+                raw_name,
+                raw_firstname,
+                raw_middlename,
+                raw_lastname,
+                raw_email,
             })
         } else if source.contains('{') {
             // Input contains attributes that prevent regex match: Expand first, then try
             // parsing.
             let expanded_source = apply_author_subs(source, parser);
+            let raw_expanded = resolve_attribute_references(source, parser);
 
             if let Some(captures) = AUTHOR.captures(&expanded_source) {
-                // After expansion, it matches the pattern: Parse normally.
-                let firstname = replace_underscores_with_spaces(captures[1].to_string());
-                let mut middlename = captures
-                    .get(2)
-                    .map(|m| replace_underscores_with_spaces(m.as_str().to_string()));
-                let mut lastname = captures
-                    .get(3)
-                    .map(|m| replace_underscores_with_spaces(m.as_str().to_string()));
-                let email = captures.get(4).map(|m| m.as_str().to_string());
+                // After expansion, it matches the pattern: Parse normally. The
+                // components are already substituted, so the transform is the
+                // identity here.
+                let (name, firstname, middlename, lastname, email) =
+                    matched_parts(&captures, str::to_string);
 
-                if middlename.is_some() && lastname.is_none() {
-                    lastname = middlename;
-                    middlename = None;
-                }
+                // Derive the raw components from the raw expansion when it
+                // matches the same pattern. Escaping only ever adds characters,
+                // so a rendered match almost always implies a raw match with the
+                // same structure; if it does not, fall back to the rendered
+                // components (they carry no literal special characters to unescape
+                // in that case).
+                let (raw_name, raw_firstname, raw_middlename, raw_lastname, raw_email) =
+                    match AUTHOR.captures(&raw_expanded) {
+                        Some(raw_captures) => matched_parts(&raw_captures, str::to_string),
 
-                // Reconstruct the full name from its parsed parts so interior
-                // whitespace between the names is condensed (matching Asciidoctor).
-                let name = join_name_parts(&firstname, middlename.as_deref(), lastname.as_deref());
+                        None => (
+                            name.clone(),
+                            firstname.clone(),
+                            middlename.clone(),
+                            lastname.clone(),
+                            email.clone(),
+                        ),
+                    };
 
                 Some(Self {
                     name,
@@ -136,6 +172,11 @@ impl Author {
                     middlename,
                     lastname,
                     email,
+                    raw_name,
+                    raw_firstname,
+                    raw_middlename,
+                    raw_lastname,
+                    raw_email,
                 })
             } else if names_only {
                 // An attribute-entry value that still fails the pattern after
@@ -143,30 +184,27 @@ impl Author {
                 // reference resolving to a four-plus-part name behaves like its
                 // literal equivalent. The expanded value is used before any HTML
                 // encoding so a trailing `<email>` can still be split off.
-                Some(partition_names_only(&expanded_source))
+                Some(partition_names_only(&expanded_source, &raw_expanded))
             } else {
                 // Even after expansion the value does not match the author
-                // pattern, so it becomes a single name. `apply_author_subs`
-                // already applied the header substitution group – special
-                // characters (escaping any literal `<`, `>`, or `&`) followed by
-                // attribute references – so the expanded value is stored as is,
-                // mirroring Asciidoctor's `apply_header_subs`.
-                let name_with_spaces = replace_underscores_with_spaces(expanded_source);
-                Some(Self {
-                    name: name_with_spaces.clone(),
-                    firstname: name_with_spaces,
-                    middlename: None,
-                    lastname: None,
-                    email: None,
-                })
+                // pattern, so it becomes a single name. The rendered value has the
+                // header substitution group applied (escaping any literal `<`,
+                // `>`, or `&`), mirroring Asciidoctor's `apply_header_subs`; the
+                // raw value expands the references without that escaping.
+                Some(single_name_author(
+                    replace_underscores_with_spaces(expanded_source),
+                    replace_underscores_with_spaces(raw_expanded),
+                ))
             }
         } else if names_only {
             // Input comes from an attribute entry (e.g. `:author:`) and does not
             // match the author pattern – typically a name with four or more parts
             // or one containing punctuation such as a comma. Asciidoctor still
             // partitions it by splitting on whitespace into at most three parts,
-            // assigning any trailing parts to `lastname`.
-            Some(partition_names_only(source))
+            // assigning any trailing parts to `lastname`. This path applies no
+            // special-characters substitution, so the raw and rendered values are
+            // identical.
+            Some(partition_names_only(source, source))
         } else {
             // Input doesn't contain attributes and doesn't match the author
             // pattern. Asciidoctor stores the whole line as the author,
@@ -174,19 +212,12 @@ impl Author {
             // Asciidoctor only converts underscore-joined names while
             // partitioning a *matching* line, not in this fallback.
             //
-            // The header substitution group still applies, so any literal `<`,
-            // `>`, or `&` is escaped consistently – matching Asciidoctor's
-            // `apply_header_subs` and the attribute-reference path above, rather
-            // than returning the name raw only because it lacks an attribute
-            // reference.
-            let name = apply_author_special_characters(&condense_whitespace(source), parser);
-            Some(Self {
-                name: name.clone(),
-                firstname: name,
-                middlename: None,
-                lastname: None,
-                email: None,
-            })
+            // The rendered value has the header substitution group applied, so any
+            // literal `<`, `>`, or `&` is escaped – matching Asciidoctor's
+            // `apply_header_subs`. The raw value keeps those characters as written.
+            let raw_name = condense_whitespace(source);
+            let name = apply_author_special_characters(&raw_name, parser);
+            Some(single_name_author(name, raw_name))
         }
     }
 
@@ -240,13 +271,7 @@ impl Author {
         if segments.is_empty() {
             // The value was nothing but markup: keep the rendered value as the
             // single name.
-            return Some(Self {
-                firstname: name.clone(),
-                name,
-                middlename: None,
-                lastname: None,
-                email: None,
-            });
+            return Some(single_name_author(name.clone(), name));
         }
 
         let firstname = replace_underscores_with_spaces(segments.remove(0));
@@ -264,7 +289,15 @@ impl Author {
             ),
         };
 
+        // This path partitions an already-substituted value, so it applies no
+        // further special-characters substitution: the raw values equal the
+        // rendered ones.
         Some(Self {
+            raw_name: name.clone(),
+            raw_firstname: firstname.clone(),
+            raw_middlename: middlename.clone(),
+            raw_lastname: lastname.clone(),
+            raw_email: None,
             name,
             firstname,
             middlename,
@@ -280,6 +313,10 @@ impl Author {
     /// separately.
     pub(crate) fn with_email(mut self, email: Option<String>) -> Self {
         if let Some(email) = email {
+            // The email arrives from a companion `email_N` attribute value, which
+            // carries no author-line special-characters escaping of its own, so
+            // the raw and rendered emails are the same.
+            self.raw_email = Some(email.clone());
             self.email = Some(email);
         }
 
@@ -323,6 +360,53 @@ impl Author {
     /// brackets (`< >`). A URL can be used in place of the email address.
     pub fn email(&self) -> Option<&str> {
         self.email.as_deref()
+    }
+
+    /// Returns the full name of the author *before* the header substitution
+    /// group escapes any literal special characters.
+    ///
+    /// This is [`name`](Self::name) with attribute references resolved but any
+    /// literal `<`, `>`, or `&` written on the author line left unescaped,
+    /// mirroring Asciidoctor's internal `metadata` hash. Use it when the value
+    /// will be HTML-escaped downstream, so the escaping happens exactly once.
+    pub fn raw_name(&self) -> &str {
+        &self.raw_name
+    }
+
+    /// Returns the first name of the author *before* the header substitution
+    /// group escapes any literal special characters.
+    ///
+    /// See [`raw_name`](Self::raw_name) for how the raw value differs from
+    /// [`firstname`](Self::firstname).
+    pub fn raw_firstname(&self) -> &str {
+        &self.raw_firstname
+    }
+
+    /// Returns the middle name of the author *before* the header substitution
+    /// group escapes any literal special characters.
+    ///
+    /// See [`raw_name`](Self::raw_name) for how the raw value differs from
+    /// [`middlename`](Self::middlename).
+    pub fn raw_middlename(&self) -> Option<&str> {
+        self.raw_middlename.as_deref()
+    }
+
+    /// Returns the last name of the author *before* the header substitution
+    /// group escapes any literal special characters.
+    ///
+    /// See [`raw_name`](Self::raw_name) for how the raw value differs from
+    /// [`lastname`](Self::lastname).
+    pub fn raw_lastname(&self) -> Option<&str> {
+        self.raw_lastname.as_deref()
+    }
+
+    /// Returns the email address of the author *before* the header substitution
+    /// group escapes any literal special characters.
+    ///
+    /// See [`raw_name`](Self::raw_name) for how the raw value differs from
+    /// [`email`](Self::email).
+    pub fn raw_email(&self) -> Option<&str> {
+        self.raw_email.as_deref()
     }
 
     /// Returns the initials of the author.
@@ -459,10 +543,45 @@ fn join_name_parts(firstname: &str, middlename: Option<&str>, lastname: Option<&
 /// has repeating spaces condensed to a single space. Each segment then has
 /// underscore joiners replaced with spaces.
 ///
-/// `source` may already have attribute references substituted (the expanded
-/// value of a reference such as `{full-name}`); in that case any email it
-/// carries is likewise already substituted.
-fn partition_names_only(source: &str) -> Author {
+/// `escaped_source` may already have attribute references substituted (the
+/// expanded value of a reference such as `{full-name}`); in that case any email
+/// it carries is likewise already substituted.
+///
+/// `raw_source` is the same value expanded *without* the special-characters
+/// substitution and is partitioned independently to populate the author's
+/// `raw_*` fields (see the [`Author`] documentation). For an
+/// attribute entry that carries no literal special characters the two arguments
+/// are identical.
+fn partition_names_only(escaped_source: &str, raw_source: &str) -> Author {
+    let escaped = partition_parts(escaped_source);
+    let raw = partition_parts(raw_source);
+
+    Author {
+        name: escaped.name,
+        firstname: escaped.firstname,
+        middlename: escaped.middlename,
+        lastname: escaped.lastname,
+        email: escaped.email,
+        raw_name: raw.name,
+        raw_firstname: raw.firstname,
+        raw_middlename: raw.middlename,
+        raw_lastname: raw.lastname,
+        raw_email: raw.email,
+    }
+}
+
+/// The five partitioned strings produced from a single names-only author value.
+struct NameParts {
+    name: String,
+    firstname: String,
+    middlename: Option<String>,
+    lastname: Option<String>,
+    email: Option<String>,
+}
+
+/// Partition a single names-only author value into its parts, following the
+/// rules described on [`partition_names_only`].
+fn partition_parts(source: &str) -> NameParts {
     let source = source.trim();
 
     let (name_source, email) = match NAMES_ONLY_EMAIL.captures(source) {
@@ -490,12 +609,75 @@ fn partition_names_only(source: &str) -> Author {
 
     let name = join_name_parts(&firstname, middlename.as_deref(), lastname.as_deref());
 
-    Author {
+    NameParts {
         name,
         firstname,
         middlename,
         lastname,
         email,
+    }
+}
+
+/// Extract the author components from a successful [`AUTHOR`] match, applying
+/// `transform` to each captured fragment.
+///
+/// The rendered components pass `apply_author_subs` (special characters, then
+/// attribute references); the raw components pass
+/// [`resolve_attribute_references`] (attribute references only), so the two
+/// share the match's structure but differ in whether literal special characters
+/// are escaped. Returns `(name, firstname, middlename, lastname, email)`,
+/// promoting a lone middle name to the last name and reconstructing `name` from
+/// the parts so interior whitespace is condensed to a single space (matching
+/// Asciidoctor).
+fn matched_parts<F>(
+    captures: &regex::Captures,
+    transform: F,
+) -> (
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+)
+where
+    F: Fn(&str) -> String,
+{
+    let firstname = replace_underscores_with_spaces(transform(&captures[1]));
+
+    let mut middlename = captures
+        .get(2)
+        .map(|m| replace_underscores_with_spaces(transform(m.as_str())));
+
+    let mut lastname = captures
+        .get(3)
+        .map(|m| replace_underscores_with_spaces(transform(m.as_str())));
+
+    let email = captures.get(4).map(|m| transform(m.as_str()));
+
+    if middlename.is_some() && lastname.is_none() {
+        lastname = middlename;
+        middlename = None;
+    }
+
+    let name = join_name_parts(&firstname, middlename.as_deref(), lastname.as_deref());
+
+    (name, firstname, middlename, lastname, email)
+}
+
+/// Build a single-name [`Author`] – one whose whole value is the `name` with no
+/// separate first/middle/last/email parts – from its rendered and raw forms.
+fn single_name_author(name: String, raw_name: String) -> Author {
+    Author {
+        firstname: name.clone(),
+        name,
+        middlename: None,
+        lastname: None,
+        email: None,
+        raw_firstname: raw_name.clone(),
+        raw_name,
+        raw_middlename: None,
+        raw_lastname: None,
+        raw_email: None,
     }
 }
 
@@ -633,6 +815,25 @@ fn apply_author_subs(source: &str, parser: &Parser) -> String {
     content.rendered().to_string()
 }
 
+/// Resolve attribute references in `source` *without* applying the special-
+/// characters substitution.
+///
+/// This yields the raw form of an author fragment – attribute references
+/// expanded, but any literal `<`, `>`, or `&` left as written – which populates
+/// the [`Author`] `raw_*` fields. It is the attribute-references half of
+/// [`apply_author_subs`], mirroring the value Asciidoctor keeps in its
+/// internal, pre-substitution `metadata` hash.
+fn resolve_attribute_references(source: &str, parser: &Parser) -> String {
+    use crate::content::SubstitutionStep;
+
+    let span = Span::new(source);
+    let mut content = Content::from(span);
+
+    SubstitutionStep::AttributeReferences.apply(&mut content, parser, None);
+
+    content.rendered().to_string()
+}
+
 /// Apply the special-characters substitution to `source`, escaping every
 /// literal `<`, `>`, and `&` – except the leading `&` of a numeric HTML
 /// character reference, which is left intact so a name such as `AsciiDoc&#174;`
@@ -684,6 +885,112 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::Author;
+
+    // The `raw_*` accessors return the author value with attribute references
+    // resolved but the header substitution group's special-characters escaping
+    // *not* applied – the value Asciidoctor keeps in its internal `metadata`
+    // hash. The rendered accessors are unaffected and keep escaping literal `<`,
+    // `>`, and `&` to match `doc.author`/`{author}`.
+    mod raw_accessors {
+        use crate::{Parser, document::Author};
+
+        // Parse `src` and return its single, first author.
+        fn only_author(src: &str) -> Author {
+            let mut parser = Parser::default();
+            let doc = parser.parse(src);
+            doc.authors().first().cloned().unwrap()
+        }
+
+        #[test]
+        fn plain_name_has_no_special_characters_so_raw_equals_rendered() {
+            let a = only_author("= Doc\nKismet R. Lee <kismet@asciidoctor.org>\n\nbody\n");
+
+            assert_eq!(a.name(), "Kismet R. Lee");
+            assert_eq!(a.raw_name(), "Kismet R. Lee");
+            assert_eq!(a.firstname(), "Kismet");
+            assert_eq!(a.raw_firstname(), "Kismet");
+            assert_eq!(a.middlename(), Some("R."));
+            assert_eq!(a.raw_middlename(), Some("R."));
+            assert_eq!(a.lastname(), Some("Lee"));
+            assert_eq!(a.raw_lastname(), Some("Lee"));
+            assert_eq!(a.email(), Some("kismet@asciidoctor.org"));
+            assert_eq!(a.raw_email(), Some("kismet@asciidoctor.org"));
+        }
+
+        #[test]
+        fn implicit_line_with_literal_angle_brackets_keeps_them_raw() {
+            // A line that does not match the author pattern (here because of the
+            // comma) becomes a single name. The rendered value escapes the literal
+            // angle brackets – matching Asciidoctor's `doc.author` – while the raw
+            // value keeps them as written.
+            let a = only_author(
+                "= Doc\nStuart Rackham, founder of AsciiDoc <founder@asciidoc.org>\n\nbody\n",
+            );
+
+            assert_eq!(
+                a.name(),
+                "Stuart Rackham, founder of AsciiDoc &lt;founder@asciidoc.org&gt;"
+            );
+
+            assert_eq!(
+                a.raw_name(),
+                "Stuart Rackham, founder of AsciiDoc <founder@asciidoc.org>"
+            );
+
+            assert_eq!(
+                a.raw_firstname(),
+                "Stuart Rackham, founder of AsciiDoc <founder@asciidoc.org>"
+            );
+        }
+
+        #[test]
+        fn literal_ampersand_is_escaped_only_in_the_rendered_value() {
+            // A downstream converter that HTML-escapes the raw name gets a single
+            // level of escaping rather than the double-escaped `&amp;amp;` it would
+            // get from re-escaping the already-escaped rendered value.
+            let a = only_author("= Doc\nBen & Jerry\n\nbody\n");
+
+            assert_eq!(a.name(), "Ben &amp; Jerry");
+            assert_eq!(a.raw_name(), "Ben & Jerry");
+            assert_eq!(a.middlename(), Some("&amp;"));
+            assert_eq!(a.raw_middlename(), Some("&"));
+        }
+
+        #[test]
+        fn four_part_name_with_email_keeps_brackets_raw() {
+            let a = only_author("= Doc\nFour Names Not Supported <doc@example.com>\n\nbody\n");
+
+            assert_eq!(a.name(), "Four Names Not Supported &lt;doc@example.com&gt;");
+            assert_eq!(a.raw_name(), "Four Names Not Supported <doc@example.com>");
+        }
+
+        #[test]
+        fn attribute_reference_resolves_then_stays_a_single_raw_name() {
+            // The literal `<`/`>` around the referenced email keep the expanded
+            // value from matching the author pattern, so it is stored as a single
+            // name. The rendered value escapes the brackets; the raw value resolves
+            // the references but leaves the brackets literal, and – importantly –
+            // keeps the same single-name structure as the rendered value rather
+            // than re-splitting into name parts.
+            let src = concat!(
+                ":first-name: Jane\n",
+                ":last-name: Smith\n",
+                ":author-email: jane@example.com\n",
+                "= Doc\n",
+                "{first-name} {last-name} <{author-email}>\n\n",
+                "body\n",
+            );
+
+            let a = only_author(src);
+
+            assert_eq!(a.name(), "Jane Smith &lt;jane@example.com&gt;");
+            assert_eq!(a.raw_name(), "Jane Smith <jane@example.com>");
+            assert_eq!(a.middlename(), None);
+            assert_eq!(a.raw_middlename(), None);
+            assert_eq!(a.lastname(), None);
+            assert_eq!(a.raw_lastname(), None);
+        }
+    }
 
     // The `<`-branch of Asciidoctor's `process_authors` (`names_only`), reached
     // when an `:author:` attribute value's substitution produced inline HTML.


### PR DESCRIPTION
Closes #1076.

## Heads-up: the issue's premise is partly contradicted by the parity oracle

Before implementing, I tested **Asciidoctor 2.0.26** directly. The issue expects the author *model/attribute* values to be **raw**, but the values a consumer actually reads back from Asciidoctor are **escaped**:

| Asciidoctor 2.0.26, author `Stuart Rackham, founder of AsciiDoc <founder@asciidoc.org>` | value |
|---|---|
| internal `metadata['author']` (pre-subs) | `…<founder@asciidoc.org>` (raw) |
| `doc.attributes['author']` → what `{author}` / a consumer reads | `…&lt;founder@asciidoc.org&gt;` (**escaped**) |
| `doc.author`, `authors[0].name`, `.firstname` (**model** objects) | `…&lt;founder@asciidoc.org&gt;` (**escaped**) |

`Ben & Jerry` → Asciidoctor's `doc.author` is literally `"Ben &amp; Jerry"`. And the `{author}` "renders raw" observation in the issue is a misread: the attribute is `&lt;…&gt;`, and the inline email macro fires on the address *between* the already-escaped brackets:

```
author-ref=Stuart Rackham, founder of AsciiDoc &lt;<a href="mailto:founder@asciidoc.org">founder@asciidoc.org</a>&gt;
```

So the current (post-#1072) escaped accessors **already match** Asciidoctor's public API. Making them raw would make this crate the only one of the two returning raw author values — a divergence from the oracle. The `asciidoc-html5` double-escape was a downstream renderer bug (escaping an already-escaped value); Asciidoctor's own converter inserts the author name verbatim.

## What this PR does (additive, non-breaking)

Per discussion, keep every existing escaped accessor/attribute **exactly as-is**, and **add** raw counterparts mirroring Asciidoctor's internal pre-substitution `metadata` hash:

- `Author::raw_name()`, `raw_firstname()`, `raw_middlename()`, `raw_lastname()`, `raw_email()`

These resolve attribute references but leave literal `<`, `>`, `&` unescaped, so a converter that HTML-escapes model values itself escapes exactly once (`Ben & Jerry` → `Ben &amp; Jerry`, not `&amp;amp;`). The raw values follow the **same structural decision** (part-splitting, single-name vs. partitioned) as the rendered values, so the two only ever differ in escaping.

Escaping that legitimately comes from *attribute-entry storage* (e.g. `:full-author: John Doe <john@example.com>` is stored escaped, matching Asciidoctor) flows through both representations unchanged — the raw accessor only undoes the author-line special-characters step, nothing else.

## Verification

- All existing tests pass unchanged (no escaped value moved): `4620 passed`.
- 5 new `raw_accessors` tests cover: plain names (raw == rendered), the comma+email repro, `Ben & Jerry`, four-part-name+email, and attribute-reference + literal brackets (single-name structure preserved).
- `cargo +nightly fmt --all -- --check` and `cargo clippy --all-targets` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)