### PR TITLE
feat: Expose the public inline tree accessor (inline-ast Phase 3, step 1)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -711,14 +711,27 @@ Each phase is a reviewable unit with a clear exit gate.
   design sequences the true single-artifact cutover with the single-pass builder in Phase 4.
   The opt-in flag retires with it.
 
-- **Phase 3 — expose the public inline API.** `Content::inlines()`, `IsBlock::inlines()`,
-  the public node types, and `render_with`/`render_to`. Rename `rendered()` →
-  `rendered_html()` and `rendered_content()` → `rendered_html_content()` (§3.3.1) — a
-  mechanical sweep of the ~277 golden assertions that leaves every *asserted string*
-  untouched. Resolution reports at node granularity.
+- **Phase 3 — expose the public inline API.** 🔶 **In progress.** `Content::inlines()`,
+  `IsBlock::inlines()`, the public node types, and `render_with`/`render_to`. Rename
+  `rendered()` → `rendered_html()` and `rendered_content()` → `rendered_html_content()`
+  (§3.3.1) — a mechanical sweep of the ~277 golden assertions that leaves every *asserted
+  string* untouched. Resolution reports at node granularity.
   *Exit:* node vocabulary reviewed against the `asciidoctor` port's needs (§6.6); the
   purely-structural navigation sugar kept minimal pending a re-flow consumer; doc + README
   updated (the security section gets its `Raw`-node anchor).
+
+  *Step 1 landed as (expose the read-only tree accessor):* the tree accessor
+  [`Content::inlines`](../../parser/src/content/content.rs) — populated during Phase 2 but
+  crate-internal until now — is **public**, and a parallel
+  [`IsBlock::inlines`](../../parser/src/blocks/is_block.rs) is the block-level counterpart of
+  [`IsBlock::rendered_content`](../../parser/src/blocks/is_block.rs): the same content-bearing
+  blocks carry each. A content-bearing block returns `Some(tree)` — an *empty* tree when
+  [`with_inline_tree`](../../parser/src/parser/parser.rs) is off, since the block still has
+  content the tree simply was not built for — and a block with no directly-contained inline
+  content (a compound/section block) returns `None`. The node types were already public
+  (Phase 0); this step opens the accessor that reaches them, the core of #943. The larger
+  pieces of the phase — the `rendered()` → `rendered_html()` rename and the
+  `render_with`/`render_to` fold — remain as later steps.
 
 - **Phase 4 — precision spans + ASG output.** Land the single-pass builder (Strategy B) and
   `Document::to_asg()`; validate against the ASG schema; retire the `attribute-missing`

--- a/parser/src/blocks/admonition.rs
+++ b/parser/src/blocks/admonition.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     content::Content,
     document::InterpretedValue,
+    inlines::InlineNode,
     internal::debug::DebugSliceReference,
     span::MatchedItem,
     strings::CowStr,
@@ -374,6 +375,10 @@ impl<'src> IsBlock<'src> for AdmonitionBlock<'src> {
 
     fn rendered_content(&'src self) -> Option<&'src str> {
         self.content.as_ref().map(|content| content.rendered())
+    }
+
+    fn inlines(&'src self) -> Option<&'src [InlineNode<'src>]> {
+        self.content.as_ref().map(|content| content.inlines())
     }
 
     fn child_blocks_mut(&mut self) -> &mut [Block<'src>] {

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     content::{Content, SubstitutionGroup, substitute_attributes_in_reftext},
     document::{Attribute, InterpretedValue, RefType},
+    inlines::InlineNode,
     parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings, XrefSignifier},
     span::MatchedItem,
     strings::CowStr,
@@ -1043,6 +1044,25 @@ impl<'src> IsBlock<'src> for Block<'src> {
             Self::Break(b) => b.rendered_content(),
             Self::Toc(b) => b.rendered_content(),
             Self::DocumentAttribute(b) => b.rendered_content(),
+        }
+    }
+
+    fn inlines(&'src self) -> Option<&'src [InlineNode<'src>]> {
+        match self {
+            Self::Simple(b) => b.inlines(),
+            Self::Media(b) => b.inlines(),
+            Self::Section(b) => b.inlines(),
+            Self::List(b) => b.inlines(),
+            Self::ListItem(b) => b.inlines(),
+            Self::RawDelimited(b) => b.inlines(),
+            Self::CompoundDelimited(b) => b.inlines(),
+            Self::Admonition(b) => b.inlines(),
+            Self::Quote(b) => b.inlines(),
+            Self::Table(b) => b.inlines(),
+            Self::Preamble(b) => b.inlines(),
+            Self::Break(b) => b.inlines(),
+            Self::Toc(b) => b.inlines(),
+            Self::DocumentAttribute(b) => b.inlines(),
         }
     }
 

--- a/parser/src/blocks/is_block.rs
+++ b/parser/src/blocks/is_block.rs
@@ -5,6 +5,7 @@ use crate::{
     attributes::Attrlist,
     blocks::{Block, is_built_in_context},
     content::{Content, SubstitutionGroup},
+    inlines::InlineNode,
     strings::CowStr,
 };
 
@@ -33,6 +34,25 @@ pub trait IsBlock<'src>: Debug + Eq + PartialEq {
     /// This content will contain the text _after_ substitutions have been
     /// applied.
     fn rendered_content(&'src self) -> Option<&'src str> {
+        None
+    }
+
+    /// Returns the inline AST for this block's content, if any: the structured,
+    /// read-only representation of its inline nodes.
+    ///
+    /// This is the structured counterpart of
+    /// [`rendered_content`](Self::rendered_content) – the same blocks carry
+    /// each – so a block with no directly-contained content returns `None`
+    /// here too.
+    ///
+    /// The tree is populated only when inline-tree building is enabled on the
+    /// [`Parser`](crate::Parser) (see
+    /// [`with_inline_tree`](crate::Parser::with_inline_tree)); a
+    /// content-bearing block parsed without it returns `Some(&[])` (an
+    /// empty tree), not `None`.
+    /// See [`Content::inlines`](crate::content::Content::inlines) for the
+    /// tree's guarantees.
+    fn inlines(&'src self) -> Option<&'src [InlineNode<'src>]> {
         None
     }
 

--- a/parser/src/blocks/quote.rs
+++ b/parser/src/blocks/quote.rs
@@ -11,6 +11,7 @@ use crate::{
         parse_utils::parse_blocks_until,
     },
     content::{Content, SubstitutionGroup},
+    inlines::InlineNode,
     internal::debug::DebugSliceReference,
     parser::{InlineSubstitutionRenderer, ReferenceResolver, ReferenceWarnings},
     span::MatchedItem,
@@ -777,6 +778,10 @@ impl<'src> IsBlock<'src> for QuoteBlock<'src> {
 
     fn rendered_content(&'src self) -> Option<&'src str> {
         self.content.as_ref().map(|content| content.rendered())
+    }
+
+    fn inlines(&'src self) -> Option<&'src [InlineNode<'src>]> {
+        self.content.as_ref().map(|content| content.inlines())
     }
 
     /// Returns a mutable slice of the nested blocks of a `____`-delimited

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -5,6 +5,7 @@ use crate::{
         ChildBlocks, ContentModel, IsBlock, caption::assign_block_caption, metadata::BlockMetadata,
     },
     content::{Content, SubstitutionGroup},
+    inlines::InlineNode,
     span::MatchedItem,
     strings::CowStr,
     warnings::{MatchAndWarnings, Warning, WarningType},
@@ -398,6 +399,10 @@ impl<'src> IsBlock<'src> for RawDelimitedBlock<'src> {
 
     fn rendered_content(&self) -> Option<&str> {
         Some(self.content.rendered())
+    }
+
+    fn inlines(&'src self) -> Option<&'src [InlineNode<'src>]> {
+        Some(self.content.inlines())
     }
 
     fn raw_context(&self) -> CowStr<'src> {

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -8,6 +8,7 @@ use crate::{
         metadata::{BlockMetadata, block_title_text},
     },
     content::{Content, SubstitutionGroup},
+    inlines::InlineNode,
     span::MatchedItem,
     strings::CowStr,
 };
@@ -584,6 +585,10 @@ impl<'src> IsBlock<'src> for SimpleBlock<'src> {
 
     fn rendered_content(&self) -> Option<&str> {
         Some(self.content.rendered())
+    }
+
+    fn inlines(&'src self) -> Option<&'src [InlineNode<'src>]> {
+        Some(self.content.inlines())
     }
 
     fn raw_context(&self) -> CowStr<'src> {

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -386,28 +386,28 @@ impl<'src> Content<'src> {
         self.passthroughs = passthroughs;
     }
 
-    /// Returns the inline AST for this content: the structured representation
-    /// of its inline nodes.
+    /// Returns the inline AST for this content: the structured, read-only
+    /// representation of its inline nodes.
     ///
     /// This is populated only when inline-tree building is enabled on the
     /// [`Parser`](crate::Parser) (see
     /// [`with_inline_tree`](crate::Parser::with_inline_tree)); it is an empty
     /// slice otherwise. The tree is a projection of the rendered content – the
     /// fold of the tree reproduces [`rendered`](Self::rendered) byte-for-byte –
-    /// and is not yet the canonical representation (see the inline AST
-    /// architecture design, Phase 2).
+    /// and is not yet the canonical representation (see the [inline AST
+    /// architecture design], Phase 2).
     ///
-    /// Cross-references in the tree carry their resolved destination once
-    /// resolution runs: [`resolve_references`](Self::resolve_references)
-    /// mirrors each resolved destination into the corresponding
+    /// Cross-references in the tree carry their resolved destination once a
+    /// full [`Parser::parse`](crate::Parser::parse) has resolved the document's
+    /// references: each resolved destination is mirrored into the corresponding
     /// [`Ref`](crate::inlines::Ref) node, so a caller that walks
-    /// [`inlines`](Self::inlines) after resolution sees the same destinations
-    /// the rendered string reflects (§4.3 of the design).
-    // Consumed by the differential and structural tests (and, in Phase 3, by
-    // the public inline API); the accessor is part of the tree's internal
-    // surface even where non-test code does not yet read it.
-    #[allow(dead_code)]
-    pub(crate) fn inlines(&self) -> &[InlineNode<'src>] {
+    /// [`inlines`](Self::inlines) after the parse sees the same destinations
+    /// the rendered string reflects (§4.3 of the design). Before resolution
+    /// – or for a standalone parse with no document catalog – a `Ref`
+    /// node's destination is `None`.
+    ///
+    /// [inline AST architecture design]: https://github.com/scouten/asciidoc-parser/blob/main/docs/design/inline-ast-architecture.md
+    pub fn inlines(&self) -> &[InlineNode<'src>] {
         &self.inlines
     }
 

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2160,10 +2160,10 @@ impl Parser {
     ///
     /// When enabled, each block's inline content is additionally parsed into a
     /// tree of [`InlineNode`](crate::inlines::InlineNode)s, retrievable from
-    /// its [`Content`](crate::content::Content) (a crate-internal accessor
-    /// while the inline AST is being brought up; the public accessor lands
-    /// in Phase 3). The tree is a projection of the rendered output:
-    /// folding it reproduces
+    /// its [`Content`](crate::content::Content) via
+    /// [`Content::inlines`](crate::content::Content::inlines) (or, at the block
+    /// level, [`IsBlock::inlines`](crate::blocks::IsBlock::inlines)). The tree
+    /// is a projection of the rendered output: folding it reproduces
     /// [`Content::rendered`](crate::content::Content::rendered) byte-for-byte.
     ///
     /// This is **off by default**. Building the tree currently costs a second,

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -925,6 +925,162 @@ fn is_block_inlines_is_none_for_a_block_without_direct_content() {
     assert_eq!(section.inlines(), None);
 }
 
+/// Names the [`Block`](crate::blocks::Block) variant, so a test can assert its
+/// fixture reaches every one.
+fn block_variant_name(block: &crate::blocks::Block<'_>) -> &'static str {
+    use crate::blocks::Block;
+
+    match block {
+        Block::Simple(_) => "Simple",
+        Block::Media(_) => "Media",
+        Block::Section(_) => "Section",
+        Block::List(_) => "List",
+        Block::ListItem(_) => "ListItem",
+        Block::RawDelimited(_) => "RawDelimited",
+        Block::CompoundDelimited(_) => "CompoundDelimited",
+        Block::Admonition(_) => "Admonition",
+        Block::Quote(_) => "Quote",
+        Block::Table(_) => "Table",
+        Block::Preamble(_) => "Preamble",
+        Block::Break(_) => "Break",
+        Block::Toc(_) => "Toc",
+        Block::DocumentAttribute(_) => "DocumentAttribute",
+    }
+}
+
+#[test]
+fn is_block_inlines_matches_rendered_content_across_every_block_kind() {
+    use std::collections::BTreeSet;
+
+    use crate::blocks::{FindBlocks, IsBlock};
+
+    // A document exercising all fourteen `Block` variants: a title + section
+    // give a `Preamble` (wrapping everything before the section) and a
+    // `Section`; the leaf/container blocks cover the rest. Each is walked with
+    // the inline-tree flag on so `inlines()` is populated for the
+    // content-bearing kinds.
+    let mut parser = Parser::default().with_inline_tree(true);
+    let doc = parser.parse(concat!(
+        "= Doc Title\n\n",
+        "Preamble *para*.\n\n",
+        "NOTE: A _note_.\n\n",
+        "[verse]\n____\nA `verse`.\n____\n\n",
+        "----\nlisting\n----\n\n",
+        "====\nexample\n====\n\n",
+        "* item one\n* item two\n\n",
+        "|===\n|cell\n|===\n\n",
+        "'''\n\n",
+        "image::pic.png[Alt]\n\n",
+        "toc::[]\n\n",
+        ":bodyattr: v2\n\n",
+        "== A Section\n\nSection body.\n",
+    ));
+
+    let mut seen = BTreeSet::new();
+
+    for block in doc.descendant_blocks() {
+        seen.insert(block_variant_name(block));
+
+        // `inlines()` is the structured counterpart of `rendered_content()`:
+        // the same content-bearing blocks carry each, so their presence agrees
+        // for every kind (this also drives every `Block::inlines()` dispatch
+        // arm and each block type's override).
+        assert_eq!(
+            block.inlines().is_some(),
+            block.rendered_content().is_some(),
+            "`inlines()`/`rendered_content()` presence disagree for a {} block",
+            block_variant_name(block),
+        );
+    }
+
+    // The fixture must actually reach every variant, or the walk above proves
+    // nothing about the arms it never visited.
+    let expected: BTreeSet<&str> = [
+        "Simple",
+        "Media",
+        "Section",
+        "List",
+        "ListItem",
+        "RawDelimited",
+        "CompoundDelimited",
+        "Admonition",
+        "Quote",
+        "Table",
+        "Preamble",
+        "Break",
+        "Toc",
+        "DocumentAttribute",
+    ]
+    .into_iter()
+    .collect();
+
+    assert_eq!(
+        seen, expected,
+        "the fixture did not reach every block variant"
+    );
+}
+
+#[test]
+fn is_block_inlines_carries_a_real_tree_for_each_content_bearing_kind() {
+    use crate::blocks::{Block, FindBlocks, IsBlock};
+
+    // Beyond `Some` vs `None`, the override bodies for the content-bearing block
+    // kinds must return the *actual* parsed tree – so a formatting construct in
+    // each shows up as a `Styled` node, not an empty slice.
+    let mut parser = Parser::default().with_inline_tree(true);
+    let doc = parser.parse(concat!(
+        "NOTE: A _note_.\n\n",
+        "[verse]\n____\nA `verse`.\n____\n\n",
+        "----\nlisting\n----\n",
+    ));
+
+    let mut admonition_styled = None;
+    let mut quote_styled = None;
+    let mut listing_tree_len = None;
+
+    for block in doc.descendant_blocks() {
+        let Some(tree) = block.inlines() else {
+            continue;
+        };
+
+        match block {
+            Block::Admonition(_) => {
+                admonition_styled = Some(has_styled(tree, StyleVariant::Emphasis))
+            }
+            Block::Quote(_) => quote_styled = Some(has_styled(tree, StyleVariant::Code)),
+            Block::RawDelimited(_) => listing_tree_len = Some(tree.len()),
+            _ => {}
+        }
+    }
+
+    assert_eq!(
+        admonition_styled,
+        Some(true),
+        "the admonition tree lost its `_note_` emphasis"
+    );
+    assert_eq!(
+        quote_styled,
+        Some(true),
+        "the verse tree lost its `verse` code span"
+    );
+
+    // A listing applies verbatim subs, so its tree is a single text run – but a
+    // populated one, proving the `RawDelimited` override returns the parse.
+    assert_eq!(
+        listing_tree_len,
+        Some(1),
+        "the listing tree should be one text run"
+    );
+}
+
+/// Whether `nodes` contains a top-level [`Styled`](InlineNode::Styled) node of
+/// the given variant.
+fn has_styled(nodes: &[InlineNode<'_>], variant: StyleVariant) -> bool {
+    nodes
+        .iter()
+        .any(|node| matches!(node, InlineNode::Styled(styled) if styled.variant == variant))
+}
+
 #[test]
 fn inline_tree_numbers_footnotes_in_document_order() {
     // The recording pass clones the parser *before* the authoritative pass

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -870,6 +870,61 @@ fn inline_tree_is_built_when_enabled() {
     assert!(matches!(&tree[2], InlineNode::Text { .. }));
 }
 
+// ─── Public API: `IsBlock::inlines()` ───────────────────────────────────────
+//
+// The public inline accessor (design Phase 3) is the structured counterpart of
+// `IsBlock::rendered_content()`: the same content-bearing blocks carry each. A
+// content-bearing block returns `Some(tree)` (an empty tree when the flag is
+// off); a block with no directly-contained inline content returns `None`.
+
+#[test]
+fn is_block_inlines_exposes_the_content_tree() {
+    use crate::blocks::{Block, IsBlock};
+
+    let mut parser = Parser::default().with_inline_tree(true);
+    let doc = parser.parse("One *word* is strong.");
+
+    let block = doc.child_blocks().next().expect("a block");
+
+    // The trait accessor returns the same tree the block's `Content` carries.
+    let via_trait = block.inlines().expect("a content-bearing block");
+    let Block::Simple(simple) = block else {
+        panic!("expected a simple block, got {block:?}");
+    };
+
+    assert_eq!(via_trait, simple.content().inlines());
+    assert_eq!(via_trait.len(), 3);
+    assert!(matches!(&via_trait[1], InlineNode::Styled(_)));
+}
+
+#[test]
+fn is_block_inlines_is_some_but_empty_when_flag_off() {
+    use crate::blocks::IsBlock;
+
+    // A content-bearing block parsed without tree building returns an *empty*
+    // tree, not `None` – the block still has content, the tree is just not built.
+    let mut parser = Parser::default();
+    let doc = parser.parse("One *word* is strong.");
+
+    let block = doc.child_blocks().next().expect("a block");
+
+    assert_eq!(block.inlines(), Some(&[][..]));
+}
+
+#[test]
+fn is_block_inlines_is_none_for_a_block_without_direct_content() {
+    use crate::blocks::IsBlock;
+
+    // A section is a compound block: its inline content lives in its child
+    // blocks, so the section itself has no direct tree.
+    let mut parser = Parser::default().with_inline_tree(true);
+    let doc = parser.parse("== Title\n\nBody.");
+
+    let section = doc.child_blocks().next().expect("a section block");
+
+    assert_eq!(section.inlines(), None);
+}
+
 #[test]
 fn inline_tree_numbers_footnotes_in_document_order() {
     // The recording pass clones the parser *before* the authoritative pass


### PR DESCRIPTION
## Phase 3, step 1 — expose the public inline tree accessor

The first step of **Phase 3** ([inline AST architecture design](../blob/inline-ast/docs/design/inline-ast-architecture.md), §3.3). Phase 2 built the tree and mirrored every cross-reference resolution site into it; this step opens the read-only accessor that reaches it — the core ask of #943.

### What changes

- **`Content::inlines()` is now `pub`** (was a crate-internal `pub(crate)` accessor), with consumer-facing docs. Its cross-reference note now describes the public `Parser::parse` flow instead of linking the private `resolve_references` — which rustdoc rejects for a public item under `#![deny(warnings)]`.
- **`IsBlock::inlines() -> Option<&[InlineNode]>`** (default `None`) is added as the structured counterpart of `IsBlock::rendered_content()`, overridden by the four content-bearing blocks (simple, quote, admonition, raw_delimited) and the `Block` enum dispatch.
- **`Parser::with_inline_tree`** docs now point at the public accessors.

### Contract

A content-bearing block returns `Some(tree)` — an **empty** tree unless `with_inline_tree` is enabled, since the block still has content the tree simply was not built for — and a compound/section block returns `None`.

### Not in this step

The larger Phase 3 pieces — the `rendered()` → `rendered_html()` rename and the `render_with`/`render_to` fold — remain as later steps, per the design doc's phased sequencing.

### Tests / checks

- Three new tests in `inline_recorder.rs` lock the contract: `Some(tree)`, `Some(&[])` when the flag is off, and `None` for a compound block.
- `cargo test -p asciidoc-parser` — all pass (0 failures).
- `cargo clippy --all-targets` — clean.
- `cargo doc` with `-D warnings` — clean (the private-link fix above was caught here).
- `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)