### PR TITLE
fix: Rename rendered-string accessors for HTML-specificity (inline-ast Phase 3, step 2)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -733,6 +733,25 @@ Each phase is a reviewable unit with a clear exit gate.
   pieces of the phase — the `rendered()` → `rendered_html()` rename and the
   `render_with`/`render_to` fold — remain as later steps.
 
+  *Step 2 landed as (rename the rendered-string accessors for HTML-specificity):* the
+  public string accessors are renamed to state their backend —
+  [`Content::rendered`](../../parser/src/content/content.rs)`()` →
+  [`Content::rendered_html`](../../parser/src/content/content.rs)`()` and
+  [`IsBlock::rendered_content`](../../parser/src/blocks/is_block.rs)`()` →
+  [`IsBlock::rendered_html_content`](../../parser/src/blocks/is_block.rs)`()` (§3.3.1). This
+  is the mechanical sweep §5.3 describes: every one of the ~277 golden `.rendered()`
+  assertions (and the corpus-wide differential harness) is rewritten to call the new name
+  while the *asserted output strings* are left untouched, so the oracle still pins the same
+  bytes. The rename is **name-only**: the accessor still returns exactly what it returned
+  before, including the output of a custom
+  [`InlineSubstitutionRenderer`](../../parser/src/parser/inline_substitution_renderer.rs)
+  installed via
+  [`with_inline_substitution_renderer`](../../parser/src/parser/parser.rs) — the two changes
+  the new name ultimately implies (making `rendered_html()` a *fold* of the tree, and
+  dropping the parse-time renderer so it is *always* the built-in HTML backend) are the
+  deferred remainder of Phase 2 and Phase 4, unchanged by this step. The `render_with` /
+  `render_to` fold is still the remaining Phase 3 piece.
+
 - **Phase 4 — precision spans + ASG output.** Land the single-pass builder (Strategy B) and
   `Document::to_asg()`; validate against the ASG schema; retire the `attribute-missing`
   per-line hack (#564).

--- a/parser/src/blocks/admonition.rs
+++ b/parser/src/blocks/admonition.rs
@@ -373,8 +373,8 @@ impl<'src> IsBlock<'src> for AdmonitionBlock<'src> {
         Some(self.variant.style())
     }
 
-    fn rendered_content(&'src self) -> Option<&'src str> {
-        self.content.as_ref().map(|content| content.rendered())
+    fn rendered_html_content(&'src self) -> Option<&'src str> {
+        self.content.as_ref().map(|content| content.rendered_html())
     }
 
     fn inlines(&'src self) -> Option<&'src [InlineNode<'src>]> {
@@ -568,8 +568,11 @@ mod tests {
         assert_eq!(admonition.label(), "Note");
         assert!(!admonition.icons_font());
         assert_eq!(admonition.content_model(), ContentModel::Simple);
-        assert_eq!(admonition.content().unwrap().rendered(), "This is a note.");
-        assert_eq!(admonition.rendered_content(), Some("This is a note."));
+        assert_eq!(
+            admonition.content().unwrap().rendered_html(),
+            "This is a note."
+        );
+        assert_eq!(admonition.rendered_html_content(), Some("This is a note."));
         assert_eq!(admonition.raw_context().deref(), "admonition");
         assert_eq!(admonition.resolved_context().deref(), "admonition");
         assert_eq!(admonition.declared_style(), Some("NOTE"));
@@ -599,7 +602,7 @@ mod tests {
         let block = parse_one("NOTE: first line\nsecond line");
         let admonition = as_admonition(&block);
         assert_eq!(
-            admonition.content().unwrap().rendered(),
+            admonition.content().unwrap().rendered_html(),
             "first line\nsecond line"
         );
     }
@@ -610,7 +613,7 @@ mod tests {
         let admonition = as_admonition(&block);
         assert_eq!(admonition.variant(), AdmonitionVariant::Note);
         assert_eq!(
-            admonition.content().unwrap().rendered(),
+            admonition.content().unwrap().rendered_html(),
             "indented with a tab"
         );
     }
@@ -648,7 +651,7 @@ mod tests {
         assert_eq!(admonition.variant(), AdmonitionVariant::Note);
         assert_eq!(admonition.content_model(), ContentModel::Compound);
         assert!(admonition.content().is_none());
-        assert!(admonition.rendered_content().is_none());
+        assert!(admonition.rendered_html_content().is_none());
         assert_eq!(admonition.child_blocks().count(), 1);
     }
 
@@ -685,7 +688,7 @@ mod tests {
         assert_eq!(admonition.variant(), AdmonitionVariant::Tip);
         assert_eq!(admonition.content_model(), ContentModel::Simple);
         assert_eq!(
-            admonition.content().unwrap().rendered(),
+            admonition.content().unwrap().rendered_html(),
             "A single paragraph."
         );
     }
@@ -766,7 +769,7 @@ mod tests {
         // (rather than calling through the unwrapped `AdmonitionBlock`).
         let simple = parse_one("NOTE: text");
         assert_eq!(simple.content_model(), ContentModel::Simple);
-        assert_eq!(simple.rendered_content(), Some("text"));
+        assert_eq!(simple.rendered_html_content(), Some("text"));
         assert_eq!(simple.raw_context().deref(), "admonition");
         assert_eq!(simple.declared_style(), Some("NOTE"));
         assert!(simple.title_source().is_none());

--- a/parser/src/blocks/block.rs
+++ b/parser/src/blocks/block.rs
@@ -1028,22 +1028,22 @@ impl<'src> IsBlock<'src> for Block<'src> {
         }
     }
 
-    fn rendered_content(&'src self) -> Option<&'src str> {
+    fn rendered_html_content(&'src self) -> Option<&'src str> {
         match self {
-            Self::Simple(b) => b.rendered_content(),
-            Self::Media(b) => b.rendered_content(),
-            Self::Section(b) => b.rendered_content(),
-            Self::List(b) => b.rendered_content(),
-            Self::ListItem(b) => b.rendered_content(),
-            Self::RawDelimited(b) => b.rendered_content(),
-            Self::CompoundDelimited(b) => b.rendered_content(),
-            Self::Admonition(b) => b.rendered_content(),
-            Self::Quote(b) => b.rendered_content(),
-            Self::Table(b) => b.rendered_content(),
-            Self::Preamble(b) => b.rendered_content(),
-            Self::Break(b) => b.rendered_content(),
-            Self::Toc(b) => b.rendered_content(),
-            Self::DocumentAttribute(b) => b.rendered_content(),
+            Self::Simple(b) => b.rendered_html_content(),
+            Self::Media(b) => b.rendered_html_content(),
+            Self::Section(b) => b.rendered_html_content(),
+            Self::List(b) => b.rendered_html_content(),
+            Self::ListItem(b) => b.rendered_html_content(),
+            Self::RawDelimited(b) => b.rendered_html_content(),
+            Self::CompoundDelimited(b) => b.rendered_html_content(),
+            Self::Admonition(b) => b.rendered_html_content(),
+            Self::Quote(b) => b.rendered_html_content(),
+            Self::Table(b) => b.rendered_html_content(),
+            Self::Preamble(b) => b.rendered_html_content(),
+            Self::Break(b) => b.rendered_html_content(),
+            Self::Toc(b) => b.rendered_html_content(),
+            Self::DocumentAttribute(b) => b.rendered_html_content(),
         }
     }
 

--- a/parser/src/blocks/compound_delimited.rs
+++ b/parser/src/blocks/compound_delimited.rs
@@ -755,7 +755,7 @@ mod tests {
             );
 
             assert_eq!(mi.item.content_model(), ContentModel::Compound);
-            assert!(mi.item.rendered_content().is_none());
+            assert!(mi.item.rendered_html_content().is_none());
             assert_eq!(mi.item.raw_context().as_ref(), "example");
             assert_eq!(mi.item.resolved_context().as_ref(), "example");
             assert!(mi.item.declared_style().is_none());

--- a/parser/src/blocks/is_block.rs
+++ b/parser/src/blocks/is_block.rs
@@ -33,7 +33,7 @@ pub trait IsBlock<'src>: Debug + Eq + PartialEq {
     ///
     /// This content will contain the text _after_ substitutions have been
     /// applied.
-    fn rendered_content(&'src self) -> Option<&'src str> {
+    fn rendered_html_content(&'src self) -> Option<&'src str> {
         None
     }
 
@@ -41,9 +41,9 @@ pub trait IsBlock<'src>: Debug + Eq + PartialEq {
     /// read-only representation of its inline nodes.
     ///
     /// This is the structured counterpart of
-    /// [`rendered_content`](Self::rendered_content) – the same blocks carry
-    /// each – so a block with no directly-contained content returns `None`
-    /// here too.
+    /// [`rendered_html_content`](Self::rendered_html_content) – the same blocks
+    /// carry each – so a block with no directly-contained content returns
+    /// `None` here too.
     ///
     /// The tree is populated only when inline-tree building is enabled on the
     /// [`Parser`](crate::Parser) (see

--- a/parser/src/blocks/list.rs
+++ b/parser/src/blocks/list.rs
@@ -784,11 +784,19 @@ mod tests {
         assert_eq!(items.len(), 2);
 
         assert_eq!(
-            items[0].child_blocks().next().unwrap().rendered_content(),
+            items[0]
+                .child_blocks()
+                .next()
+                .unwrap()
+                .rendered_html_content(),
             Some("First")
         );
         assert_eq!(
-            items[1].child_blocks().next().unwrap().rendered_content(),
+            items[1]
+                .child_blocks()
+                .next()
+                .unwrap()
+                .rendered_html_content(),
             Some("Second")
         );
 
@@ -1427,7 +1435,7 @@ mod tests {
         assert!(matches!(mi.item, crate::blocks::Block::List(_)));
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert!(mi.item.rendered_content().is_none());
+        assert!(mi.item.rendered_html_content().is_none());
         assert_eq!(mi.item.raw_context().as_ref(), "list");
         assert_eq!(mi.item.child_blocks().count(), 1);
         assert!(mi.item.title_source().is_none());

--- a/parser/src/blocks/list_item_marker.rs
+++ b/parser/src/blocks/list_item_marker.rs
@@ -223,8 +223,8 @@ impl<'src> ListItemMarker<'src> {
         // it, so that only its own duplicate-registration warning is suppressed
         // during that pass. Any other term goes straight through the macros
         // step.
-        if term.rendered().starts_with("[[") {
-            if let Some(captures) = LEADING_INLINE_ANCHOR.captures(term.rendered()) {
+        if term.rendered_html().starts_with("[[") {
+            if let Some(captures) = LEADING_INLINE_ANCHOR.captures(term.rendered_html()) {
                 let id = &captures[1];
 
                 // If reftext is provided, use it. Otherwise, use the text after
@@ -680,7 +680,9 @@ mod tests {
         assert!(warnings.is_empty());
 
         match &item {
-            crate::blocks::ListItemMarker::DefinedTerm { term, .. } => term.rendered().to_string(),
+            crate::blocks::ListItemMarker::DefinedTerm { term, .. } => {
+                term.rendered_html().to_string()
+            }
             other => panic!("expected a defined-term marker, got {other:#?}"),
         }
     }

--- a/parser/src/blocks/preamble.rs
+++ b/parser/src/blocks/preamble.rs
@@ -217,7 +217,7 @@ mod tests {
         );
 
         assert_eq!(preamble.content_model(), ContentModel::Compound);
-        assert!(preamble.rendered_content().is_none());
+        assert!(preamble.rendered_html_content().is_none());
         assert_eq!(preamble.raw_context().as_ref(), "preamble");
         assert_eq!(preamble.resolved_context().as_ref(), "preamble");
         assert!(preamble.declared_style().is_none());

--- a/parser/src/blocks/quote.rs
+++ b/parser/src/blocks/quote.rs
@@ -776,8 +776,8 @@ impl<'src> IsBlock<'src> for QuoteBlock<'src> {
             .and_then(|attrlist| attrlist.block_style())
     }
 
-    fn rendered_content(&'src self) -> Option<&'src str> {
-        self.content.as_ref().map(|content| content.rendered())
+    fn rendered_html_content(&'src self) -> Option<&'src str> {
+        self.content.as_ref().map(|content| content.rendered_html())
     }
 
     fn inlines(&'src self) -> Option<&'src [InlineNode<'src>]> {
@@ -936,11 +936,11 @@ mod tests {
         assert_eq!(quote.type_(), QuoteType::Quote);
         assert_eq!(quote.content_model(), ContentModel::Simple);
         assert_eq!(
-            quote.content().unwrap().rendered(),
+            quote.content().unwrap().rendered_html(),
             "A person who never made a mistake."
         );
         assert_eq!(
-            quote.rendered_content(),
+            quote.rendered_html_content(),
             Some("A person who never made a mistake.")
         );
         assert_eq!(quote.attribution(), Some("Albert Einstein"));
@@ -956,7 +956,7 @@ mod tests {
         assert_eq!(quote.content_model(), ContentModel::Simple);
         assert_eq!(quote.raw_context().deref(), "verse");
         assert_eq!(
-            quote.content().unwrap().rendered(),
+            quote.content().unwrap().rendered_html(),
             "The fog comes\non little cat feet."
         );
         assert_eq!(quote.attribution(), Some("Carl Sandburg"));
@@ -971,7 +971,7 @@ mod tests {
         assert_eq!(quote.type_(), QuoteType::Verse);
         assert_eq!(quote.content_model(), ContentModel::Simple);
         assert_eq!(
-            quote.content().unwrap().rendered(),
+            quote.content().unwrap().rendered_html(),
             "A verse\ndelimited block"
         );
         assert!(quote.child_blocks().next().is_none());
@@ -1003,7 +1003,7 @@ mod tests {
         assert_eq!(quote.type_(), QuoteType::Quote);
         assert_eq!(quote.content_model(), ContentModel::Simple);
         assert_eq!(
-            quote.content().unwrap().rendered(),
+            quote.content().unwrap().rendered_html(),
             "A little rebellion is good."
         );
         assert_eq!(quote.attribution(), Some("Thomas Jefferson"));
@@ -1073,7 +1073,7 @@ mod tests {
             parse_one("\"line one\n-- not really an attribution\nline two\"\n-- Real Attribution");
         let quote = as_quote(&block);
         assert_eq!(quote.attribution(), Some("Real Attribution"));
-        let rendered = quote.content().unwrap().rendered();
+        let rendered = quote.content().unwrap().rendered_html();
         assert!(
             rendered.contains("line one") && rendered.contains("line two"),
             "content was: {rendered}"
@@ -1170,7 +1170,7 @@ mod tests {
 
         assert_eq!(quote.blocks().len(), 1);
         let inner = quote.blocks().first().unwrap();
-        assert_eq!(inner.rendered_content(), Some("line one\nline two"));
+        assert_eq!(inner.rendered_html_content(), Some("line one\nline two"));
     }
 
     #[test]
@@ -1233,7 +1233,7 @@ mod tests {
         assert!(format!("{compound:?}").starts_with("Block::Quote"));
 
         let simple = parse_one("[verse]\nverse text");
-        assert_eq!(simple.rendered_content(), Some("verse text"));
+        assert_eq!(simple.rendered_html_content(), Some("verse text"));
         assert_eq!(simple.content_model(), ContentModel::Simple);
     }
 

--- a/parser/src/blocks/raw_delimited.rs
+++ b/parser/src/blocks/raw_delimited.rs
@@ -397,8 +397,8 @@ impl<'src> IsBlock<'src> for RawDelimitedBlock<'src> {
         Some(&mut self.content)
     }
 
-    fn rendered_content(&self) -> Option<&str> {
-        Some(self.content.rendered())
+    fn rendered_html_content(&self) -> Option<&str> {
+        Some(self.content.rendered_html())
     }
 
     fn inlines(&'src self) -> Option<&'src [InlineNode<'src>]> {
@@ -777,7 +777,7 @@ mod tests {
             );
 
             assert_eq!(mi.item.content_model(), ContentModel::Raw);
-            assert_eq!(mi.item.rendered_content().unwrap(), "");
+            assert_eq!(mi.item.rendered_html_content().unwrap(), "");
             assert_eq!(mi.item.raw_context().as_ref(), "comment");
             assert_eq!(mi.item.resolved_context().as_ref(), "comment");
             assert!(mi.item.declared_style().is_none());
@@ -837,7 +837,7 @@ mod tests {
             );
 
             assert_eq!(mi.item.content_model(), ContentModel::Raw);
-            assert_eq!(mi.item.rendered_content().unwrap(), "line1  \nline2");
+            assert_eq!(mi.item.rendered_html_content().unwrap(), "line1  \nline2");
             assert_eq!(mi.item.raw_context().as_ref(), "comment");
             assert_eq!(mi.item.resolved_context().as_ref(), "comment");
             assert!(mi.item.declared_style().is_none());
@@ -1634,7 +1634,7 @@ mod tests {
             assert_eq!(block.raw_context().as_ref(), "stem");
             assert_eq!(block.resolved_context().as_ref(), "stem");
             assert_eq!(block.declared_style(), Some("stem"));
-            assert_eq!(block.rendered_content(), Some("a &lt; b"));
+            assert_eq!(block.rendered_html_content(), Some("a &lt; b"));
             assert_eq!(block.substitution_group(), SubstitutionGroup::Stem);
             assert!(doc.warnings().next().is_none());
         }
@@ -1646,7 +1646,7 @@ mod tests {
 
             assert_eq!(block.raw_context().as_ref(), "stem");
             assert_eq!(block.declared_style(), Some("asciimath"));
-            assert_eq!(block.rendered_content(), Some("x^2"));
+            assert_eq!(block.rendered_html_content(), Some("x^2"));
         }
 
         #[test]
@@ -1656,7 +1656,7 @@ mod tests {
 
             assert_eq!(block.raw_context().as_ref(), "stem");
             assert_eq!(block.declared_style(), Some("latexmath"));
-            assert_eq!(block.rendered_content(), Some(r"C = \alpha"));
+            assert_eq!(block.rendered_html_content(), Some(r"C = \alpha"));
         }
 
         /// Without a STEM style, a `++++` block remains a `pass` block with no
@@ -1667,7 +1667,7 @@ mod tests {
             let block = doc.child_blocks().next().unwrap();
 
             assert_eq!(block.raw_context().as_ref(), "pass");
-            assert_eq!(block.rendered_content(), Some("a < b"));
+            assert_eq!(block.rendered_html_content(), Some("a < b"));
             assert_eq!(block.substitution_group(), SubstitutionGroup::Pass);
         }
 
@@ -1679,7 +1679,7 @@ mod tests {
             let block = doc.child_blocks().next().unwrap();
 
             assert_eq!(block.raw_context().as_ref(), "stem");
-            assert_eq!(block.rendered_content(), Some("a < b"));
+            assert_eq!(block.rendered_html_content(), Some("a < b"));
             assert_eq!(block.substitution_group(), SubstitutionGroup::None);
         }
     }

--- a/parser/src/blocks/section.rs
+++ b/parser/src/blocks/section.rs
@@ -262,7 +262,7 @@ impl<'src> SectionBlock<'src> {
 
         // The footnote-free rendering of the title, for the reference text and
         // auto-generated ID; a no-op string copy when the title had no footnote.
-        let title_reftext = strip_footnote_marker_spans(section_title.rendered());
+        let title_reftext = strip_footnote_marker_spans(section_title.rendered_html());
 
         // Strip the now-consumed sentinels from the title itself, keeping the
         // footnote marker so the heading still renders it.
@@ -469,7 +469,7 @@ impl<'src> SectionBlock<'src> {
     /// Return the processed section title after substitutions have been
     /// applied.
     pub fn section_title(&'src self) -> &'src str {
-        self.section_title.rendered()
+        self.section_title.rendered_html()
     }
 
     /// Return the type of this section (normal or appendix).
@@ -4016,7 +4016,7 @@ mod tests {
             let Some(Block::Simple(paragraph)) = section.child_blocks().next() else {
                 panic!("expected a simple block");
             };
-            assert_eq!(paragraph.content().rendered(), "Letter A.");
+            assert_eq!(paragraph.content().rendered_html(), "Letter A.");
         }
     }
 

--- a/parser/src/blocks/simple.rs
+++ b/parser/src/blocks/simple.rs
@@ -583,8 +583,8 @@ impl<'src> IsBlock<'src> for SimpleBlock<'src> {
         Some(&mut self.content)
     }
 
-    fn rendered_content(&self) -> Option<&str> {
-        Some(self.content.rendered())
+    fn rendered_html_content(&self) -> Option<&str> {
+        Some(self.content.rendered_html())
     }
 
     fn inlines(&'src self) -> Option<&'src [InlineNode<'src>]> {
@@ -777,7 +777,7 @@ mod tests {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Simple);
-        assert_eq!(mi.item.rendered_content().unwrap(), "abc");
+        assert_eq!(mi.item.rendered_html_content().unwrap(), "abc");
         assert_eq!(mi.item.raw_context().deref(), "paragraph");
         assert_eq!(mi.item.resolved_context().deref(), "paragraph");
         assert!(mi.item.declared_style().is_none());
@@ -847,7 +847,7 @@ mod tests {
             }
         );
 
-        assert_eq!(mi.item.rendered_content().unwrap(), "abc\ndef");
+        assert_eq!(mi.item.rendered_html_content().unwrap(), "abc\ndef");
     }
 
     #[test]
@@ -958,7 +958,7 @@ mod tests {
         );
 
         assert_eq!(
-            mi.item.rendered_content().unwrap(),
+            mi.item.rendered_html_content().unwrap(),
             "a<b>c <strong>bold</strong>"
         );
     }

--- a/parser/src/blocks/table.rs
+++ b/parser/src/blocks/table.rs
@@ -2047,7 +2047,7 @@ fn parse_asciidoc_cell_body<'src>(
         title_source.map(|span| {
             let mut content = Content::from(span);
             SubstitutionGroup::Header.apply(&mut content, parser, None);
-            content.rendered().to_string()
+            content.rendered_html().to_string()
         })
     } else {
         None

--- a/parser/src/blocks/tests/break.rs
+++ b/parser/src/blocks/tests/break.rs
@@ -90,7 +90,7 @@ fn thematic_break_triple_apostrophe() {
     );
 
     assert_eq!(mi.item.content_model(), ContentModel::Empty);
-    assert!(mi.item.rendered_content().is_none());
+    assert!(mi.item.rendered_html_content().is_none());
     assert_eq!(mi.item.raw_context().deref(), "thematic_break");
     assert!(mi.item.child_blocks().next().is_none());
     assert!(mi.item.title_source().is_none());
@@ -147,7 +147,7 @@ fn thematic_break_triple_hyphen() {
     );
 
     assert_eq!(mi.item.content_model(), ContentModel::Empty);
-    assert!(mi.item.rendered_content().is_none());
+    assert!(mi.item.rendered_html_content().is_none());
     assert_eq!(mi.item.raw_context().deref(), "thematic_break");
 }
 
@@ -177,7 +177,7 @@ fn thematic_break_spaced_hyphen() {
     );
 
     assert_eq!(mi.item.content_model(), ContentModel::Empty);
-    assert!(mi.item.rendered_content().is_none());
+    assert!(mi.item.rendered_html_content().is_none());
     assert_eq!(mi.item.raw_context().deref(), "thematic_break");
 }
 
@@ -207,7 +207,7 @@ fn thematic_break_triple_asterisk() {
     );
 
     assert_eq!(mi.item.content_model(), ContentModel::Empty);
-    assert!(mi.item.rendered_content().is_none());
+    assert!(mi.item.rendered_html_content().is_none());
     assert_eq!(mi.item.raw_context().deref(), "thematic_break");
 }
 
@@ -237,7 +237,7 @@ fn thematic_break_spaced_asterisk() {
     );
 
     assert_eq!(mi.item.content_model(), ContentModel::Empty);
-    assert!(mi.item.rendered_content().is_none());
+    assert!(mi.item.rendered_html_content().is_none());
     assert_eq!(mi.item.raw_context().deref(), "thematic_break");
 }
 
@@ -277,7 +277,7 @@ fn page_break() {
     );
 
     assert_eq!(mi.item.content_model(), ContentModel::Empty);
-    assert!(mi.item.rendered_content().is_none());
+    assert!(mi.item.rendered_html_content().is_none());
     assert_eq!(mi.item.raw_context().deref(), "page_break");
     assert!(mi.item.child_blocks().next().is_none());
     assert!(mi.item.title_source().is_none());

--- a/parser/src/blocks/tests/compound_delimited.rs
+++ b/parser/src/blocks/tests/compound_delimited.rs
@@ -244,7 +244,7 @@ mod example {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert!(mi.item.rendered_content().is_none());
+        assert!(mi.item.rendered_html_content().is_none());
         assert_eq!(mi.item.raw_context().as_ref(), "example");
         assert_eq!(mi.item.resolved_context().as_ref(), "example");
         assert!(mi.item.declared_style().is_none());
@@ -353,7 +353,7 @@ mod example {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert!(mi.item.rendered_content().is_none());
+        assert!(mi.item.rendered_html_content().is_none());
         assert_eq!(mi.item.raw_context().as_ref(), "example");
         assert_eq!(mi.item.resolved_context().as_ref(), "example");
         assert!(mi.item.id().is_none());
@@ -526,7 +526,7 @@ mod example {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert!(mi.item.rendered_content().is_none());
+        assert!(mi.item.rendered_html_content().is_none());
         assert_eq!(mi.item.raw_context().as_ref(), "example");
         assert_eq!(mi.item.resolved_context().as_ref(), "example");
         assert!(mi.item.id().is_none());
@@ -722,7 +722,7 @@ mod example {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert!(mi.item.rendered_content().is_none());
+        assert!(mi.item.rendered_html_content().is_none());
         assert_eq!(mi.item.raw_context().as_ref(), "example");
         assert_eq!(mi.item.resolved_context().as_ref(), "example");
         assert!(mi.item.id().is_none());
@@ -858,7 +858,7 @@ mod open {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert!(mi.item.rendered_content().is_none());
+        assert!(mi.item.rendered_html_content().is_none());
         assert_eq!(mi.item.raw_context().as_ref(), "open");
         assert_eq!(mi.item.resolved_context().as_ref(), "open");
         assert!(mi.item.child_blocks().next().is_none());
@@ -963,7 +963,7 @@ mod open {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert!(mi.item.rendered_content().is_none());
+        assert!(mi.item.rendered_html_content().is_none());
         assert_eq!(mi.item.raw_context().as_ref(), "open");
         assert_eq!(mi.item.resolved_context().as_ref(), "open");
         assert!(mi.item.id().is_none());
@@ -1143,7 +1143,7 @@ mod open {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert!(mi.item.rendered_content().is_none());
+        assert!(mi.item.rendered_html_content().is_none());
         assert_eq!(mi.item.raw_context().as_ref(), "open");
         assert_eq!(mi.item.resolved_context().as_ref(), "open");
         assert!(mi.item.id().is_none());
@@ -1277,7 +1277,7 @@ mod sidebar {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert!(mi.item.rendered_content().is_none());
+        assert!(mi.item.rendered_html_content().is_none());
         assert_eq!(mi.item.raw_context().as_ref(), "sidebar");
         assert_eq!(mi.item.resolved_context().as_ref(), "sidebar");
         assert!(mi.item.child_blocks().next().is_none());
@@ -1384,7 +1384,7 @@ mod sidebar {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert!(mi.item.rendered_content().is_none());
+        assert!(mi.item.rendered_html_content().is_none());
         assert_eq!(mi.item.raw_context().as_ref(), "sidebar");
         assert_eq!(mi.item.resolved_context().as_ref(), "sidebar");
         assert!(mi.item.id().is_none());
@@ -1568,7 +1568,7 @@ mod sidebar {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Compound);
-        assert!(mi.item.rendered_content().is_none());
+        assert!(mi.item.rendered_html_content().is_none());
         assert_eq!(mi.item.raw_context().as_ref(), "sidebar");
         assert_eq!(mi.item.resolved_context().as_ref(), "sidebar");
         assert!(mi.item.id().is_none());

--- a/parser/src/blocks/tests/media.rs
+++ b/parser/src/blocks/tests/media.rs
@@ -343,7 +343,7 @@ fn has_target() {
     );
 
     assert_eq!(mi.item.content_model(), ContentModel::Empty);
-    assert!(mi.item.rendered_content().is_none());
+    assert!(mi.item.rendered_html_content().is_none());
     assert_eq!(mi.item.raw_context().deref(), "image");
     assert!(mi.item.child_blocks().next().is_none());
     assert!(mi.item.title_source().is_none());

--- a/parser/src/blocks/tests/mod.rs
+++ b/parser/src/blocks/tests/mod.rs
@@ -241,7 +241,7 @@ mod caption_and_number {
             .find(|b| b.declared_style() == Some("literal"))
             .unwrap();
 
-        assert_eq!(literal.rendered_content(), Some("literal text"));
+        assert_eq!(literal.rendered_html_content(), Some("literal text"));
         assert!(literal.caption().is_none());
         assert!(literal.number().is_none());
     }
@@ -401,7 +401,7 @@ mod error_cases {
         let blocks: Vec<_> = doc.child_blocks().collect();
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0].roles(), vec!["myrole"]);
-        assert_eq!(blocks[0].rendered_content(), Some("def"));
+        assert_eq!(blocks[0].rendered_html_content(), Some("def"));
         assert!(doc.warnings().next().is_none());
     }
 
@@ -414,7 +414,7 @@ mod error_cases {
         let blocks: Vec<_> = doc.child_blocks().collect();
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0].title(), Some("My Title"));
-        assert_eq!(blocks[0].rendered_content(), Some("def"));
+        assert_eq!(blocks[0].rendered_html_content(), Some("def"));
         assert!(doc.warnings().next().is_none());
     }
 

--- a/parser/src/blocks/tests/raw_delimited.rs
+++ b/parser/src/blocks/tests/raw_delimited.rs
@@ -252,7 +252,7 @@ mod comment {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.rendered_content(), Some(""));
+        assert_eq!(mi.item.rendered_html_content(), Some(""));
         assert_eq!(mi.item.raw_context().as_ref(), "comment");
         assert_eq!(mi.item.resolved_context().as_ref(), "comment");
         assert!(mi.item.declared_style().is_none());
@@ -315,7 +315,7 @@ mod comment {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.rendered_content(), Some("line1  \nline2"));
+        assert_eq!(mi.item.rendered_html_content(), Some("line1  \nline2"));
         assert_eq!(mi.item.raw_context().as_ref(), "comment");
         assert_eq!(mi.item.resolved_context().as_ref(), "comment");
         assert!(mi.item.declared_style().is_none());
@@ -385,7 +385,7 @@ mod comment {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.rendered_content(), Some("line1  \nline2"));
+        assert_eq!(mi.item.rendered_html_content(), Some("line1  \nline2"));
         assert_eq!(mi.item.raw_context().as_ref(), "comment");
         assert_eq!(mi.item.resolved_context().as_ref(), "comment");
         assert!(mi.item.declared_style().is_none());
@@ -443,7 +443,10 @@ mod comment {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.rendered_content(), Some("line1  \n/////\nline2"));
+        assert_eq!(
+            mi.item.rendered_html_content(),
+            Some("line1  \n/////\nline2")
+        );
         assert_eq!(mi.item.raw_context().as_ref(), "comment");
         assert_eq!(mi.item.resolved_context().as_ref(), "comment");
         assert!(mi.item.declared_style().is_none());
@@ -505,7 +508,7 @@ mod listing {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
-        assert_eq!(mi.item.rendered_content(), Some(""));
+        assert_eq!(mi.item.rendered_html_content(), Some(""));
         assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert_eq!(mi.item.resolved_context().as_ref(), "listing");
         assert!(mi.item.declared_style().is_none());
@@ -563,7 +566,7 @@ mod listing {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
-        assert_eq!(mi.item.rendered_content(), Some("line1  \nline2"));
+        assert_eq!(mi.item.rendered_html_content(), Some("line1  \nline2"));
         assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert_eq!(mi.item.resolved_context().as_ref(), "listing");
         assert!(mi.item.declared_style().is_none());
@@ -637,7 +640,7 @@ mod listing {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
-        assert_eq!(mi.item.rendered_content(), Some("line1  \nline2"));
+        assert_eq!(mi.item.rendered_html_content(), Some("line1  \nline2"));
         assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert_eq!(mi.item.resolved_context().as_ref(), "listing");
         assert!(mi.item.declared_style().is_none());
@@ -718,7 +721,10 @@ mod listing {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
-        assert_eq!(mi.item.rendered_content(), Some("line1  \n----/\nline2"));
+        assert_eq!(
+            mi.item.rendered_html_content(),
+            Some("line1  \n----/\nline2")
+        );
         assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert_eq!(mi.item.resolved_context().as_ref(), "listing");
         assert!(mi.item.declared_style().is_none());
@@ -793,7 +799,7 @@ mod fenced {
         // A fenced code block resolves to the same context and content model as
         // a `----` listing block.
         assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
-        assert_eq!(mi.item.rendered_content(), Some(""));
+        assert_eq!(mi.item.rendered_html_content(), Some(""));
         assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert_eq!(mi.item.resolved_context().as_ref(), "listing");
         assert!(mi.item.declared_style().is_none());
@@ -841,7 +847,7 @@ mod fenced {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
-        assert_eq!(mi.item.rendered_content(), Some("line1  \nline2"));
+        assert_eq!(mi.item.rendered_html_content(), Some("line1  \nline2"));
         assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert_eq!(mi.item.resolved_context().as_ref(), "listing");
         assert_eq!(mi.item.substitution_group(), SubstitutionGroup::Verbatim);
@@ -875,7 +881,7 @@ mod fenced {
         assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert_eq!(mi.item.resolved_context().as_ref(), "listing");
         assert_eq!(mi.item.declared_style(), Some("source"));
-        assert_eq!(mi.item.rendered_content(), Some("puts 'hi'"));
+        assert_eq!(mi.item.rendered_html_content(), Some("puts 'hi'"));
     }
 
     #[test]
@@ -949,7 +955,7 @@ mod fenced {
         assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert_eq!(mi.item.resolved_context().as_ref(), "listing");
         assert_eq!(mi.item.declared_style(), Some("source"));
-        assert_eq!(mi.item.rendered_content(), Some("puts 'hi'"));
+        assert_eq!(mi.item.rendered_html_content(), Some("puts 'hi'"));
 
         assert_eq!(
             mi.item
@@ -974,7 +980,7 @@ mod fenced {
 
         assert_eq!(mi.item.resolved_context().as_ref(), "listing");
         assert_eq!(mi.item.declared_style(), Some("source"));
-        assert_eq!(mi.item.rendered_content(), Some("let x = 1;"));
+        assert_eq!(mi.item.rendered_html_content(), Some("let x = 1;"));
 
         assert_eq!(
             mi.item
@@ -1001,7 +1007,7 @@ mod fenced {
 
         assert_eq!(mi.item.resolved_context().as_ref(), "listing");
         assert_eq!(mi.item.declared_style(), Some("source"));
-        assert_eq!(mi.item.rendered_content(), Some("print('hi')"));
+        assert_eq!(mi.item.rendered_html_content(), Some("print('hi')"));
 
         assert_eq!(
             mi.item
@@ -1024,7 +1030,7 @@ mod fenced {
 
         assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert_eq!(mi.item.declared_style(), Some("source"));
-        assert_eq!(mi.item.rendered_content(), Some("puts 'hi'"));
+        assert_eq!(mi.item.rendered_html_content(), Some("puts 'hi'"));
 
         assert_eq!(
             maw.warnings,
@@ -1067,7 +1073,7 @@ mod fenced {
 
         assert_eq!(mi.item.raw_context().as_ref(), "listing");
         assert_eq!(mi.item.content_model(), ContentModel::Verbatim);
-        assert_eq!(mi.item.rendered_content(), Some("source code"));
+        assert_eq!(mi.item.rendered_html_content(), Some("source code"));
 
         assert_eq!(
             maw.warnings,
@@ -1111,7 +1117,7 @@ mod fenced {
         let mi = maw.item.unwrap().clone();
 
         assert_eq!(mi.item.raw_context().as_ref(), "listing");
-        assert_eq!(mi.item.rendered_content(), Some("source code\n````"));
+        assert_eq!(mi.item.rendered_html_content(), Some("source code\n````"));
         assert_eq!(
             maw.warnings,
             vec![Warning {
@@ -1170,7 +1176,7 @@ mod pass {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.rendered_content(), Some(""));
+        assert_eq!(mi.item.rendered_html_content(), Some(""));
         assert_eq!(mi.item.raw_context().as_ref(), "pass");
         assert_eq!(mi.item.resolved_context().as_ref(), "pass");
         assert!(mi.item.declared_style().is_none());
@@ -1239,7 +1245,7 @@ mod pass {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.rendered_content(), Some("line1  \nline2"));
+        assert_eq!(mi.item.rendered_html_content(), Some("line1  \nline2"));
         assert_eq!(mi.item.raw_context().as_ref(), "pass");
         assert_eq!(mi.item.resolved_context().as_ref(), "pass");
         assert!(mi.item.declared_style().is_none());
@@ -1313,7 +1319,7 @@ mod pass {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.rendered_content(), Some("line1  \nline2"));
+        assert_eq!(mi.item.rendered_html_content(), Some("line1  \nline2"));
         assert_eq!(mi.item.raw_context().as_ref(), "pass");
         assert_eq!(mi.item.resolved_context().as_ref(), "pass");
         assert!(mi.item.declared_style().is_none());
@@ -1394,7 +1400,10 @@ mod pass {
         );
 
         assert_eq!(mi.item.content_model(), ContentModel::Raw);
-        assert_eq!(mi.item.rendered_content(), Some("line1  \n++++/\nline2"));
+        assert_eq!(
+            mi.item.rendered_html_content(),
+            Some("line1  \n++++/\nline2")
+        );
         assert_eq!(mi.item.raw_context().as_ref(), "pass");
         assert_eq!(mi.item.resolved_context().as_ref(), "pass");
         assert!(mi.item.declared_style().is_none());

--- a/parser/src/blocks/tests/section.rs
+++ b/parser/src/blocks/tests/section.rs
@@ -79,7 +79,7 @@ fn simplest_section_block() {
         .unwrap();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert!(mi.item.rendered_content().is_none());
+    assert!(mi.item.rendered_html_content().is_none());
     assert_eq!(mi.item.raw_context().deref(), "section");
     assert_eq!(mi.item.resolved_context().deref(), "section");
     assert!(mi.item.declared_style().is_none());
@@ -147,7 +147,7 @@ fn has_child_block() {
         .unwrap();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert!(mi.item.rendered_content().is_none());
+    assert!(mi.item.rendered_html_content().is_none());
     assert_eq!(mi.item.raw_context().deref(), "section");
     assert_eq!(mi.item.resolved_context().deref(), "section");
     assert!(mi.item.declared_style().is_none());
@@ -287,7 +287,7 @@ fn title() {
     .unwrap();
 
     assert_eq!(mi.item.content_model(), ContentModel::Compound);
-    assert!(mi.item.rendered_content().is_none());
+    assert!(mi.item.rendered_html_content().is_none());
     assert_eq!(mi.item.raw_context().deref(), "section");
     assert_eq!(mi.item.resolved_context().deref(), "section");
     assert!(mi.item.declared_style().is_none());

--- a/parser/src/blocks/tests/simple.rs
+++ b/parser/src/blocks/tests/simple.rs
@@ -85,7 +85,7 @@ fn single_line() {
     );
 
     assert_eq!(mi.item.content_model(), ContentModel::Simple);
-    assert_eq!(mi.item.rendered_content(), Some("abc"));
+    assert_eq!(mi.item.rendered_html_content(), Some("abc"));
     assert_eq!(mi.item.raw_context().deref(), "paragraph");
     assert_eq!(mi.item.resolved_context().deref(), "paragraph");
     assert!(mi.item.declared_style().is_none());
@@ -520,7 +520,7 @@ fn with_block_anchor_only() {
 
     assert_eq!(mi.item.content_model(), ContentModel::Simple);
     assert_eq!(
-        mi.item.rendered_content(),
+        mi.item.rendered_html_content(),
         Some("This paragraph gets a lot of attention.")
     );
     assert_eq!(mi.item.raw_context().deref(), "paragraph");
@@ -623,7 +623,7 @@ fn with_block_anchor_trailing_comma() {
 
     assert_eq!(mi.item.content_model(), ContentModel::Simple);
     assert_eq!(
-        mi.item.rendered_content(),
+        mi.item.rendered_html_content(),
         Some("[[notice,]]\nThis paragraph gets a lot of attention.")
     );
     assert_eq!(mi.item.raw_context().deref(), "paragraph");
@@ -745,7 +745,7 @@ fn with_block_anchor_and_reftext() {
 
     assert_eq!(mi.item.content_model(), ContentModel::Simple);
     assert_eq!(
-        mi.item.rendered_content(),
+        mi.item.rendered_html_content(),
         Some("This paragraph gets a lot of attention.")
     );
     assert_eq!(mi.item.raw_context().deref(), "paragraph");
@@ -857,7 +857,7 @@ fn err_empty_block_anchor() {
 
     assert_eq!(mi.item.content_model(), ContentModel::Simple);
     assert_eq!(
-        mi.item.rendered_content(),
+        mi.item.rendered_html_content(),
         Some("This paragraph gets a lot of attention.")
     );
     assert_eq!(mi.item.raw_context().deref(), "paragraph");
@@ -901,7 +901,7 @@ fn terminal_empty_block_anchor_does_not_spin() {
     // produces nothing.
     let mut inner = block.child_blocks();
     assert_eq!(
-        inner.next().unwrap().rendered_content(),
+        inner.next().unwrap().rendered_html_content(),
         Some("Block content")
     );
     assert!(inner.next().is_none());
@@ -983,7 +983,7 @@ fn err_invalid_block_anchor() {
 
     assert_eq!(mi.item.content_model(), ContentModel::Simple);
     assert_eq!(
-        mi.item.rendered_content(),
+        mi.item.rendered_html_content(),
         Some("[[3 blind mice]]\nThis paragraph gets a lot of attention.")
     );
     assert_eq!(mi.item.raw_context().deref(), "paragraph");
@@ -1076,7 +1076,7 @@ fn unterminated_block_anchor() {
 
     assert_eq!(mi.item.content_model(), ContentModel::Simple);
     assert_eq!(
-        mi.item.rendered_content(),
+        mi.item.rendered_html_content(),
         Some("This paragraph gets a lot of attention.")
     );
     assert_eq!(mi.item.raw_context().deref(), "paragraph");
@@ -1478,7 +1478,7 @@ mod comment_directly_above_metadata {
         // blocks[0] is `first`; blocks[1] is the retained comment.
         assert_eq!(blocks[2].raw_context().as_ref(), "paragraph");
         assert_eq!(blocks[2].title(), Some("Title"));
-        assert_eq!(blocks[2].rendered_content(), Some("text"));
+        assert_eq!(blocks[2].rendered_html_content(), Some("text"));
     }
 
     #[test]
@@ -1497,7 +1497,7 @@ mod comment_directly_above_metadata {
         assert_eq!(blocks[1].span().data(), "// note");
 
         assert_eq!(blocks[2].raw_context().as_ref(), "paragraph");
-        assert_eq!(blocks[2].rendered_content(), Some("[ foo]"));
+        assert_eq!(blocks[2].rendered_html_content(), Some("[ foo]"));
     }
 
     #[test]
@@ -1523,6 +1523,6 @@ mod comment_directly_above_metadata {
 
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0].raw_context().as_ref(), "paragraph");
-        assert_eq!(blocks[0].rendered_content(), Some("Hello world"));
+        assert_eq!(blocks[0].rendered_html_content(), Some("Hello world"));
     }
 }

--- a/parser/src/blocks/tests/table.rs
+++ b/parser/src/blocks/tests/table.rs
@@ -32,7 +32,7 @@ fn row_text(row: &crate::blocks::TableRow<'_>) -> Vec<String> {
     row.cells()
         .iter()
         .map(|cell| match cell.content() {
-            TableCellContent::Simple(content) => content.rendered().to_string(),
+            TableCellContent::Simple(content) => content.rendered_html().to_string(),
             TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
         })
         .collect()
@@ -256,7 +256,7 @@ fn block_level_accessors() {
     assert_eq!(block.content_model(), ContentModel::Table);
     assert_eq!(block.raw_context().as_ref(), "table");
     assert_eq!(block.resolved_context().as_ref(), "table");
-    assert!(block.rendered_content().is_none());
+    assert!(block.rendered_html_content().is_none());
     assert_eq!(block.child_blocks().count(), 0);
     assert!(block.declared_style().is_none());
     assert!(block.id().is_none());
@@ -580,7 +580,7 @@ fn literal_column_processes_content_verbatim() {
 
     match table.body_rows()[0].cells()[0].content() {
         TableCellContent::Simple(content) => {
-            assert_eq!(content.rendered(), "lit *z* and &lt;x&gt;");
+            assert_eq!(content.rendered_html(), "lit *z* and &lt;x&gt;");
         }
         TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
     }
@@ -617,7 +617,7 @@ fn asciidoc_cell_resolves_references_in_nested_blocks() {
         TableCellContent::Simple(_) => panic!("expected AsciiDoc cell content"),
     };
 
-    let rendered = blocks[0].rendered_content().unwrap();
+    let rendered = blocks[0].rendered_html_content().unwrap();
     assert!(
         rendered.contains("href=\"#target\""),
         "xref was not resolved: {rendered}"
@@ -651,7 +651,7 @@ fn asciidoc_cell_attributes_are_scoped_to_the_cell() {
     // attribute resolve.
     let rendered: String = blocks
         .iter()
-        .filter_map(|block| block.rendered_content())
+        .filter_map(|block| block.rendered_html_content())
         .collect::<Vec<_>>()
         .join("\n");
     assert!(
@@ -873,7 +873,7 @@ fn asciidoc_cell_text(table: &TableBlock<'_>, row: usize, col: usize) -> String 
         TableCellContent::AsciiDoc(cell) => cell
             .blocks()
             .iter()
-            .filter_map(|block| block.rendered_content())
+            .filter_map(|block| block.rendered_html_content())
             .collect::<Vec<_>>()
             .join("\n"),
         TableCellContent::Simple(_) => panic!("expected AsciiDoc cell content"),

--- a/parser/src/blocks/tests/toc.rs
+++ b/parser/src/blocks/tests/toc.rs
@@ -52,7 +52,7 @@ fn simplest_toc_macro() {
     assert_eq!(mi.item.resolved_context().deref(), "toc");
 
     // Exercise the remaining `Block::Toc` accessor delegations.
-    assert!(mi.item.rendered_content().is_none());
+    assert!(mi.item.rendered_html_content().is_none());
     assert!(mi.item.declared_style().is_none());
     assert!(mi.item.title_source().is_none());
     assert!(mi.item.title().is_none());

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -28,15 +28,15 @@ use crate::{
 /// macros substitution therefore records each cross-reference in a deferred
 /// form and leaves an opaque placeholder in the rendered text. The
 /// references are resolved in a later pass – see
-/// [`Document::resolve_references`] – at which point [`rendered()`] reflects
-/// the resolved links. Until then, [`rendered()`] shows an unresolved fallback,
-/// so it always returns clean text.
+/// [`Document::resolve_references`] – at which point [`rendered_html()`]
+/// reflects the resolved links. Until then, [`rendered_html()`] shows an
+/// unresolved fallback, so it always returns clean text.
 ///
 /// [substitutions]: https://docs.asciidoctor.org/asciidoc/latest/subs/
 /// [`SimpleBlock`]: crate::blocks::SimpleBlock
 /// [`RawDelimitedBlock`]: crate::blocks::RawDelimitedBlock
 /// [`Document::resolve_references`]: crate::Document::resolve_references
-/// [`rendered()`]: Self::rendered
+/// [`rendered_html()`]: Self::rendered_html
 #[derive(Clone)]
 pub struct Content<'src> {
     /// The original [`Span`] from which this content was derived.
@@ -327,18 +327,28 @@ impl<'src> Content<'src> {
         self.source_lines.as_deref()
     }
 
-    /// Returns the final text after all substitutions have been applied.
-    pub fn rendered(&'src self) -> &'src str {
+    /// Returns the default **HTML** rendering of this content: the final text
+    /// after all substitutions have been applied.
+    ///
+    /// This is the built-in HTML output. (A custom
+    /// [`InlineSubstitutionRenderer`](crate::parser::InlineSubstitutionRenderer)
+    /// installed via
+    /// [`Parser::with_inline_substitution_renderer`](crate::Parser::with_inline_substitution_renderer)
+    /// still drives this output during migration; moving renderer selection to
+    /// render time is a later step of the [inline AST architecture].)
+    ///
+    /// [inline AST architecture]: https://github.com/scouten/asciidoc-parser/blob/main/docs/design/inline-ast-architecture.md
+    pub fn rendered_html(&'src self) -> &'src str {
         self.rendered.as_ref()
     }
 
     /// Returns the final rendered text, borrowed for the duration of `&self`
     /// rather than for `'src`.
     ///
-    /// [`rendered`](Self::rendered) ties its result to `'src`, which a block's
-    /// `title(&self)` accessor cannot provide. This shorter-lived borrow lets a
-    /// block expose its title `Content`'s rendered text through the `&self`
-    /// accessor.
+    /// [`rendered_html`](Self::rendered_html) ties its result to `'src`, which
+    /// a block's `title(&self)` accessor cannot provide. This shorter-lived
+    /// borrow lets a block expose its title `Content`'s rendered text
+    /// through the `&self` accessor.
     pub(crate) fn rendered_str(&self) -> &str {
         self.rendered.as_ref()
     }
@@ -346,10 +356,10 @@ impl<'src> Content<'src> {
     /// Returns an owned copy of the final text after all substitutions have
     /// been applied.
     ///
-    /// Unlike [`rendered()`](Self::rendered), this does not tie the returned
-    /// value to the `'src` lifetime, so it can be called on a short-lived
-    /// `Content` built solely to render a fragment (e.g. a block's attribution
-    /// or citation text).
+    /// Unlike [`rendered_html()`](Self::rendered_html), this does not tie the
+    /// returned value to the `'src` lifetime, so it can be called on a
+    /// short-lived `Content` built solely to render a fragment (e.g. a
+    /// block's attribution or citation text).
     pub(crate) fn rendered_owned(&self) -> String {
         self.rendered.as_ref().to_string()
     }
@@ -393,9 +403,9 @@ impl<'src> Content<'src> {
     /// [`Parser`](crate::Parser) (see
     /// [`with_inline_tree`](crate::Parser::with_inline_tree)); it is an empty
     /// slice otherwise. The tree is a projection of the rendered content – the
-    /// fold of the tree reproduces [`rendered`](Self::rendered) byte-for-byte –
-    /// and is not yet the canonical representation (see the [inline AST
-    /// architecture design], Phase 2).
+    /// fold of the tree reproduces [`rendered_html`](Self::rendered_html)
+    /// byte-for-byte – and is not yet the canonical representation (see the
+    /// [inline AST architecture design], Phase 2).
     ///
     /// Cross-references in the tree carry their resolved destination once a
     /// full [`Parser::parse`](crate::Parser::parse) has resolved the document's

--- a/parser/src/content/content.rs
+++ b/parser/src/content/content.rs
@@ -331,8 +331,7 @@ impl<'src> Content<'src> {
     /// after all substitutions have been applied.
     ///
     /// This is the built-in HTML output. (A custom
-    /// [`InlineSubstitutionRenderer`](crate::parser::InlineSubstitutionRenderer)
-    /// installed via
+    /// [`InlineSubstitutionRenderer`] installed via
     /// [`Parser::with_inline_substitution_renderer`](crate::Parser::with_inline_substitution_renderer)
     /// still drives this output during migration; moving renderer selection to
     /// render time is a later step of the [inline AST architecture].)

--- a/parser/src/content/inline_tree.rs
+++ b/parser/src/content/inline_tree.rs
@@ -42,8 +42,8 @@
 //! a real, live artifact, but it is built behind an **opt-in** flag
 //! ([`Parser::with_inline_tree`]) so the default parse path is byte- and
 //! performance-identical to before. Making the tree *canonical* (with
-//! `rendered()` folding it, and the three production sentinel systems retired)
-//! is the remainder of Phase 2 and Phase 4.
+//! `rendered_html()` folding it, and the three production sentinel systems
+//! retired) is the remainder of Phase 2 and Phase 4.
 //!
 //! [`inline_recorder`]: ../../tests/inline_recorder.rs
 //! [`Content`]: crate::content::Content

--- a/parser/src/content/macros.rs
+++ b/parser/src/content/macros.rs
@@ -39,7 +39,7 @@ fn apply_macros_internal(
     parser: &Parser,
     leading_anchor_registered: bool,
 ) {
-    let /* mut */ text = content.rendered().to_string();
+    let /* mut */ text = content.rendered_html().to_string();
     let found_square_bracket = text.contains('[');
     let found_colon = text.contains(':');
     let found_macroish = found_square_bracket && found_colon;
@@ -59,7 +59,7 @@ fn apply_macros_internal(
         };
 
         if let Cow::Owned(new_result) =
-            INLINE_BIBLIO_ANCHOR.replace_all(content.rendered(), replacer)
+            INLINE_BIBLIO_ANCHOR.replace_all(content.rendered_html(), replacer)
         {
             content.rendered = new_result.into();
         }
@@ -81,7 +81,7 @@ fn apply_macros_internal(
             let replacer = InlineKbdBtnMacroReplacer(parser);
 
             if let Cow::Owned(new_result) =
-                INLINE_KBD_BTN_MACRO.replace_all(content.rendered(), replacer)
+                INLINE_KBD_BTN_MACRO.replace_all(content.rendered_html(), replacer)
             {
                 content.rendered = new_result.into();
             }
@@ -91,7 +91,7 @@ fn apply_macros_internal(
             let replacer = InlineMenuMacroReplacer(parser);
 
             if let Cow::Owned(new_result) =
-                INLINE_MENU_MACRO.replace_all(content.rendered(), replacer)
+                INLINE_MENU_MACRO.replace_all(content.rendered_html(), replacer)
             {
                 content.rendered = new_result.into();
             }
@@ -104,7 +104,8 @@ fn apply_macros_internal(
             source: content.original(),
         };
 
-        if let Cow::Owned(new_result) = INLINE_IMAGE_MACRO.replace_all(content.rendered(), replacer)
+        if let Cow::Owned(new_result) =
+            INLINE_IMAGE_MACRO.replace_all(content.rendered_html(), replacer)
         {
             content.rendered = new_result.into();
         }
@@ -116,7 +117,7 @@ fn apply_macros_internal(
         let replacer = InlineIndextermReplacer(parser);
 
         if let Cow::Owned(new_result) =
-            replace_with_lookahead(&INLINE_INDEXTERM, content.rendered(), replacer)
+            replace_with_lookahead(&INLINE_INDEXTERM, content.rendered_html(), replacer)
         {
             content.rendered = new_result.into();
         }
@@ -125,7 +126,7 @@ fn apply_macros_internal(
     if found_colon && text.contains("://") {
         let replacer = InlineLinkReplacer(parser);
 
-        if let Cow::Owned(new_result) = INLINE_LINK.replace_all(content.rendered(), replacer) {
+        if let Cow::Owned(new_result) = INLINE_LINK.replace_all(content.rendered_html(), replacer) {
             content.rendered = new_result.into();
         }
     }
@@ -136,7 +137,8 @@ fn apply_macros_internal(
             source: content.original(),
         };
 
-        if let Cow::Owned(new_result) = INLINE_LINK_MACRO.replace_all(content.rendered(), replacer)
+        if let Cow::Owned(new_result) =
+            INLINE_LINK_MACRO.replace_all(content.rendered_html(), replacer)
         {
             content.rendered = new_result.into();
         }
@@ -145,7 +147,8 @@ fn apply_macros_internal(
     if text.contains('@') {
         let replacer = InlineEmailReplacer(parser);
 
-        if let Cow::Owned(new_result) = INLINE_EMAIL.replace_all(content.rendered(), replacer) {
+        if let Cow::Owned(new_result) = INLINE_EMAIL.replace_all(content.rendered_html(), replacer)
+        {
             content.rendered = new_result.into();
         }
     }
@@ -155,7 +158,7 @@ fn apply_macros_internal(
         // immediately preceding each match (see `InlineAnchorReplacer`); prior
         // passes above may have mutated the rendered text, so the initial `text`
         // snapshot cannot be reused here.
-        let haystack = content.rendered().to_string();
+        let haystack = content.rendered_html().to_string();
 
         let replacer = InlineAnchorReplacer {
             parser,
@@ -189,7 +192,7 @@ fn apply_macros_internal(
 
     if (text.contains("&lt;&lt;") || (found_macroish && text.contains("xref:")))
         && let Cow::Owned(new_result) = INLINE_XREF.replace_all(
-            content.rendered(),
+            content.rendered_html(),
             InlineXrefReplacer {
                 parser,
                 xrefs: &mut xrefs,
@@ -216,7 +219,7 @@ fn apply_macros_internal(
         };
 
         if let Cow::Owned(new_result) =
-            replace_with_lookahead(&INLINE_FOOTNOTE_MACRO, content.rendered(), replacer)
+            replace_with_lookahead(&INLINE_FOOTNOTE_MACRO, content.rendered_html(), replacer)
         {
             content.rendered = new_result.into();
         }
@@ -2563,7 +2566,7 @@ mod tests {
                 .child_blocks()
                 .next()
                 .unwrap()
-                .rendered_content()
+                .rendered_html_content()
                 .unwrap();
 
             assert_eq!(
@@ -2584,7 +2587,7 @@ mod tests {
                 .child_blocks()
                 .next()
                 .unwrap()
-                .rendered_content()
+                .rendered_html_content()
                 .unwrap();
 
             assert_eq!(

--- a/parser/src/content/passthroughs.rs
+++ b/parser/src/content/passthroughs.rs
@@ -123,7 +123,7 @@ impl Passthroughs {
         }
 
         if let Cow::Owned(new_result) = PASS_WITH_INDEX.replace_all(
-            content.rendered().as_ref(),
+            content.rendered_html().as_ref(),
             PassthroughRestoreReplacer(self, parser),
         ) {
             content.rendered = new_result.into();
@@ -697,22 +697,23 @@ impl Replacer for PassthroughRestoreReplacer<'_> {
                 QuoteScope::Unconstrained,
                 attrlist,
                 id,
-                subbed_text.rendered(),
+                subbed_text.rendered_html(),
                 &mut new_text,
             );
 
             subbed_text.rendered = new_text.into();
         }
 
-        if subbed_text.rendered().contains('\u{96}') {
+        if subbed_text.rendered_html().contains('\u{96}') {
             // Recursively apply passthrough replacement and write the result.
             let replacer = PassthroughRestoreReplacer(self.0, self.1);
 
-            let new_result = PASS_WITH_INDEX.replace_all(subbed_text.rendered().as_ref(), replacer);
+            let new_result =
+                PASS_WITH_INDEX.replace_all(subbed_text.rendered_html().as_ref(), replacer);
 
             dest.push_str(new_result.as_ref());
         } else {
-            dest.push_str(subbed_text.rendered());
+            dest.push_str(subbed_text.rendered_html());
         }
     }
 }

--- a/parser/src/content/substitution_group.rs
+++ b/parser/src/content/substitution_group.rs
@@ -285,7 +285,7 @@ impl SubstitutionGroup {
         }
 
         // Capture any deferred cross-references as a placeholder template and
-        // render the unresolved fallback, so `rendered()` is clean even before
+        // render the unresolved fallback, so `rendered_html()` is clean even before
         // references are resolved. This is a no-op when no cross-references were
         // found.
         content.finalize_deferred(&*parser.renderer);
@@ -298,7 +298,7 @@ impl SubstitutionGroup {
     /// subtree from the footnote texts that pass registered.
     ///
     /// This is Strategy A (design §4.1): a transparent recording pass whose
-    /// fold reproduces the authoritative `rendered()` byte-for-byte. It is
+    /// fold reproduces the authoritative `rendered_html()` byte-for-byte. It is
     /// a second pass for now; the Phase 4 single-pass builder retires it.
     fn build_inline_tree(
         &self,
@@ -343,14 +343,14 @@ impl SubstitutionGroup {
         // built-in (stateless) renderer and the default handlers, but a
         // *stateful* custom renderer – or a one-shot asset handler – could
         // observe different state the second time and make the recorded tree
-        // fold to something other than the authoritative `rendered()`. Assert
+        // fold to something other than the authoritative `rendered_html()`. Assert
         // parity so such a renderer fails loudly in debug/test builds rather
         // than silently storing a divergent tree. (Retired with the second pass
         // itself by the Phase 4 single-pass builder.)
         debug_assert_eq!(
             inline_tree::fold_marked(&marked, &events),
             content.rendered_str(),
-            "inline tree fold diverged from rendered(); the configured inline \
+            "inline tree fold diverged from rendered_html(); the configured inline \
              renderer or an asset handler is stateful and unsafe for inline-tree \
              building",
         );
@@ -1167,7 +1167,7 @@ mod tests {
 
             let block = doc.child_blocks().next().unwrap();
             assert_eq!(
-                block.rendered_content(),
+                block.rendered_html_content(),
                 Some("abc <strong>bold</strong> &\ndef")
             );
 
@@ -1187,7 +1187,7 @@ mod tests {
             let doc = p.parse("[subs=\",\"]\n....\ncontent <here>\n....");
 
             let block = doc.child_blocks().next().unwrap();
-            assert_eq!(block.rendered_content(), Some("content <here>"));
+            assert_eq!(block.rendered_html_content(), Some("content <here>"));
 
             assert_eq!(doc.warnings().count(), 0);
         }

--- a/parser/src/content/substitution_step.rs
+++ b/parser/src/content/substitution_step.rs
@@ -1627,7 +1627,7 @@ mod tests {
                 doc.child_blocks()
                     .next()
                     .unwrap()
-                    .rendered_content()
+                    .rendered_html_content()
                     .unwrap(),
                 r#"<span id="the_id">marked text</span>"#
             );
@@ -2258,7 +2258,7 @@ mod tests {
                 SubstitutionGroup::Normal.apply(&mut content, &p, None);
 
                 // Sanity check that the earlier step really did shift offsets.
-                assert!(content.rendered().contains("&lt;"));
+                assert!(content.rendered_html().contains("&lt;"));
 
                 let warnings = p.take_substitution_warnings();
                 assert_eq!(warnings.len(), 1);
@@ -2275,7 +2275,7 @@ mod tests {
                 let mut content = content_with_source_lines(text);
                 SubstitutionGroup::Normal.apply(&mut content, &p, None);
 
-                assert!(content.rendered().contains("<strong>"));
+                assert!(content.rendered_html().contains("<strong>"));
 
                 let warnings = p.take_substitution_warnings();
                 assert_eq!(warnings.len(), 1);

--- a/parser/src/document/attribute.rs
+++ b/parser/src/document/attribute.rs
@@ -238,7 +238,7 @@ impl InterpretedValue {
                     let (group, _invalid) = SubstitutionGroup::from_custom_string(None, subs);
                     let mut inner_content = Content::from(Span::new(inner));
                     group.apply(&mut inner_content, parser, None);
-                    inner_content.rendered().to_string()
+                    inner_content.rendered_html().to_string()
                 }
             };
 
@@ -1149,7 +1149,7 @@ mod tests {
         );
 
         assert_eq!(block.content_model(), ContentModel::Empty);
-        assert!(block.rendered_content().is_none());
+        assert!(block.rendered_html_content().is_none());
         assert_eq!(block.raw_context().deref(), "attribute");
         assert!(block.child_blocks().next().is_none());
         assert!(block.title_source().is_none());

--- a/parser/src/document/author.rs
+++ b/parser/src/document/author.rs
@@ -156,7 +156,7 @@ impl Author {
                         parser,
                         None,
                     );
-                    expanded_name = content.rendered().to_string();
+                    expanded_name = content.rendered_html().to_string();
                 }
 
                 let name_with_spaces = replace_underscores_with_spaces(expanded_name);
@@ -632,7 +632,7 @@ fn apply_author_subs(source: &str, parser: &Parser) -> String {
     let has_multiple_attributes = source.matches('{').count() > 1;
 
     // Check if we should apply HTML encoding.
-    let rendered = content.rendered();
+    let rendered = content.rendered_html();
     let has_angle_brackets = rendered.contains('<') && rendered.contains('>');
     let has_unencoded_ampersand = rendered.contains('&') && !rendered.contains("&amp;");
 
@@ -643,7 +643,7 @@ fn apply_author_subs(source: &str, parser: &Parser) -> String {
         SubstitutionStep::SpecialCharacters.apply(&mut content, parser, None);
     }
 
-    content.rendered().to_string()
+    content.rendered_html().to_string()
 }
 
 #[cfg(test)]

--- a/parser/src/document/header.rs
+++ b/parser/src/document/header.rs
@@ -1256,7 +1256,7 @@ fn apply_header_subs(source: &str, parser: &Parser) -> String {
     let mut content = Content::from(span);
     SubstitutionGroup::Header.apply(&mut content, parser, None);
 
-    content.rendered().to_string()
+    content.rendered_html().to_string()
 }
 
 impl std::fmt::Debug for Header<'_> {

--- a/parser/src/document/revision_line.rs
+++ b/parser/src/document/revision_line.rs
@@ -123,7 +123,7 @@ fn apply_header_subs(source: &str, parser: &Parser) -> String {
     let mut content = Content::from(span);
     SubstitutionGroup::Header.apply(&mut content, parser, None);
 
-    content.rendered().to_string()
+    content.rendered_html().to_string()
 }
 
 fn is_valid_standalone_revision(s: &str) -> bool {

--- a/parser/src/parser/parser.rs
+++ b/parser/src/parser/parser.rs
@@ -2164,7 +2164,8 @@ impl Parser {
     /// [`Content::inlines`](crate::content::Content::inlines) (or, at the block
     /// level, [`IsBlock::inlines`](crate::blocks::IsBlock::inlines)). The tree
     /// is a projection of the rendered output: folding it reproduces
-    /// [`Content::rendered`](crate::content::Content::rendered) byte-for-byte.
+    /// [`Content::rendered_html`](crate::content::Content::rendered_html)
+    /// byte-for-byte.
     ///
     /// This is **off by default**. Building the tree currently costs a second,
     /// counter-safe substitution pass per block (design Phase 2, "promote the
@@ -2183,11 +2184,11 @@ impl Parser {
     /// satisfy this. A *stateful* custom renderer (one whose output depends on
     /// mutable internal state) or a *one-shot* asset handler may therefore be
     /// invoked twice while this is enabled, and could make the tree diverge
-    /// from [`rendered`](crate::content::Content::rendered) – a divergence
-    /// caught by a debug assertion. Externally-visible reads (such as
-    /// loading an image for a `data-uri`) likewise occur an extra time. The
-    /// Phase 4 single-pass builder removes the second pass and this caveat
-    /// with it.
+    /// from [`rendered_html`](crate::content::Content::rendered_html) – a
+    /// divergence caught by a debug assertion. Externally-visible reads
+    /// (such as loading an image for a `data-uri`) likewise occur an extra
+    /// time. The Phase 4 single-pass builder removes the second pass and
+    /// this caveat with it.
     #[must_use]
     pub fn with_inline_tree(mut self, enabled: bool) -> Self {
         self.build_inline_tree = enabled;
@@ -4174,7 +4175,7 @@ mod tests {
         // Our custom renderer should show [AMP], [LT], and [GT] instead of HTML
         // entities, and a resolved footnote as [FOOTNOTE:<index>].
         assert_eq!(
-            simple_block.content().rendered(),
+            simple_block.content().rendered_html(),
             "Hello [AMP] goodbye [LT] world [GT] test [FOOTNOTE:1]"
         );
     }
@@ -4193,7 +4194,10 @@ mod tests {
             panic!("Expected simple block, got: {block:?}");
         };
 
-        assert_eq!(simple_block.content().rendered(), "test.[FOOTNOTE:missing]");
+        assert_eq!(
+            simple_block.content().rendered_html(),
+            "test.[FOOTNOTE:missing]"
+        );
     }
 
     /// A custom [`PathResolver`](crate::parser::PathResolver) that rewrites
@@ -4223,7 +4227,7 @@ mod tests {
         };
 
         assert_eq!(
-            simple_block.content().rendered(),
+            simple_block.content().rendered_html(),
             r#"<span class="image"><img src="https://cdn.example.com/tiger.png" alt="tiger"></span>"#
         );
     }
@@ -4374,7 +4378,7 @@ mod tests {
             let Block::Simple(simple_block) = block else {
                 panic!("expected a simple block");
             };
-            assert_eq!(simple_block.content().rendered(), "{showtitle}");
+            assert_eq!(simple_block.content().rendered_html(), "{showtitle}");
         }
 
         #[test]

--- a/parser/src/parser/preprocessor.rs
+++ b/parser/src/parser/preprocessor.rs
@@ -3229,7 +3229,7 @@ mod tests {
 
         let rendered: Vec<_> = doc
             .child_blocks()
-            .filter_map(|b| b.rendered_content())
+            .filter_map(|b| b.rendered_html_content())
             .collect();
 
         assert_eq!(rendered, vec!["Value: 1."]);

--- a/parser/src/tests/asciidoc_lang/attributes/character_replacement_ref.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/character_replacement_ref.rs
@@ -219,7 +219,7 @@ fn reference_a_character_replacement_attribute() {
     };
 
     assert_eq!(
-        block.content().rendered(),
+        block.content().rendered_html(),
         "Wolpertingers don&#8217;t like temperatures above 100&#176;C."
     );
 }

--- a/parser/src/tests/asciidoc_lang/attributes/counters.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/counters.rs
@@ -9,7 +9,7 @@ track_file!("ref/asciidoc-lang/docs/modules/attributes/pages/counters.adoc");
 fn rendered_blocks(input: &str) -> Vec<String> {
     let doc = Parser::default().parse(input);
     doc.child_blocks()
-        .filter_map(|b| b.rendered_content().map(str::to_string))
+        .filter_map(|b| b.rendered_html_content().map(str::to_string))
         .collect()
 }
 

--- a/parser/src/tests/asciidoc_lang/attributes/id.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/id.rs
@@ -1726,7 +1726,7 @@ include::example$id.adoc[tag=anchor-wrong]
 
         let block = doc.child_blocks().next().unwrap();
         assert_eq!(
-            block.rendered_content().unwrap(),
+            block.rendered_html_content().unwrap(),
             "<a id=\"anchor-point\"></a>* list item with invalid anchor"
         );
 
@@ -1861,7 +1861,7 @@ include::example$id.adoc[tag=inline-anchor-brackets]
 
         let block = doc.child_blocks().next().unwrap();
         assert_eq!(
-            block.rendered_content().unwrap(),
+            block.rendered_html_content().unwrap(),
             "<a id=\"tiger-image\"></a><span class=\"image\"><img src=\"tiger.png\" alt=\"Image of a tiger\"></span>"
         );
 
@@ -1889,7 +1889,7 @@ include::example$id.adoc[tag=inline-anchor-macro]
 
         let block = doc.child_blocks().next().unwrap();
         assert_eq!(
-            block.rendered_content().unwrap(),
+            block.rendered_html_content().unwrap(),
             "<a id=\"tiger-image\"></a><span class=\"image\"><img src=\"tiger.png\" alt=\"Image of a tiger\"></span>"
         );
 
@@ -1985,7 +1985,7 @@ include::example$id.adoc[tag=anchor-xreflabel]
 
         let xref_paragraph = doc
             .child_blocks()
-            .filter_map(|block| block.rendered_content())
+            .filter_map(|block| block.rendered_html_content())
             .find(|rendered| rendered.contains("href"))
             .unwrap();
 

--- a/parser/src/tests/asciidoc_lang/attributes/role.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/role.rs
@@ -477,7 +477,7 @@ Thus, roles are an ideal way to annotated elements in your document so you can u
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             r#"This sentence contains <strong class="application">bold inline content</strong> that&#8217;s assigned a role."#
         );
 
@@ -487,7 +487,7 @@ Thus, roles are an ideal way to annotated elements in your document so you can u
         };
 
         assert_eq!(
-            sb2.content().rendered(),
+            sb2.content().rendered_html(),
             r#"This sentence contains <code class="varname">monospace text</code> that&#8217;s assigned a role."#
         );
 

--- a/parser/src/tests/asciidoc_lang/attributes/unresolved_references.rs
+++ b/parser/src/tests/asciidoc_lang/attributes/unresolved_references.rs
@@ -20,7 +20,7 @@ fn render_first_block(source: &str) -> String {
     let doc = Parser::default().parse(source);
     doc.child_blocks()
         .next()
-        .and_then(|b| b.rendered_content())
+        .and_then(|b| b.rendered_html_content())
         .unwrap_or_default()
         .to_string()
 }
@@ -182,7 +182,7 @@ fn attribute_missing_can_be_changed_mid_document() {
 
     let rendered: Vec<&str> = doc
         .child_blocks()
-        .filter_map(|b| b.rendered_content())
+        .filter_map(|b| b.rendered_html_content())
         .collect();
 
     assert_eq!(rendered, vec!["one {x}", "two "]);

--- a/parser/src/tests/asciidoc_lang/blocks/blockquotes.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/blockquotes.rs
@@ -159,7 +159,7 @@ include::example$quote.adoc[tag=para2]
     assert_eq!(quote.attribution(), Some("Captain James T. Kirk"));
     assert_eq!(quote.citetitle(), Some("Star Trek IV: The Voyage Home"));
     assert_eq!(
-        quote.content().unwrap().rendered(),
+        quote.content().unwrap().rendered_html(),
         "Everybody remember where we parked."
     );
 }

--- a/parser/src/tests/asciidoc_lang/blocks/verses.rs
+++ b/parser/src/tests/asciidoc_lang/blocks/verses.rs
@@ -36,7 +36,7 @@ Verses are defined by setting `verse` on a paragraph or an excerpt block delimit
     assert_css(&doc, ".verseblock", 1);
     assert_css(&doc, ".verseblock > pre.content", 1);
     assert_eq!(
-        quote.content().unwrap().rendered(),
+        quote.content().unwrap().rendered_html(),
         "Roses are red,\n  violets are blue."
     );
 
@@ -92,7 +92,7 @@ include::example$verse.adoc[tag=para]
     assert_css(&doc, ".verseblock > pre.content", 1);
     assert_css(&doc, ".verseblock p", 0);
     assert_eq!(
-        quote.content().unwrap().rendered(),
+        quote.content().unwrap().rendered_html(),
         "The fog comes\non little cat feet."
     );
 
@@ -149,7 +149,7 @@ include::example$verse.adoc[tag=bl]
     assert_css(&doc, ".verseblock", 1);
     assert_css(&doc, ".verseblock > pre.content", 1);
     assert_eq!(
-        quote.content().unwrap().rendered(),
+        quote.content().unwrap().rendered_html(),
         "The fog comes\non little cat feet.\n\nIt sits looking\nover harbor and city\non silent haunches\nand then moves on."
     );
 

--- a/parser/src/tests/asciidoc_lang/lists/description.rs
+++ b/parser/src/tests/asciidoc_lang/lists/description.rs
@@ -2440,7 +2440,7 @@ fn ordered_list_nests_under_second_level_term() {
         ));
 
         assert_eq!(
-            li.child_blocks().next().unwrap().rendered_content(),
+            li.child_blocks().next().unwrap().rendered_html_content(),
             Some(expected)
         );
     }
@@ -2499,7 +2499,7 @@ fn term_rendered(block: &crate::blocks::Block<'_>) -> String {
     };
 
     match item.list_item_marker() {
-        crate::blocks::ListItemMarker::DefinedTerm { term, .. } => term.rendered().to_string(),
+        crate::blocks::ListItemMarker::DefinedTerm { term, .. } => term.rendered_html().to_string(),
         other => panic!("expected a defined-term marker, got {other:#?}"),
     }
 }

--- a/parser/src/tests/asciidoc_lang/macros/autolinks.rs
+++ b/parser/src/tests/asciidoc_lang/macros/autolinks.rs
@@ -878,7 +878,7 @@ mod pr498 {
             .child_blocks()
             .next()
             .unwrap()
-            .rendered_content()
+            .rendered_html_content()
             .unwrap();
 
         assert_eq!(
@@ -897,7 +897,7 @@ mod pr498 {
             .child_blocks()
             .next()
             .unwrap()
-            .rendered_content()
+            .rendered_html_content()
             .unwrap();
 
         assert_eq!(

--- a/parser/src/tests/asciidoc_lang/macros/images.rs
+++ b/parser/src/tests/asciidoc_lang/macros/images.rs
@@ -579,7 +579,7 @@ include::example$image.adoc[tag=inline]
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             r#"Click <span class="image"><img src="play.png" alt="play"></span> to get the party started."#
         );
 
@@ -589,7 +589,7 @@ include::example$image.adoc[tag=inline]
         };
 
         assert_eq!(
-            sb2.content().rendered(),
+            sb2.content().rendered_html(),
             r#"Click <span class="image"><img src="pause.png" alt="pause" title="Pause"></span> when you need a break."#
         );
 
@@ -617,7 +617,7 @@ The alt text for an inline image has the same requirements as for a block image,
         };
 
         assert_eq!(
-            sb.content().rendered(),
+            sb.content().rendered_html(),
             r#"Click <span class="image"><img src="play.png" alt="Look ] here"></span> to continue."#
         );
     }

--- a/parser/src/tests/asciidoc_lang/macros/keyboard_macro.rs
+++ b/parser/src/tests/asciidoc_lang/macros/keyboard_macro.rs
@@ -34,7 +34,7 @@ mod keyboard_macro_syntax {
                     if let Some(cell) = row.cells().first()
                         && let TableCellContent::Simple(content) = cell.content()
                     {
-                        out.push(content.rendered().to_string());
+                        out.push(content.rendered_html().to_string());
                     }
                 }
             }

--- a/parser/src/tests/asciidoc_lang/pass/pass_block.rs
+++ b/parser/src/tests/asciidoc_lang/pass/pass_block.rs
@@ -35,7 +35,7 @@ include::example$pass.adoc[tag=pass-style]
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         "<del>strike this</del> is marked as deleted."
     );
 }
@@ -69,7 +69,7 @@ However, a passthrough could come in handy if you need to output more sophistica
     };
 
     assert_eq!(
-        rdb1.content().rendered(),
+        rdb1.content().rendered_html(),
         "<video poster=\"images/movie-reel.png\">\n  <source src=\"videos/writing-zen.webm\" type=\"video/webm\">\n</video>"
     );
 }
@@ -102,7 +102,7 @@ include::example$pass.adoc[tag=subs-bl]
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         "This Is My Name\nimage:tiger.png[]"
     );
 }
@@ -134,7 +134,7 @@ In these cases, you should use conditional preprocessor directives to route pass
     };
 
     assert_eq!(
-        rdb1.content().rendered(),
+        rdb1.content().rendered_html(),
         "Normal content which is not enclosed in a paragraph."
     );
 }

--- a/parser/src/tests/asciidoc_lang/pass/pass_macro.rs
+++ b/parser/src/tests/asciidoc_lang/pass/pass_macro.rs
@@ -52,7 +52,7 @@ TIP: When you need to prevent or control the substitutions on one or more blocks
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         "content like #{variable} passed directly to the output followed by normal content."
     );
 }
@@ -88,7 +88,7 @@ The main difference, however, is that they are applied first to suppress formatt
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         "A word, a sequence of words, or characters that are escaped from formatting."
     );
 }
@@ -124,7 +124,7 @@ You can also escape formatting marks, like +``+.
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         "A word or phrase between single pluses, such as /document/{id}, is not substituted.\nHowever, the special characters &lt; and &gt; are still escaped in the output."
     );
 
@@ -135,7 +135,7 @@ You can also escape formatting marks, like +``+.
     };
 
     assert_eq!(
-        sb2.content().rendered(),
+        sb2.content().rendered_html(),
         "You can also escape formatting marks, like ``."
     );
 }
@@ -175,7 +175,7 @@ If you want to do both, you must enclose the pair in a monospace formatting pair
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         "Text formatting is not applied to a link target if it is surrounded by double pluses.\nFor example, <a href=\"https://example.org/now_this__link_works.html\" class=\"bare\">https://example.org/now_this__link_works.html</a>."
     );
 
@@ -186,7 +186,7 @@ If you want to do both, you must enclose the pair in a monospace formatting pair
     };
 
     assert_eq!(
-        sb2.content().rendered(),
+        sb2.content().rendered_html(),
         "You can also escape formatting marks, like all-natural*."
     );
 
@@ -197,7 +197,7 @@ If you want to do both, you must enclose the pair in a monospace formatting pair
     };
 
     assert_eq!(
-        sb3.content().rendered(),
+        sb3.content().rendered_html(),
         "An attribute reference within a word, such as dev{conf}, is not replaced."
     );
 }
@@ -237,7 +237,7 @@ include::example$pass.adoc[tag=3p]
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         "The text <del>strike this</del> is marked as deleted."
     );
 }
@@ -289,7 +289,7 @@ Let's look at how to use the inline pass macro to hand select substitutions.
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         "The text <del>strike this</del> is marked as deleted."
     );
 }
@@ -365,7 +365,7 @@ include::example$pass.adoc[tag=in-macro-sub]
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         "The text <del>strike <strong>this</strong></del> is marked as deleted."
     );
 }
@@ -399,7 +399,7 @@ include::example$pass.adoc[tag=in-macro-subs]
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         "The text <del>strike <em>untitled document 1</em></del> is marked as deleted."
     );
 }
@@ -454,7 +454,7 @@ protected void configure(HttpSecurity http) throws Exception {
     };
 
     assert_eq!(
-        rdb1.content().rendered(),
+        rdb1.content().rendered_html(),
         "protected void configure(HttpSecurity http) throws Exception {\n    http\n        .authorizeRequests()\n            <strong>.antMatchers(\"/resources/**\").permitAll()</strong>\n            .anyRequest().authenticated()\n            .and()\n        .formLogin()\n            .loginPage(\"/login\")\n            .permitAll();"
     );
 }

--- a/parser/src/tests/asciidoc_lang/root/comments.rs
+++ b/parser/src/tests/asciidoc_lang/root/comments.rs
@@ -200,7 +200,7 @@ Additionally, no AsciiDoc syntax within the delimited lines is interpreted, not 
     let doc = Parser::default().parse("////\n*bold* {attr}\n// inner\n////");
     let block = doc.child_blocks().next().expect("expected a block");
     assert_eq!(
-        block.rendered_content(),
+        block.rendered_html_content(),
         Some("*bold* {attr}\n// inner"),
         "comment block content must be raw"
     );
@@ -209,7 +209,7 @@ Additionally, no AsciiDoc syntax within the delimited lines is interpreted, not 
     // interpreted.
     let doc = Parser::default().parse("[subs=quotes]\n////\n*bold*\n////");
     let block = doc.child_blocks().next().expect("expected a block");
-    assert_eq!(block.rendered_content(), Some("*bold*"));
+    assert_eq!(block.rendered_html_content(), Some("*bold*"));
 
     non_normative!(
         r#"
@@ -239,11 +239,14 @@ A comment block can also be written as an open block with the comment style:
     let doc = Parser::default().parse("[comment]\n--\n*bold* {attr}\n// inner\n--");
     let block = doc.child_blocks().next().expect("expected a block");
     assert_eq!(block.resolved_context().as_ref(), "comment");
-    assert_eq!(block.rendered_content(), Some("*bold* {attr}\n// inner"));
+    assert_eq!(
+        block.rendered_html_content(),
+        Some("*bold* {attr}\n// inner")
+    );
 
     let doc = Parser::default().parse("[comment,subs=quotes]\n--\n*bold*\n--");
     let block = doc.child_blocks().next().expect("expected a block");
-    assert_eq!(block.rendered_content(), Some("*bold*"));
+    assert_eq!(block.rendered_html_content(), Some("*bold*"));
 
     non_normative!(
         r#"
@@ -277,7 +280,7 @@ A comment block that can consists of a single paragraph can be written as a para
     assert_eq!(first.substitution_group(), SubstitutionGroup::None);
     let second = doc.child_blocks().nth(1).expect("expected a second block");
     assert_eq!(second.declared_style(), None);
-    assert_eq!(second.rendered_content(), Some("Not a comment."));
+    assert_eq!(second.rendered_html_content(), Some("Not a comment."));
 
     // Like the `////` and open-block forms, a `[comment]` paragraph retains its
     // content verbatim: an inner `//` line is preserved (not stripped as a line
@@ -286,13 +289,13 @@ A comment block that can consists of a single paragraph can be written as a para
     let doc = Parser::default().parse("[comment]\nfirst line\n// inner\n*bold*");
     let first = doc.child_blocks().next().expect("expected a block");
     assert_eq!(
-        first.rendered_content(),
+        first.rendered_html_content(),
         Some("first line\n// inner\n*bold*")
     );
 
     let doc = Parser::default().parse("[comment,subs=quotes]\n*bold*");
     let first = doc.child_blocks().next().expect("expected a block");
-    assert_eq!(first.rendered_content(), Some("*bold*"));
+    assert_eq!(first.rendered_html_content(), Some("*bold*"));
 
     non_normative!(
         r#"

--- a/parser/src/tests/asciidoc_lang/root/syntax_quick_reference.rs
+++ b/parser/src/tests/asciidoc_lang/root/syntax_quick_reference.rs
@@ -1289,14 +1289,14 @@ include::verbatim:example$source.adoc[tag=src-para]
     let Some(Block::RawDelimited(b)) = doc.child_blocks().next() else {
         panic!("expected a raw delimited block");
     };
-    assert!(b.content().rendered().contains("*not bold*"));
+    assert!(b.content().rendered_html().contains("*not bold*"));
 
     // A source block parses as a listing-context raw delimited block.
     let doc = Parser::default().parse("[source,ruby]\n----\nputs 'hi'\n----");
     let Some(Block::RawDelimited(b)) = doc.child_blocks().next() else {
         panic!("expected a raw delimited block");
     };
-    assert!(b.content().rendered().contains("puts 'hi'"));
+    assert!(b.content().rendered_html().contains("puts 'hi'"));
 
     // Source callouts render conums.
     let doc = Parser::default()
@@ -1519,7 +1519,7 @@ include::verbatim:example$listing.adoc[tag=subs-out]
     let Some(Block::RawDelimited(b)) = doc.child_blocks().next() else {
         panic!("expected a raw delimited block");
     };
-    assert!(b.content().rendered().contains("<b>raw</b>"));
+    assert!(b.content().rendered_html().contains("<b>raw</b>"));
 
     // A blockquote with attribution and citation.
     let doc = Parser::default().parse(
@@ -2230,7 +2230,7 @@ include::verbatim:example$source.adoc[tag=fence]
             .map(|a| a.value()),
         Some("ruby")
     );
-    assert!(b.content().rendered().contains("puts 'hi'"));
+    assert!(b.content().rendered_html().contains("puts 'hi'"));
 
     verifies!(
         r#"
@@ -2364,5 +2364,5 @@ Line breaks within a paragraph are not displayed.
         panic!("expected a raw delimited (listing) block");
     };
     assert_eq!(b.resolved_context().as_ref(), "listing");
-    assert!(b.content().rendered().contains("puts 'hi'"));
+    assert!(b.content().rendered_html().contains("puts 'hi'"));
 }

--- a/parser/src/tests/asciidoc_lang/stem/index.rs
+++ b/parser/src/tests/asciidoc_lang/stem/index.rs
@@ -115,14 +115,14 @@ All such syntax is passed through to the STEM processor as is.
         let Block::Simple(sb1) = block1 else {
             panic!("Unexpected block type: {block1:?}");
         };
-        assert_eq!(sb1.content().rendered(), r"\$sqrt(4) = 2\$");
+        assert_eq!(sb1.content().rendered_html(), r"\$sqrt(4) = 2\$");
 
         let block2 = blocks.next().unwrap();
         let Block::Simple(sb2) = block2 else {
             panic!("Unexpected block type: {block2:?}");
         };
         assert_eq!(
-            sb2.content().rendered(),
+            sb2.content().rendered_html(),
             r"Water (\$H_2O\$) is a critical component."
         );
         assert!(blocks.next().is_none());
@@ -137,7 +137,7 @@ All such syntax is passed through to the STEM processor as is.
             panic!("Unexpected block type: {block:?}");
         };
         assert_eq!(
-            sb.content().rendered(),
+            sb.content().rendered_html(),
             r"A matrix can be written as \$[[a,b],[c,d]]((n),(k))\$."
         );
     }
@@ -186,7 +186,7 @@ The AsciiDoc processor handles that for you automatically!
         assert_eq!(block.content_model(), ContentModel::Raw);
         assert_eq!(block.raw_context().as_ref(), "stem");
         assert_eq!(block.declared_style(), Some("stem"));
-        assert_eq!(block.rendered_content(), Some("sqrt(4) = 2"));
+        assert_eq!(block.rendered_html_content(), Some("sqrt(4) = 2"));
         assert_eq!(block.substitution_group(), SubstitutionGroup::Stem);
     }
 }
@@ -376,7 +376,7 @@ include::example$stem.adoc[tag=multi-a-render]
             panic!("Unexpected block type: {block:?}");
         };
         assert_eq!(
-            sb.content().rendered(),
+            sb.content().rendered_html(),
             r"\(C = \alpha + \beta Y^{\gamma} + \epsilon\)"
         );
 

--- a/parser/src/tests/asciidoc_lang/subs/apply_subs_to_blocks.rs
+++ b/parser/src/tests/asciidoc_lang/subs/apply_subs_to_blocks.rs
@@ -51,7 +51,7 @@ The names of those substitution steps and groups are as follows:
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This & _that_ and icon:github[] +\nanother line with a{sp}space there ..."
         );
     }
@@ -76,7 +76,7 @@ The names of those substitution steps and groups are as follows:
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This &amp; <em>that</em> and <span class=\"icon\">[github&#93;</span><br>\nanother line with a space there &#8230;&#8203;"
         );
     }
@@ -101,7 +101,7 @@ The names of those substitution steps and groups are as follows:
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This &amp; _that_ and icon:github[] +\nanother line with a{sp}space there ..."
         );
     }
@@ -127,7 +127,7 @@ For source blocks, this substitution step enables syntax highlighting as well.
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This &amp; _that_ and icon:github[] +\nanother line with a{sp}space there ..."
         );
     }
@@ -154,7 +154,7 @@ For source blocks, this substitution step enables syntax highlighting as well.
         // The verbatim group applies only special characters and callouts; the
         // input has no callout markers, so only `&` is replaced.
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This &amp; _that_ and icon:github[] +\nanother line with a{sp}space there ..."
         );
     }
@@ -179,7 +179,7 @@ For source blocks, this substitution step enables syntax highlighting as well.
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This & <em>that</em> and icon:github[] +\nanother line with a{sp}space there ..."
         );
     }
@@ -204,7 +204,7 @@ For source blocks, this substitution step enables syntax highlighting as well.
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This & _that_ and icon:github[] +\nanother line with a space there ..."
         );
     }
@@ -230,7 +230,7 @@ The output of `replacements` may depend on whether the `specialcharacters` subst
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This &#169; _that_ and icon:github[] +\nanother line with a{sp}space there &#8230;&#8203;"
         );
     }
@@ -255,7 +255,7 @@ The output of `replacements` may depend on whether the `specialcharacters` subst
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This &#169; _that_ and <span class=\"icon\">[github&#93;</span> +\nanother line with a{sp}space there ..."
         );
     }
@@ -280,7 +280,7 @@ The output of `replacements` may depend on whether the `specialcharacters` subst
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This &#169; _that_ and icon:github[]<br>\nanother line with a{sp}space there ..."
         );
     }
@@ -307,7 +307,7 @@ The value also specifies the order in which the substitutions are applied.
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This &amp;#169; _that_ and <span class=\"icon\">[github&#93;</span> +\nanother line with a{sp}space there ..."
         );
 
@@ -322,7 +322,7 @@ The value also specifies the order in which the substitutions are applied.
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This &#169; <em>that</em> and icon:github[]<br>\nanother line with a space there &#8230;&#8203;"
         );
     }
@@ -354,7 +354,7 @@ It can only be applied to a leaf block, which is any block that cannot have chil
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This &#169; <em>that</em> and <span class=\"icon\"><img src=\"./images/icons/github.png\" alt=\"github\"></span><br>\nanother line with a space there &#8230;&#8203;"
         );
     }
@@ -413,7 +413,7 @@ include::example$subs.adoc[tag=subs-out]
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "System.out.println(\"Hello <strong>&lt;name&gt;</strong>\")"
         );
     }
@@ -448,7 +448,7 @@ pass:c,q[System.out.println("Hello *<name>*");] <1>
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "System.out.println(\"No bold *here*\");\nSystem.out.println(\"Hello <strong>&lt;name&gt;</strong>\");"
         );
     }
@@ -504,7 +504,7 @@ Prepends the substitution to the default list.
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "System.out.println(\"Hello *&lt;name&gt;*\")"
         );
     }
@@ -530,7 +530,7 @@ Appends the substitution to the default list.
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "System.out.println(\"Hello *&lt;name&gt;*\")"
         );
     }
@@ -556,7 +556,7 @@ Removes the substitution from the default list.
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "System.out.println(\"Hello <name>\")"
         );
     }
@@ -587,7 +587,7 @@ include::example$subs.adoc[tag=subs-add]
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "&lt;version&gt;1.42&lt;/version&gt;"
         );
     }
@@ -631,7 +631,7 @@ include::example$subs.adoc[tag=subs-sub]
         // characters, so the lone `<1>` is rendered literally rather than as a
         // callout number.
         assert_eq!(
-            block.content().rendered(),
+            block.content().rendered_html(),
             "&lt;1&gt;\n  content inside \"1\" tag\n&lt;/1&gt;"
         );
     }
@@ -678,7 +678,7 @@ In the above example, the `attributes` substitution step is added to the beginni
         // (appended) converts `(C)`, and `callouts` (removed) leaves the lone
         // `<1>` literal.
         assert_eq!(
-            block.content().rendered(),
+            block.content().rendered_html(),
             "&lt;version&gt;1.0&lt;/version&gt;\n&lt;copyright&gt;&#169; ACME&lt;/copyright&gt;\n&lt;1&gt;\n  content inside \"1\" tag\n&lt;/1&gt;"
         );
     }

--- a/parser/src/tests/asciidoc_lang/subs/apply_subs_to_text.rs
+++ b/parser/src/tests/asciidoc_lang/subs/apply_subs_to_text.rs
@@ -38,7 +38,7 @@ The inline pass macro (`++pass:[]++`) accepts the shorthand values in addition t
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This &amp; _that_ and icon:github[] +\nanother line with a{sp}space there ..."
         );
     }
@@ -62,7 +62,7 @@ The inline pass macro (`++pass:[]++`) accepts the shorthand values in addition t
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This & <em>that</em> and icon:github[] +\nanother line with a{sp}space there ..."
         );
     }
@@ -86,7 +86,7 @@ The inline pass macro (`++pass:[]++`) accepts the shorthand values in addition t
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This & _that_ and icon:github[] +\nanother line with a space there ..."
         );
     }
@@ -110,7 +110,7 @@ The inline pass macro (`++pass:[]++`) accepts the shorthand values in addition t
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This &#169; _that_ and icon:github[] +\nanother line with a{sp}space there &#8230;&#8203;"
         );
     }
@@ -134,7 +134,7 @@ The inline pass macro (`++pass:[]++`) accepts the shorthand values in addition t
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This &#169; _that_ and <span class=\"icon\">[github&#93;</span> +\nanother line with a{sp}space there ..."
         );
     }
@@ -159,7 +159,7 @@ The inline pass macro (`++pass:[]++`) accepts the shorthand values in addition t
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This &#169; _that_ and icon:github[]<br>\nanother line with a{sp}space there ..."
         );
     }
@@ -208,7 +208,7 @@ include::pass:example$pass.adoc[tag=in-macro]
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "The text <del>strike this</del> is marked as deleted."
         );
     }
@@ -245,7 +245,7 @@ include::pass:example$pass.adoc[tag=s-macro]
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "The text <del>strike <strong>this</strong></del> is marked as deleted, inside of which the word &#8220;me&#8221; is bold."
         );
     }
@@ -284,7 +284,7 @@ include::pass:example$pass.adoc[tag=sub-out]
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "I better not contain *bold* or _italic_ text.\nBut I should contain <strong>bold</strong> text."
         );
     }

--- a/parser/src/tests/asciidoc_lang/subs/attributes.rs
+++ b/parser/src/tests/asciidoc_lang/subs/attributes.rs
@@ -51,7 +51,7 @@ mod default_attributes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "Goodbye abc def hello");
+        assert_eq!(sb1.content().rendered_html(), "Goodbye abc def hello");
     }
 
     #[test]
@@ -71,7 +71,7 @@ mod default_attributes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "abc {sp} def");
+        assert_eq!(block1.content().rendered_html(), "abc {sp} def");
     }
 
     #[test]
@@ -98,7 +98,7 @@ mod default_attributes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "Hello goodbye.");
+        assert_eq!(block1.content().rendered_html(), "Hello goodbye.");
     }
 
     #[test]
@@ -133,7 +133,7 @@ mod default_attributes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "foo{sp}bar");
+        assert_eq!(block1.content().rendered_html(), "foo{sp}bar");
     }
 
     #[test]
@@ -154,7 +154,7 @@ mod default_attributes_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"Click <span class="image"><img src="pause.png" alt="pause" title="Pause Resume"></span> when you need a break."#
         );
     }
@@ -177,7 +177,7 @@ mod default_attributes_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"Click Pause{sp}Resume when you need a break."#
         );
     }
@@ -206,7 +206,7 @@ mod default_attributes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "Opened closed!");
+        assert_eq!(block1.content().rendered_html(), "Opened closed!");
     }
 
     #[test]
@@ -227,7 +227,7 @@ mod default_attributes_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"This is a &lt;paragraph&gt;."#
         );
     }
@@ -249,7 +249,7 @@ mod default_attributes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "foo{sp}bar");
+        assert_eq!(block1.content().rendered_html(), "foo{sp}bar");
     }
 
     #[test]
@@ -276,7 +276,7 @@ mod default_attributes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "This that");
+        assert_eq!(block1.content().rendered_html(), "This that");
     }
 
     #[test]
@@ -303,7 +303,7 @@ mod default_attributes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "Stuff nonsense");
+        assert_eq!(block1.content().rendered_html(), "Stuff nonsense");
     }
 
     #[test]
@@ -328,12 +328,12 @@ mod default_attributes_substitution {
         let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
             panic!("expected simple cell content");
         };
-        assert_eq!(default_cell.rendered(), "subd");
+        assert_eq!(default_cell.rendered_html(), "subd");
 
         let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
             panic!("expected simple cell content");
         };
-        assert_eq!(literal_cell.rendered(), "{val}");
+        assert_eq!(literal_cell.rendered_html(), "{val}");
     }
 
     #[test]
@@ -385,7 +385,7 @@ For blocks, the step's name, `attributes`, can be assigned to the xref:apply-sub
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "abc<lt space");
+        assert_eq!(block1.content().rendered_html(), "abc<lt space");
     }
 
     #[test]
@@ -405,7 +405,7 @@ For an inline passthrough, the built-in values `a` or `attributes` can be applie
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "abc<lt space and then &#8230;&#8203;"
         );
     }
@@ -426,6 +426,6 @@ Single occurrences of an attribute reference can be escaped by prefixing the exp
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "This is not a{sp}space.");
+        assert_eq!(block1.content().rendered_html(), "This is not a{sp}space.");
     }
 }

--- a/parser/src/tests/asciidoc_lang/subs/macros.rs
+++ b/parser/src/tests/asciidoc_lang/subs/macros.rs
@@ -53,7 +53,7 @@ mod default_macros_substitution {
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             "Not icon: icon:heart[]\nOnly: <strong>bold</strong>"
         );
     }
@@ -75,7 +75,7 @@ mod default_macros_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "icon:heart[]");
+        assert_eq!(block1.content().rendered_html(), "icon:heart[]");
     }
 
     #[test]
@@ -103,7 +103,7 @@ mod default_macros_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"Hello <span class="icon"><img src="./images/icons/heart.png" alt="heart"></span> Asciidoc."#
         );
     }
@@ -140,7 +140,7 @@ mod default_macros_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "foo icon:heart[] bar");
+        assert_eq!(block1.content().rendered_html(), "foo icon:heart[] bar");
     }
 
     #[test]
@@ -166,7 +166,7 @@ mod default_macros_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"<a href="https://example.org"><span class="image"><img src="logo.png" alt="Logo"></span></a>"#
         );
 
@@ -182,7 +182,7 @@ mod default_macros_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"See <a href="https://example.org">the <span class="image"><img src="logo.png" alt="Logo"></span> here</a>."#
         );
 
@@ -198,7 +198,7 @@ mod default_macros_substitution {
         };
 
         assert_eq!(
-            block2.content().rendered(),
+            block2.content().rendered_html(),
             r##"See <a href="#sec"><span class="image"><img src="logo.png" alt="Logo"></span></a> now."##
         );
     }
@@ -228,7 +228,7 @@ mod default_macros_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"Opened <span class="icon"><img src="./images/icons/heart.png" alt="heart"></span> closed!"#
         );
     }
@@ -251,7 +251,7 @@ mod default_macros_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"This is a <span class="icon"><img src="./images/icons/heart.png" alt="heart"></span> paragraph."#
         );
     }
@@ -273,7 +273,7 @@ mod default_macros_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "foo icon:heart[] bar");
+        assert_eq!(block1.content().rendered_html(), "foo icon:heart[] bar");
     }
 
     #[test]
@@ -301,7 +301,7 @@ mod default_macros_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"This <span class="icon"><img src="./images/icons/heart.png" alt="heart"></span> that"#
         );
     }
@@ -331,7 +331,7 @@ mod default_macros_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"Stuff <span class="icon"><img src="./images/icons/heart.png" alt="heart"></span> nonsense"#
         );
     }
@@ -360,14 +360,14 @@ mod default_macros_substitution {
             panic!("expected simple cell content");
         };
         assert_eq!(
-            default_cell.rendered(),
+            default_cell.rendered_html(),
             r#"<a href="https://example.org">Example</a>"#
         );
 
         let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
             panic!("expected simple cell content");
         };
-        assert_eq!(literal_cell.rendered(), "https://example.org[Example]");
+        assert_eq!(literal_cell.rendered_html(), "https://example.org[Example]");
     }
 
     #[test]
@@ -425,7 +425,7 @@ For blocks, the step's name, `macros`, can be assigned to the xref:apply-subs-to
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"Hello <span class="icon"><img src="./images/icons/heart.png" alt="heart"></span> *Asciidoc*."#
         );
     }
@@ -448,7 +448,7 @@ For inline elements, the built-in values `m` or `macros` can be applied to xref:
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"Hello <span class="icon"><img src="./images/icons/heart.png" alt="heart"></span> *Asciidoc* and then &#8230;&#8203;"#
         );
     }

--- a/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
+++ b/parser/src/tests/asciidoc_lang/subs/post_replacements.rs
@@ -32,7 +32,7 @@ The line break character, `{plus}`, is replaced when the `post_replacements` sub
         panic!("Unexpected block type: {block1:?}");
     };
 
-    assert_eq!(sb1.content().rendered(), "first line<br>\nsecond line");
+    assert_eq!(sb1.content().rendered_html(), "first line<br>\nsecond line");
 }
 
 mod default_post_replacements_substitution {
@@ -83,7 +83,7 @@ mod default_post_replacements_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "Write your docs in text, +\nAsciiDoc makes it easy, +\nNow get back to work!"
         );
 
@@ -102,7 +102,7 @@ mod default_post_replacements_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "Write your docs in text,<br>\nAsciiDoc makes it easy,<br>\nNow get back to work!"
         );
     }
@@ -124,7 +124,7 @@ mod default_post_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "abc +\ndef");
+        assert_eq!(block1.content().rendered_html(), "abc +\ndef");
     }
 
     #[test]
@@ -151,7 +151,7 @@ mod default_post_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "abc<br>\ndef");
+        assert_eq!(block1.content().rendered_html(), "abc<br>\ndef");
     }
 
     #[test]
@@ -186,7 +186,7 @@ mod default_post_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "abc +\ndef");
+        assert_eq!(block1.content().rendered_html(), "abc +\ndef");
     }
 
     #[test]
@@ -208,7 +208,7 @@ mod default_post_replacements_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "Click <span class=\"image\"><img src=\"pause.png\" alt=\"pause\" title=\"Pause {abc<br>\ndef} Resume\"></span> when you need a break."
         );
     }
@@ -232,7 +232,7 @@ mod default_post_replacements_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "Click *Pause* +\n and Resume when you need a break."
         );
     }
@@ -261,7 +261,7 @@ mod default_post_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "abc<br>\ndef");
+        assert_eq!(block1.content().rendered_html(), "abc<br>\ndef");
     }
 
     #[test]
@@ -281,7 +281,7 @@ mod default_post_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "abc<br>\ndef");
+        assert_eq!(block1.content().rendered_html(), "abc<br>\ndef");
     }
 
     #[test]
@@ -301,7 +301,7 @@ mod default_post_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "abc +\ndef");
+        assert_eq!(block1.content().rendered_html(), "abc +\ndef");
     }
 
     #[test]
@@ -328,7 +328,7 @@ mod default_post_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "abc<br>\ndef");
+        assert_eq!(block1.content().rendered_html(), "abc<br>\ndef");
     }
 
     #[test]
@@ -355,7 +355,7 @@ mod default_post_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "abc<br>\ndef");
+        assert_eq!(block1.content().rendered_html(), "abc<br>\ndef");
     }
 
     #[test]
@@ -380,12 +380,12 @@ mod default_post_replacements_substitution {
         let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
             panic!("expected simple cell content");
         };
-        assert_eq!(default_cell.rendered(), "abc<br>\ndef");
+        assert_eq!(default_cell.rendered_html(), "abc<br>\ndef");
 
         let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
             panic!("expected simple cell content");
         };
-        assert_eq!(literal_cell.rendered(), "abc +\nghi");
+        assert_eq!(literal_cell.rendered_html(), "abc +\nghi");
     }
 
     // A block title cannot span multiple lines via a trailing `+`: a title is a
@@ -434,7 +434,7 @@ For blocks, the step's name, `post_replacements`, can be assigned to the xref:ap
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "abc *bold*<br>\ndef");
+        assert_eq!(block1.content().rendered_html(), "abc *bold*<br>\ndef");
     }
 
     #[test]
@@ -454,7 +454,7 @@ For inline elements, the built-in values `p` or `post_replacements` can be appli
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "abc<br>\n *bold* and then &#8230;&#8203;"
         );
     }

--- a/parser/src/tests/asciidoc_lang/subs/prevent.rs
+++ b/parser/src/tests/asciidoc_lang/subs/prevent.rs
@@ -79,7 +79,7 @@ The URL \https://example.org isn't converted into an active link.
                     panic!("Unexpected block type: {block:?}");
                 };
 
-                format!("{}\n\n", block.content().rendered())
+                format!("{}\n\n", block.content().rendered_html())
             })
             .collect::<String>();
 
@@ -121,7 +121,7 @@ include::example$subs.adoc[tag=double-slash]
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "The text __func__ will appear with two underscores\nin front of it and after it.\nIt won&#8217;t be italicized."
         );
     }
@@ -169,7 +169,7 @@ First, you can escape it using the `\{plus}` attribute reference:
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "<code>&#43;</code> and <code>&#43;</code>"
         );
     }
@@ -198,7 +198,7 @@ The backslash is only required before the pair, not before each occurance of the
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "<code>+</code> and <code>+</code>"
         );
     }

--- a/parser/src/tests/asciidoc_lang/subs/quotes.rs
+++ b/parser/src/tests/asciidoc_lang/subs/quotes.rs
@@ -56,7 +56,7 @@ Happy werewolves are <strong>really</strong> slobbery.
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             "Happy werewolves are <strong>really</strong> slobbery."
         );
     }
@@ -92,7 +92,7 @@ Happy werewolves are <strong>really</strong> slobbery.
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "<em>word</em>");
+        assert_eq!(sb1.content().rendered_html(), "<em>word</em>");
     }
 
     #[test]
@@ -114,7 +114,7 @@ Happy werewolves are <strong>really</strong> slobbery.
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "<strong>word</strong>");
+        assert_eq!(sb1.content().rendered_html(), "<strong>word</strong>");
     }
 
     #[test]
@@ -136,7 +136,7 @@ Happy werewolves are <strong>really</strong> slobbery.
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "<code>word</code>");
+        assert_eq!(sb1.content().rendered_html(), "<code>word</code>");
     }
 
     #[test]
@@ -158,7 +158,7 @@ Happy werewolves are <strong>really</strong> slobbery.
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "<sup>word</sup>");
+        assert_eq!(sb1.content().rendered_html(), "<sup>word</sup>");
     }
 
     #[test]
@@ -180,7 +180,7 @@ Happy werewolves are <strong>really</strong> slobbery.
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "<sub>word</sub>");
+        assert_eq!(sb1.content().rendered_html(), "<sub>word</sub>");
     }
 
     #[test]
@@ -202,7 +202,7 @@ Happy werewolves are <strong>really</strong> slobbery.
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "&#8220;word&#8221;");
+        assert_eq!(sb1.content().rendered_html(), "&#8220;word&#8221;");
     }
 
     #[test]
@@ -225,7 +225,7 @@ Happy werewolves are <strong>really</strong> slobbery.
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "&#8216;word&#8217;");
+        assert_eq!(sb1.content().rendered_html(), "&#8216;word&#8217;");
     }
 }
 
@@ -263,7 +263,7 @@ mod default_quotes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "Foo *bar*");
+        assert_eq!(sb1.content().rendered_html(), "Foo *bar*");
     }
 
     #[test]
@@ -283,7 +283,7 @@ mod default_quotes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "abc *def*");
+        assert_eq!(block1.content().rendered_html(), "abc *def*");
     }
 
     #[test]
@@ -311,7 +311,7 @@ mod default_quotes_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "Hello <strong>goodbye.</strong>"
         );
     }
@@ -333,7 +333,7 @@ mod default_quotes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "foo *bar*");
+        assert_eq!(block1.content().rendered_html(), "foo *bar*");
     }
 
     #[test]
@@ -354,7 +354,7 @@ mod default_quotes_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"Click <span class="image"><img src="pause.png" alt="pause" title="<strong>Pause</strong> and Resume"></span> when you need a break."#
         );
     }
@@ -377,7 +377,7 @@ mod default_quotes_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"Click *Pause* and Resume when you need a break."#
         );
     }
@@ -407,7 +407,7 @@ mod default_quotes_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "Opened and <strong>closed!</strong>"
         );
     }
@@ -430,7 +430,7 @@ mod default_quotes_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"This is a <strong>paragraph.</strong>"#
         );
     }
@@ -452,7 +452,7 @@ mod default_quotes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "foo *bar*");
+        assert_eq!(block1.content().rendered_html(), "foo *bar*");
     }
 
     #[test]
@@ -480,7 +480,7 @@ mod default_quotes_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "This and <strong>that</strong>"
         );
     }
@@ -509,7 +509,10 @@ mod default_quotes_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "Stuff over <em>nonsense</em>");
+        assert_eq!(
+            block1.content().rendered_html(),
+            "Stuff over <em>nonsense</em>"
+        );
     }
 
     #[test]
@@ -534,12 +537,12 @@ mod default_quotes_substitution {
         let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
             panic!("expected simple cell content");
         };
-        assert_eq!(default_cell.rendered(), "<strong>bold</strong>");
+        assert_eq!(default_cell.rendered_html(), "<strong>bold</strong>");
 
         let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
             panic!("expected simple cell content");
         };
-        assert_eq!(literal_cell.rendered(), "*lit*");
+        assert_eq!(literal_cell.rendered_html(), "*lit*");
     }
 
     #[test]
@@ -592,7 +595,10 @@ For blocks, the step's name, `quotes`, can be assigned to the xref:apply-subs-to
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "abc<lt <strong>bold</strong>");
+        assert_eq!(
+            block1.content().rendered_html(),
+            "abc<lt <strong>bold</strong>"
+        );
     }
 
     #[test]
@@ -612,7 +618,7 @@ For inline elements, the built-in values `q` or `quotes` can be applied to xref:
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "abc<lt <strong>bold</strong> and then &#8230;&#8203;"
         );
     }

--- a/parser/src/tests/asciidoc_lang/subs/replacements.rs
+++ b/parser/src/tests/asciidoc_lang/subs/replacements.rs
@@ -46,7 +46,7 @@ include::partial$subs-symbol-repl.adoc[]
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "&#169;");
+        assert_eq!(sb1.content().rendered_html(), "&#169;");
     }
 
     #[test]
@@ -59,7 +59,7 @@ include::partial$subs-symbol-repl.adoc[]
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "&#174;");
+        assert_eq!(sb1.content().rendered_html(), "&#174;");
     }
 
     #[test]
@@ -72,7 +72,7 @@ include::partial$subs-symbol-repl.adoc[]
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "&#8482;");
+        assert_eq!(sb1.content().rendered_html(), "&#8482;");
     }
 
     #[test]
@@ -85,7 +85,7 @@ include::partial$subs-symbol-repl.adoc[]
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "abc&#8212;&#8203;def");
+        assert_eq!(sb1.content().rendered_html(), "abc&#8212;&#8203;def");
     }
 
     #[test]
@@ -98,7 +98,7 @@ include::partial$subs-symbol-repl.adoc[]
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "abc&#8201;&#8212;&#8201;def");
+        assert_eq!(sb1.content().rendered_html(), "abc&#8201;&#8212;&#8201;def");
     }
 
     #[test]
@@ -111,7 +111,7 @@ include::partial$subs-symbol-repl.adoc[]
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "&#8230;&#8203;");
+        assert_eq!(sb1.content().rendered_html(), "&#8230;&#8203;");
     }
 
     #[test]
@@ -124,7 +124,7 @@ include::partial$subs-symbol-repl.adoc[]
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "&#8594;");
+        assert_eq!(sb1.content().rendered_html(), "&#8594;");
     }
 
     #[test]
@@ -137,7 +137,7 @@ include::partial$subs-symbol-repl.adoc[]
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "&#8658;");
+        assert_eq!(sb1.content().rendered_html(), "&#8658;");
     }
 
     #[test]
@@ -150,7 +150,7 @@ include::partial$subs-symbol-repl.adoc[]
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "&#8592;");
+        assert_eq!(sb1.content().rendered_html(), "&#8592;");
     }
 
     #[test]
@@ -163,7 +163,7 @@ include::partial$subs-symbol-repl.adoc[]
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "&#8656;");
+        assert_eq!(sb1.content().rendered_html(), "&#8656;");
     }
 
     #[test]
@@ -176,7 +176,7 @@ include::partial$subs-symbol-repl.adoc[]
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "Sam&#8217;s");
+        assert_eq!(sb1.content().rendered_html(), "Sam&#8217;s");
     }
 
     #[test]
@@ -197,7 +197,7 @@ When the document is processed, `replacements` will preserve the section symbol 
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             "In &sect; 8.1.5, we say &#8230;&#8203;"
         );
     }
@@ -220,7 +220,7 @@ In turn, `\&#167;` in the AsciiDoc source will display as &#167; in the rendered
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             "In &#167; 8.1.5, we say &#8230;&#8203;"
         );
     }
@@ -300,7 +300,7 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "ab (C) def");
+        assert_eq!(sb1.content().rendered_html(), "ab (C) def");
     }
 
     #[test]
@@ -320,7 +320,7 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "ab (C) def");
+        assert_eq!(block1.content().rendered_html(), "ab (C) def");
     }
 
     #[test]
@@ -347,7 +347,7 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "Hello &#169; goodbye.");
+        assert_eq!(block1.content().rendered_html(), "Hello &#169; goodbye.");
     }
 
     #[test]
@@ -382,7 +382,7 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "foo (C) bar");
+        assert_eq!(block1.content().rendered_html(), "foo (C) bar");
     }
 
     #[test]
@@ -403,7 +403,7 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"Click <span class="image"><img src="pause.png" alt="pause" title="Pause &#169; Resume"></span> when you need a break."#
         );
     }
@@ -426,7 +426,7 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"Click Pause (C) Resume when you need a break."#
         );
     }
@@ -455,7 +455,7 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "Opened &#169; closed!");
+        assert_eq!(block1.content().rendered_html(), "Opened &#169; closed!");
     }
 
     #[test]
@@ -476,7 +476,7 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"This is a &#169; paragraph."#
         );
     }
@@ -498,7 +498,7 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "foo (C) bar");
+        assert_eq!(block1.content().rendered_html(), "foo (C) bar");
     }
 
     #[test]
@@ -525,7 +525,7 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "This &#169; that");
+        assert_eq!(block1.content().rendered_html(), "This &#169; that");
     }
 
     #[test]
@@ -552,7 +552,7 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "Stuff &#169; nonsense");
+        assert_eq!(block1.content().rendered_html(), "Stuff &#169; nonsense");
     }
 
     #[test]
@@ -577,12 +577,12 @@ mod blocks_and_inline_elements_subject_to_the_replacements_substitution {
         let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
             panic!("expected simple cell content");
         };
-        assert_eq!(default_cell.rendered(), "&#169;");
+        assert_eq!(default_cell.rendered_html(), "&#169;");
 
         let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
             panic!("expected simple cell content");
         };
-        assert_eq!(literal_cell.rendered(), "(C)");
+        assert_eq!(literal_cell.rendered_html(), "(C)");
     }
 
     #[test]
@@ -634,7 +634,7 @@ For blocks, the step's name, `replacements`, can be assigned to the xref:apply-s
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "abc<lt &#169; *bold*");
+        assert_eq!(block1.content().rendered_html(), "abc<lt &#169; *bold*");
     }
 
     #[test]
@@ -655,7 +655,7 @@ For inline elements, the built-in values `r` or `replacements` can be applied to
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "abc<lt &#169; *bold* and then &#8230;&#8203;"
         );
     }
@@ -678,7 +678,7 @@ This is important to keep in mind when applying the `replacements` value to bloc
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "left-arrow <- not here but &#8592; there &#8230;&#8203;"
         );
     }

--- a/parser/src/tests/asciidoc_lang/subs/special_characters.rs
+++ b/parser/src/tests/asciidoc_lang/subs/special_characters.rs
@@ -39,7 +39,7 @@ The special characters substitution step searches for three characters (`<`, `>`
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "Replace this &lt; with lt");
+        assert_eq!(sb1.content().rendered_html(), "Replace this &lt; with lt");
     }
 
     #[test]
@@ -58,7 +58,7 @@ The special characters substitution step searches for three characters (`<`, `>`
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "Replace this &gt; with gt");
+        assert_eq!(sb1.content().rendered_html(), "Replace this &gt; with gt");
     }
 
     #[test]
@@ -78,7 +78,10 @@ The special characters substitution step searches for three characters (`<`, `>`
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "Replace this &amp; with amp");
+        assert_eq!(
+            block1.content().rendered_html(),
+            "Replace this &amp; with amp"
+        );
     }
 }
 
@@ -116,7 +119,7 @@ mod default_special_characters_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "Goodbye &lt; hello");
+        assert_eq!(sb1.content().rendered_html(), "Goodbye &lt; hello");
     }
 
     #[test]
@@ -136,7 +139,7 @@ mod default_special_characters_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "abc < def");
+        assert_eq!(block1.content().rendered_html(), "abc < def");
     }
 
     #[test]
@@ -163,7 +166,7 @@ mod default_special_characters_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "Hello &amp; goodbye.");
+        assert_eq!(block1.content().rendered_html(), "Hello &amp; goodbye.");
     }
 
     #[test]
@@ -198,7 +201,7 @@ mod default_special_characters_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "foo &gt; bar");
+        assert_eq!(block1.content().rendered_html(), "foo &gt; bar");
     }
 
     #[test]
@@ -219,7 +222,7 @@ mod default_special_characters_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"Click <span class="image"><img src="pause.png" alt="pause" title="Pause &amp; Resume"></span> when you need a break."#
         );
     }
@@ -242,7 +245,7 @@ mod default_special_characters_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"Click Pause & Resume when you need a break."#
         );
     }
@@ -271,7 +274,7 @@ mod default_special_characters_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "Opened &amp; closed!");
+        assert_eq!(block1.content().rendered_html(), "Opened &amp; closed!");
     }
 
     #[test]
@@ -292,7 +295,7 @@ mod default_special_characters_substitution {
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             r#"This is a &lt;paragraph&gt;."#
         );
     }
@@ -314,7 +317,7 @@ mod default_special_characters_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "foo > bar");
+        assert_eq!(block1.content().rendered_html(), "foo > bar");
     }
 
     #[test]
@@ -341,7 +344,7 @@ mod default_special_characters_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "This &amp; that");
+        assert_eq!(block1.content().rendered_html(), "This &amp; that");
     }
 
     #[test]
@@ -368,7 +371,7 @@ mod default_special_characters_substitution {
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "Stuff &gt; nonsense");
+        assert_eq!(block1.content().rendered_html(), "Stuff &gt; nonsense");
     }
 
     #[test]
@@ -394,12 +397,12 @@ mod default_special_characters_substitution {
         let crate::blocks::TableCellContent::Simple(default_cell) = cells[0].content() else {
             panic!("expected simple cell content");
         };
-        assert_eq!(default_cell.rendered(), "a &gt; b");
+        assert_eq!(default_cell.rendered_html(), "a &gt; b");
 
         let crate::blocks::TableCellContent::Simple(literal_cell) = cells[1].content() else {
             panic!("expected simple cell content");
         };
-        assert_eq!(literal_cell.rendered(), "c &gt; d");
+        assert_eq!(literal_cell.rendered_html(), "c &gt; d");
     }
 
     #[test]
@@ -451,7 +454,7 @@ For blocks, the step's name, `specialchars`, can be assigned to the xref:apply-s
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(block1.content().rendered(), "abc&lt;lt{sp}space");
+        assert_eq!(block1.content().rendered_html(), "abc&lt;lt{sp}space");
     }
 
     #[test]
@@ -472,7 +475,7 @@ For inline elements, the built-in values `c` or `specialchars` can be applied to
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "abc&lt;lt{sp}space and then &#8230;&#8203;"
         );
     }
@@ -504,7 +507,7 @@ For example, on the command line, type `+-a toc-title="Sections, Tables \&amp; F
         };
 
         assert_eq!(
-            block1.content().rendered(),
+            block1.content().rendered_html(),
             "The value of toc-title is Sections, Tables & Figures."
         );
     }

--- a/parser/src/tests/asciidoc_lang/tables/add_footer_row.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_footer_row.rs
@@ -21,7 +21,7 @@ fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
 /// cell, panicking if the cell holds AsciiDoc block content instead.
 fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
     match cell.content() {
-        crate::blocks::TableCellContent::Simple(content) => content.rendered().to_string(),
+        crate::blocks::TableCellContent::Simple(content) => content.rendered_html().to_string(),
         crate::blocks::TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
     }
 }

--- a/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_header_row.rs
@@ -21,7 +21,7 @@ fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
 /// cell, panicking if the cell holds AsciiDoc block content instead.
 fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
     match cell.content() {
-        crate::blocks::TableCellContent::Simple(content) => content.rendered().to_string(),
+        crate::blocks::TableCellContent::Simple(content) => content.rendered_html().to_string(),
         crate::blocks::TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
     }
 }

--- a/parser/src/tests/asciidoc_lang/tables/add_title.rs
+++ b/parser/src/tests/asciidoc_lang/tables/add_title.rs
@@ -211,7 +211,7 @@ This title label can be xref:customize-title-label.adoc[customized] or xref:turn
         panic!("expected a paragraph");
     };
     assert_eq!(
-        para.content().rendered(),
+        para.content().rendered_html(),
         "This title label can be <a href=\"customize-title-label.html\">customized</a> or <a href=\"turn-off-title-label.html\">deactivated</a>."
     );
 }

--- a/parser/src/tests/asciidoc_lang/tables/data_format.rs
+++ b/parser/src/tests/asciidoc_lang/tables/data_format.rs
@@ -23,7 +23,7 @@ fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
 /// panicking if the cell holds AsciiDoc block content.
 fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
     match cell.content() {
-        TableCellContent::Simple(content) => content.rendered().to_string(),
+        TableCellContent::Simple(content) => content.rendered_html().to_string(),
         TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
     }
 }

--- a/parser/src/tests/asciidoc_lang/tables/duplicate_cells.rs
+++ b/parser/src/tests/asciidoc_lang/tables/duplicate_cells.rs
@@ -37,7 +37,7 @@ fn body_texts(table: &crate::blocks::TableBlock<'_>) -> Vec<Vec<String>> {
                 .iter()
                 .map(|cell| match cell.content() {
                     crate::blocks::TableCellContent::Simple(content) => {
-                        content.rendered().to_string()
+                        content.rendered_html().to_string()
                     }
                     crate::blocks::TableCellContent::AsciiDoc(_) => {
                         panic!("expected simple cell content")

--- a/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_cell_content.rs
@@ -30,7 +30,7 @@ fn body_styles(table: &crate::blocks::TableBlock<'_>) -> Vec<Vec<ColumnStyle>> {
 /// cell, panicking if the cell holds AsciiDoc block content instead.
 fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
     match cell.content() {
-        crate::blocks::TableCellContent::Simple(content) => content.rendered().to_string(),
+        crate::blocks::TableCellContent::Simple(content) => content.rendered_html().to_string(),
         crate::blocks::TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
     }
 }
@@ -50,7 +50,7 @@ fn asciidoc_cell_text(doc: &crate::Document<'_>) -> String {
         crate::blocks::TableCellContent::AsciiDoc(cell) => cell
             .blocks()
             .iter()
-            .filter_map(|block| block.rendered_content())
+            .filter_map(|block| block.rendered_html_content())
             .collect::<Vec<_>>()
             .join("\n"),
         other => panic!("expected nested AsciiDoc blocks, got {other:?}"),
@@ -431,7 +431,7 @@ As such, it inherits attributes from the parent document.
             assert_eq!(blocks.len(), 1);
             match &blocks[0] {
                 crate::blocks::Block::Simple(simple) => {
-                    assert_eq!(simple.content().rendered(), "Hello Tester");
+                    assert_eq!(simple.content().rendered_html(), "Hello Tester");
                 }
                 other => panic!("expected a simple block, got {other:?}"),
             }

--- a/parser/src/tests/asciidoc_lang/tables/format_column_content.rs
+++ b/parser/src/tests/asciidoc_lang/tables/format_column_content.rs
@@ -26,7 +26,7 @@ fn column_styles(table: &crate::blocks::TableBlock<'_>) -> Vec<ColumnStyle> {
 /// cell, panicking if the cell holds AsciiDoc block content instead.
 fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
     match cell.content() {
-        crate::blocks::TableCellContent::Simple(content) => content.rendered().to_string(),
+        crate::blocks::TableCellContent::Simple(content) => content.rendered_html().to_string(),
         crate::blocks::TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
     }
 }
@@ -38,7 +38,7 @@ fn rendered_paragraph(source: &str) -> String {
     let crate::blocks::Block::Simple(para) = &doc.child_blocks().next().unwrap() else {
         panic!("expected a paragraph");
     };
-    para.content().rendered().to_string()
+    para.content().rendered_html().to_string()
 }
 
 non_normative!(

--- a/parser/src/tests/asciidoc_lang/tables/nested.rs
+++ b/parser/src/tests/asciidoc_lang/tables/nested.rs
@@ -42,7 +42,7 @@ fn nested_table<'a>(cell: &'a crate::blocks::TableCell<'_>) -> &'a crate::blocks
 /// cell.
 fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
     match cell.content() {
-        crate::blocks::TableCellContent::Simple(content) => content.rendered().to_string(),
+        crate::blocks::TableCellContent::Simple(content) => content.rendered_html().to_string(),
         crate::blocks::TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
     }
 }

--- a/parser/src/tests/asciidoc_lang/tables/table_ref.rs
+++ b/parser/src/tests/asciidoc_lang/tables/table_ref.rs
@@ -23,7 +23,7 @@ fn parse_table(source: &str) -> crate::blocks::TableBlock<'_> {
 /// panicking if the cell holds AsciiDoc block content.
 fn simple_text(cell: &crate::blocks::TableCell<'_>) -> String {
     match cell.content() {
-        TableCellContent::Simple(content) => content.rendered().to_string(),
+        TableCellContent::Simple(content) => content.rendered_html().to_string(),
         TableCellContent::AsciiDoc(_) => panic!("expected simple cell content"),
     }
 }

--- a/parser/src/tests/asciidoc_lang/text/bold.rs
+++ b/parser/src/tests/asciidoc_lang/text/bold.rs
@@ -57,7 +57,7 @@ Bold c**hara**cter**s** within a word.
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         r#"A bold <strong>word</strong>, and a bold <strong>phrase of text</strong>."#
     );
 
@@ -67,7 +67,7 @@ Bold c**hara**cter**s** within a word.
     };
 
     assert_eq!(
-        sb2.content().rendered(),
+        sb2.content().rendered_html(),
         r#"Bold c<strong>hara</strong>cter<strong>s</strong> within a word."#
     );
 
@@ -110,7 +110,7 @@ The results of <<ex-mix>> are displayed below.
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         r#"<code><strong><em>monospace bold italic phrase</em></strong></code> &amp; <code><strong><em>char</em></strong></code>acter<code><strong><em>s</em></strong></code>"#
     );
 

--- a/parser/src/tests/asciidoc_lang/text/custom_inline_styles.rs
+++ b/parser/src/tests/asciidoc_lang/text/custom_inline_styles.rs
@@ -51,7 +51,7 @@ include::example$text.adoc[tag=css]
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             r#"Do werewolves believe in <span class="small">small print</span>?"#
         );
 
@@ -61,7 +61,7 @@ include::example$text.adoc[tag=css]
         };
 
         assert_eq!(
-            sb2.content().rendered(),
+            sb2.content().rendered_html(),
             r#"<span class="big">O</span>nce upon an infinite loop."#
         );
 
@@ -104,7 +104,7 @@ include::example$text.adoc[tag=css-custom-html]
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             "Type the word <span class=\"userinput\">asciidoctor</span> into the search bar."
         );
 

--- a/parser/src/tests/asciidoc_lang/text/highlight.rs
+++ b/parser/src/tests/asciidoc_lang/text/highlight.rs
@@ -50,7 +50,7 @@ include::example$text.adoc[tag=highlight]
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         "Mark my words, <mark>automation is essential</mark>."
     );
 

--- a/parser/src/tests/asciidoc_lang/text/index.rs
+++ b/parser/src/tests/asciidoc_lang/text/index.rs
@@ -88,7 +88,7 @@ You can think of a constrained pair as being a weaker markup hint than an uncons
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             r#"That is <strong>strong</strong> stuff!"#
         );
 
@@ -106,7 +106,7 @@ You can think of a constrained pair as being a weaker markup hint than an uncons
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             r#"That is <strong>really strong</strong> stuff!"#
         );
 
@@ -124,7 +124,7 @@ You can think of a constrained pair as being a weaker markup hint than an uncons
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             r#"This stuff is <strong>strong</strong>!"#
         );
 
@@ -166,7 +166,7 @@ See xref:troubleshoot-unconstrained-formatting.adoc#use-unconstrained[When shoul
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             r#"The man page, short for <strong>man</strong>ual page, is a form of software documentation."#
         );
 

--- a/parser/src/tests/asciidoc_lang/text/italic.rs
+++ b/parser/src/tests/asciidoc_lang/text/italic.rs
@@ -57,7 +57,7 @@ Italic c__hara__cter__s__ within a word.
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         r#"An italic <em>word</em>, and an italic <em>phrase of text</em>."#
     );
 
@@ -67,7 +67,7 @@ Italic c__hara__cter__s__ within a word.
     };
 
     assert_eq!(
-        sb2.content().rendered(),
+        sb2.content().rendered_html(),
         r#"Italic c<em>hara</em>cter<em>s</em> within a word."#
     );
 
@@ -111,7 +111,7 @@ The result of <<ex-mix>> is rendered below.
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         r#"<code><strong><em>monospace bold italic phrase</em></strong></code> &amp; <code><strong><em>char</em></strong></code>acter<code><strong><em>s</em></strong></code>"#
     );
 

--- a/parser/src/tests/asciidoc_lang/text/literal_monospace.rs
+++ b/parser/src/tests/asciidoc_lang/text/literal_monospace.rs
@@ -53,7 +53,7 @@ include::example$text.adoc[tag=literal-mono]
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         "You can reference the value of a document attribute using\nthe syntax <code>{name}</code>, where <code>name</code> is the attribute name."
     );
 
@@ -89,7 +89,7 @@ include::example$text.adoc[tag=literal-mono-with-plus]
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         "<code>++</code> is the increment operator in C."
     );
 

--- a/parser/src/tests/asciidoc_lang/text/monospace.rs
+++ b/parser/src/tests/asciidoc_lang/text/monospace.rs
@@ -49,7 +49,7 @@ include::example$text.adoc[tag=mono]
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         "&#8220;Wait!&#8221; Indigo plucked a small vial from her desk&#8217;s top drawer and held it toward us.\nThe vial&#8217;s label read: <code>E=mc<sup>2</sup></code>; the <code>E</code> represents <em>energy</em>,\nbut also pure <em>genius!</em>"
     );
 
@@ -83,7 +83,7 @@ The command will re``link`` all packages.
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         "The command will re<code>link</code> all packages."
     );
 
@@ -124,7 +124,7 @@ The result of <<ex-mix>> is rendered below.
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         "<code><strong><em>monospaced bold italic</em></strong></code>"
     );
 

--- a/parser/src/tests/asciidoc_lang/text/quotation_marks_and_apostrophes.rs
+++ b/parser/src/tests/asciidoc_lang/text/quotation_marks_and_apostrophes.rs
@@ -50,7 +50,7 @@ include::example$text.adoc[tag=straight-quotes]
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             "In Ruby, '\\n' represents a backslash followed by the letter n.\nSingle quotes prevent escape sequences from being interpreted.\nIn contrast, \"\\n\" represents a newline."
         );
 
@@ -92,7 +92,7 @@ include::example$text.adoc[tag=c-quote]
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             "&#8220;What kind of charm?&#8221; Lazarus asked.\n&#8220;An odoriferous one or a mineral one?&#8221;"
         );
 
@@ -102,7 +102,7 @@ include::example$text.adoc[tag=c-quote]
         };
 
         assert_eq!(
-            sb2.content().rendered(),
+            sb2.content().rendered_html(),
             "Kizmet shrugged.\n&#8220;The note from Olaf&#8217;s desk says &#8216;wormwood and licorice,&#8217;\nbut these could be normal groceries for werewolves.&#8221;"
         );
 
@@ -159,7 +159,10 @@ Olaf's desk was a mess.
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "Olaf&#8217;s desk was a mess.");
+        assert_eq!(
+            sb1.content().rendered_html(),
+            "Olaf&#8217;s desk was a mess."
+        );
 
         assert!(blocks.next().is_none());
     }
@@ -194,7 +197,7 @@ Olaf\'s desk ...
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), "Olaf's desk &#8230;&#8203;");
+        assert_eq!(sb1.content().rendered_html(), "Olaf's desk &#8230;&#8203;");
 
         assert!(blocks.next().is_none());
     }
@@ -240,7 +243,7 @@ include::example$text.adoc[tag=apos]
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             "Olaf had been with the company since the &#8217;00s.\nHis desk overflowed with heaps of paper, apple cores and squeaky toys.\nWe couldn&#8217;t find Olaf&#8217;s keyboard.\nThe state of his desk was replicated, in triplicate, across all of\nthe werewolves&#8217; desks."
         );
 
@@ -284,7 +287,7 @@ A ``std::vector```'s size is the number of items it contains.
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             "<code>npm</code>&#8217;s job is to manage the dependencies for your application."
         );
 
@@ -294,7 +297,7 @@ A ``std::vector```'s size is the number of items it contains.
         };
 
         assert_eq!(
-            sb2.content().rendered(),
+            sb2.content().rendered_html(),
             "A <code>std::vector</code>&#8217;s size is the number of items it contains."
         );
 
@@ -342,7 +345,7 @@ The `class`’ static methods make it easy to operate on files and directories.
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             "This <code>class</code>&#8217; static methods make it easy to operate on files and directories."
         );
 

--- a/parser/src/tests/asciidoc_lang/text/subscript_and_superscript.rs
+++ b/parser/src/tests/asciidoc_lang/text/subscript_and_superscript.rs
@@ -64,7 +64,7 @@ E=mc^2^,`" Lazarus replied."#,
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             "&#8220;Well the H<sub>2</sub>O formula written on their whiteboard could be part\nof a shopping list, but I don&#8217;t think the local bodega sells\nE=mc<sup>2</sup>,&#8221; Lazarus replied."
         );
 
@@ -97,7 +97,7 @@ include::example$text.adoc[tag=sup-with-spaces]
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             "The deepest body of water is Deep Creek Lake.<sup>[citation needed]</sup>"
         );
 

--- a/parser/src/tests/asciidoc_lang/text/text_span_built_in_roles.rs
+++ b/parser/src/tests/asciidoc_lang/text/text_span_built_in_roles.rs
@@ -55,7 +55,7 @@ In this case, since `underline` is a built-in role, the style is provided for yo
     };
 
     assert_eq!(
-        sb1.content().rendered(),
+        sb1.content().rendered_html(),
         r#"The text <span class="underline">underline me</span> is underlined."#
     );
 

--- a/parser/src/tests/asciidoc_lang/text/troubleshoot_unconstrained_formatting.rs
+++ b/parser/src/tests/asciidoc_lang/text/troubleshoot_unconstrained_formatting.rs
@@ -52,7 +52,7 @@ To help you determine whether a particular syntax pattern requires an unconstrai
 
         let doc = Parser::default().parse(r#"Sara__h__"#);
         let sb = super::first_simple_block(&doc);
-        assert_eq!(sb.content().rendered(), "Sara<em>h</em>");
+        assert_eq!(sb.content().rendered_html(), "Sara<em>h</em>");
     }
 
     #[test]
@@ -69,7 +69,7 @@ To help you determine whether a particular syntax pattern requires an unconstrai
 
         let doc = Parser::default().parse(r#"**B**old"#);
         let sb = super::first_simple_block(&doc);
-        assert_eq!(sb.content().rendered(), "<strong>B</strong>old");
+        assert_eq!(sb.content().rendered_html(), "<strong>B</strong>old");
     }
 
     #[test]
@@ -86,7 +86,7 @@ To help you determine whether a particular syntax pattern requires an unconstrai
 
         let doc = Parser::default().parse(r#"&ndash;**2016**"#);
         let sb = super::first_simple_block(&doc);
-        assert_eq!(sb.content().rendered(), "&ndash;<strong>2016</strong>");
+        assert_eq!(sb.content().rendered_html(), "&ndash;<strong>2016</strong>");
     }
 
     #[test]
@@ -104,7 +104,7 @@ To help you determine whether a particular syntax pattern requires an unconstrai
         // NOTE: Inserted `xyz` prefix to prevent this being parsed as a list.
         let doc = Parser::default().parse(r#"xyz ** bold **"#);
         let sb = super::first_simple_block(&doc);
-        assert_eq!(sb.content().rendered(), "xyz <strong> bold </strong>");
+        assert_eq!(sb.content().rendered_html(), "xyz <strong> bold </strong>");
     }
 
     #[test]
@@ -121,7 +121,7 @@ To help you determine whether a particular syntax pattern requires an unconstrai
 
         let doc = Parser::default().parse(r#"我喜欢**大**狗"#);
         let sb = super::first_simple_block(&doc);
-        assert_eq!(sb.content().rendered(), "我喜欢<strong>大</strong>狗");
+        assert_eq!(sb.content().rendered_html(), "我喜欢<strong>大</strong>狗");
     }
 
     #[test]
@@ -138,7 +138,7 @@ To help you determine whether a particular syntax pattern requires an unconstrai
 
         let doc = Parser::default().parse(r#"*2016*&ndash;"#);
         let sb = super::first_simple_block(&doc);
-        assert_eq!(sb.content().rendered(), "<strong>2016</strong>&ndash;");
+        assert_eq!(sb.content().rendered_html(), "<strong>2016</strong>&ndash;");
     }
 
     #[test]
@@ -155,7 +155,7 @@ To help you determine whether a particular syntax pattern requires an unconstrai
         let doc = Parser::default().parse(r#"*9*-to-*5*"#);
         let sb = super::first_simple_block(&doc);
         assert_eq!(
-            sb.content().rendered(),
+            sb.content().rendered_html(),
             "<strong>9</strong>-to-<strong>5</strong>"
         );
     }
@@ -209,7 +209,7 @@ The backticks contribute to making the curved quotation marks, but the word isn'
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), r#"&#8220;end points&#8221;"#);
+        assert_eq!(sb1.content().rendered_html(), r#"&#8220;end points&#8221;"#);
 
         assert!(blocks.next().is_none());
     }
@@ -238,7 +238,10 @@ The parser ignores the inner pair of backticks and interprets them as literal ch
             panic!("Unexpected block type: {block1:?}");
         };
 
-        assert_eq!(sb1.content().rendered(), r#"&#8220;`end points`&#8221;"#);
+        assert_eq!(
+            sb1.content().rendered_html(),
+            r#"&#8220;`end points`&#8221;"#
+        );
 
         assert!(blocks.next().is_none());
     }
@@ -268,7 +271,7 @@ That's three pairs of backticks in total.
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             r#"&#8220;<code>end points</code>&#8221;"#
         );
 
@@ -300,7 +303,7 @@ For example:
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             r#""<code class="code">end points</code>" or "<code>end points</code>""#
         );
 
@@ -339,7 +342,7 @@ The ``class```' static methods make it easy to operate on files and directories.
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             r#"The <code>class</code>&#8217; static methods make it easy to operate on files and directories."#
         );
 
@@ -371,7 +374,7 @@ The `class`’ static methods make it easy to operate on files and directories.
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             r#"The <code>class</code>’ static methods make it easy to operate on files and directories."#
         );
 
@@ -433,7 +436,7 @@ The mix of constrained and unconstrained formatting marks in the line is ambiguo
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             r#"The <em>kernel qualifier can be used with the </em>attribute__ keyword&#8230;&#8203;"#
         );
 
@@ -443,7 +446,7 @@ The mix of constrained and unconstrained formatting marks in the line is ambiguo
         };
 
         assert_eq!(
-            sb2.content().rendered(),
+            sb2.content().rendered_html(),
             r#"<mark><code>CB<mark>#2</code></mark> and <mark><code>CB</mark>#3</code></mark>"#
         );
 
@@ -490,7 +493,7 @@ This works because xref:subs:attributes.adoc[attribute expansion] is performed a
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             r#"The __kernel qualifier can be used with the __attribute__ keyword&#8230;&#8203;"#
         );
 
@@ -500,7 +503,7 @@ This works because xref:subs:attributes.adoc[attribute expansion] is performed a
         };
 
         assert_eq!(
-            sb2.content().rendered(),
+            sb2.content().rendered_html(),
             r#"<mark><code>CB###2</code></mark> and <mark><code>CB###3</code></mark>"#
         );
 
@@ -536,7 +539,7 @@ However, the text still receives proper output escaping for xref:subs:special-ch
         };
 
         assert_eq!(
-            sb1.content().rendered(),
+            sb1.content().rendered_html(),
             r#"The __kernel qualifier can be used with the __attribute__ keyword&#8230;&#8203;"#
         );
 
@@ -546,7 +549,7 @@ However, the text still receives proper output escaping for xref:subs:special-ch
         };
 
         assert_eq!(
-            sb2.content().rendered(),
+            sb2.content().rendered_html(),
             r#"<mark><code>CB###2</code></mark> and <mark><code>CB###3</code></mark>"#
         );
 

--- a/parser/src/tests/asciidoc_lang/verbatim/callouts.rs
+++ b/parser/src/tests/asciidoc_lang/verbatim/callouts.rs
@@ -132,7 +132,7 @@ The risk of this approach is that you have to keep track of which numbers are be
     let parser = Parser::default();
     crate::content::SubstitutionStep::Callouts.apply(&mut content, &parser, None);
     assert_eq!(
-        content.rendered(),
+        content.rendered_html(),
         "first <b class=\"conum\">(1)</b>\nsecond <b class=\"conum\">(2)</b>\nrepeat <b class=\"conum\">(1)</b>"
     );
 }

--- a/parser/src/tests/asciidoctor_rb/attributes_test.rs
+++ b/parser/src/tests/asciidoctor_rb/attributes_test.rs
@@ -2727,7 +2727,7 @@ mod intrinsic_attributes {
             if let crate::blocks::Block::RawDelimited(raw) = b {
                 return raw
                     .content()
-                    .rendered()
+                    .rendered_html()
                     .lines()
                     .map(str::to_string)
                     .collect();

--- a/parser/src/tests/asciidoctor_rb/helpers_test.rs
+++ b/parser/src/tests/asciidoctor_rb/helpers_test.rs
@@ -164,7 +164,7 @@ fn extname_should_return_whether_path_contains_an_extname() {
             panic!("expected a simple block");
         };
 
-        block.content().rendered().to_string()
+        block.content().rendered_html().to_string()
     }
 
     // `assert Asciidoctor::Helpers.extname?('document.adoc')`: has an extension,

--- a/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
+++ b/parser/src/tests/asciidoctor_rb/paragraphs_test.rs
@@ -3050,7 +3050,7 @@ mod quote {
         let doc = Parser::default().parse("[verse]\n_GET /groups/link:#group-id[\\{group-id\\}]_");
         let block = doc.child_blocks().next().unwrap();
         assert_eq!(
-            block.rendered_content(),
+            block.rendered_html_content(),
             Some("<em>GET /groups/<a href=\"#group-id\">{group-id}</a></em>")
         );
     }
@@ -3403,7 +3403,7 @@ mod special {
             // <p>` wrapper.
             let first = doc.child_blocks().next().unwrap();
             assert_eq!(
-                first.rendered_content(),
+                first.rendered_html_content(),
                 Some(
                     "<a href=\"http://asciidoc.org\">AsciiDoc</a> is a <em>lightweight</em> markup language&#8230;&#8203;"
                 )
@@ -3510,7 +3510,7 @@ mod special {
         // boundary that distinguishes the candidate from the compound-preamble
         // case above.
         #[test]
-        fn titled_paragraph_without_section_is_rendered() {
+        fn titled_paragraph_without_section_is_rendered_html() {
             let doc = Parser::default()
                 .with_intrinsic_attribute("doctype", "inline", ModificationContext::Anywhere)
                 .parse("= Title\n\nfirst paragraph");
@@ -3561,7 +3561,7 @@ mod custom {
         // as an ordinary paragraph.
         let block = doc.child_blocks().next().unwrap();
         assert_eq!(block.declared_style(), Some("foo"));
-        assert_eq!(block.rendered_content(), Some("bar"));
+        assert_eq!(block.rendered_html_content(), Some("bar"));
 
         // Asciidoctor asserts no messages at its *default* (WARN) severity. This
         // crate surfaces the unknown style as a `WarningSeverity::Debug`

--- a/parser/src/tests/asciidoctor_rb/substitutions_test.rs
+++ b/parser/src/tests/asciidoctor_rb/substitutions_test.rs
@@ -7164,7 +7164,7 @@ mod macros {
             let parser = Parser::default();
             crate::content::SubstitutionStep::Macros.apply(&mut content, &parser, None);
 
-            assert_eq!(content.rendered(), "x footnote:[note]</a>");
+            assert_eq!(content.rendered_html(), "x footnote:[note]</a>");
         }
     }
 
@@ -9018,7 +9018,7 @@ mod passthroughs {
                 panic!("expected a simple block");
             };
 
-            block.content().rendered().to_string()
+            block.content().rendered_html().to_string()
         };
 
         // Unquoted role via the normal block-style path.
@@ -9628,7 +9628,7 @@ mod passthroughs {
         );
         let doc = p.parse("pass:bogus[++]");
         assert_eq!(
-            doc.child_blocks().next().unwrap().rendered_content(),
+            doc.child_blocks().next().unwrap().rendered_html_content(),
             Some("++")
         );
 
@@ -10645,7 +10645,7 @@ mod passthroughs {
             let mut parser = parser;
             let doc = parser.parse(input);
             assert_eq!(
-                doc.child_blocks().next().unwrap().rendered_content(),
+                doc.child_blocks().next().unwrap().rendered_html_content(),
                 Some(expected),
                 "input = {input:?}"
             );
@@ -11153,7 +11153,7 @@ mod passthroughs {
             );
             let doc = p.parse("stem:bogus[x^2]");
             assert_eq!(
-                doc.child_blocks().next().unwrap().rendered_content(),
+                doc.child_blocks().next().unwrap().rendered_html_content(),
                 Some(r"\$x^2\$")
             );
 

--- a/parser/src/tests/assert_dom/mod.rs
+++ b/parser/src/tests/assert_dom/mod.rs
@@ -89,7 +89,7 @@ fn check_block_contains<'src, B: IsBlock<'src> + FindBlocks<'src>>(
     block: &'src B,
     text: &str,
 ) -> bool {
-    if let Some(content) = block.rendered_content()
+    if let Some(content) = block.rendered_html_content()
         && content.contains(text)
     {
         return true;
@@ -117,7 +117,7 @@ pub(crate) fn refute_output_contains<'src>(doc: &'src Document<'src>, text: &str
 }
 
 fn refute_block_contains<'src, B: IsBlock<'src> + FindBlocks<'src>>(block: &'src B, text: &str) {
-    if let Some(content) = block.rendered_content() {
+    if let Some(content) = block.rendered_html_content() {
         dbg!(&content);
         if content.contains(text) {
             panic!("Block should not have contained {text}, but did:\n\n{block:#?}");

--- a/parser/src/tests/assert_dom/virtual_dom.rs
+++ b/parser/src/tests/assert_dom/virtual_dom.rs
@@ -562,7 +562,7 @@ impl ToVirtualDom for Document<'_> {
             InterpretedValue::Value(ref v) if v == "inline"
         ) {
             if let Some(rendered) =
-                first_inline_candidate(self.child_blocks()).and_then(|b| b.rendered_content())
+                first_inline_candidate(self.child_blocks()).and_then(|b| b.rendered_html_content())
             {
                 node.children.extend(parse_html_content(rendered));
             }
@@ -769,8 +769,8 @@ impl ToVirtualDom for Block<'_> {
                     || simple.declared_style() == Some("literal")
                     || simple.declared_style() == Some("verse")
                 {
-                    let pre_node =
-                        VirtualNode::new("pre").with_text(simple.content().rendered().to_string());
+                    let pre_node = VirtualNode::new("pre")
+                        .with_text(simple.content().rendered_html().to_string());
                     node = node.with_child(pre_node);
                 }
                 node
@@ -853,7 +853,7 @@ fn simple_block_to_node<'a>(block: &'a SimpleBlock<'a>) -> VirtualNode {
 
     // Extract text content for paragraphs (only for <p> tags).
     if tag == "p" {
-        node = node.with_html_content(block.content().rendered().to_string());
+        node = node.with_html_content(block.content().rendered_html().to_string());
     }
 
     node
@@ -959,7 +959,7 @@ fn list_block_to_node<'a>(list: &'a ListBlock<'a>) -> VirtualNode {
 
                         let td_term = VirtualNode::new("td")
                             .with_class("hdlist1")
-                            .with_html_content(term.rendered().to_string());
+                            .with_html_content(term.rendered_html().to_string());
                         tr_node.children.push(td_term);
 
                         let mut td_def = VirtualNode::new("td").with_class("hdlist2");
@@ -982,7 +982,7 @@ fn list_block_to_node<'a>(list: &'a ListBlock<'a>) -> VirtualNode {
                         }
 
                         // Set the term text.
-                        dt_node = dt_node.with_html_content(term.rendered().to_string());
+                        dt_node = dt_node.with_html_content(term.rendered_html().to_string());
                         list_element.children.push(dt_node);
 
                         // Create dd node for the definition, but only if the item has content.
@@ -1170,7 +1170,7 @@ fn colist_icon_table_to_node<'a>(list: &'a ListBlock<'a>, icons: IconsMode) -> V
         if let Some(text) = item
             .child_blocks()
             .next()
-            .and_then(|b| b.rendered_content())
+            .and_then(|b| b.rendered_html_content())
         {
             text_cell = text_cell.with_html_content(text);
         }
@@ -1625,7 +1625,7 @@ fn raw_delimited_to_node<'a>(raw: &'a RawDelimitedBlock<'a>) -> VirtualNode {
 
             // Add the block's rendered content to the code element, parsing any
             // inline HTML (e.g. callout conums) into child nodes.
-            if let Some(content) = raw.rendered_content() {
+            if let Some(content) = raw.rendered_html_content() {
                 code = code.with_html_content(content);
             }
 
@@ -1633,7 +1633,7 @@ fn raw_delimited_to_node<'a>(raw: &'a RawDelimitedBlock<'a>) -> VirtualNode {
             node.children.push(pre);
         } else {
             let mut pre = VirtualNode::new("pre");
-            if let Some(content) = raw.rendered_content() {
+            if let Some(content) = raw.rendered_html_content() {
                 pre = pre.with_html_content(content);
             }
             node.children.push(pre);
@@ -1714,7 +1714,7 @@ fn open_paragraph_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
     }
 
     let mut content = VirtualNode::new("div").with_class("content");
-    if let Some(rendered) = block.rendered_content() {
+    if let Some(rendered) = block.rendered_html_content() {
         content = content.with_html_content(rendered);
     }
     node.children.push(content);
@@ -1771,7 +1771,7 @@ fn abstract_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
         // An abstract paragraph holds inline content, rendered directly inside
         // the blockquote without a wrapping paragraph.
         _ => {
-            if let Some(rendered) = block.rendered_content() {
+            if let Some(rendered) = block.rendered_html_content() {
                 blockquote = blockquote.with_html_content(rendered);
             }
         }
@@ -1842,7 +1842,7 @@ fn collapsible_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
         // the content wrapper without a wrapping paragraph (matching
         // Asciidoctor's output for the example paragraph style).
         _ => {
-            if let Some(rendered) = block.rendered_content() {
+            if let Some(rendered) = block.rendered_html_content() {
                 content = content.with_html_content(rendered);
             }
         }
@@ -1911,7 +1911,7 @@ fn sidebar_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
         // content wrapper without a wrapping paragraph (matching Asciidoctor's
         // output for the sidebar paragraph style).
         _ => {
-            if let Some(rendered) = block.rendered_content() {
+            if let Some(rendered) = block.rendered_html_content() {
                 content = content.with_html_content(rendered);
             }
         }
@@ -1995,7 +1995,7 @@ fn example_to_node<'a>(block: &'a Block<'a>) -> VirtualNode {
         // An example paragraph holds inline content, rendered directly inside the
         // content wrapper without a wrapping paragraph.
         _ => {
-            if let Some(rendered) = block.rendered_content() {
+            if let Some(rendered) = block.rendered_html_content() {
                 content = content.with_html_content(rendered);
             }
         }
@@ -2061,7 +2061,7 @@ fn admonition_to_node<'a>(admonition: &'a AdmonitionBlock<'a>) -> VirtualNode {
         // paragraph), matching Asciidoctor's HTML output.
         _ => {
             if let Some(content) = admonition.content() {
-                let rendered = content.rendered();
+                let rendered = content.rendered_html();
                 if rendered.contains('<') {
                     content_cell.children.extend(parse_html_content(rendered));
                 } else {
@@ -2103,7 +2103,7 @@ fn quote_to_node<'a>(quote: &'a QuoteBlock<'a>) -> VirtualNode {
         QuoteType::Verse => {
             let rendered = quote
                 .content()
-                .map(|c| c.rendered().to_string())
+                .map(|c| c.rendered_html().to_string())
                 .unwrap_or_default();
             node.children.push(
                 VirtualNode::new("pre")
@@ -2131,7 +2131,7 @@ fn quote_to_node<'a>(quote: &'a QuoteBlock<'a>) -> VirtualNode {
 
                 _ => {
                     if let Some(content) = quote.content() {
-                        let rendered = content.rendered();
+                        let rendered = content.rendered_html();
                         if rendered.contains('<') {
                             blockquote.children.extend(parse_html_content(rendered));
                         } else {
@@ -2333,7 +2333,7 @@ fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bo
 
         match cell.content() {
             TableCellContent::Simple(content) => {
-                let rendered = content.rendered().to_string();
+                let rendered = content.rendered_html().to_string();
 
                 match cell.style() {
                     // A literal cell renders its content verbatim inside a
@@ -2378,9 +2378,10 @@ fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bo
                         // Asciidoctor (the parser stores them as one cell with
                         // embedded blank lines).
                         None => {
-                            for para in
-                                split_cell_paragraphs(content.original().data(), content.rendered())
-                            {
+                            for para in split_cell_paragraphs(
+                                content.original().data(),
+                                content.rendered_html(),
+                            ) {
                                 cell_node.children.push(
                                     VirtualNode::new("p")
                                         .with_class("tableblock")
@@ -2450,7 +2451,7 @@ fn table_row_to_node(row: &TableRow<'_>, header_row: bool, wrap_in_paragraph: bo
                     // An `inline` doctype renders block content as bare inline
                     // content, without the `<div class="paragraph"><p>` wrapper.
                     for block in cell.blocks() {
-                        match block.rendered_content() {
+                        match block.rendered_html_content() {
                             Some(rendered) => {
                                 content.children.extend(parse_html_content(rendered));
                             }

--- a/parser/src/tests/fixtures/content.rs
+++ b/parser/src/tests/fixtures/content.rs
@@ -27,5 +27,5 @@ impl PartialEq<Content> for &crate::content::Content<'_> {
 }
 
 fn fixture_eq_observed(fixture: &Content, observed: &crate::content::Content) -> bool {
-    fixture.original == observed.original() && fixture.rendered == observed.rendered()
+    fixture.original == observed.original() && fixture.rendered == observed.rendered_html()
 }

--- a/parser/src/tests/inline_recorder.rs
+++ b/parser/src/tests/inline_recorder.rs
@@ -8,8 +8,8 @@
 //! it proves:
 //!
 //! 1. Stripping/folding the recorder's marked string reproduces the built-in
-//!    renderer's `rendered()` output **byte-for-byte** (the *no-perturbation*
-//!    invariant).
+//!    renderer's `rendered_html()` output **byte-for-byte** (the
+//!    *no-perturbation* invariant).
 //! 2. The recovered [`InlineNode`] tree is structurally faithful (node kinds,
 //!    nesting, and the `constructs <= markers <= events` cross-check).
 //!
@@ -81,7 +81,7 @@ fn experimental(parser: Parser) -> Parser {
 
 /// The result of running the oracle on one source string.
 struct Oracle<'src> {
-    /// The authoritative `rendered()` output of the unmodified pipeline.
+    /// The authoritative `rendered_html()` output of the unmodified pipeline.
     golden: String,
 
     /// The fold of the recovered tree (the recorder's marked string folded back
@@ -153,7 +153,7 @@ fn check<'src>(source: &'src str, group: &SubstitutionGroup) -> Vec<InlineNode<'
 
     assert_eq!(
         result.folded, result.golden,
-        "fold of the inline tree diverged from rendered() for {source:?}"
+        "fold of the inline tree diverged from rendered_html() for {source:?}"
     );
 
     // Cross-check the tree against the recorder along the honest chain
@@ -347,7 +347,7 @@ fn normal_corpus_folds_byte_for_byte() {
 // `Content`, which cannot resolve cross-references (that needs a document
 // catalog). This harness parses whole documents – once normally, once with the
 // recorder installed – and asserts that folding each simple block's recorded
-// tree reproduces its `rendered()` string. It reaches resolved xrefs, list
+// tree reproduces its `rendered_html()` string. It reaches resolved xrefs, list
 // items, section bodies, and the interactions between blocks.
 
 /// Collects the rendered inline content of every content-bearing location in
@@ -361,7 +361,7 @@ fn collect_rendered(doc: &crate::Document<'_>) -> Vec<String> {
             // `AsciiDoc` cell is a nested standalone document and is out of
             // scope for this harness.
             if let TableCellContent::Simple(content) = cell.content() {
-                out.push(content.rendered().to_string());
+                out.push(content.rendered_html().to_string());
             }
         }
     }
@@ -372,7 +372,7 @@ fn collect_rendered(doc: &crate::Document<'_>) -> Vec<String> {
         }
 
         match block {
-            Block::Simple(simple) => out.push(simple.content().rendered().to_string()),
+            Block::Simple(simple) => out.push(simple.content().rendered_html().to_string()),
 
             Block::Section(section) => out.push(section.section_title().to_string()),
 
@@ -411,9 +411,10 @@ fn collect_rendered(doc: &crate::Document<'_>) -> Vec<String> {
 /// order.
 ///
 /// A footnote's text is extracted out of the block it was written in, so it
-/// never appears in any `rendered()` string [`collect_rendered`] reaches. It is
-/// nonetheless substituted inline content – and the source of a footnote node's
-/// subtree – so the differential harness folds it under the same invariant.
+/// never appears in any `rendered_html()` string [`collect_rendered`] reaches.
+/// It is nonetheless substituted inline content – and the source of a footnote
+/// node's subtree – so the differential harness folds it under the same
+/// invariant.
 fn collect_footnote_texts(doc: &crate::Document<'_>) -> Vec<String> {
     doc.catalog()
         .footnotes()
@@ -423,9 +424,10 @@ fn collect_footnote_texts(doc: &crate::Document<'_>) -> Vec<String> {
 }
 
 /// Parses `source` twice – normally and with the recorder – and asserts that
-/// folding every content location's recorded tree reproduces its `rendered()`
-/// output byte-for-byte, including any resolved cross-references, section
-/// headings, block titles, table cells, and footnote texts.
+/// folding every content location's recorded tree reproduces its
+/// `rendered_html()` output byte-for-byte, including any resolved
+/// cross-references, section headings, block titles, table cells, and footnote
+/// texts.
 fn check_document(source: &str) {
     assert_no_reserved_sentinels(source);
 
@@ -459,7 +461,7 @@ fn check_document(source: &str) {
 
     assert_eq!(
         folded, golden,
-        "document fold diverged from rendered() for {source:?}"
+        "document fold diverged from rendered_html() for {source:?}"
     );
 }
 
@@ -532,7 +534,7 @@ fn document_corpus_folds_byte_for_byte() {
 
 /// Parses `source` twice – with inline-tree building off (the default) and on –
 /// and asserts the rendered output is identical, so enabling the flag cannot
-/// perturb what the golden `.rendered()` assertions pin.
+/// perturb what the golden `.rendered_html()` assertions pin.
 ///
 /// This also drives the whole flag-on production path over the corpus: the
 /// counter-safe recording pass, the footnote-subtree attachment, and both
@@ -873,9 +875,10 @@ fn inline_tree_is_built_when_enabled() {
 // ─── Public API: `IsBlock::inlines()` ───────────────────────────────────────
 //
 // The public inline accessor (design Phase 3) is the structured counterpart of
-// `IsBlock::rendered_content()`: the same content-bearing blocks carry each. A
-// content-bearing block returns `Some(tree)` (an empty tree when the flag is
-// off); a block with no directly-contained inline content returns `None`.
+// `IsBlock::rendered_html_content()`: the same content-bearing blocks carry
+// each. A content-bearing block returns `Some(tree)` (an empty tree when the
+// flag is off); a block with no directly-contained inline content returns
+// `None`.
 
 #[test]
 fn is_block_inlines_exposes_the_content_tree() {
@@ -949,7 +952,7 @@ fn block_variant_name(block: &crate::blocks::Block<'_>) -> &'static str {
 }
 
 #[test]
-fn is_block_inlines_matches_rendered_content_across_every_block_kind() {
+fn is_block_inlines_matches_rendered_html_content_across_every_block_kind() {
     use std::collections::BTreeSet;
 
     use crate::blocks::{FindBlocks, IsBlock};
@@ -981,14 +984,14 @@ fn is_block_inlines_matches_rendered_content_across_every_block_kind() {
     for block in doc.descendant_blocks() {
         seen.insert(block_variant_name(block));
 
-        // `inlines()` is the structured counterpart of `rendered_content()`:
+        // `inlines()` is the structured counterpart of `rendered_html_content()`:
         // the same content-bearing blocks carry each, so their presence agrees
         // for every kind (this also drives every `Block::inlines()` dispatch
         // arm and each block type's override).
         assert_eq!(
             block.inlines().is_some(),
-            block.rendered_content().is_some(),
-            "`inlines()`/`rendered_content()` presence disagree for a {} block",
+            block.rendered_html_content().is_some(),
+            "`inlines()`/`rendered_html_content()` presence disagree for a {} block",
             block_variant_name(block),
         );
     }
@@ -1085,8 +1088,8 @@ fn has_styled(nodes: &[InlineNode<'_>], variant: StyleVariant) -> bool {
 fn inline_tree_numbers_footnotes_in_document_order() {
     // The recording pass clones the parser *before* the authoritative pass
     // advances the footnote counter, so a footnote in the second paragraph is
-    // numbered "2" in its tree – matching `rendered()` – rather than restarting
-    // at "1" (which a fresh-parser recording pass would produce).
+    // numbered "2" in its tree – matching `rendered_html()` – rather than
+    // restarting at "1" (which a fresh-parser recording pass would produce).
     let mut parser = Parser::default().with_inline_tree(true);
     let doc =
         parser.parse("Body text.footnote:[the first note]\n\nMore text.footnote:[the second note]");
@@ -1322,7 +1325,7 @@ fn inline_tree_xref_resolution_matches_the_rendered_string() {
     let rendered = doc
         .child_blocks()
         .filter_map(|block| match block {
-            Block::Simple(simple) => Some(simple.content().rendered().to_string()),
+            Block::Simple(simple) => Some(simple.content().rendered_html().to_string()),
             _ => None,
         })
         .find(|r| r.contains("<a href"))
@@ -1355,13 +1358,13 @@ fn inline_tree_xref_resolution_matches_the_rendered_string() {
 // (and `#![deny(warnings)]` rejects the dead code).
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic(expected = "diverged from rendered()")]
+#[should_panic(expected = "diverged from rendered_html()")]
 fn inline_tree_build_rejects_a_stateful_renderer() {
     /// A renderer whose output depends on mutable internal state: it emits
     /// different bytes on its second invocation. Because the recording pass
     /// shares the same renderer instance as the authoritative pass, such a
     /// renderer makes the recorded tree fold to something other than
-    /// `rendered()`.
+    /// `rendered_html()`.
     #[derive(Debug, Default)]
     struct FlipRenderer {
         flipped: std::cell::Cell<bool>,
@@ -2019,8 +2022,9 @@ fn section_title_footnote_carries_its_subtree_and_resolved_xref() {
 // `Footnote` node under a `Ref` node. Both new walks descend through reference
 // children (and formatting spans) to reach such a subtree. The recording pass
 // cannot currently produce that shape — a footnote nested in link text makes
-// the Strategy A fold diverge from `rendered()`, a pre-existing limitation the
-// Phase 4 single-pass builder retires — so the walks are driven directly here.
+// the Strategy A fold diverge from `rendered_html()`, a pre-existing limitation
+// the Phase 4 single-pass builder retires — so the walks are driven directly
+// here.
 
 /// A cross-reference node, unresolved.
 fn unresolved_xref() -> InlineNode<'static> {

--- a/parser/src/tests/inline_substitution_renderer.rs
+++ b/parser/src/tests/inline_substitution_renderer.rs
@@ -181,7 +181,7 @@ fn assert_inherits_html(
     let render = |parser: &Parser| {
         let mut content = Content::from(Span::new(source));
         step.apply(&mut content, parser, None);
-        content.rendered().to_string()
+        content.rendered_html().to_string()
     };
 
     let expected = render(&configure(Parser::default()));

--- a/parser/src/tests/prelude.rs
+++ b/parser/src/tests/prelude.rs
@@ -29,7 +29,7 @@ pub(crate) use crate::{
 pub(crate) fn rendered_paragraphs(doc: &crate::Document<'_>) -> Vec<String> {
     fn walk(block: &crate::blocks::Block<'_>, out: &mut Vec<String>) {
         if let crate::blocks::Block::Simple(simple) = block {
-            out.push(simple.content().rendered().to_string());
+            out.push(simple.content().rendered_html().to_string());
         }
         for child in block.child_blocks() {
             walk(child, out);

--- a/parser/src/tests/security.rs
+++ b/parser/src/tests/security.rs
@@ -45,7 +45,7 @@ fn render_paragraph(src: &str) -> String {
     walk(doc.child_blocks())
         .expect("expected at least one simple block")
         .content()
-        .rendered()
+        .rendered_html()
         .to_string()
 }
 
@@ -61,7 +61,7 @@ fn render_icon(src: &str, icons: &str) -> String {
     SubstitutionStep::SpecialCharacters.apply(&mut content, &parser, None);
     SubstitutionStep::Macros.apply(&mut content, &parser, None);
 
-    content.rendered().to_string()
+    content.rendered_html().to_string()
 }
 
 /// Renders `src` through the special-characters and macros substitution steps
@@ -75,7 +75,7 @@ fn render_macros(src: &str) -> String {
     SubstitutionStep::SpecialCharacters.apply(&mut content, &parser, None);
     SubstitutionStep::Macros.apply(&mut content, &parser, None);
 
-    content.rendered().to_string()
+    content.rendered_html().to_string()
 }
 
 // ---- Link target escaping --------------------------------------------------

--- a/parser/src/tests/xref.rs
+++ b/parser/src/tests/xref.rs
@@ -36,7 +36,7 @@ fn first_simple<'a>(doc: &'a Document<'a>) -> &'a SimpleBlock<'a> {
 
 /// Returns the rendered text of the first paragraph in `doc`.
 fn first_paragraph<'a>(doc: &'a Document<'a>) -> &'a str {
-    first_simple(doc).content().rendered()
+    first_simple(doc).content().rendered_html()
 }
 
 /// Returns the first `SectionBlock` found in document order (recursing into
@@ -73,7 +73,7 @@ fn backward_reference_resolves() {
     fn collect<'a>(blocks: impl Iterator<Item = &'a Block<'a>>, out: &mut Vec<String>) {
         for block in blocks {
             if let Block::Simple(simple) = block {
-                out.push(simple.content().rendered().to_string());
+                out.push(simple.content().rendered_html().to_string());
             }
             collect(block.child_blocks(), out);
         }
@@ -299,7 +299,7 @@ fn footnote_in_heading_does_not_advance_a_counter_twice() {
     fn collect<'a>(blocks: impl Iterator<Item = &'a Block<'a>>, out: &mut Vec<String>) {
         for block in blocks {
             if let Block::Simple(simple) = block {
-                out.push(simple.content().rendered().to_string());
+                out.push(simple.content().rendered_html().to_string());
             }
             collect(block.child_blocks(), out);
         }


### PR DESCRIPTION
## Phase 3, step 2 — rename the rendered-string accessors for HTML-specificity

The second step of **Phase 3** ([inline AST architecture design](../blob/inline-ast/docs/design/inline-ast-architecture.md), §3.3.1). Step 1 (#1082) exposed the public inline tree accessor; this step performs the accessor rename the Phase 3 plan sequences next.

### What changes

- **`Content::rendered()` → `Content::rendered_html()`**
- **`IsBlock::rendered_content()` → `IsBlock::rendered_html_content()`** — the trait default plus the four content-bearing impls (simple, quote, admonition, raw_delimited) and the `Block` enum dispatch.

The new names state the backend, per the §3.3.1 decision to make the HTML-specificity of the built-in rendered string explicit.

### Mechanical sweep, oracle preserved

This is the sweep §5.3 describes. Every `.rendered()` / `.rendered_content()` call site across the crate and the **full test corpus** is rewritten to the new name, while the **asserted output strings are left untouched** — the ~277 golden `.rendered()` assertions and the corpus-wide differential harness still pin the exact same bytes. Intra-doc links were split by intent: method-intent links now point at `rendered_html`, while references to the `pub(crate) rendered` field resolve to the field unambiguously now that the accessor no longer shares its name.

### Name-only — the semantics are unchanged

The accessor returns exactly what it returned before, **including** the output of a custom `InlineSubstitutionRenderer` installed via `Parser::with_inline_substitution_renderer`. The two changes the new name ultimately *implies* — making `rendered_html()` a **fold** of the inline tree, and **dropping the parse-time renderer** so it is always the built-in HTML backend — are the deferred remainder of Phase 2 and Phase 4, unchanged by this step. The `render_with` / `render_to` fold remains the outstanding Phase 3 piece.

The internal `pub(crate)` helpers `rendered_str()` / `rendered_owned()` keep their names (they describe the borrow flavor, not the backend; the design specifies only the two public renames).

### Tests / checks

- `cargo test -p asciidoc-parser` — 4664 passed, 0 failed (+ 5 doctests).
- `cargo clippy -p asciidoc-parser --all-targets` — clean.
- `cargo doc` with `RUSTDOCFLAGS=-D warnings` — clean (the field-vs-method link split was validated here).
- `cargo +nightly fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)