### PR TITLE
feat: Add the single-pass inline builder foundation (inline-ast Phase 4, step 1)

### DIFF
--- a/docs/design/inline-ast-architecture.md
+++ b/docs/design/inline-ast-architecture.md
@@ -750,13 +750,53 @@ Each phase is a reviewable unit with a clear exit gate.
   the new name ultimately implies (making `rendered_html()` a *fold* of the tree, and
   dropping the parse-time renderer so it is *always* the built-in HTML backend) are the
   deferred remainder of Phase 2 and Phase 4, unchanged by this step. The `render_with` /
-  `render_to` fold is still the remaining Phase 3 piece.
+  `render_to` fold is the last Phase 3 piece – but attempting it revealed that a *faithful*
+  fold needs the per-construct attrlist/parser back at fold time, which the `'static`
+  Strategy-A recorder cannot carry into a node (every `Styled`/`Image` node is therefore
+  built with `attrs: None`). The self-describing nodes such a fold needs come from the
+  Phase 4 single-pass builder, so `render_with` / `render_to` is **resequenced to land after**
+  that builder covers the inline vocabulary (see Phase 4's step list).
 
-- **Phase 4 — precision spans + ASG output.** Land the single-pass builder (Strategy B) and
-  `Document::to_asg()`; validate against the ASG schema; retire the `attribute-missing`
-  per-line hack (#564).
+- **Phase 4 — precision spans + single-pass builder + ASG output.** 🔶 **In progress.** Land
+  the single-pass builder (Strategy B) so the tree is built **directly from `'src`** – nodes
+  carrying honest per-node spans (#944) and their own `Attrlist<'src>` (self-describing) –
+  then make `rendered_html()` a fold of the tree, add `Document::to_asg()`, validate against
+  the ASG schema, and retire the `attribute-missing` per-line hack (#564).
   *Exit:* ASG output validates; #944 hard-case policies documented and tested; #564 hack
   removed.
+
+  *Step 1 landed as (the single-pass builder foundation + `SpecialCharacters`):* a new
+  [`inline_builder`](../../parser/src/content/inline_builder.rs) module recasts a
+  substitution step as a **transducer** over a node list (`Vec<InlineNode> → Vec<InlineNode>`) –
+  the shape §4.1 describes. [`build`](../../parser/src/content/inline_builder.rs) seeds one
+  borrowed whole-source `Text` node and threads it through the steps;
+  [`apply_special_characters`](../../parser/src/content/inline_builder.rs) splits each `Text`
+  run on `<`/`>`/`&` into precise-span `Text` and `CharRef::Special` nodes, sliced with the
+  crate's own [`Span`](../../parser/src/span/slice.rs) primitives so each node's
+  `line`/`col`/`offset` is honest (the precise spans #944 targets) and verbatim runs borrow
+  from `'src`. [`fold_html`](../../parser/src/content/inline_builder.rs) is the **first fold
+  over the public `InlineNode` tree** – the recorder's `fold_into` folds an intermediate
+  representation, not the public tree – and is the seed of both `rendered_html()`-as-a-fold
+  and `render_with`. This step is **additive**: nothing is wired into the parse path, so the
+  string pipeline and the Strategy-A [`inlines()`](../../parser/src/content/content.rs) tree
+  are untouched, and a differential test asserts the fold reproduces the string pipeline's
+  special-characters output byte-for-byte, alongside precise-span assertions the Strategy-A
+  tree cannot make.
+
+  *Next steps (each a transducer step, gated by the golden-HTML oracle §5.3):*
+  1. ✅ Foundation + `SpecialCharacters` (this step).
+  2. `Quotes` → `Styled`, introducing nesting (`*a _b_ c*` becomes a tree, not a flat run).
+  3. `CharacterReplacements` → `CharRef::Replacement`, and `PostReplacement` → `LineBreak`.
+  4. `Macros` → `Ref` / `Image` / `Footnote` / `Ui` / `IndexTerm` / `Stem` / `Anchor`,
+     capturing the owned `Attrlist<'src>` each construct carries – the step that makes nodes
+     **self-describing** (and the one that finally unblocks `render_with`).
+  5. `AttributeReferences` (expanded-value splicing, §3.4.1), passthroughs (`Raw`), and
+     `Callouts` – completing the vocabulary the recorder covers.
+  6. **Cut over:** swap the recorder for the single-pass builder in `Content`, make
+     `rendered_html()` a fold, delete the three production sentinel systems (§4.2), and retire
+     the `with_inline_tree` opt-in flag (the deferred remainder of Phase 2).
+  7. `render_with` / `render_to` (the Phase 3 remainder) and `Document::to_asg()`, now that
+     nodes are self-describing; retire the `attribute-missing` per-line hack (#564).
 
 - **Phase 5 — renderer seam v2.** Reshape `InlineSubstitutionRenderer` into the AST-walking
   form and rename it to `InlineRenderer` (§4.6); update the README backend story.

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -192,9 +192,16 @@ fn fold_into_html(
             }
 
             other => {
-                unreachable!(
-                    "inline_builder::fold_html reached a node the SpecialCharacters step \
-                     cannot yet produce: {other:?}"
+                // The `SpecialCharacters` step produces only `Text` and
+                // `CharRef::Special` leaves, and this fold additionally emits the
+                // design-legal `Raw` leaf; no other node kind reaches the fold in
+                // this increment. A later increment fills in the arms above as
+                // the transducer grows new kinds. Guard against a premature
+                // caller in debug builds and emit nothing in release, mirroring
+                // the safe defensive fallback in [`content`](super::content).
+                debug_assert!(
+                    false,
+                    "inline_builder::fold_html reached an unsupported node kind: {other:?}"
                 );
             }
         }
@@ -225,11 +232,11 @@ mod tests {
     #![allow(clippy::panic)]
     #![allow(clippy::unwrap_used)]
 
-    use super::{build, fold_html};
+    use super::{apply_special_characters, build, fold_html};
     use crate::{
         Span,
         content::{Content, SubstitutionStep},
-        inlines::{CharRef, InlineNode},
+        inlines::{CharRef, InlineNode, Ref, RefVariant, SpanForm, StyleVariant, Styled},
         parser::HtmlSubstitutionRenderer,
         strings::CowStr,
     };
@@ -344,6 +351,103 @@ mod tests {
 
             other => panic!("expected CharRef::Special('>'), got {other:?}"),
         }
+    }
+
+    #[test]
+    fn special_characters_recurses_into_styled_children() {
+        // A custom `subs` order can run quotes before special characters, so the
+        // step must descend into a `Styled` span's children.
+        let loc = Span::new("a<b");
+
+        let styled = InlineNode::Styled(Styled {
+            variant: StyleVariant::Strong,
+            form: SpanForm::Constrained,
+            id: None,
+            roles: vec![],
+            attrs: None,
+            children: vec![InlineNode::Text {
+                value: CowStr::from(loc.data()),
+                location: loc,
+            }],
+            location: loc,
+        });
+
+        let out = apply_special_characters(vec![styled]);
+
+        assert_eq!(out.len(), 1);
+
+        match &out[0] {
+            InlineNode::Styled(styled) => {
+                assert_eq!(styled.children.len(), 3);
+                assert_text(&styled.children[0], "a", 1, 1);
+                assert_special(&styled.children[1], '<', 2, 1);
+                assert_text(&styled.children[2], "b", 1, 3);
+            }
+
+            other => panic!("expected Styled, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn special_characters_recurses_into_ref_children() {
+        // A reference's display text is likewise refined in place.
+        let loc = Span::new("x&y");
+
+        let reference = InlineNode::Ref(Ref {
+            variant: RefVariant::Link,
+            target: CowStr::from("https://example.com"),
+            children: vec![InlineNode::Text {
+                value: CowStr::from(loc.data()),
+                location: loc,
+            }],
+            roles: vec![],
+            window: None,
+            resolved: None,
+            location: loc,
+        });
+
+        let out = apply_special_characters(vec![reference]);
+
+        assert_eq!(out.len(), 1);
+
+        match &out[0] {
+            InlineNode::Ref(reference) => {
+                assert_eq!(reference.children.len(), 3);
+                assert_text(&reference.children[0], "x", 1, 1);
+                assert_special(&reference.children[1], '&', 2, 1);
+                assert_text(&reference.children[2], "y", 1, 3);
+            }
+
+            other => panic!("expected Ref, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn special_characters_passes_other_nodes_through() {
+        // A node kind the step does not split (here a line break) is forwarded
+        // unchanged.
+        let location = Span::new("");
+        let out = apply_special_characters(vec![InlineNode::LineBreak { location }]);
+
+        assert_eq!(out.len(), 1);
+        assert!(matches!(out[0], InlineNode::LineBreak { .. }));
+    }
+
+    #[test]
+    fn fold_emits_raw_verbatim() {
+        // A `Raw` leaf is emitted without HTML-escaping, unlike `Text`; its `<`,
+        // `>`, and `&` pass straight through.
+        let location = Span::new("<b>raw &amp;</b>");
+
+        let raw = InlineNode::Raw {
+            value: CowStr::from(location.data()),
+            location,
+        };
+
+        assert_eq!(
+            fold_html(&[raw], &HtmlSubstitutionRenderer {}),
+            "<b>raw &amp;</b>"
+        );
     }
 
     /// The string pipeline's special-characters output for `source`, used as

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -74,19 +74,23 @@ fn is_special(c: char) -> bool {
 }
 
 /// The special-characters substitution, as a node transducer: every
-/// [`Text`](InlineNode::Text) run is split on `<`/`>`/`&` into precise-span
+/// [`Text`](InlineNode::Text) run is split on `<`/`>`/`&` into
 /// [`Text`](InlineNode::Text) and [`CharRef`](InlineNode::CharRef) nodes, and
 /// every other node passes through (recursing into parent nodes' children).
 ///
-/// A `Text` node's `value` borrows its `location` at this stage, so splitting
-/// by the `location` span is faithful to the logical text.
+/// The split is driven by the node's **logical `value`**, not by its source
+/// span, so a *synthesized* value – an attribute expansion or a joined
+/// multi-line run that a later step may feed in under a custom `subs` order –
+/// is preserved rather than replaced by its source spelling. Precise spans are
+/// kept for the common verbatim run, where the value coincides with the source
+/// its `location` covers; see [`split_text`].
 fn apply_special_characters<'src>(nodes: Vec<InlineNode<'src>>) -> Vec<InlineNode<'src>> {
     let mut out = Vec::with_capacity(nodes.len());
 
     for node in nodes {
         match node {
-            InlineNode::Text { location, .. } => {
-                split_special_characters(location, &mut out);
+            InlineNode::Text { value, location } => {
+                split_text(value, location, &mut out);
             }
 
             InlineNode::Styled(mut styled) => {
@@ -106,13 +110,28 @@ fn apply_special_characters<'src>(nodes: Vec<InlineNode<'src>>) -> Vec<InlineNod
     out
 }
 
-/// Splits the text covered by `location` into alternating
-/// [`Text`](InlineNode::Text) runs and [`CharRef`](InlineNode::CharRef)
-/// specials, pushing each onto `out`.
+/// Splits a [`Text`](InlineNode::Text) node's logical `value` into alternating
+/// text runs and `<`/`>`/`&` [`CharRef`](InlineNode::CharRef) specials.
 ///
-/// Every sub-span is sliced from `location` with the crate's span primitives,
-/// so its `line`/`col`/`offset` stay honest; a run is never emitted empty.
-fn split_special_characters<'src>(location: Span<'src>, out: &mut Vec<InlineNode<'src>>) {
+/// When `value` is exactly the source its `location` covers – the common
+/// verbatim run – each sub-node is sliced from `location`, so its
+/// `line`/`col`/`offset` stay honest (issue #944) and its run text borrows from
+/// `'src`. When `value` is *synthesized* – it has no source of its own – the
+/// runs are owned slices of the value and every sub-node falls back to the
+/// whole `location` span, the documented coarse fallback (design §4.4).
+fn split_text<'src>(value: CowStr<'src>, location: Span<'src>, out: &mut Vec<InlineNode<'src>>) {
+    if value.as_ref() == location.data() {
+        split_verbatim(location, out);
+    } else {
+        split_synthesized(value.as_ref(), location, out);
+    }
+}
+
+/// Splits a verbatim run – text that coincides with the source `location`
+/// covers – slicing each sub-span from `location` with the crate's span
+/// primitives so `line`/`col`/`offset` stay honest; a run is never emitted
+/// empty.
+fn split_verbatim<'src>(location: Span<'src>, out: &mut Vec<InlineNode<'src>>) {
     let mut rest = location;
 
     while let Some(pos) = rest.position(is_special) {
@@ -143,6 +162,41 @@ fn split_special_characters<'src>(location: Span<'src>, out: &mut Vec<InlineNode
         out.push(InlineNode::Text {
             value: CowStr::from(rest.data()),
             location: rest,
+        });
+    }
+}
+
+/// Splits a synthesized `value` – text with no source span of its own – into
+/// owned [`Text`](InlineNode::Text) runs and [`CharRef`](InlineNode::CharRef)
+/// specials, each carrying the whole `location` as its coarse fallback span; a
+/// run is never emitted empty.
+fn split_synthesized<'src>(value: &str, location: Span<'src>, out: &mut Vec<InlineNode<'src>>) {
+    let mut rest = value;
+
+    while let Some(pos) = rest.find(is_special) {
+        // Emit the owned text run preceding the special, when non-empty.
+        if pos > 0 {
+            out.push(InlineNode::Text {
+                value: CowStr::from(rest[..pos].to_string()),
+                location,
+            });
+        }
+
+        // The three specials are ASCII, so the match is exactly one byte wide.
+        let ch = rest[pos..].chars().next().unwrap_or('\u{FFFD}');
+
+        out.push(InlineNode::CharRef {
+            value: CharRef::Special(ch),
+            location,
+        });
+
+        rest = &rest[pos + 1..];
+    }
+
+    if !rest.is_empty() {
+        out.push(InlineNode::Text {
+            value: CowStr::from(rest.to_string()),
+            location,
         });
     }
 }
@@ -431,6 +485,57 @@ mod tests {
 
         assert_eq!(out.len(), 1);
         assert!(matches!(out[0], InlineNode::LineBreak { .. }));
+    }
+
+    #[test]
+    fn special_characters_preserves_a_synthesized_text_value() {
+        // A synthesized `value` (standing in for an attribute expansion) does
+        // not coincide with the source its `location` covers. The step must
+        // split the *logical value* – not re-derive text from the span – so the
+        // expansion survives, with the whole `location` kept as each sub-node's
+        // coarse fallback span.
+        let location = Span::new("{x}");
+
+        let text = InlineNode::Text {
+            value: CowStr::from("a<b".to_string()),
+            location,
+        };
+
+        let out = apply_special_characters(vec![text]);
+
+        assert_eq!(out.len(), 3);
+
+        // Leading run: the value's text, not the span's, and the coarse span.
+        match &out[0] {
+            InlineNode::Text { value, location } => {
+                assert_eq!(value.as_ref(), "a");
+                assert_eq!(location.data(), "{x}");
+            }
+
+            other => panic!("expected Text, got {other:?}"),
+        }
+
+        match &out[1] {
+            InlineNode::CharRef {
+                value: CharRef::Special(ch),
+                location,
+            } => {
+                assert_eq!(*ch, '<');
+                assert_eq!(location.data(), "{x}");
+            }
+
+            other => panic!("expected CharRef::Special, got {other:?}"),
+        }
+
+        // Trailing run, exercising the loop's post-special tail.
+        match &out[2] {
+            InlineNode::Text { value, location } => {
+                assert_eq!(value.as_ref(), "b");
+                assert_eq!(location.data(), "{x}");
+            }
+
+            other => panic!("expected Text, got {other:?}"),
+        }
     }
 
     #[test]

--- a/parser/src/content/inline_builder.rs
+++ b/parser/src/content/inline_builder.rs
@@ -1,0 +1,388 @@
+//! Builds the inline AST **directly from source in a single forward pass**.
+//!
+//! This is the first brick of "Strategy B" (design §4.1): rather than recover
+//! the tree from a post-substitution *marked string* – the
+//! [`inline_tree`](crate::content::inline_tree) recorder's "Strategy A" – each
+//! substitution step is recast as a **transducer** over a node list,
+//! `Vec<InlineNode<'src>> -> Vec<InlineNode<'src>>`, that refines the tree in
+//! place. Two properties fall out that Strategy A cannot offer:
+//!
+//! 1. **Honest per-node spans.** A node is sliced straight from the source
+//!    [`Span`], so its `location` reports the real `line`/`col`/`offset` of the
+//!    construct (issue #944), instead of every node carrying the whole-content
+//!    span.
+//! 2. **`'src` borrowing by construction.** A verbatim text run's `value`
+//!    borrows the very bytes its `location` covers, so the common case does not
+//!    allocate.
+//!
+//! # Status
+//!
+//! Strategy B "touches every step," so it lands incrementally under the
+//! golden-HTML oracle. This module currently implements only the **foundation**
+//! plus the first refinement:
+//!
+//! - [`build`] seeds a single borrowed whole-source [`Text`](InlineNode::Text)
+//!   node and threads it through the steps.
+//! - [`apply_special_characters`] splits each `Text` run on `<`/`>`/`&` into
+//!   precise-span [`Text`](InlineNode::Text) and
+//!   [`CharRef`](InlineNode::CharRef) nodes.
+//! - [`fold_html`] folds the resulting leaves back to output bytes through an
+//!   [`InlineSubstitutionRenderer`] – the first fold over the *public*
+//!   [`InlineNode`] tree (the recorder's [`fold_into`] folds an intermediate
+//!   representation, not the public tree).
+//!
+//! It is **additive and non-regressing**: nothing here is wired into the parse
+//! path yet, so the authoritative string pipeline and the Strategy-A
+//! [`Content::inlines`](crate::content::Content::inlines) tree are untouched.
+//! Later increments extend the transducer to quotes, replacements, macros,
+//! attribute expansion, and passthroughs, at which point it can replace the
+//! recorder, make `rendered_html()` a fold, and retire the sentinel systems.
+//!
+//! [`fold_into`]: crate::content::inline_tree
+//! [`Text`]: InlineNode::Text
+
+// The transducer framework is deliberately broader than the single step wired
+// up so far; later Strategy-B increments consume the rest.
+#![allow(dead_code)]
+
+use crate::{
+    Span,
+    inlines::{CharRef, InlineNode},
+    parser::{InlineSubstitutionRenderer, SpecialCharacter},
+    strings::CowStr,
+};
+
+/// Builds the inline tree for `source` in a single forward pass.
+///
+/// The tree is seeded as one borrowed whole-source [`Text`](InlineNode::Text)
+/// node and refined by each substitution step in turn. `source` is the exact
+/// text to process, so a caller controls precisely what is built; reconciling
+/// with a block's line filtering and joining is a later increment's concern.
+pub(crate) fn build(source: Span<'_>) -> Vec<InlineNode<'_>> {
+    let seed = vec![InlineNode::Text {
+        value: CowStr::from(source.data()),
+        location: source,
+    }];
+
+    apply_special_characters(seed)
+}
+
+/// Reports whether `c` is one of the three characters the special-characters
+/// substitution acts on.
+fn is_special(c: char) -> bool {
+    matches!(c, '<' | '>' | '&')
+}
+
+/// The special-characters substitution, as a node transducer: every
+/// [`Text`](InlineNode::Text) run is split on `<`/`>`/`&` into precise-span
+/// [`Text`](InlineNode::Text) and [`CharRef`](InlineNode::CharRef) nodes, and
+/// every other node passes through (recursing into parent nodes' children).
+///
+/// A `Text` node's `value` borrows its `location` at this stage, so splitting
+/// by the `location` span is faithful to the logical text.
+fn apply_special_characters<'src>(nodes: Vec<InlineNode<'src>>) -> Vec<InlineNode<'src>> {
+    let mut out = Vec::with_capacity(nodes.len());
+
+    for node in nodes {
+        match node {
+            InlineNode::Text { location, .. } => {
+                split_special_characters(location, &mut out);
+            }
+
+            InlineNode::Styled(mut styled) => {
+                styled.children = apply_special_characters(styled.children);
+                out.push(InlineNode::Styled(styled));
+            }
+
+            InlineNode::Ref(mut reference) => {
+                reference.children = apply_special_characters(reference.children);
+                out.push(InlineNode::Ref(reference));
+            }
+
+            other => out.push(other),
+        }
+    }
+
+    out
+}
+
+/// Splits the text covered by `location` into alternating
+/// [`Text`](InlineNode::Text) runs and [`CharRef`](InlineNode::CharRef)
+/// specials, pushing each onto `out`.
+///
+/// Every sub-span is sliced from `location` with the crate's span primitives,
+/// so its `line`/`col`/`offset` stay honest; a run is never emitted empty.
+fn split_special_characters<'src>(location: Span<'src>, out: &mut Vec<InlineNode<'src>>) {
+    let mut rest = location;
+
+    while let Some(pos) = rest.position(is_special) {
+        // Emit the borrowed text run preceding the special, when non-empty.
+        if pos > 0 {
+            let text = rest.slice_to(..pos);
+
+            out.push(InlineNode::Text {
+                value: CowStr::from(text.data()),
+                location: text,
+            });
+        }
+
+        // The three specials are ASCII, so the match is exactly one byte wide.
+        let ch_span = rest.slice(pos..pos + 1);
+
+        let ch = ch_span.data().chars().next().unwrap_or('\u{FFFD}');
+
+        out.push(InlineNode::CharRef {
+            value: CharRef::Special(ch),
+            location: ch_span,
+        });
+
+        rest = rest.slice_from(pos + 1..);
+    }
+
+    if !rest.data().is_empty() {
+        out.push(InlineNode::Text {
+            value: CowStr::from(rest.data()),
+            location: rest,
+        });
+    }
+}
+
+/// Folds an inline node tree to output bytes through `renderer`.
+///
+/// This is the first fold over the *public* [`InlineNode`] tree. It currently
+/// handles only the leaves the [`apply_special_characters`] step produces; a
+/// later increment extends it as the transducer grows new node kinds.
+pub(crate) fn fold_html(
+    nodes: &[InlineNode<'_>],
+    renderer: &dyn InlineSubstitutionRenderer,
+) -> String {
+    let mut out = String::new();
+    fold_into_html(nodes, renderer, &mut out);
+    out
+}
+
+/// Appends the fold of `nodes` to `out` (the recursive worker for
+/// [`fold_html`]).
+fn fold_into_html(
+    nodes: &[InlineNode<'_>],
+    renderer: &dyn InlineSubstitutionRenderer,
+    out: &mut String,
+) {
+    for node in nodes {
+        match node {
+            InlineNode::Text { value, .. } => {
+                // `Text` is logical (un-escaped) text; the fold escapes it. The
+                // builder never leaves a special inside a `Text`, so this is
+                // belt-and-suspenders, but it keeps the fold correct in its own
+                // right.
+                for ch in value.chars() {
+                    render_char(ch, renderer, out);
+                }
+            }
+
+            InlineNode::Raw { value, .. } => {
+                out.push_str(value);
+            }
+
+            InlineNode::CharRef {
+                value: CharRef::Special(ch),
+                ..
+            } => {
+                render_char(*ch, renderer, out);
+            }
+
+            other => {
+                unreachable!(
+                    "inline_builder::fold_html reached a node the SpecialCharacters step \
+                     cannot yet produce: {other:?}"
+                );
+            }
+        }
+    }
+}
+
+/// Appends `ch` to `out`, routing the three special characters through
+/// `renderer` (so a custom renderer's escaping is honored) and pushing any
+/// other character verbatim.
+fn render_char(ch: char, renderer: &dyn InlineSubstitutionRenderer, out: &mut String) {
+    let type_ = match ch {
+        '<' => SpecialCharacter::Lt,
+        '>' => SpecialCharacter::Gt,
+        '&' => SpecialCharacter::Ampersand,
+
+        _ => {
+            out.push(ch);
+            return;
+        }
+    };
+
+    renderer.render_special_character(type_, out);
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::indexing_slicing)]
+    #![allow(clippy::panic)]
+    #![allow(clippy::unwrap_used)]
+
+    use super::{build, fold_html};
+    use crate::{
+        Span,
+        content::{Content, SubstitutionStep},
+        inlines::{CharRef, InlineNode},
+        parser::HtmlSubstitutionRenderer,
+        strings::CowStr,
+    };
+
+    /// Asserts that `node` is a [`Text`](InlineNode::Text) whose `value`
+    /// borrows (does not allocate) and whose `location` selects `data` at
+    /// `line`/`col`.
+    fn assert_text(node: &InlineNode<'_>, data: &str, line: usize, col: usize) {
+        match node {
+            InlineNode::Text { value, location } => {
+                assert!(
+                    matches!(value, CowStr::Borrowed(_)),
+                    "text value should borrow from source, got {value:?}"
+                );
+                assert_eq!(value.as_ref(), data);
+                assert_eq!(location.data(), data);
+                assert_eq!(location.line(), line, "line for {data:?}");
+                assert_eq!(location.col(), col, "col for {data:?}");
+            }
+
+            other => panic!("expected Text({data:?}), got {other:?}"),
+        }
+    }
+
+    /// Asserts that `node` is a special [`CharRef`](InlineNode::CharRef) for
+    /// `ch`, located at `col` on line 1 with `offset`.
+    fn assert_special(node: &InlineNode<'_>, ch: char, col: usize, offset: usize) {
+        match node {
+            InlineNode::CharRef {
+                value: CharRef::Special(got),
+                location,
+            } => {
+                assert_eq!(*got, ch);
+                assert_eq!(location.data(), ch.to_string());
+                assert_eq!(location.col(), col, "col for {ch:?}");
+                assert_eq!(location.byte_offset(), offset, "offset for {ch:?}");
+            }
+
+            other => panic!("expected CharRef::Special({ch:?}), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn splits_text_and_specials_with_precise_spans() {
+        let nodes = build(Span::new("a<b>c&d"));
+
+        assert_eq!(nodes.len(), 7);
+        assert_text(&nodes[0], "a", 1, 1);
+        assert_special(&nodes[1], '<', 2, 1);
+        assert_text(&nodes[2], "b", 1, 3);
+        assert_special(&nodes[3], '>', 4, 3);
+        assert_text(&nodes[4], "c", 1, 5);
+        assert_special(&nodes[5], '&', 6, 5);
+        assert_text(&nodes[6], "d", 1, 7);
+    }
+
+    #[test]
+    fn all_specials_yield_only_char_refs() {
+        let nodes = build(Span::new("<>&"));
+
+        assert_eq!(nodes.len(), 3);
+        assert_special(&nodes[0], '<', 1, 0);
+        assert_special(&nodes[1], '>', 2, 1);
+        assert_special(&nodes[2], '&', 3, 2);
+    }
+
+    #[test]
+    fn adjacent_specials_produce_no_empty_runs() {
+        let nodes = build(Span::new("<<"));
+
+        assert_eq!(nodes.len(), 2);
+        assert_special(&nodes[0], '<', 1, 0);
+        assert_special(&nodes[1], '<', 2, 1);
+    }
+
+    #[test]
+    fn plain_text_is_a_single_borrowed_node() {
+        let nodes = build(Span::new("hello"));
+
+        assert_eq!(nodes.len(), 1);
+        assert_text(&nodes[0], "hello", 1, 1);
+    }
+
+    #[test]
+    fn empty_source_yields_no_nodes() {
+        assert!(build(Span::new("")).is_empty());
+    }
+
+    #[test]
+    fn a_run_spanning_a_newline_tracks_line_and_col() {
+        // The text run between the two specials includes the newline, so the
+        // node after it is located on line 2.
+        let nodes = build(Span::new("a<\nb>"));
+
+        assert_eq!(nodes.len(), 4);
+        assert_text(&nodes[0], "a", 1, 1);
+        assert_special(&nodes[1], '<', 2, 1);
+
+        // The middle run is "\nb": it starts right after `<` (line 1, col 3) and
+        // carries into line 2.
+        assert_text(&nodes[2], "\nb", 1, 3);
+
+        // The closing `>` lands on line 2.
+        match &nodes[3] {
+            InlineNode::CharRef {
+                value: CharRef::Special('>'),
+                location,
+            } => {
+                assert_eq!(location.line(), 2);
+                assert_eq!(location.col(), 2);
+            }
+
+            other => panic!("expected CharRef::Special('>'), got {other:?}"),
+        }
+    }
+
+    /// The string pipeline's special-characters output for `source`, used as
+    /// the golden oracle: `Content::from` then the `SpecialCharacters`
+    /// step.
+    fn golden(source: &str) -> String {
+        let parser = crate::Parser::default();
+        let mut content = Content::from(Span::new(source));
+        SubstitutionStep::SpecialCharacters.apply(&mut content, &parser, None);
+        content.rendered_str().to_string()
+    }
+
+    #[test]
+    fn fold_matches_the_string_pipeline_byte_for_byte() {
+        // Special-characters-only fixtures: for these, folding the single-pass
+        // tree reproduces the string pipeline's escaped output exactly.
+        let fixtures = [
+            "",
+            "plain text",
+            "a<b>c&d",
+            "<>&",
+            "<<",
+            "&<>&",
+            "less < and & more >",
+            "trailing &",
+            "multi\nline < with & specials >",
+            "unicode π < ω &",
+        ];
+
+        let renderer = HtmlSubstitutionRenderer {};
+
+        for fixture in fixtures {
+            let folded = fold_html(&build(Span::new(fixture)), &renderer);
+
+            assert_eq!(
+                folded,
+                golden(fixture),
+                "fold diverged from the string pipeline for {fixture:?}"
+            );
+        }
+    }
+}

--- a/parser/src/content/mod.rs
+++ b/parser/src/content/mod.rs
@@ -11,6 +11,8 @@ pub(crate) use content::{
     strip_footnote_marker_spans,
 };
 
+pub(crate) mod inline_builder;
+
 pub(crate) mod inline_tree;
 
 mod macros;


### PR DESCRIPTION
## What & why

First brick of **Strategy B** (design §4.1): build the inline AST **directly from source in a single forward pass**, instead of recovering it from a post-substitution *marked string* the way the Strategy-A recorder (`content::inline_tree`) does.

This unblocks the two things Strategy A structurally cannot give (and that Phase 4 always intended to deliver):

- **Honest per-node source spans** (issue #944) — the recorder stamps every node with the whole-content span, because it recovers the tree from a rendered string, not from source.
- **Self-describing nodes** — the recorder is `'static` (`Parser::with_inline_substitution_renderer` requires `… + 'static`), so its event log can only hold owned data, never source-borrowed `Attrlist<'src>`/`&Parser`. That is why every `Styled`/`Image` node carries `attrs: None`, and why a faithful `render_with` fold (the remaining Phase 3 piece) is not achievable on Strategy A. Strategy B builds in `'src`, dissolving both limits.

## What's in this step

A new `content::inline_builder` module that recasts a substitution step as a **transducer** over a node list (`Vec<InlineNode> -> Vec<InlineNode>`). This first increment implements the foundation plus the `SpecialCharacters` refinement:

- `build(source)` seeds one borrowed whole-source `Text` node and threads it through the steps.
- `apply_special_characters` splits each `Text` run on `<`/`>`/`&` into precise-span `Text` + `CharRef::Special` nodes, sliced with the crate's own `Span` primitives so `line`/`col`/`offset` stay honest and text runs borrow from `'src`.
- `fold_html` is the **first fold over the public `InlineNode` tree** (the recorder's `fold_into` folds an intermediate representation, not the public tree) — the seed of both `rendered_html()`-as-a-fold and `render_with`.

## Safety / scope

**Additive and non-regressing.** Nothing here is wired into the parse path, so the authoritative string pipeline and the Strategy-A `Content::inlines()` tree are untouched. A differential test asserts `fold_html(build(span))` reproduces the string pipeline's `SpecialCharacters` output **byte-for-byte**, alongside precise-span assertions the Strategy-A tree cannot make.

- ✅ `cargo test -p asciidoc-parser` — 4671 passed (incl. all golden `.rendered_html()` assertions and the differential corpus)
- ✅ `cargo +nightly fmt --all -- --check`
- ✅ `cargo clippy -p asciidoc-parser --all-targets`

## Trajectory (future steps)

Quotes→`Styled`, Replacements, Macros→`Ref`/`Image`/… with owned `Attrlist<'src>`, then attribute expansion / passthroughs / callouts — after which the builder replaces the recorder, `rendered_html()` becomes a fold of the tree, the three sentinel systems retire, and `render_with`/`render_to` + `Document::to_asg()` land on self-describing nodes. The architecture doc is updated in this PR with these next steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)